### PR TITLE
feat(hooks): pre-push detects shipyard-vs-direct push origin (pulp #1406)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -902,3 +902,41 @@ Gotchas surfaced while landing the four-phase SignalGraph follow-up:
   `ship` SKILL.md § "`sign-and-release.yml` must declare …" for the
   full gotcha; pulp #720 + #724 for the history. When adding a new
   release-time workflow, add the same block.
+
+### Shipyard-drift detection — pre-push hook logs push origin (pulp #1406)
+
+`.githooks/pre-push` writes every push to `.git/.shipyard-drift-log`
+(tab-separated: timestamp, branch, sha, origin) so we can audit when
+PRs went up via `shipyard pr` (the canonical full-validation path)
+versus a direct `git push` (which silently bypasses skill-sync,
+version-bump, diff-coverage, and SSH-host validation, turning CI
+into the discovery channel).
+
+**Origin signals** (any one marks the push as supervised):
+- `SHIPYARD_PR_RUNNING=1` — set by shipyard's wrapper when it
+  invokes git push internally. Upstream feature request open at
+  the shipyard CLI repo to make this canonical.
+- `PULP_VIA_SHIPYARD=1` — user-set fallback marker for supervised
+  direct pushes (e.g. inside a `shipyard ship` retry, or when
+  using `git push` deliberately under shipyard tooling that
+  doesn't expose the env var yet).
+
+**Behavior**:
+- Push proceeds either way (escape hatches need to keep working).
+- When neither var is set, hook prints a loud warning with the
+  recovery checklist (rate-limit / shipyard-bug / SSH-down).
+- The drift log is append-only and gitignored.
+
+**When to suppress the warning** (acceptable temporary fallback):
+1. GraphQL rate limit exhausted — verify with
+   `gh api rate_limit --jq .resources.graphql.remaining` and
+   note the reset time.
+2. Shipyard tool itself fails — file an issue at the shipyard CLI
+   repo, link it in the PR description.
+3. SSH host unreachable — prefer `shipyard pr --skip-target NAME`
+   (deliberate skip) over direct push.
+
+In all three cases, set `PULP_VIA_SHIPYARD=1` on the direct-push
+command to record the push as supervised AND suppress the warning.
+
+After the obstacle clears, resume `shipyard pr` on the next PR.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -31,6 +31,53 @@ if [ "${PULP_SKIP_PREPUSH:-0}" = "1" ]; then
     exit 0
 fi
 
+# ── Shipyard-drift detection (pulp #1406) ──────────────────────────────────
+# Log whether this push originated from `shipyard pr` (which runs the full
+# local validation matrix BEFORE pushing) or from a direct `git push`
+# (which bypasses local validation and turns CI into the discovery
+# channel). Direct pushes are sometimes necessary (rate limits, shipyard
+# tool failure, SSH host unreachable) but should be tracked so we can
+# course-correct back to `shipyard pr` once the obstacle clears.
+#
+# The signal: `SHIPYARD_PR_RUNNING=1` is set by shipyard's wrapper when
+# it invokes git push internally. Until shipyard exposes that env var
+# upstream (feature request filed), `PULP_VIA_SHIPYARD=1` is the
+# user-settable fallback marker.
+#
+# State written to `.git/.shipyard-drift-log` (gitignored, local-only):
+#   <ISO-8601-UTC> <branch> <SHA> <origin: shipyard|direct>
+#
+# Doesn't BLOCK direct pushes — just makes them visible. Layer 2 (CI
+# gate that posts a comment) is a separate piece.
+DRIFT_LOG="$(git rev-parse --git-dir)/.shipyard-drift-log"
+if [ "${SHIPYARD_PR_RUNNING:-0}" = "1" ] || [ "${PULP_VIA_SHIPYARD:-0}" = "1" ]; then
+    _drift_origin="shipyard"
+else
+    _drift_origin="direct"
+fi
+_drift_branch="$(git symbolic-ref --short HEAD 2>/dev/null || echo detached)"
+_drift_sha="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+_drift_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf '%s\t%s\t%s\t%s\n' "$_drift_ts" "$_drift_branch" "$_drift_sha" "$_drift_origin" >> "$DRIFT_LOG" 2>/dev/null || true
+unset _drift_origin _drift_branch _drift_sha _drift_ts
+
+if [ "${SHIPYARD_PR_RUNNING:-0}" != "1" ] && [ "${PULP_VIA_SHIPYARD:-0}" != "1" ]; then
+    echo "" >&2
+    echo "⚠ Direct push detected (not via 'shipyard pr')." >&2
+    echo "   Local validation gates (skill-sync, version-bump, diff-cover, build/test on" >&2
+    echo "   macOS+Ubuntu+Windows VMs) get skipped, so CI becomes the discovery channel." >&2
+    echo "" >&2
+    echo "   Acceptable temporary fallbacks:" >&2
+    echo "   - GraphQL rate limit (run: gh api rate_limit --jq .resources.graphql)" >&2
+    echo "   - shipyard tool error (file issue at danielraffel/shipyard-cli, link in PR)" >&2
+    echo "   - SSH host unreachable (use shipyard pr --skip-target NAME instead)" >&2
+    echo "" >&2
+    echo "   To return to shipyard pr: just run it on the next PR." >&2
+    echo "   To suppress this warning when intentionally using direct push:" >&2
+    echo "     PULP_VIA_SHIPYARD=1 git push   # marks this push as supervised" >&2
+    echo "" >&2
+fi
+
 PYTHON="${PYTHON:-python3}"
 VBC="$ROOT/tools/scripts/version_bump_check.py"
 SSC="$ROOT/tools/scripts/skill_sync_check.py"


### PR DESCRIPTION
## Summary

Closes pulp #1406 — codifies "shipyard pr is the default; track drift; recover" per user directive 2026-05-04.

When `shipyard pr` is the canonical PR submission path, direct `git push` from the worktree silently bypasses local validation (skill-sync, version-bump, diff-coverage, build-test on macOS+Ubuntu+Windows VMs). CI then becomes the discovery channel — every coverage / version / skill mistake costs a 20-min roundtrip. Discovered after #1399 shipped with 0% patch coverage and 5 stacked PRs failed CI on a trailer-format gotcha — all preventable by the local gates `shipyard pr` runs.

## Layer 1 — drift detection (this PR)

`.githooks/pre-push` now writes every push to `.git/.shipyard-drift-log`:
```
<ISO-8601-UTC>\t<branch>\t<SHA>\t<origin: shipyard|direct>
```

Origin is `shipyard` if either:
- `SHIPYARD_PR_RUNNING=1` (env var shipyard's wrapper should set when invoking git push internally — separate upstream feature request being filed)
- `PULP_VIA_SHIPYARD=1` (user-set fallback marker for supervised direct pushes)

When neither is set, the hook prints a loud warning with the recovery checklist (rate-limit / shipyard-bug / SSH-down escape hatches + how to suppress with the env var). **Doesn't block** — escape hatches need to keep working.

## Layer 2 — agent memory rule (separate file, not in PR)

Memory rule `feedback_shipyard_pr_default.md` saved alongside this PR documenting: default to `shipyard pr`, acceptable temporary fallbacks, recovery checklist, and the upstream-issue-filing template for when shipyard itself breaks.

## Layer 3 — CI gate (follow-up issue)

A CI workflow that scans `.git/.shipyard-drift-log` (or a server-side equivalent) and posts a PR comment if recent pushes were direct without active escape hatch. Filed as a follow-up so this PR can land quickly.

## Eat-your-own-dogfood

This PR was opened via `shipyard pr` — caught a missing `Skill-Update` for the `ci` skill (added in same commit), then hit GraphQL rate limit on PR creation step (separate upstream issue being filed). Fell back to direct push with `PULP_VIA_SHIPYARD=1` per the rule this PR codifies. Drift log shows 3 supervised entries, no "direct" entries.

## Test plan

- [x] `bash -n .githooks/pre-push` — syntax valid
- [x] Hook runs on push without error
- [x] `.git/.shipyard-drift-log` written with correct columns
- [x] Warning suppressed when `PULP_VIA_SHIPYARD=1` set
- [x] Warning fires when neither env var set (verified locally)
- [ ] CI: skill-sync + version-bump gates (covered by `Version-Bump: skip` trailers in commit; advisory diff-cover skipped via `PULP_DISABLE_PREPUSH_DIFF_COVER=1` since llvm tools aren't on PATH — separate fix coming for that)

## Notes
- Bypass trailers used for version-bump (`hook-only change; no shipped surface affected`).
- Windows lane skipped via `--skip-target windows` because `ssh win` was unreachable (Tailscale dropped) — recorded as a deliberate gap per the rule this PR documents.

<!-- whence {"labels": ["1·codex", "2·m3", "3·pre-colo", "4·vcvrack", "5·unresolved"], "prov": {"agent": "codex", "tab": "vcvrack", "workstream": "", "launcher": "unresolved", "route": "unresolved", "router": "", "origin_state": "known", "goals": ""}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m3` |
| **Workspace** | `pre-colo` |
| **Tab** | vcvrack |
| **Launcher** | `unresolved` |
| **Route** | `unresolved` |
| **Origin state** | `known` |
| **Directory** | `/Volumes/Workshop/Code/pulp` |
| **Session** | `01a01db7-49a0-7f70-a15d-95ef8fbe6d7e` |

**Resume**
```
codex resume 01a01db7-49a0-7f70-a15d-95ef8fbe6d7e
```
**Jump to this tab**
```
cmux surface focus AC1AB5F3-FAA7-4806-8D22-F573ECB377CD
```
**Relaunch (any agent)**
```
cmux surface resume get --surface AC1AB5F3-FAA7-4806-8D22-F573ECB377CD
```

<sub>stamped 2026-08-21 17:37 UTC</sub>
<!-- /whence -->