### PR TITLE
feat(canvas2d): wire drop-shadow filter in SkiaCanvas + #1657 systemic controls

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -137,6 +137,39 @@ fi
 # configure+build cost on doc-only or workflow-only PRs that CI's coverage
 # workflow itself bypasses for the gate.
 diff_cover_failed=0
+
+# Compat status-flip gate (#1657 control #2) — when a compat.json entry
+# flips from partial to supported, require that the same diff also
+# modified/added at least one test file.
+compat_flip_failed=0
+check_compat_status_flips() {
+    local base="$1"
+    local compat_file="compat.json"
+    shift
+
+    if ! git diff --name-only "$base...HEAD" 2>/dev/null | grep -q "^$compat_file$"; then
+        return 0
+    fi
+
+    local test_changed=0
+    if git diff --name-only "$base...HEAD" 2>/dev/null | grep -qE '^(test/|tools/harness/tests/)'; then
+        test_changed=1
+    fi
+
+    # Check for partial→supported flips in compat.json.
+    local flips
+    flips=$(git diff "$base...HEAD" -- "$compat_file" 2>/dev/null | grep -cE '^\-.*"partial"' || echo 0)
+    local flips_to
+    flips_to=$(git diff "$base...HEAD" -- "$compat_file" 2>/dev/null | grep -cE '^\+.*"supported"' || echo 0)
+
+    if [ "${flips:-0}" -gt 0 ] && [ "${flips_to:-0}" -gt 0 ] && [ "$test_changed" -eq 0 ]; then
+        echo "[pre-push] compat_status_flip: status flips detected (partial→supported) in compat.json" >&2
+        echo "[pre-push]   but no test files changed (test/ or tools/harness/tests/)." >&2
+        echo "[pre-push]   partial→supported flips require new/modified test coverage (pulp #1657)." >&2
+        compat_flip_failed=1
+    fi
+}
+check_compat_status_flips "$BASE"
 DIFF_COVER_SH="$ROOT/tools/scripts/local_diff_cover.sh"
 if [ -f "$DIFF_COVER_SH" ] && [ "${PULP_SKIP_DIFF_COVER:-0}" != "1" ]; then
     if changed=$(git diff --name-only "$BASE...HEAD" 2>/dev/null); then
@@ -154,7 +187,7 @@ fi
 # to advisory; `PULP_DISABLE_PREPUSH_DIFF_COVER=1` demotes the
 # diff-cover gate only.
 
-if [ "$fail" = "0" ] && [ "$diff_cover_failed" = "0" ]; then
+if [ "$fail" = "0" ] && [ "$diff_cover_failed" = "0" ] && [ "$compat_flip_failed" = "0" ]; then
     echo "[pre-push] gates clean." >&2
     exit 0
 fi
@@ -168,19 +201,24 @@ if [ "$diff_cover_failed" = "1" ] && [ "$disable_diff" = "1" ]; then
     diff_cover_failed=0
 fi
 
+if [ "$compat_flip_failed" = "1" ] && [ "$disable_main" = "1" ]; then
+    echo "[pre-push] PULP_DISABLE_PREPUSH_GATES=1 — compat status-flip failure DEMOTED to advisory." >&2
+    compat_flip_failed=0
+fi
+
 if [ "$fail" = "1" ] && [ "$disable_main" = "1" ]; then
     echo "[pre-push] PULP_DISABLE_PREPUSH_GATES=1 — skill/version/compat/deps gate failures DEMOTED to advisory." >&2
     fail=0
 fi
 
-if [ "$fail" = "0" ] && [ "$diff_cover_failed" = "0" ]; then
+if [ "$fail" = "0" ] && [ "$diff_cover_failed" = "0" ] && [ "$compat_flip_failed" = "0" ]; then
     echo "[pre-push] gate failures present but demoted by env override; push allowed. Fix before merging." >&2
     exit 0
 fi
 
 echo "[pre-push] gate failure(s) above; blocking push." >&2
 echo "[pre-push] To bypass (use sparingly; CI still runs the same gates):" >&2
-echo "[pre-push]   PULP_DISABLE_PREPUSH_GATES=1 git push          # demote skill/version/compat/deps" >&2
+echo "[pre-push]   PULP_DISABLE_PREPUSH_GATES=1 git push          # demote skill/version/compat/deps/flip" >&2
 echo "[pre-push]   PULP_DISABLE_PREPUSH_DIFF_COVER=1 git push     # demote diff-cover only" >&2
 echo "[pre-push]   PULP_SKIP_PREPUSH=1 git push                   # skip ALL gates (emergencies)" >&2
 exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -156,13 +156,19 @@ check_compat_status_flips() {
         test_changed=1
     fi
 
-    # Check for partial→supported flips in compat.json.
-    local flips
-    flips=$(git diff "$base...HEAD" -- "$compat_file" 2>/dev/null | grep -cE '^\-.*"partial"' || echo 0)
-    local flips_to
-    flips_to=$(git diff "$base...HEAD" -- "$compat_file" 2>/dev/null | grep -cE '^\+.*"supported"' || echo 0)
+    # Check for partial→supported flips in compat.json using a simple heuristic.
+    # If the diff removes any line containing "partial" and adds any line
+    # containing "supported", assume a status flip.
+    local flips=0
+    local flips_to=0
+    if git diff "$base...HEAD" -- "$compat_file" 2>/dev/null | grep -qE '^\-.*"partial"'; then
+        flips=1
+    fi
+    if git diff "$base...HEAD" -- "$compat_file" 2>/dev/null | grep -qE '^\+.*"supported"'; then
+        flips_to=1
+    fi
 
-    if [ "${flips:-0}" -gt 0 ] && [ "${flips_to:-0}" -gt 0 ] && [ "$test_changed" -eq 0 ]; then
+    if [ "$flips" -eq 1 ] && [ "$flips_to" -eq 1 ] && [ "$test_changed" -eq 0 ]; then
         echo "[pre-push] compat_status_flip: status flips detected (partial→supported) in compat.json" >&2
         echo "[pre-push]   but no test files changed (test/ or tools/harness/tests/)." >&2
         echo "[pre-push]   partial→supported flips require new/modified test coverage (pulp #1657)." >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
 - feat(view/css+rn): transform function fan-out — scaleX/Y, skewX/Y, rotateX/Y/Z, matrix3d (refs pulp #1434, Triage #9) ([#1487](https://github.com/danielraffel/pulp/pull/1487))
 
 <a id="v0782"></a>
+## [0.79.0]
+
 ## [0.78.2] - 2026-05-06
 
 - feat(import-ir): Phase 1 spike — IR types + Claude Design HTML adapter + 5-scenario harness (closes pulp #1486 phase 1) ([#1499](https://github.com/danielraffel/pulp/pull/1499))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.78.4
+    VERSION 0.79.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/compat.json
+++ b/compat.json
@@ -1,18 +1,18 @@
 {
   "compat-schema-version": "0.3",
-  "_comment": "Compat matrix per #1027. This file is the spec-driven inventory of every prop / style / API surface Pulp's React + DOM-lite consumers might use, mapped to its current implementation status. Status values: supported | partial | missing | wontfix. The 'mapsTo' field names the bridge / Yoga / Skia path the prop lowers to. The 'tests' field records validation references; legacy free-form test paths may coexist with typed routes such as semantic:<fixture-id>, visual:<fixture-id>, dom:<fixture-id>, behavior:<fixture-id>, unit:<test-id>, or cannot-validate:<tracking-id>. The audit was generated 2026-04-30 by walking three reference specs (Yoga via React Native Layout Props, React Native View / Text / Transform Style Props, and the most-used MDN CSS reference) and cross-referencing against four implementation surfaces: packages/pulp-react/src/prop-applier.ts (the @pulp/react switch), core/view/js/web-compat-style-decl.js (the DOM-lite CSS adapter), core/view/src/widget_bridge.cpp (the C++ bridge \u2014 251 register_function entries), and core/view/include/pulp/view/{view,geometry}.hpp (the Flex / View widget surface).",
+  "_comment": "Compat matrix per #1027. This file is the spec-driven inventory of every prop / style / API surface Pulp's React + DOM-lite consumers might use, mapped to its current implementation status. Status values: supported | partial | missing | wontfix. The 'mapsTo' field names the bridge / Yoga / Skia path the prop lowers to. The 'tests' field records validation references; legacy free-form test paths may coexist with typed routes such as semantic:<fixture-id>, visual:<fixture-id>, dom:<fixture-id>, behavior:<fixture-id>, unit:<test-id>, or cannot-validate:<tracking-id>. The audit was generated 2026-04-30 by walking three reference specs (Yoga via React Native Layout Props, React Native View / Text / Transform Style Props, and the most-used MDN CSS reference) and cross-referencing against four implementation surfaces: packages/pulp-react/src/prop-applier.ts (the @pulp/react switch), core/view/js/web-compat-style-decl.js (the DOM-lite CSS adapter), core/view/src/widget_bridge.cpp (the C++ bridge — 251 register_function entries), and core/view/include/pulp/view/{view,geometry}.hpp (the Flex / View widget surface).",
   "_audit": {
     "_evidence_grace_until": "2026-05-22",
     "generated": "2026-05-04",
     "main_sha": "a5f4f5ac",
     "spec_sources": {
-      "yoga": "https://www.yogalayout.dev/docs/styling \u2014 list cross-checked against https://reactnative.dev/docs/layout-props which mirrors the upstream Yoga API",
+      "yoga": "https://www.yogalayout.dev/docs/styling — list cross-checked against https://reactnative.dev/docs/layout-props which mirrors the upstream Yoga API",
       "rn_view": "https://reactnative.dev/docs/view-style-props",
       "rn_text": "https://reactnative.dev/docs/text-style-props",
       "rn_transform": "https://reactnative.dev/docs/transforms",
       "rn_layout": "https://reactnative.dev/docs/layout-props",
-      "css": "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties \u2014 top ~150 commonly-used properties across layout, box-model, typography, color, transforms, flex/grid, opacity. Print, paged-media, and CSS-fonts loading specifics are out of scope.",
-      "canvas2d": "https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D \u2014 HTML Living Standard CanvasRenderingContext2D",
+      "css": "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties — top ~150 commonly-used properties across layout, box-model, typography, color, transforms, flex/grid, opacity. Print, paged-media, and CSS-fonts loading specifics are out of scope.",
+      "canvas2d": "https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D — HTML Living Standard CanvasRenderingContext2D",
       "html_element": "https://developer.mozilla.org/en-US/docs/Web/API/Element + HTMLElement attribute coverage, ARIA attributes, dataset, classList, the DocumentFragment shim"
     },
     "implementation_surfaces": [
@@ -31,15 +31,15 @@
     ],
     "_notes_on_consumer_surfaces": "The same prop can have different status across consumer surfaces. 'css/*' tracks what core/view/js/web-compat-style-decl.js (the DOM-lite el.style adapter) routes; 'rn/*' tracks what packages/pulp-react/src/prop-applier.ts (the React renderer for @pulp/react JSX intrinsics) routes; 'yoga/*' tracks the underlying Yoga-shaped layout surface in core/view/include/pulp/view/geometry.hpp::FlexStyle; 'canvas2d/*' tracks the Canvas2D shim in web-compat-canvas.js paired with the canvas* family in widget_bridge.cpp + the Skia/CG backends in core/canvas/; 'html/*' tracks the DOM-lite Element / HTMLElement surface in web-compat-element.js + web-compat-document.js. Where a prop is supported by one consumer but not another, both are noted explicitly in 'notes'.",
     "_changelog": {
-      "2026-04-30": "Initial population \u2014 361 entries across css/, rn/, yoga/. react/, html/, canvas2d/ stubbed. PR #1166.",
+      "2026-04-30": "Initial population — 361 entries across css/, rn/, yoga/. react/, html/, canvas2d/ stubbed. PR #1166.",
       "2026-05-04": "Refresh after PRs #1167, #1169, #1173, #1174, #1291, #1297, #1344, #1345, #1347, #1348, #1353. Populated canvas2d/ (~60 entries) and html/ (~30 entries). Added rn/d, rn/viewBox, rn/fill, rn/stroke, rn/strokeWidth, rn/overlay (SvgPath + overlay-routing). Updated css/border, css/borderRadius, css/borderColor, css/fontFamily status to reflect per-attribute setter routing. Added css/_hover_pseudo for :hover stylesheet support.",
       "2026-05-05": "pulp #1434 batch 4: React Native shorthand aliases marginHorizontal / marginVertical / paddingHorizontal / paddingVertical now fan out at the JS-side translators (web-compat-style-decl.js + prop-applier.ts) to the existing per-edge bridge setters. Reclassified rn/* + yoga/* entries from missing -> supported and added new css/* entries (4 new keys; css count 195 -> 199).",
-      "2026-05-06": "pulp #1545: yoga catalog work. Promoted yoga/flexBasis from partial -> supported after re-verifying YGNodeStyleSetFlexBasisPercent fires for 'NN%' strings end-to-end through the bridge (test [issue-1545] in test_widget_bridge.cpp). The 'content' keyword stays in unsupportedValues (Yoga itself does not expose it). yoga/boxSizing was also added as a placeholder entry but kept at status `missing` \u2014 the FlexStyle::box_sizing field + YGNodeStyleSetBoxSizing dispatch is a forward dependency on pulp #1516 (PR #1538) and will flip to `supported` once #1538 merges (yoga count stays at 53 + 1 placeholder = 54 total entries).",
-      "2026-05-06_1551": "pulp #1551 (Phase A3 Bundle 3 inside pulp #1434 umbrella): pure catalog add of 13 already-implemented css/* meta entries \u2014 `__StyleSheet`, `__matchMedia`, `__pseudo_active` / `__pseudo_disabled` / `__pseudo_focus` / `__pseudo_hover`, `__selector_child` / `__selector_class` / `__selector_descendant` / `__selector_id` / `__selector_tag`, `__setProperty_var`, `__var`. Documents existing wiring in `core/view/js/web-compat-document.js`, `web-compat-style-decl.js`, `css-parser.js` and `web-compat.js`. No code changes; +13 instant supported entries. css count 199 -> 212.",
+      "2026-05-06": "pulp #1545: yoga catalog work. Promoted yoga/flexBasis from partial -> supported after re-verifying YGNodeStyleSetFlexBasisPercent fires for 'NN%' strings end-to-end through the bridge (test [issue-1545] in test_widget_bridge.cpp). The 'content' keyword stays in unsupportedValues (Yoga itself does not expose it). yoga/boxSizing was also added as a placeholder entry but kept at status `missing` — the FlexStyle::box_sizing field + YGNodeStyleSetBoxSizing dispatch is a forward dependency on pulp #1516 (PR #1538) and will flip to `supported` once #1538 merges (yoga count stays at 53 + 1 placeholder = 54 total entries).",
+      "2026-05-06_1551": "pulp #1551 (Phase A3 Bundle 3 inside pulp #1434 umbrella): pure catalog add of 13 already-implemented css/* meta entries — `__StyleSheet`, `__matchMedia`, `__pseudo_active` / `__pseudo_disabled` / `__pseudo_focus` / `__pseudo_hover`, `__selector_child` / `__selector_class` / `__selector_descendant` / `__selector_id` / `__selector_tag`, `__setProperty_var`, `__var`. Documents existing wiring in `core/view/js/web-compat-document.js`, `web-compat-style-decl.js`, `css-parser.js` and `web-compat.js`. No code changes; +13 instant supported entries. css count 199 -> 212.",
       "2026-05-06_1544": "pulp #1544: Added yoga/flex and yoga/flexFlow catalog entries documenting the unsupported CSS shorthand surface on the Yoga side (yoga count 53 -> 55). PR #1563.",
       "2026-05-07": "pulp #1434 A4 Bundles 2-7: css NOT-IMPL closure. 30 entries flipped missing -> partial / noop / wontfix across animations tail (animationPlayState), logical-edge fan-out (margin/padding Block/Inline Start/End -- 7 entries), overflow per-axis + 3D (overflowX, overflowY, overflowWrap, perspective, perspectiveOrigin), text rendering tail (textIndent, verticalAlign, wordBreak, writingMode, scroll* -- 8), isolation + clipPath + mask + direction + mixBlendMode (6), and resize + fontVariant (2). New bridge fns: setTextIndent, setVerticalAlign, setWordBreak, setFontVariant. Extended setAnimation with the \"play_state\" control token. Synthetic __pseudo_classes_note flipped wontfix. Catalog css count holds at 212; missing -> 0.",
       "2026-05-07_B2": "Phase B.2 visual accounting: bumped compat-schema-version to 0.3 so tests can carry typed validation routes; backfilled semantic Yoga fixture refs for the checked-in layout goldens without changing support status counts.",
-      "2026-05-07_W3css3": "pulp #1434 Wave 3 css.3 + Codex P1 audit follow-through on #1508. css/animationPlayState flipped partial \u2192 supported by adding View::tick_animations(dt) which honors the `paused` keyword (no-op when paused, advance-each-CssAnimation otherwise) \u2014 the playback driver pause/resume gap the previous A4 Bundle 2 entry had explicitly deferred. Prop-applier `animationPlayState` case added (was missing; only the JS shim path existed). Verified the two Codex P1 fixes from #1508 hold in the final form: (1) setAnimation(id, \"name\"|\"duration\"|... , value) control-token ABI is implemented in the bridge alongside the positional ABI so the JS shim's per-longhand calls land on the staged_animation slot rather than missing the keyframes registry, (2) animationDuration in prop-applier.ts dispatches to setAnimation/duration, not setTransitionDuration. css count holds at 212."
+      "2026-05-07_W3css3": "pulp #1434 Wave 3 css.3 + Codex P1 audit follow-through on #1508. css/animationPlayState flipped partial → supported by adding View::tick_animations(dt) which honors the `paused` keyword (no-op when paused, advance-each-CssAnimation otherwise) — the playback driver pause/resume gap the previous A4 Bundle 2 entry had explicitly deferred. Prop-applier `animationPlayState` case added (was missing; only the JS shim path existed). Verified the two Codex P1 fixes from #1508 hold in the final form: (1) setAnimation(id, \"name\"|\"duration\"|... , value) control-token ABI is implemented in the bridge alongside the positional ABI so the JS shim's per-longhand calls land on the staged_animation slot rather than missing the keyframes registry, (2) animationDuration in prop-applier.ts dispatches to setAnimation/duration, not setTransitionDuration. css count holds at 212."
     },
     "counts": {
       "css": 212,
@@ -51,7 +51,7 @@
       "imports": 5
     },
     "changelog": {
-      "2026-05-07_W4css": "pulp Wave 4 css extensive \u2014 DIVERGE sweep. Drove the css surface from 128 PASS / 49 DIVERGE (60.4%) to 177 PASS / 0 DIVERGE (83.5%) in a single pass \u2014 the 35 non-PASS remainder is fully architectural (10 noop intentional stubs + 25 wontfix). Per-entry reclassifications follow the Wave 1 backgroundAttachment precedent: paint-time / architectural value-coverage caveats moved out of unsupportedValues into notes; status flipped partial -> supported when value-coverage is complete; partial-deferred-* used when a real subsystem (image loader, HarfBuzz, paint pipeline) is the gating block. Border family (5) arch-solid-only-pen; border-radius (2) arch-skia-rrect-single-radius; background family (5) arch-deferred-image-loader / arch-skia-no-conic-gradient / arch-single-bg; mask family (2) arch-paint-deferred; layout-length (2) arch-yoga-no-intrinsic-sizing + arch-no-calc-eval + single-level-cascade for em/rem; outline family (4) arch-numeric-only + arch-no-cascade-color + arch-paint-px-only; overflow (3) arch-scroll-via-scrollview + arch-axis-tied-overflow; display (1) arch-flex-only; enum cleanups (8) cursor / pointerEvents / textDecoration / userSelect / visibility / whiteSpace / fontStyle label trimming + arch caveats. Drift count: 7 -> 0 on css. css count holds at 212."
+      "2026-05-07_W4css": "pulp Wave 4 css extensive — DIVERGE sweep. Drove the css surface from 128 PASS / 49 DIVERGE (60.4%) to 177 PASS / 0 DIVERGE (83.5%) in a single pass — the 35 non-PASS remainder is fully architectural (10 noop intentional stubs + 25 wontfix). Per-entry reclassifications follow the Wave 1 backgroundAttachment precedent: paint-time / architectural value-coverage caveats moved out of unsupportedValues into notes; status flipped partial -> supported when value-coverage is complete; partial-deferred-* used when a real subsystem (image loader, HarfBuzz, paint pipeline) is the gating block. Border family (5) arch-solid-only-pen; border-radius (2) arch-skia-rrect-single-radius; background family (5) arch-deferred-image-loader / arch-skia-no-conic-gradient / arch-single-bg; mask family (2) arch-paint-deferred; layout-length (2) arch-yoga-no-intrinsic-sizing + arch-no-calc-eval + single-level-cascade for em/rem; outline family (4) arch-numeric-only + arch-no-cascade-color + arch-paint-px-only; overflow (3) arch-scroll-via-scrollview + arch-axis-tied-overflow; display (1) arch-flex-only; enum cleanups (8) cursor / pointerEvents / textDecoration / userSelect / visibility / whiteSpace / fontStyle label trimming + arch caveats. Drift count: 7 -> 0 on css. css count holds at 212."
     }
   },
   "css": {
@@ -68,12 +68,12 @@
         "@media / @keyframes / @supports / @import at-rules",
         ":focus-within / :focus-visible / :checked / :nth-child / :not(...)",
         "attribute selectors in rule keys (`[data-role='x']`)",
-        "rule reordering (StyleSheets layer in attach order \u2014 no specificity-based sort)"
+        "rule reordering (StyleSheets layer in attach order — no specificity-based sort)"
       ],
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add \u2014 already implemented (StyleSheet has been available since the DOM-lite shim landed and was extended for `:hover` support in pulp #1149 / #1345). The same engine drives both JS-API consumers (`new StyleSheet(...)`) and HTML-input consumers (parsed `<style>` tags via `_parseCssText`).",
+      "notes": "pulp #1551 catalog add — already implemented (StyleSheet has been available since the DOM-lite shim landed and was extended for `:hover` support in pulp #1149 / #1345). The same engine drives both JS-API consumers (`new StyleSheet(...)`) and HTML-input consumers (parsed `<style>` tags via `_parseCssText`).",
       "issue": "1551"
     },
     "css/__hover_pseudo": {
@@ -97,7 +97,7 @@
     },
     "css/__matchMedia": {
       "status": "supported",
-      "mapsTo": "core/view/js/css-parser.js `_matchMediaQuery` (lines 593-617) evaluates a media-query string against the current root size obtained from `getRootSize()`. Stylesheets and matched-media @rules consume this directly. The `window.matchMedia(query)` wrapper that returns a MediaQueryList shim lives in core/view/js/web-compat.js (lines 2101-2114) but that file is NOT loaded by the WidgetBridge prelude chain \u2014 the wrapper is reachable only when web-compat.js is loaded explicitly.",
+      "mapsTo": "core/view/js/css-parser.js `_matchMediaQuery` (lines 593-617) evaluates a media-query string against the current root size obtained from `getRootSize()`. Stylesheets and matched-media @rules consume this directly. The `window.matchMedia(query)` wrapper that returns a MediaQueryList shim lives in core/view/js/web-compat.js (lines 2101-2114) but that file is NOT loaded by the WidgetBridge prelude chain — the wrapper is reachable only when web-compat.js is loaded explicitly.",
       "supportedValues": [
         "(min-width: <px>)",
         "(max-width: <px>)",
@@ -109,7 +109,7 @@
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add \u2014 already implemented. Existing `WebCompat: matchMedia min-width` and `WebCompat: matchMedia orientation landscape` cases in test_web_compat_prelude.cpp exercise the parser; pulp #1551 adds an end-to-end case that walks through `window.matchMedia()` and asserts the returned MediaQueryList shape. Wave 4 css extensive \u2014 drift cleanup \u2014 value-coverage is complete (the parser handles the documented query forms; live re-evaluation on resize + extended @media features are paint/runtime-deferred follow-ups documented in mapsTo). Reclassified as runtime-side gap rather than value-coverage gap.",
+      "notes": "pulp #1551 catalog add — already implemented. Existing `WebCompat: matchMedia min-width` and `WebCompat: matchMedia orientation landscape` cases in test_web_compat_prelude.cpp exercise the parser; pulp #1551 adds an end-to-end case that walks through `window.matchMedia()` and asserts the returned MediaQueryList shape. Wave 4 css extensive — drift cleanup — value-coverage is complete (the parser handles the documented query forms; live re-evaluation on resize + extended @media features are paint/runtime-deferred follow-ups documented in mapsTo). Reclassified as runtime-side gap rather than value-coverage gap.",
       "issue": "1551"
     },
     "css/__pseudo_active": {
@@ -121,13 +121,13 @@
         "ordinary CSS properties inside the `:active` rule body (anything the inline-setter trap routes)"
       ],
       "unsupportedValues": [
-        "`:active` combined with descendant / child combinators in the `<style>` text parser (the underlying `_parseSelector` handles them but the text parser is conservative \u2014 see #1323)",
+        "`:active` combined with descendant / child combinators in the `<style>` text parser (the underlying `_parseSelector` handles them but the text parser is conservative — see #1323)",
         "key + mouse `:active` (synthesized only on mousedown/mouseup; no keyboard activation today)"
       ],
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add \u2014 already implemented. Wiring is parallel to `:hover` but uses mousedown/mouseup edges instead of mouseenter/mouseleave.",
+      "notes": "pulp #1551 catalog add — already implemented. Wiring is parallel to `:hover` but uses mousedown/mouseup edges instead of mouseenter/mouseleave.",
       "issue": "1551"
     },
     "css/__pseudo_classes_note": {
@@ -147,7 +147,7 @@
         "etc."
       ],
       "tests": [],
-      "notes": "Pulp routes hover/click/etc. through bridge event registrations (registerHover, registerClick) rather than through CSS pseudo-classes. JSX consumers wire interactivity via on* event props, not via CSS. Superseded by the per-pseudo-class catalog entries (`css/__pseudo_hover`, `css/__pseudo_focus`, `css/__pseudo_active`, `css/__pseudo_disabled`) added in pulp #1551. pulp #1434 A4 Bundle 6 closure: status flipped missing \u2192 wontfix (architectural \u2014 the per-pseudo entries are the canonical claim).",
+      "notes": "Pulp routes hover/click/etc. through bridge event registrations (registerHover, registerClick) rather than through CSS pseudo-classes. JSX consumers wire interactivity via on* event props, not via CSS. Superseded by the per-pseudo-class catalog entries (`css/__pseudo_hover`, `css/__pseudo_focus`, `css/__pseudo_active`, `css/__pseudo_disabled`) added in pulp #1551. pulp #1434 A4 Bundle 6 closure: status flipped missing → wontfix (architectural — the per-pseudo entries are the canonical claim).",
       "issue": ""
     },
     "css/__pseudo_disabled": {
@@ -158,13 +158,13 @@
         "rules apply on attach / appendChild when `el.disabled === true`"
       ],
       "unsupportedValues": [
-        "live re-application when `disabled` is toggled at runtime (StyleSheet._applyTo runs at attach / appendChild time only \u2014 toggling `el.disabled` after attach does not currently re-invoke the disabled-branch \u2014 tracked separately if it bites a consumer)",
+        "live re-application when `disabled` is toggled at runtime (StyleSheet._applyTo runs at attach / appendChild time only — toggling `el.disabled` after attach does not currently re-invoke the disabled-branch — tracked separately if it bites a consumer)",
         "snapshot-restore symmetry (unlike `:hover` / `:focus` / `:active`, the disabled branch does not snapshot pre-disabled values to restore on re-enable; consumers should treat it as one-way styling)"
       ],
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add \u2014 already implemented. The pseudo branch is wired distinctly from `:hover` / `:focus` / `:active` because `:disabled` is not interaction-driven \u2014 it gates on element state.",
+      "notes": "pulp #1551 catalog add — already implemented. The pseudo branch is wired distinctly from `:hover` / `:focus` / `:active` because `:disabled` is not interaction-driven — it gates on element state.",
       "issue": "1551"
     },
     "css/__pseudo_focus": {
@@ -183,7 +183,7 @@
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add \u2014 already implemented. Wiring is parallel to `:hover` / `:active` and routes through the same `addEventListener` channel so it coexists with JSX `onFocus` / `onBlur` handlers.",
+      "notes": "pulp #1551 catalog add — already implemented. Wiring is parallel to `:hover` / `:active` and routes through the same `addEventListener` channel so it coexists with JSX `onFocus` / `onBlur` handlers.",
       "issue": "1551"
     },
     "css/__pseudo_hover": {
@@ -196,21 +196,21 @@
         "ordinary CSS properties inside the `:hover` rule body"
       ],
       "unsupportedValues": [
-        "`:hover` combinators in the `<style>` text parser (e.g. `.a:hover .b`) \u2014 see #1323",
+        "`:hover` combinators in the `<style>` text parser (e.g. `.a:hover .b`) — see #1323",
         "synthesized hover from touch / pen input (relies on native mouseenter / mouseleave from registerHover)"
       ],
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]",
         "test/web-compat/test_css_hover_translation.cpp"
       ],
-      "notes": "pulp #1551 catalog add \u2014 already implemented. Companion to the original `css/__hover_pseudo` entry, with full multi-rule + idempotency + native-arming details captured. Hover rules originate either from the JS-API (`new StyleSheet({...})`) or from `<style>` text parsed via `_parseCssText`.",
+      "notes": "pulp #1551 catalog add — already implemented. Companion to the original `css/__hover_pseudo` entry, with full multi-rule + idempotency + native-arming details captured. Hover rules originate either from the JS-API (`new StyleSheet({...})`) or from `<style>` text parsed via `_parseCssText`.",
       "issue": "1551"
     },
     "css/__selector_child": {
       "status": "supported",
-      "mapsTo": "core/view/js/web-compat-document.js _parseSelector (lines 296-335): splits on ` > ` and recurses with `direct=true`. _matchesSelector (lines 337-367): when `parsed.direct` is set, the element's immediate `_parentElement` must match the parent selector \u2014 descendant ancestors do NOT count.",
+      "mapsTo": "core/view/js/web-compat-document.js _parseSelector (lines 296-335): splits on ` > ` and recurses with `direct=true`. _matchesSelector (lines 337-367): when `parsed.direct` is set, the element's immediate `_parentElement` must match the parent selector — descendant ancestors do NOT count.",
       "supportedValues": [
-        "<parent> > <child> (chained: `div > section > .item` \u2014 left-associative reduction in `_parseSelector`)"
+        "<parent> > <child> (chained: `div > section > .item` — left-associative reduction in `_parseSelector`)"
       ],
       "unsupportedValues": [
         "adjacent-sibling combinator `+` (not parsed today)",
@@ -220,7 +220,7 @@
         "test/web-compat/test_selector_matching.cpp",
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add \u2014 already implemented. Existing `Selector: JS parser distinguishes child and descendant combinators` test exercises this; the issue-1551 case adds a structural-selector smoke that runs alongside the others.",
+      "notes": "pulp #1551 catalog add — already implemented. Existing `Selector: JS parser distinguishes child and descendant combinators` test exercises this; the issue-1551 case adds a structural-selector smoke that runs alongside the others.",
       "issue": "1551"
     },
     "css/__selector_class": {
@@ -228,18 +228,18 @@
       "mapsTo": "core/view/js/web-compat-document.js _parseSelector (lines 296-335) tokenises `.foo.bar` into `parsed.classes = ['foo', 'bar']`. _matchesSelector (lines 344-347) requires every class to be present in `el.classList` (Element.classList is the standard contains/add/remove API).",
       "supportedValues": [
         ".foo",
-        ".foo.bar (compound \u2014 every listed class must match)",
+        ".foo.bar (compound — every listed class must match)",
         "tag.class compounds (`button.primary`)"
       ],
       "unsupportedValues": [
         "namespace-qualified class selectors",
-        "case-insensitive class matching (matching is case-sensitive \u2014 matches CSS spec for non-quirks-mode HTML)"
+        "case-insensitive class matching (matching is case-sensitive — matches CSS spec for non-quirks-mode HTML)"
       ],
       "tests": [
         "test/web-compat/test_selector_matching.cpp",
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add \u2014 already implemented. Class selectors are the most common StyleSheet rule shape in Pulp consumers (Spectr's editor.js, FilterBank, react renderer's className-driven styling).",
+      "notes": "pulp #1551 catalog add — already implemented. Class selectors are the most common StyleSheet rule shape in Pulp consumers (Spectr's editor.js, FilterBank, react renderer's className-driven styling).",
       "issue": "1551"
     },
     "css/__selector_descendant": {
@@ -250,13 +250,13 @@
         "chained descendant combinators (`section .row .item`)"
       ],
       "unsupportedValues": [
-        "interleaved descendant + child combinators in the `<style>` text parser (the underlying `_parseSelector` handles them but the inline `<style>` text parser deliberately limits to flat selectors \u2014 see #1323)"
+        "interleaved descendant + child combinators in the `<style>` text parser (the underlying `_parseSelector` handles them but the inline `<style>` text parser deliberately limits to flat selectors — see #1323)"
       ],
       "tests": [
         "test/web-compat/test_selector_matching.cpp",
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add \u2014 already implemented.",
+      "notes": "pulp #1551 catalog add — already implemented.",
       "issue": "1551"
     },
     "css/__selector_id": {
@@ -274,7 +274,7 @@
         "test/web-compat/test_selector_matching.cpp",
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add \u2014 already implemented. Note that `document.getElementById` uses a separate `#id`-prefixed lookup table in `__elements__` \u2014 the selector path here goes through `_findMatch` via `querySelector` / `querySelectorAll` and StyleSheet `_applyTo`.",
+      "notes": "pulp #1551 catalog add — already implemented. Note that `document.getElementById` uses a separate `#id`-prefixed lookup table in `__elements__` — the selector path here goes through `_findMatch` via `querySelector` / `querySelectorAll` and StyleSheet `_applyTo`.",
       "issue": "1551"
     },
     "css/__selector_tag": {
@@ -290,18 +290,18 @@
       "unsupportedValues": [
         "namespace-qualified tag names (`svg|circle`)",
         "universal selector `*` (not parsed)",
-        "case-sensitive tag matching (matching is case-insensitive \u2014 both sides lower-cased \u2014 matches HTML quirks)"
+        "case-sensitive tag matching (matching is case-insensitive — both sides lower-cased — matches HTML quirks)"
       ],
       "tests": [
         "test/web-compat/test_selector_matching.cpp",
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add \u2014 already implemented.",
+      "notes": "pulp #1551 catalog add — already implemented.",
       "issue": "1551"
     },
     "css/__setProperty_var": {
       "status": "supported",
-      "mapsTo": "core/view/js/web-compat-style-decl.js CSSStyleDeclaration.prototype.setProperty (lines 1259-1279): when `name` starts with `--`, slices the prefix and tries `parseCSSLength(value)` first \u2014 on success calls `setMotionToken(tokenName, parsed.value)` so the bridge motion-token system picks up the new value. On length-parse failure, tries `parseCSSColor(value)` and on success routes through `applyTokenDiff` as a theme color override. getPropertyValue routes back through `getMotionToken` for `--` names.",
+      "mapsTo": "core/view/js/web-compat-style-decl.js CSSStyleDeclaration.prototype.setProperty (lines 1259-1279): when `name` starts with `--`, slices the prefix and tries `parseCSSLength(value)` first — on success calls `setMotionToken(tokenName, parsed.value)` so the bridge motion-token system picks up the new value. On length-parse failure, tries `parseCSSColor(value)` and on success routes through `applyTokenDiff` as a theme color override. getPropertyValue routes back through `getMotionToken` for `--` names.",
       "supportedValues": [
         "el.style.setProperty('--accent', '12px')",
         "el.style.setProperty('--accent', '#ff0000')",
@@ -310,14 +310,14 @@
         "el.style.removeProperty('--accent')"
       ],
       "unsupportedValues": [
-        "scoped (per-element) custom property cascading \u2014 the bridge motion-token namespace is shared across the document; `--name` is effectively a global token, not a CSS-cascade scoped variable",
+        "scoped (per-element) custom property cascading — the bridge motion-token namespace is shared across the document; `--name` is effectively a global token, not a CSS-cascade scoped variable",
         "string / list / shadow / gradient values (only length and color tokens are routed)",
         "the `!important` flag on the third argument"
       ],
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add \u2014 already implemented. Pairs with `css/__var` \u2014 `setProperty('--name', value)` writes the token, `var(--name)` reads it back through `_resolveVar`. Both share the motion-token bridge so JS-driven token mutation immediately affects the next layout/paint pass.",
+      "notes": "pulp #1551 catalog add — already implemented. Pairs with `css/__var` — `setProperty('--name', value)` writes the token, `var(--name)` reads it back through `_resolveVar`. Both share the motion-token bridge so JS-driven token mutation immediately affects the next layout/paint pass.",
       "issue": "1551"
     },
     "css/__var": {
@@ -329,14 +329,14 @@
         "any CSS property assignment (`width`, `color`, `margin`, etc.) whose string value contains a `var(...)` call"
       ],
       "unsupportedValues": [
-        "nested var inside a fallback (`var(--a, var(--b, 0))`) \u2014 the regex is single-pass; nested fallbacks are not re-resolved",
-        "var() inside more elaborate function calls where the captured group breaks on inner commas (`var()` inside `linear-gradient(...)` etc. \u2014 works as long as the fallback does not itself contain a comma)",
-        "scoped (per-element) cascading \u2014 see notes in `css/__setProperty_var`"
+        "nested var inside a fallback (`var(--a, var(--b, 0))`) — the regex is single-pass; nested fallbacks are not re-resolved",
+        "var() inside more elaborate function calls where the captured group breaks on inner commas (`var()` inside `linear-gradient(...)` etc. — works as long as the fallback does not itself contain a comma)",
+        "scoped (per-element) cascading — see notes in `css/__setProperty_var`"
       ],
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add \u2014 already implemented. `var(--name)` is the read side of the bridge motion-token system; `setProperty('--name', value)` is the write side. Together they let consumers parameterise inline styles with named tokens without going through the full CSS-cascade engine.",
+      "notes": "pulp #1551 catalog add — already implemented. `var(--name)` is the read side of the bridge motion-token system; `setProperty('--name', value)` is the write side. Together they let consumers parameterise inline styles with named tokens without going through the full CSS-cascade engine.",
       "issue": "1551"
     },
     "css/alignContent": {
@@ -357,7 +357,7 @@
         "normal"
       ],
       "tests": [],
-      "notes": "pulp #1434 (sub-agent #12 follow-up): bridge gained 'align_content' setFlex case + FlexStyle.align_content/align_content_space fields. The CSS translator already routed via setFlex(id, 'align_content', _cssToFlex(resolved)) \u2014 just needed the bridge backend. Multi-line flex (`flexWrap: 'wrap'`) cross-axis distribution now works.",
+      "notes": "pulp #1434 (sub-agent #12 follow-up): bridge gained 'align_content' setFlex case + FlexStyle.align_content/align_content_space fields. The CSS translator already routed via setFlex(id, 'align_content', _cssToFlex(resolved)) — just needed the bridge backend. Multi-line flex (`flexWrap: 'wrap'`) cross-axis distribution now works.",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "css/alignItems": {
@@ -375,7 +375,7 @@
         "last baseline"
       ],
       "tests": [],
-      "notes": "FlexAlign enum has {start, center, end, stretch, auto_} -- no baseline support. pulp #1434 rn batch B: baseline now wired via FlexAlign::baseline \u2192 YGAlignBaseline.",
+      "notes": "FlexAlign enum has {start, center, end, stretch, auto_} -- no baseline support. pulp #1434 rn batch B: baseline now wired via FlexAlign::baseline → YGAlignBaseline.",
       "issue": ""
     },
     "css/alignSelf": {
@@ -423,7 +423,7 @@
         "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\""
       ],
-      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
       "issue": ""
     },
     "css/animationDelay": {
@@ -441,7 +441,7 @@
         "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\""
       ],
-      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
       "issue": ""
     },
     "css/animationDirection": {
@@ -463,7 +463,7 @@
         "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\""
       ],
-      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes. Wave 1 drift cleanup \u2014 animation-name resolution + direction enum stored on CssAnimation entries (PR 1 of #1508 ladder); harness verifies all 4 spec values claimed.",
+      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes. Wave 1 drift cleanup — animation-name resolution + direction enum stored on CssAnimation entries (PR 1 of #1508 ladder); harness verifies all 4 spec values claimed.",
       "issue": ""
     },
     "css/animationDuration": {
@@ -481,7 +481,7 @@
         "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\""
       ],
-      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
       "issue": ""
     },
     "css/animationFillMode": {
@@ -503,7 +503,7 @@
         "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\""
       ],
-      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes. Wave 1 drift cleanup \u2014 fill-mode enum stored on CssAnimation entries (PR 1 of #1508 ladder); harness verifies all 4 spec values claimed.",
+      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes. Wave 1 drift cleanup — fill-mode enum stored on CssAnimation entries (PR 1 of #1508 ladder); harness verifies all 4 spec values claimed.",
       "issue": ""
     },
     "css/animationIterationCount": {
@@ -521,7 +521,7 @@
         "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\""
       ],
-      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
       "issue": ""
     },
     "css/animationName": {
@@ -539,12 +539,12 @@
         "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\""
       ],
-      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
       "issue": ""
     },
     "css/animationPlayState": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js forwards `animation-play-state` through setAnimation(id, \"play_state\", value); the bridge stores the keyword on View::animation_play_state_. View::tick_animations(dt) honors the keyword by skipping the timeline advance when value is \"paused\" (web spec semantic) \u2014 animations resume on the next tick when the keyword flips back to \"running\".",
+      "mapsTo": "web-compat-style-decl.js forwards `animation-play-state` through setAnimation(id, \"play_state\", value); the bridge stores the keyword on View::animation_play_state_. View::tick_animations(dt) honors the keyword by skipping the timeline advance when value is \"paused\" (web spec semantic) — animations resume on the next tick when the keyword flips back to \"running\".",
       "supportedValues": [
         "running",
         "paused"
@@ -555,7 +555,7 @@
         "test/test_widget_bridge.cpp::\"View::tick_animations honors paused play_state\"",
         "packages/pulp-react/test/prop-applier-animation.test.ts::\"animationPlayState routes to setAnimation/play_state\""
       ],
-      "notes": "pulp #1434 Wave 3 css.3: status flipped partial \u2192 supported. View::tick_animations(dt) advances active_animations_ entries in-place but is a no-op when animation_play_state_ == \"paused\", giving the play-state keyword its full pause/resume semantic without coupling the existing seed-only flow to a frame-driven dispatcher. The per-property tween-to-View commit step is the orthogonal PR-2-of-the-original-ladder follow-up; play-state pause/resume is independently testable today.",
+      "notes": "pulp #1434 Wave 3 css.3: status flipped partial → supported. View::tick_animations(dt) advances active_animations_ entries in-place but is a no-op when animation_play_state_ == \"paused\", giving the play-state keyword its full pause/resume semantic without coupling the existing seed-only flow to a frame-driven dispatcher. The per-property tween-to-View commit step is the orthogonal PR-2-of-the-original-ladder follow-up; play-state pause/resume is independently testable today.",
       "issue": ""
     },
     "css/animationTimingFunction": {
@@ -573,7 +573,7 @@
         "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\""
       ],
-      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
       "issue": ""
     },
     "css/aspectRatio": {
@@ -588,12 +588,12 @@
       "tests": [
         "test/web-compat/test_layout_aspect_ratio.cpp"
       ],
-      "notes": "pulp #1434 \u2014 three value forms accepted: plain number ('1.5'), 'width / height' ratio ('16/9' -> 1.778), and 'auto' (clears slot). Both 'aspectRatio' (camelCase) and 'aspect-ratio' (kebab-case) work; setProperty auto-converts kebab to camel.",
+      "notes": "pulp #1434 — three value forms accepted: plain number ('1.5'), 'width / height' ratio ('16/9' -> 1.778), and 'auto' (clears slot). Both 'aspectRatio' (camelCase) and 'aspect-ratio' (kebab-case) work; setProperty auto-converts kebab to camel.",
       "issue": "1434"
     },
     "css/backdropFilter": {
       "status": "supported",
-      "mapsTo": "parses blur(Npx) \u2192 setBackdropFilter(id, blur_px)",
+      "mapsTo": "parses blur(Npx) → setBackdropFilter(id, blur_px)",
       "supportedValues": [
         "blur(<px>)",
         "none",
@@ -603,7 +603,7 @@
       "tests": [
         "test/web-compat/test_css_translator_gaps_1434.cpp [issue-1434-batch-3]"
       ],
-      "notes": "Blur-only. CSS shim parses the blur(Npx) substring; non-matching filter functions are ignored. None / empty clears the slot. Wave 4 css extensive \u2014 non-blur filter functions are arch-blur-only-backdrop (the bridge slot View::backdrop_filter_blur_ is scalar; the multi-function chain that the foreground filter chain uses is queued behind SkImageFilters compose-list parity). Authors who need brightness/saturate stack via the foreground filter property which IS chain-aware.",
+      "notes": "Blur-only. CSS shim parses the blur(Npx) substring; non-matching filter functions are ignored. None / empty clears the slot. Wave 4 css extensive — non-blur filter functions are arch-blur-only-backdrop (the bridge slot View::backdrop_filter_blur_ is scalar; the multi-function chain that the foreground filter chain uses is queued behind SkImageFilters compose-list parity). Authors who need brightness/saturate stack via the foreground filter property which IS chain-aware.",
       "issue": "1434"
     },
     "css/backfaceVisibility": {
@@ -615,7 +615,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1615 \u2014 downgraded from `supported` to `noop`: the bridge function exists but is paint-time inert under the current 2D-affine transform model, and the CSS DOM path has no `case \"backfaceVisibility\"` arm. Will flip back to `supported` when 3D transforms land.",
+      "notes": "pulp #1615 — downgraded from `supported` to `noop`: the bridge function exists but is paint-time inert under the current 2D-affine transform model, and the CSS DOM path has no `case \"backfaceVisibility\"` arm. Will flip back to `supported` when 3D transforms land.",
       "issue": "1026"
     },
     "css/background": {
@@ -627,35 +627,35 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Background shorthand supports only color OR a gradient. Wave 1 architectural reclassification \u2014 url() / image / conic-gradient / multiple-bg are partial-deferred-image-loader (image src loader and viewport-relative paint not in Pulp's pipeline); color + linear-gradient round-trip end-to-end. Wave 4 css extensive \u2014 url() / image() / image-set() are arch-deferred-image-loader (no asset-fetch pipeline at the JS shim \u2014 image loading is the orthogonal follow-up). conic-gradient is arch-skia-no-conic-gradient (Skia's SkGradientShader doesn't natively support conical sweeps; angle-sweep emulation would require offscreen rasterization and is an explicit non-goal at this surface). multiple backgrounds + size-in-shorthand are arch-single-bg (the View::background_ slot stores a single background; mirrors the box-shadow single-shadow pattern). Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
+      "notes": "Background shorthand supports only color OR a gradient. Wave 1 architectural reclassification — url() / image / conic-gradient / multiple-bg are partial-deferred-image-loader (image src loader and viewport-relative paint not in Pulp's pipeline); color + linear-gradient round-trip end-to-end. Wave 4 css extensive — url() / image() / image-set() are arch-deferred-image-loader (no asset-fetch pipeline at the JS shim — image loading is the orthogonal follow-up). conic-gradient is arch-skia-no-conic-gradient (Skia's SkGradientShader doesn't natively support conical sweeps; angle-sweep emulation would require offscreen rasterization and is an explicit non-goal at this surface). multiple backgrounds + size-in-shorthand are arch-single-bg (the View::background_ slot stores a single background; mirrors the box-shadow single-shadow pattern). Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
       "issue": ""
     },
     "css/backgroundAttachment": {
       "status": "supported",
       "mapsTo": "web-compat-style-decl.js -> setBackgroundAttachment(id, kw); bridge stores keyword on View::background_attachment_ slot. No paint impact today.",
       "supportedValues": [
-        "scroll (conformant default \u2014 pulp's layout is non-scrolling so the spec behavior coincides with our render path)"
+        "scroll (conformant default — pulp's layout is non-scrolling so the spec behavior coincides with our render path)"
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp \u2014 [issue-1517]"
+        "test/test_widget_bridge.cpp — [issue-1517]"
       ],
-      "notes": "pulp #1517 \u2014 accepts the keyword without crashing; paint impact is exactly zero because pulp doesn't model scroll contexts. `scroll` is the spec-conformant default for our case. Status `noop` means the property is wired through but has no rendered effect. Wave 1 architectural reclassification \u2014 `fixed` / `local` are arch-no-scroll-context (Pulp's layout is non-scrolling so `scroll` is the spec-conformant default; viewport-relative paint origin and scroll-context coupling are not modeled). Wave 1 drift cleanup \u2014 noop status retained; cleared unsupportedValues since `fixed` / `local` are arch-no-scroll-context (Pulp doesn't model scroll contexts; the default `scroll` is the spec-conformant rendering).",
+      "notes": "pulp #1517 — accepts the keyword without crashing; paint impact is exactly zero because pulp doesn't model scroll contexts. `scroll` is the spec-conformant default for our case. Status `noop` means the property is wired through but has no rendered effect. Wave 1 architectural reclassification — `fixed` / `local` are arch-no-scroll-context (Pulp's layout is non-scrolling so `scroll` is the spec-conformant default; viewport-relative paint origin and scroll-context coupling are not modeled). Wave 1 drift cleanup — noop status retained; cleared unsupportedValues since `fixed` / `local` are arch-no-scroll-context (Pulp doesn't model scroll contexts; the default `scroll` is the spec-conformant rendering).",
       "issue": "1517"
     },
     "css/backgroundClip": {
       "status": "supported",
       "mapsTo": "web-compat-style-decl.js -> setBackgroundClip(id, kw); bridge stores keyword on View::background_clip_ slot.",
       "supportedValues": [
-        "border-box (default; pulp paints bg edge-to-edge \u2014 same as the spec default)",
+        "border-box (default; pulp paints bg edge-to-edge — same as the spec default)",
         "padding-box (no-op on solid bg; same visual as border-box)",
         "content-box (no-op on solid bg; same visual as border-box)"
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp \u2014 [issue-1517]"
+        "test/test_widget_bridge.cpp — [issue-1517]"
       ],
-      "notes": "pulp #1517 \u2014 keyword stored on View; the box-flavor variants are visual no-ops on solid backgrounds (which is what pulp paints today). The `text` variant requires real paint-chain composition and is deferred. Wave 1 architectural reclassification \u2014 `text` keyword is partial-deferred-paint-composition (slot stored on View::background_clip_; paint-time SkBlendMode::kSrcIn against text glyphs requires paint-chain composition not in pipeline today). Wave 4 css extensive \u2014 text is arch-paint-deferred (paint-time SkBlendMode::kSrcIn against text glyphs is the follow-up; the slot stores the value so the wiring is ready). Reclassified as paint-side gap rather than value-coverage gap.",
+      "notes": "pulp #1517 — keyword stored on View; the box-flavor variants are visual no-ops on solid backgrounds (which is what pulp paints today). The `text` variant requires real paint-chain composition and is deferred. Wave 1 architectural reclassification — `text` keyword is partial-deferred-paint-composition (slot stored on View::background_clip_; paint-time SkBlendMode::kSrcIn against text glyphs requires paint-chain composition not in pipeline today). Wave 4 css extensive — text is arch-paint-deferred (paint-time SkBlendMode::kSrcIn against text glyphs is the follow-up; the slot stores the value so the wiring is ready). Reclassified as paint-side gap rather than value-coverage gap.",
       "issue": "1517"
     },
     "css/backgroundColor": {
@@ -678,7 +678,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up. color-mix() and currentColor remain unsupported (deferred); wide-gamut HDR via Skia SkColor4f is a follow-up \u2014 current path converts to sRGB hex.",
+      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up. color-mix() and currentColor remain unsupported (deferred); wide-gamut HDR via Skia SkColor4f is a follow-up — current path converts to sRGB hex.",
       "issue": ""
     },
     "css/backgroundImage": {
@@ -690,25 +690,25 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "url() image backgrounds not implemented. Wave 1 architectural reclassification \u2014 url() / image-set() / conic-gradient / multiple-bg are partial-deferred-image-loader (image src loader not in Pulp's pipeline); linear-gradient + radial-gradient round-trip end-to-end. Wave 4 css extensive \u2014 url() / image-set() are arch-deferred-image-loader (no asset-fetch pipeline at the JS shim). conic-gradient is arch-skia-no-conic-gradient. multiple is arch-single-bg. Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
+      "notes": "url() image backgrounds not implemented. Wave 1 architectural reclassification — url() / image-set() / conic-gradient / multiple-bg are partial-deferred-image-loader (image src loader not in Pulp's pipeline); linear-gradient + radial-gradient round-trip end-to-end. Wave 4 css extensive — url() / image-set() are arch-deferred-image-loader (no asset-fetch pipeline at the JS shim). conic-gradient is arch-skia-no-conic-gradient. multiple is arch-single-bg. Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
       "issue": ""
     },
     "css/backgroundOrigin": {
       "status": "supported",
       "mapsTo": "web-compat-style-decl.js -> setBackgroundOrigin(id, kw); bridge stores keyword on View::background_origin_ slot. No paint impact today.",
       "supportedValues": [
-        "border-box / padding-box / content-box \u2014 all accepted, all stored, all paint identically because pulp doesn't paint repeating gradient tiles (the only case where this would matter)"
+        "border-box / padding-box / content-box — all accepted, all stored, all paint identically because pulp doesn't paint repeating gradient tiles (the only case where this would matter)"
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp \u2014 [issue-1517]"
+        "test/test_widget_bridge.cpp — [issue-1517]"
       ],
-      "notes": "pulp #1517 \u2014 value stored for round-tripping; paint impact is zero because the property only matters for repeating gradient tiles. When pulp adds gradient-tile paint, the slot is already populated. Wave 1 drift cleanup \u2014 noop \u2192 supported (wired through web-compat-style-decl.js; the box-flavor variants are visual no-ops on solid backgrounds, which is what Pulp paints today \u2014 matches CSS spec default behavior).",
+      "notes": "pulp #1517 — value stored for round-tripping; paint impact is zero because the property only matters for repeating gradient tiles. When pulp adds gradient-tile paint, the slot is already populated. Wave 1 drift cleanup — noop → supported (wired through web-compat-style-decl.js; the box-flavor variants are visual no-ops on solid backgrounds, which is what Pulp paints today — matches CSS spec default behavior).",
       "issue": "1517"
     },
     "css/backgroundPosition": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js:1418 forwards `background-position` to setBackgroundPosition(id, value); bridge function is registered (widget_bridge.cpp Wave 5 css.5) and stores the keyword on View::background_position_. Storage-only today: pulp's solid-bg paint path doesn't honor position offsets, which only matter for url() / image-set() raster backgrounds (deferred to image-loader slice \u2014 see backgroundImage).",
+      "mapsTo": "web-compat-style-decl.js:1418 forwards `background-position` to setBackgroundPosition(id, value); bridge function is registered (widget_bridge.cpp Wave 5 css.5) and stores the keyword on View::background_position_. Storage-only today: pulp's solid-bg paint path doesn't honor position offsets, which only matter for url() / image-set() raster backgrounds (deferred to image-loader slice — see backgroundImage).",
       "supportedValues": [
         "<keyword>",
         "<percentage>",
@@ -716,12 +716,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 5 css.5 \u2014 registered the previously-missing setBackgroundPosition bridge fn so the JS shim no longer no-ops. Storage-only round-trip: keyword stored verbatim on View::background_position_ slot for a future raster-image paint pass to honor without a JS-side change. Solid-bg paint (which is what Pulp paints today) doesn't position because there's no raster image to position. Catalog stays `supported` since the value coverage (keyword / length / percentage) all parse and survive bridge round-trip; the architectural caveat is: with no raster background pipeline (arch-deferred-image-loader), the offsets have no visual effect.",
+      "notes": "Wave 5 css.5 — registered the previously-missing setBackgroundPosition bridge fn so the JS shim no longer no-ops. Storage-only round-trip: keyword stored verbatim on View::background_position_ slot for a future raster-image paint pass to honor without a JS-side change. Solid-bg paint (which is what Pulp paints today) doesn't position because there's no raster image to position. Catalog stays `supported` since the value coverage (keyword / length / percentage) all parse and survive bridge round-trip; the architectural caveat is: with no raster background pipeline (arch-deferred-image-loader), the offsets have no visual effect.",
       "issue": ""
     },
     "css/backgroundRepeat": {
       "status": "supported",
-      "mapsTo": "setBackgroundRepeat(id, kw) \u2014 storage-only on the View; paint-time honoring deferred",
+      "mapsTo": "setBackgroundRepeat(id, kw) — storage-only on the View; paint-time honoring deferred",
       "supportedValues": [
         "repeat",
         "no-repeat",
@@ -734,12 +734,12 @@
       "tests": [
         "test/test_widget_bridge.cpp::WidgetBridge setBackgroundRepeat stores keyword on View (issue-1552)"
       ],
-      "notes": "pulp #1552: bridge fn registered (widget_bridge.cpp). The keyword round-trips through View::set_background_repeat \u2014 the slot is preserved so future paint logic for `background-image: url(...)` / repeating gradients can honor it without an API break. For solid-color backgrounds (today's only painted case) repeat semantics are a no-op, which is why the status remains `partial` rather than `supported`. Mirrors the storage-only strategy used for text-decoration-style (pulp #1434 batch 3). Wave 1 drift cleanup \u2014 partial \u2192 supported (no unsupported values listed; wired through web-compat-style-decl.js).",
+      "notes": "pulp #1552: bridge fn registered (widget_bridge.cpp). The keyword round-trips through View::set_background_repeat — the slot is preserved so future paint logic for `background-image: url(...)` / repeating gradients can honor it without an API break. For solid-color backgrounds (today's only painted case) repeat semantics are a no-op, which is why the status remains `partial` rather than `supported`. Mirrors the storage-only strategy used for text-decoration-style (pulp #1434 batch 3). Wave 1 drift cleanup — partial → supported (no unsupported values listed; wired through web-compat-style-decl.js).",
       "issue": "1552"
     },
     "css/backgroundSize": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js:1413 forwards `background-size` to setBackgroundSize(id, value); bridge function is registered (widget_bridge.cpp Wave 5 css.5) and stores the keyword on View::background_size_. Storage-only today: same arch-deferred-image-loader caveat as backgroundPosition \u2014 `cover` / `contain` / `<length>` only sized-fit a raster image, and pulp paints solid bg / gradients (which auto-fit to the box).",
+      "mapsTo": "web-compat-style-decl.js:1413 forwards `background-size` to setBackgroundSize(id, value); bridge function is registered (widget_bridge.cpp Wave 5 css.5) and stores the keyword on View::background_size_. Storage-only today: same arch-deferred-image-loader caveat as backgroundPosition — `cover` / `contain` / `<length>` only sized-fit a raster image, and pulp paints solid bg / gradients (which auto-fit to the box).",
       "supportedValues": [
         "cover",
         "contain",
@@ -749,12 +749,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 5 css.5 \u2014 registered the previously-missing setBackgroundSize bridge fn so the JS shim no longer no-ops. Storage-only round-trip: keyword stored verbatim on View::background_size_ slot for a future raster-image paint pass. The `cover` / `contain` / `auto` / `<length>` / `<percentage>` value space all round-trip through bridge. Architectural caveat: arch-deferred-image-loader \u2014 without a raster bg pipeline these have no visual effect, but the catalog claim is honest because the value is captured and queryable.",
+      "notes": "Wave 5 css.5 — registered the previously-missing setBackgroundSize bridge fn so the JS shim no longer no-ops. Storage-only round-trip: keyword stored verbatim on View::background_size_ slot for a future raster-image paint pass. The `cover` / `contain` / `auto` / `<length>` / `<percentage>` value space all round-trip through bridge. Architectural caveat: arch-deferred-image-loader — without a raster bg pipeline these have no visual effect, but the catalog claim is honest because the value is captured and queryable.",
       "issue": ""
     },
     "css/border": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js: 'border' shorthand parses '<width>px solid <color>' and routes to setBorderColor(id, color) + setBorderWidth(id, width) (per-attribute, NOT the unified setBorder, to preserve any prior borderRadius). 'borderColor' / 'borderWidth' / 'borderRadius' route to their respective per-attribute setters too \u2014 see pulp #1166/#1169.",
+      "mapsTo": "web-compat-style-decl.js: 'border' shorthand parses '<width>px solid <color>' and routes to setBorderColor(id, color) + setBorderWidth(id, width) (per-attribute, NOT the unified setBorder, to preserve any prior borderRadius). 'borderColor' / 'borderWidth' / 'borderRadius' route to their respective per-attribute setters too — see pulp #1166/#1169.",
       "supportedValues": [
         "solid (only)",
         "dashed (accepted; rendered as solid per arch-solid-only-pen)",
@@ -769,7 +769,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Fixed 2026-04-26 (#1169 / audit PR #1166 finding #4): per-attribute setters now preserve unset siblings, matching CSS semantics. Setting `borderColor` after `borderRadius` no longer zeros the radius. The unified setBorder(id, color, width, radius) is still available for the React `border` object-prop path. Border style ('solid', 'dashed', 'dotted', 'double') is parsed but only the default solid pen is rendered today. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen \u2014 JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
+      "notes": "Fixed 2026-04-26 (#1169 / audit PR #1166 finding #4): per-attribute setters now preserve unset siblings, matching CSS semantics. Setting `borderColor` after `borderRadius` no longer zeros the radius. The unified setBorder(id, color, width, radius) is still available for the React `border` object-prop path. Border style ('solid', 'dashed', 'dotted', 'double') is parsed but only the default solid pen is rendered today. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen — JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
       "issue": "1166"
     },
     "css/borderBottom": {
@@ -785,7 +785,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 4 css extensive \u2014 border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen \u2014 JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
+      "notes": "Wave 4 css extensive — border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen — JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
       "issue": ""
     },
     "css/borderBottomColor": {
@@ -845,7 +845,7 @@
     },
     "css/borderColor": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js: 'borderColor' -> setBorderColor(id, color) \u2014 per-attribute, preserves width and radius.",
+      "mapsTo": "web-compat-style-decl.js: 'borderColor' -> setBorderColor(id, color) — per-attribute, preserves width and radius.",
       "supportedValues": [
         "#hex",
         "#rgba",
@@ -863,7 +863,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Fixed 2026-04-26 (#1169). Previously routed onto the unified setBorder which clobbered radius. Now uses the dedicated setBorderColor bridge fn. pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up. color-mix() and currentColor remain unsupported (deferred); wide-gamut HDR via Skia SkColor4f is a follow-up \u2014 current path converts to sRGB hex.",
+      "notes": "Fixed 2026-04-26 (#1169). Previously routed onto the unified setBorder which clobbered radius. Now uses the dedicated setBorderColor bridge fn. pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up. color-mix() and currentColor remain unsupported (deferred); wide-gamut HDR via Skia SkColor4f is a follow-up — current path converts to sRGB hex.",
       "issue": "1166"
     },
     "css/borderLeft": {
@@ -879,7 +879,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 4 css extensive \u2014 border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen \u2014 JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
+      "notes": "Wave 4 css extensive — border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen — JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
       "issue": ""
     },
     "css/borderLeftColor": {
@@ -915,7 +915,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 % accepted (parseCSSLength returns the value, forwarded to scalar bridge slot; not box-relative). Fixed 2026-04-26 (#1169). Previously routed onto setBorder and lost color/width on a subsequent borderColor/Width assignment. Wave 1 architectural reclassification \u2014 two-value elliptical + `/` separator syntax are arch-skia-rrect-single-radius (Skia rounded-rect uses a single radius today; elliptical RRect requires SkRRect path). Wave 4 css extensive \u2014 two-value elliptical + `/` separator are arch-skia-rrect-single-radius (Skia's rounded-rect today uses a single scalar per corner; elliptical RRect with separate x/y radii would require SkRRect path-construction and is an explicit non-goal at this surface).",
+      "notes": "Wave 2 css.2 — % accepted (parseCSSLength returns the value, forwarded to scalar bridge slot; not box-relative). Fixed 2026-04-26 (#1169). Previously routed onto setBorder and lost color/width on a subsequent borderColor/Width assignment. Wave 1 architectural reclassification — two-value elliptical + `/` separator syntax are arch-skia-rrect-single-radius (Skia rounded-rect uses a single radius today; elliptical RRect requires SkRRect path). Wave 4 css extensive — two-value elliptical + `/` separator are arch-skia-rrect-single-radius (Skia's rounded-rect today uses a single scalar per corner; elliptical RRect with separate x/y radii would require SkRRect path-construction and is an explicit non-goal at this surface).",
       "issue": "1166"
     },
     "css/borderRight": {
@@ -931,7 +931,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 4 css extensive \u2014 border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen \u2014 JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
+      "notes": "Wave 4 css extensive — border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen — JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
       "issue": ""
     },
     "css/borderRightColor": {
@@ -987,7 +987,7 @@
         "test/test_widget_bridge.cpp::\"setBorderStyle maps each keyword to the right enum\"",
         "test/test_widget_bridge.cpp::\"dashed border emits set_line_dash command then clears it\""
       ],
-      "notes": "pulp #1434 Triage #10 \u2014 Skia paint installs SkDashPathEffect for dashed/dotted (CG falls through to solid via the canvas-base no-op set_line_dash). View::BorderStyle enum stores the keyword; bridge maps strings; Skia honors at stroke time. Other named styles (double/groove/ridge/inset/outset) currently degrade to solid \u2014 paint-side compositions are a follow-up. none/hidden short-circuit the stroke entirely.",
+      "notes": "pulp #1434 Triage #10 — Skia paint installs SkDashPathEffect for dashed/dotted (CG falls through to solid via the canvas-base no-op set_line_dash). View::BorderStyle enum stores the keyword; bridge maps strings; Skia honors at stroke time. Other named styles (double/groove/ridge/inset/outset) currently degrade to solid — paint-side compositions are a follow-up. none/hidden short-circuit the stroke entirely.",
       "issue": ""
     },
     "css/borderTop": {
@@ -1003,7 +1003,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 4 css extensive \u2014 border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen \u2014 JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
+      "notes": "Wave 4 css extensive — border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen — JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
       "issue": ""
     },
     "css/borderTopColor": {
@@ -1027,7 +1027,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 % accepted. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 elliptical x/y form is arch-skia-rrect-single-radius (single scalar slot per corner; elliptical paths require SkRRect rebuild and are an explicit non-goal at this surface).",
+      "notes": "Wave 2 css.2 — % accepted. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — elliptical x/y form is arch-skia-rrect-single-radius (single scalar slot per corner; elliptical paths require SkRRect rebuild and are an explicit non-goal at this surface).",
       "issue": ""
     },
     "css/borderTopRightRadius": {
@@ -1064,12 +1064,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 thin/medium/thick keyword expansion + % acceptance. Per CSS Backgrounds & Borders L3, thin/medium/thick are author-named widths; canonical browser values are 1/3/5px but pulp picks 1/2/4 for a slightly thinner ladder at 1x DPI (authors who want exact browser parity pass numeric px).",
+      "notes": "Wave 2 css.2 — thin/medium/thick keyword expansion + % acceptance. Per CSS Backgrounds & Borders L3, thin/medium/thick are author-named widths; canonical browser values are 1/3/5px but pulp picks 1/2/4 for a slightly thinner ladder at 1x DPI (authors who want exact browser parity pass numeric px).",
       "issue": ""
     },
     "css/bottom": {
       "status": "supported",
-      "mapsTo": "setBottom(id, px); JS shim resolves em/rem (\u00d7 14px default), vh/vw (\u00d7 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
+      "mapsTo": "setBottom(id, px); JS shim resolves em/rem (× 14px default), vh/vw (× 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
       "supportedValues": [
         "px",
         "%",
@@ -1080,7 +1080,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
+      "notes": "Wave 2 css.2 — em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "css/boxShadow": {
@@ -1092,7 +1092,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Single-shadow only. Multiple comma-separated shadows are not split. pulp #1434 Triage #15: catalog status flipped supported\u2192partial \u2014 single-shadow with optional inset is wired (web-compat-style-decl.js:565); multi-shadow comma-separated lists are deferred. Wave 4 css extensive \u2014 multi-shadow comma-separated lists are arch-single-shadow (View::shadow_ stores a single ShadowSpec; stacking multiple drop-shadows would require a layered SkLayer paint pass and is an explicit non-goal \u2014 when authors need two shadows they use boxShadow + filter:drop-shadow).",
+      "notes": "Single-shadow only. Multiple comma-separated shadows are not split. pulp #1434 Triage #15: catalog status flipped supported→partial — single-shadow with optional inset is wired (web-compat-style-decl.js:565); multi-shadow comma-separated lists are deferred. Wave 4 css extensive — multi-shadow comma-separated lists are arch-single-shadow (View::shadow_ stores a single ShadowSpec; stacking multiple drop-shadows would require a layered SkLayer paint pass and is an explicit non-goal — when authors need two shadows they use boxShadow + filter:drop-shadow).",
       "issue": ""
     },
     "css/boxSizing": {
@@ -1101,14 +1101,14 @@
       "supportedValues": [
         "content-box",
         "border-box",
-        "border-box (pulp default; declared width/height includes padding+border \u2014 matches Yoga 3.x's own default and what virtually every modern web design expects)",
+        "border-box (pulp default; declared width/height includes padding+border — matches Yoga 3.x's own default and what virtually every modern web design expects)",
         "content-box (CSS spec default; padding+border are outside declared dimensions, so a 100px-wide box with 10px padding has 120px outer width)"
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp \u2014 [issue-1516]"
+        "test/test_widget_bridge.cpp — [issue-1516]"
       ],
-      "notes": "pulp #1516 \u2014 Yoga 3.2.1's native YGNodeStyleSetBoxSizing does the spec-correct math; previously the JS shim silently no-op'd because the bridge didn't register setBoxSizing. The default is `border-box` (matches Yoga 3.x's default + pulp's implicit pre-#1516 behavior + the de-facto `* { box-sizing: border-box }` web reset). Consumers that explicitly want CSS-spec content-box semantics can opt in via `boxSizing: 'content-box'`. High-leverage change for design imports \u2014 Figma / v0 / Claude Design HTML exports often emit explicit boxSizing declarations that previously dropped silently.",
+      "notes": "pulp #1516 — Yoga 3.2.1's native YGNodeStyleSetBoxSizing does the spec-correct math; previously the JS shim silently no-op'd because the bridge didn't register setBoxSizing. The default is `border-box` (matches Yoga 3.x's default + pulp's implicit pre-#1516 behavior + the de-facto `* { box-sizing: border-box }` web reset). Consumers that explicitly want CSS-spec content-box semantics can opt in via `boxSizing: 'content-box'`. High-leverage change for design imports — Figma / v0 / Claude Design HTML exports often emit explicit boxSizing declarations that previously dropped silently.",
       "issue": "1516"
     },
     "css/captionSide": {
@@ -1135,14 +1135,14 @@
     },
     "css/clipPath": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js parses `clip-path` and forwards path(\"...\") to setClipPath(id, svg_d). Skia parses via SkPath::FromSVGString and the canvas installs the clip on paint (#1540). url() / circle() / inset() / polygon() / ellipse() are deferred \u2014 the bridge stores an empty path so previous values don't linger.",
+      "mapsTo": "web-compat-style-decl.js parses `clip-path` and forwards path(\"...\") to setClipPath(id, svg_d). Skia parses via SkPath::FromSVGString and the canvas installs the clip on paint (#1540). url() / circle() / inset() / polygon() / ellipse() are deferred — the bridge stores an empty path so previous values don't linger.",
       "supportedValues": [
         "path(\"...\")",
         "none"
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 6: status flipped missing \u2192 partial. Wiring landed in #1540 (clip_path_svg). Wave 1 architectural reclassification \u2014 Pulp wires only SVG `path()` by design (arch-path-only); url() / circle() / ellipse() / inset() / polygon() / box keywords are explicit non-goals (the Skia path is the universal primitive).",
+      "notes": "pulp #1434 A4 Bundle 6: status flipped missing → partial. Wiring landed in #1540 (clip_path_svg). Wave 1 architectural reclassification — Pulp wires only SVG `path()` by design (arch-path-only); url() / circle() / ellipse() / inset() / polygon() / box keywords are explicit non-goals (the Skia path is the universal primitive).",
       "issue": ""
     },
     "css/color": {
@@ -1165,7 +1165,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up. color-mix() and currentColor remain unsupported (deferred); wide-gamut HDR via Skia SkColor4f is a follow-up \u2014 current path converts to sRGB hex.",
+      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up. color-mix() and currentColor remain unsupported (deferred); wide-gamut HDR via Skia SkColor4f is a follow-up — current path converts to sRGB hex.",
       "issue": ""
     },
     "css/columnCount": {
@@ -1181,14 +1181,14 @@
     },
     "css/columnGap": {
       "status": "supported",
-      "mapsTo": "setFlex(id, 'column_gap', px) for numeric, 'NN%' string for percent (best-effort: stored on the scalar FlexStyle.column_gap slot since Yoga has no YGNodeStyleSetGapPercent API yet \u2014 treated as px until upstream Yoga ships percent-aware gap).",
+      "mapsTo": "setFlex(id, 'column_gap', px) for numeric, 'NN%' string for percent (best-effort: stored on the scalar FlexStyle.column_gap slot since Yoga has no YGNodeStyleSetGapPercent API yet — treated as px until upstream Yoga ships percent-aware gap).",
       "supportedValues": [
         "px",
         "% (best-effort scalar)"
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 % accepted at the JS+bridge layer; honest stored-as-scalar caveat documented above. Status stays partial because Yoga doesn't yet honor percent gaps (px-equivalent only). Wave 4 css extensive \u2014 % is best-effort (stored on the scalar slot, treated as px-equivalent) until upstream Yoga ships YGNodeStyleSetGapPercent \u2014 tracked as deferred-yoga-percent-gap. Status flipped partial -> supported because every CSS-spec value (px / %) round-trips through the bridge today; the % honoring is the orthogonal Yoga upstream follow-up.",
+      "notes": "Wave 2 css.2 — % accepted at the JS+bridge layer; honest stored-as-scalar caveat documented above. Status stays partial because Yoga doesn't yet honor percent gaps (px-equivalent only). Wave 4 css extensive — % is best-effort (stored on the scalar slot, treated as px-equivalent) until upstream Yoga ships YGNodeStyleSetGapPercent — tracked as deferred-yoga-percent-gap. Status flipped partial -> supported because every CSS-spec value (px / %) round-trips through the bridge today; the % honoring is the orthogonal Yoga upstream follow-up.",
       "issue": ""
     },
     "css/columnRule": {
@@ -1281,7 +1281,7 @@
     },
     "css/cursor": {
       "status": "supported",
-      "mapsTo": "setCursor(id, value) \u2014 widget_bridge.cpp maps the full CSS keyword set to View::CursorStyle. col-resize/ew-resize/e-resize/w-resize \u2192 horizontal_resize; row-resize/ns-resize/n-resize/s-resize \u2192 vertical_resize; nwse/nw/se \u2192 top_left_resize; nesw/ne/sw \u2192 top_right_resize; move/all-scroll \u2192 multi_directional_resize; none/hidden \u2192 invisible; pointer/crosshair/text/grab/grabbing/not-allowed/no-drop/vertical-text mapped 1:1.",
+      "mapsTo": "setCursor(id, value) — widget_bridge.cpp maps the full CSS keyword set to View::CursorStyle. col-resize/ew-resize/e-resize/w-resize → horizontal_resize; row-resize/ns-resize/n-resize/s-resize → vertical_resize; nwse/nw/se → top_left_resize; nesw/ne/sw → top_right_resize; move/all-scroll → multi_directional_resize; none/hidden → invisible; pointer/crosshair/text/grab/grabbing/not-allowed/no-drop/vertical-text mapped 1:1.",
       "supportedValues": [
         "default",
         "pointer",
@@ -1323,19 +1323,19 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"setCursor maps the full CSS keyword set\""
       ],
-      "notes": "pulp #1434 Triage #7 \u2014 cursor enum fan-out. Unknown keywords fall back to default. CSS values without a CursorStyle slot today (alias/copy/cell/zoom-in/zoom-out/help/wait/progress/context-menu) also fall back to default; tracked for a follow-up that adds dedicated CursorStyle slots + platform-specific glyphs. url() cursor images are not supported (browser-specific feature). Wave 1 architectural reclassification \u2014 auto/cell/context-menu/help/progress/wait/zoom-in/zoom-out fall back to default by design (arch-platform-cursor-set; Pulp uses pointer/text/grab/grabbing + the resize family by design \u2014 adding more requires platform-specific glyphs and is an explicit OOS). Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 auto / cell / context-menu / help / progress / wait / zoom-in / zoom-out are arch-platform-cursor-set (accepted at the bridge \u2014 setCursor falls back to the default cursor glyph for unknown keywords). Adding dedicated CursorStyle slots + platform-specific glyph dispatch is the follow-up.",
+      "notes": "pulp #1434 Triage #7 — cursor enum fan-out. Unknown keywords fall back to default. CSS values without a CursorStyle slot today (alias/copy/cell/zoom-in/zoom-out/help/wait/progress/context-menu) also fall back to default; tracked for a follow-up that adds dedicated CursorStyle slots + platform-specific glyphs. url() cursor images are not supported (browser-specific feature). Wave 1 architectural reclassification — auto/cell/context-menu/help/progress/wait/zoom-in/zoom-out fall back to default by design (arch-platform-cursor-set; Pulp uses pointer/text/grab/grabbing + the resize family by design — adding more requires platform-specific glyphs and is an explicit OOS). Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — auto / cell / context-menu / help / progress / wait / zoom-in / zoom-out are arch-platform-cursor-set (accepted at the bridge — setCursor falls back to the default cursor glyph for unknown keywords). Adding dedicated CursorStyle slots + platform-specific glyph dispatch is the follow-up.",
       "issue": ""
     },
     "css/direction": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js forwards `direction` to setDirection(id, value). The bridge maps to View::WritingDirection; Yoga honors at layout time and Skia paragraph_style at text shape time (#1506). Logical-edge mapping in the JS shim still uses the LTR fast path; direction-aware logical\u2192physical resolution is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js forwards `direction` to setDirection(id, value). The bridge maps to View::WritingDirection; Yoga honors at layout time and Skia paragraph_style at text shape time (#1506). Logical-edge mapping in the JS shim still uses the LTR fast path; direction-aware logical→physical resolution is the follow-up.",
       "supportedValues": [
         "ltr",
         "rtl"
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 6: status flipped missing \u2192 partial. Bridge wiring landed in #1506; CSS surface gets the same setDirection routing. Wave 1 drift cleanup \u2014 logical-edge mapping verified via Bundle 3 fast-path (#1506).",
+      "notes": "pulp #1434 A4 Bundle 6: status flipped missing → partial. Bridge wiring landed in #1506; CSS surface gets the same setDirection routing. Wave 1 drift cleanup — logical-edge mapping verified via Bundle 3 fast-path (#1506).",
       "issue": ""
     },
     "css/display": {
@@ -1357,7 +1357,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Yoga's underlying view model is exclusively flex. 'block' is silently aliased to 'flex'. RN's display enum is {none, flex, contents} which matches us better than CSS. The Display enum on the C++ View has no direct field -- visibility is implemented via View::set_visible. There is no 'partial' display rendering -- non-flex values render as flex with default direction. 2026-04-28 (#1167 / pulp #1147): `display: flex` now defaults flex-direction to 'row' to match CSS web compat (Pulp's underlying widgets default to 'col' / FlexDirection::column from RN convention, so the JS shim emits an explicit 'row' when the consumer didn't declare flexDirection / flex-direction / flex-flow with a direction token). Wave 1 architectural reclassification \u2014 non-flex display modes are arch-flex-only per CLAUDE.md design philosophy (Yoga's view model is exclusively flex; 'block' is silently aliased to 'flex'; grid/inline/inline-block/table/contents/inline-flex/inline-grid/list-item won't fix without violating the flex-only design). Wave 4 css extensive \u2014 non-flex display modes (inline / inline-block / inline-flex / inline-grid / grid / contents / table / table-row / table-cell) are arch-flex-only (Yoga's view model is exclusively flex; these values round-trip through the JS shim \u2014 `block` is silently aliased to `flex`, `none` hides via setVisible(id, false), the rest fall through to flex with default direction). Adding non-flex layout would violate the flex-only design (per CLAUDE.md). Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
+      "notes": "Yoga's underlying view model is exclusively flex. 'block' is silently aliased to 'flex'. RN's display enum is {none, flex, contents} which matches us better than CSS. The Display enum on the C++ View has no direct field -- visibility is implemented via View::set_visible. There is no 'partial' display rendering -- non-flex values render as flex with default direction. 2026-04-28 (#1167 / pulp #1147): `display: flex` now defaults flex-direction to 'row' to match CSS web compat (Pulp's underlying widgets default to 'col' / FlexDirection::column from RN convention, so the JS shim emits an explicit 'row' when the consumer didn't declare flexDirection / flex-direction / flex-flow with a direction token). Wave 1 architectural reclassification — non-flex display modes are arch-flex-only per CLAUDE.md design philosophy (Yoga's view model is exclusively flex; 'block' is silently aliased to 'flex'; grid/inline/inline-block/table/contents/inline-flex/inline-grid/list-item won't fix without violating the flex-only design). Wave 4 css extensive — non-flex display modes (inline / inline-block / inline-flex / inline-grid / grid / contents / table / table-row / table-cell) are arch-flex-only (Yoga's view model is exclusively flex; these values round-trip through the JS shim — `block` is silently aliased to `flex`, `none` hides via setVisible(id, false), the rest fall through to flex with default direction). Adding non-flex layout would violate the flex-only design (per CLAUDE.md). Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
       "issue": "1147"
     },
     "css/emptyCells": {
@@ -1393,7 +1393,7 @@
         "test/test_widget_bridge.cpp::\"setFilter parses chained functions in source order\"",
         "test/test_widget_bridge.cpp::\"setFilter parses brightness/contrast/grayscale/etc\""
       ],
-      "notes": "pulp #1434 Phase A2-4 \u2014 full CSS filter chain. setFilter parses the function-call sequence into View::FilterOp[]; view.cpp paint hands off to canvas.save_layer_with_filters; Skia composes via SkImageFilters::Compose + SkColorFilters::Matrix per filter. CG path falls back to blur-only collapse (no SkColorFilter equivalent yet). Full function set: blur / brightness / contrast / grayscale / hue-rotate / invert / opacity / saturate / sepia / drop-shadow. CG canvas backend currently degrades the chain to blur-only collapse (color-matrix filters silently no-op); SkColorFilter-equivalent for CG is a follow-up.",
+      "notes": "pulp #1434 Phase A2-4 — full CSS filter chain. setFilter parses the function-call sequence into View::FilterOp[]; view.cpp paint hands off to canvas.save_layer_with_filters; Skia composes via SkImageFilters::Compose + SkColorFilters::Matrix per filter. CG path falls back to blur-only collapse (no SkColorFilter equivalent yet). Full function set: blur / brightness / contrast / grayscale / hue-rotate / invert / opacity / saturate / sepia / drop-shadow. CG canvas backend currently degrades the chain to blur-only collapse (color-matrix filters silently no-op); SkColorFilter-equivalent for CG is a follow-up.",
       "issue": ""
     },
     "css/flex": {
@@ -1409,7 +1409,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "The CSS shorthand keywords (auto/none/initial) parse as NaN and silently set flex_grow=0. Wave 1 drift cleanup \u2014 'auto'/'none'/'initial' keywords wired via yoga A4 (#1622); previously parsed as NaN and silently set flex_grow=0.",
+      "notes": "The CSS shorthand keywords (auto/none/initial) parse as NaN and silently set flex_grow=0. Wave 1 drift cleanup — 'auto'/'none'/'initial' keywords wired via yoga A4 (#1622); previously parsed as NaN and silently set flex_grow=0.",
       "issue": ""
     },
     "css/flexBasis": {
@@ -1423,7 +1423,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Yoga supports 'auto' and percentages; Pulp accepts only px float. pulp #1434 rn batch C: % and auto wired via FlexStyle::dim_flex_basis. Wave 4 css extensive \u2014 `content` keyword is arch-yoga-no-content-basis (Yoga's flex-basis is a scalar / percent / auto; the `content` keyword would require intrinsic-size resolution which Yoga doesn't model today). Authors use `auto` for the equivalent fall-back behaviour.",
+      "notes": "Yoga supports 'auto' and percentages; Pulp accepts only px float. pulp #1434 rn batch C: % and auto wired via FlexStyle::dim_flex_basis. Wave 4 css extensive — `content` keyword is arch-yoga-no-content-basis (Yoga's flex-basis is a scalar / percent / auto; the `content` keyword would require intrinsic-size resolution which Yoga doesn't model today). Authors use `auto` for the equivalent fall-back behaviour.",
       "issue": ""
     },
     "css/flexDirection": {
@@ -1442,7 +1442,7 @@
     },
     "css/flexFlow": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js shorthand parser fans out into setFlex(direction, ...) and setFlex(flex_wrap, ...) \u2014 supports row / column / row-reverse / column-reverse and wrap / nowrap / wrap-reverse.",
+      "mapsTo": "web-compat-style-decl.js shorthand parser fans out into setFlex(direction, ...) and setFlex(flex_wrap, ...) — supports row / column / row-reverse / column-reverse and wrap / nowrap / wrap-reverse.",
       "supportedValues": [
         "row|column|row-reverse|column-reverse",
         "nowrap|no-wrap|wrap|wrap-reverse",
@@ -1452,7 +1452,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"flex-flow shorthand recognizes wrap-reverse\""
       ],
-      "notes": "pulp #1434 Triage #14 \u2014 extended shorthand parser to recognize -reverse modes.",
+      "notes": "pulp #1434 Triage #14 — extended shorthand parser to recognize -reverse modes.",
       "issue": ""
     },
     "css/flexGrow": {
@@ -1490,7 +1490,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"setFlex flex_wrap accepts wrap-reverse keyword\""
       ],
-      "notes": "pulp #1434 Triage #14 \u2014 FlexStyle.flex_wrap converted from bool to tri-state enum; YGWrapWrapReverse is dispatched for wrap-reverse.",
+      "notes": "pulp #1434 Triage #14 — FlexStyle.flex_wrap converted from bool to tri-state enum; YGWrapWrapReverse is dispatched for wrap-reverse.",
       "issue": ""
     },
     "css/float": {
@@ -1508,21 +1508,21 @@
     },
     "css/fontFamily": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js + widget_bridge.cpp setFontFamily \u2014 both layers split CSS lists on commas, trim, strip outer quotes, and pick the first non-empty family. Bridge stores the value on Label or in the View's inheritable_font_family_ slot (cascade). PR #1174 + pulp #1434 Phase A2-5.",
+      "mapsTo": "web-compat-style-decl.js + widget_bridge.cpp setFontFamily — both layers split CSS lists on commas, trim, strip outer quotes, and pick the first non-empty family. Bridge stores the value on Label or in the View's inheritable_font_family_ slot (cascade). PR #1174 + pulp #1434 Phase A2-5.",
       "supportedValues": [
         "single font name (quoted or not)",
-        "comma-separated font lists ('JetBrains Mono', ui-monospace, monospace) \u2014 first non-empty family wins"
+        "comma-separated font lists ('JetBrains Mono', ui-monospace, monospace) — first non-empty family wins"
       ],
       "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp \u2014 [issue-1434-fontfamily]"
+        "test/test_widget_bridge.cpp — [issue-1434-fontfamily]"
       ],
-      "notes": "Wave 2 css.4 \u2014 reclassified partial -> partial-deferred-#932 (whole-list fallback is gated on Skia SkFontMgr font registration in pulp #932, not a JS-side gap). Phase A2-5 (pulp #1434) added @pulp/react JSX dispatch and a bridge-side list parser so direct setFontFamily('id', 'A, B, C') calls are now correct. The cascade slot on container Views means container-level fontFamily reaches descendant Labels via parent-walk (mirrors letter_spacing / font_weight). Wave 4 css extensive \u2014 drift cleanup \u2014 value-coverage is complete (single name + comma-separated list both round-trip; first family wins). The Skia SkFontMgr fallback-chain gating (pulp #932) is documented in mapsTo / notes; reclassified as paint-side architectural gap rather than a value-coverage gap.",
+      "notes": "Wave 2 css.4 — reclassified partial -> partial-deferred-#932 (whole-list fallback is gated on Skia SkFontMgr font registration in pulp #932, not a JS-side gap). Phase A2-5 (pulp #1434) added @pulp/react JSX dispatch and a bridge-side list parser so direct setFontFamily('id', 'A, B, C') calls are now correct. The cascade slot on container Views means container-level fontFamily reaches descendant Labels via parent-walk (mirrors letter_spacing / font_weight). Wave 4 css extensive — drift cleanup — value-coverage is complete (single name + comma-separated list both round-trip; first family wins). The Skia SkFontMgr fallback-chain gating (pulp #932) is documented in mapsTo / notes; reclassified as paint-side architectural gap rather than a value-coverage gap.",
       "issue": "1151"
     },
     "css/fontSize": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js: parseCSSLength + em/rem/% resolution (\u00d7 default 14px) + smaller/larger keyword expansion (0.83x/1.2x); -> setFontSize(id, px).",
+      "mapsTo": "web-compat-style-decl.js: parseCSSLength + em/rem/% resolution (× default 14px) + smaller/larger keyword expansion (0.83x/1.2x); -> setFontSize(id, px).",
       "supportedValues": [
         "px",
         "em",
@@ -1533,7 +1533,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 em/rem/% resolved against the default 14px font-size (matches resolveLength fallback). smaller/larger expand to 0.83x and 1.2x per CSS spec. Multi-level cascade (resolving em against an actual ancestor font-size) is the follow-up; the single-level resolver covers the common case.",
+      "notes": "Wave 2 css.2 — em/rem/% resolved against the default 14px font-size (matches resolveLength fallback). smaller/larger expand to 0.83x and 1.2x per CSS spec. Multi-level cascade (resolving em against an actual ancestor font-size) is the follow-up; the single-level resolver covers the common case.",
       "issue": ""
     },
     "css/fontStyle": {
@@ -1546,7 +1546,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.4 \u2014 oblique alias upgrades a silent no-op (the bridge previously only honored 'italic') to the closest visual approximation. Real oblique requires SkFont variation axes which is the follow-up. Wave 4 css extensive \u2014 label cleanup \u2014 `oblique` claims the bare keyword (the bridge aliases to italic which is the closest visual approximation today). `oblique <angle>` is arch-paint-deferred (real oblique requires SkFont variation axes which is the documented follow-up).",
+      "notes": "Wave 2 css.4 — oblique alias upgrades a silent no-op (the bridge previously only honored 'italic') to the closest visual approximation. Real oblique requires SkFont variation axes which is the follow-up. Wave 4 css extensive — label cleanup — `oblique` claims the bare keyword (the bridge aliases to italic which is the closest visual approximation today). `oblique <angle>` is arch-paint-deferred (real oblique requires SkFont variation axes which is the documented follow-up).",
       "issue": ""
     },
     "css/fontVariant": {
@@ -1557,12 +1557,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 7: status flipped missing \u2192 partial. setFontVariant bridge fn now exists; mirrors rn/fontVariant. Wave 4 css extensive \u2014 HarfBuzz feature integration is arch-paint-deferred (the bridge stores the value on View::font_variant_; HarfBuzz line-break/feature wiring at paint time is the follow-up tracked in mapsTo). Reclassified as paint-side gap rather than value-coverage gap.",
+      "notes": "pulp #1434 A4 Bundle 7: status flipped missing → partial. setFontVariant bridge fn now exists; mirrors rn/fontVariant. Wave 4 css extensive — HarfBuzz feature integration is arch-paint-deferred (the bridge stores the value on View::font_variant_; HarfBuzz line-break/feature wiring at paint time is the follow-up tracked in mapsTo). Reclassified as paint-side gap rather than value-coverage gap.",
       "issue": ""
     },
     "css/fontWeight": {
       "status": "supported",
-      "mapsTo": "translate keyword/numeric \u2192 setFontWeight(id, n)",
+      "mapsTo": "translate keyword/numeric → setFontWeight(id, n)",
       "supportedValues": [
         "100..900 (numeric)",
         "normal",
@@ -1575,12 +1575,12 @@
         "test/web-compat/test_css_translator_gaps_1434.cpp [issue-1434-batch-3]",
         "packages/pulp-react/test/prop-applier-fontweight.test.ts"
       ],
-      "notes": "Keyword-to-numeric: normal\u2192400, bold\u2192700, lighter\u2192300, bolder\u2192700. Numeric keywords parse unchanged. Mirrored in @pulp/react prop-applier (_normalizeFontWeight).",
+      "notes": "Keyword-to-numeric: normal→400, bold→700, lighter→300, bolder→700. Numeric keywords parse unchanged. Mirrored in @pulp/react prop-applier (_normalizeFontWeight).",
       "issue": "1434"
     },
     "css/gap": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js: single-token form -> setFlex(id, 'gap', px); two-token form 'row col' -> setFlex(row_gap) + setFlex(column_gap). % accepted (best-effort scalar \u2014 same caveat as rowGap/columnGap).",
+      "mapsTo": "web-compat-style-decl.js: single-token form -> setFlex(id, 'gap', px); two-token form 'row col' -> setFlex(row_gap) + setFlex(column_gap). % accepted (best-effort scalar — same caveat as rowGap/columnGap).",
       "supportedValues": [
         "px (number)",
         "% (best-effort scalar)",
@@ -1588,7 +1588,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 two-value form fans out to row_gap + column_gap; % accepted at JS+bridge (Yoga gap is scalar-only today, no YGNodeStyleSetGapPercent yet).",
+      "notes": "Wave 2 css.2 — two-value form fans out to row_gap + column_gap; % accepted at JS+bridge (Yoga gap is scalar-only today, no YGNodeStyleSetGapPercent yet).",
       "issue": ""
     },
     "css/gridArea": {
@@ -1606,7 +1606,7 @@
         "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\""
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridAutoColumns": {
@@ -1624,7 +1624,7 @@
         "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\""
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridAutoFlow": {
@@ -1642,7 +1642,7 @@
         "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\""
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridAutoRows": {
@@ -1660,7 +1660,7 @@
         "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\""
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridColumn": {
@@ -1678,7 +1678,7 @@
         "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\""
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridRow": {
@@ -1696,7 +1696,7 @@
         "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\""
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridTemplateAreas": {
@@ -1714,7 +1714,7 @@
         "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\""
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridTemplateColumns": {
@@ -1732,7 +1732,7 @@
         "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\""
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridTemplateRows": {
@@ -1750,7 +1750,7 @@
         "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\""
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/height": {
@@ -1768,7 +1768,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1423 wired px + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end (CSS translator forwards 'auto' verbatim; bridge populates FlexStyle.dim_height.unit = auto_; yoga_layout.cpp dispatches to YGNodeStyleSetHeightAuto). Relative units (em/rem/vh/vw) remain deferred. Wave 1 architectural reclassification \u2014 min-content / max-content / fit-content are arch-yoga-limit (Yoga doesn't compute content-sized boxes); em/rem are deferred (relative-unit resolver lands later). Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 min-content / max-content / fit-content are arch-yoga-no-intrinsic-sizing (Yoga's flex layout doesn't model intrinsic sizing; use flex / flex-basis for the equivalent shrink-to-fit behaviour). calc() is arch-no-calc-eval (no expression evaluator at the JS shim layer; authors precompute or use JS variables). em/rem resolve against the default 14px font-size at the JS layer (single-level cascade per Wave 2 css.2 fontSize precedent).",
+      "notes": "pulp #1423 wired px + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end (CSS translator forwards 'auto' verbatim; bridge populates FlexStyle.dim_height.unit = auto_; yoga_layout.cpp dispatches to YGNodeStyleSetHeightAuto). Relative units (em/rem/vh/vw) remain deferred. Wave 1 architectural reclassification — min-content / max-content / fit-content are arch-yoga-limit (Yoga doesn't compute content-sized boxes); em/rem are deferred (relative-unit resolver lands later). Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — min-content / max-content / fit-content are arch-yoga-no-intrinsic-sizing (Yoga's flex layout doesn't model intrinsic sizing; use flex / flex-basis for the equivalent shrink-to-fit behaviour). calc() is arch-no-calc-eval (no expression evaluator at the JS shim layer; authors precompute or use JS variables). em/rem resolve against the default 14px font-size at the JS layer (single-level cascade per Wave 2 css.2 fontSize precedent).",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "css/inset": {
@@ -1790,7 +1790,7 @@
         "isolate"
       ],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 6: status flipped missing \u2192 wontfix. CSS isolation creates a new stacking context to contain blend modes; Pulp's render pipeline doesn't implement CSS stacking contexts (z-index is a paint-order hint only).",
+      "notes": "pulp #1434 A4 Bundle 6: status flipped missing → wontfix. CSS isolation creates a new stacking context to contain blend modes; Pulp's render pipeline doesn't implement CSS stacking contexts (z-index is a paint-order hint only).",
       "issue": ""
     },
     "css/justifyContent": {
@@ -1816,7 +1816,7 @@
     },
     "css/left": {
       "status": "supported",
-      "mapsTo": "setLeft(id, px); JS shim resolves em/rem (\u00d7 14px default), vh/vw (\u00d7 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
+      "mapsTo": "setLeft(id, px); JS shim resolves em/rem (× 14px default), vh/vw (× 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
       "supportedValues": [
         "px",
         "%",
@@ -1827,12 +1827,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
+      "notes": "Wave 2 css.2 — em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "css/letterSpacing": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js: parseCSSLength + em resolution (\u00d7 default 14px) + normal keyword (= 0); -> setLetterSpacing(id, px).",
+      "mapsTo": "web-compat-style-decl.js: parseCSSLength + em resolution (× default 14px) + normal keyword (= 0); -> setLetterSpacing(id, px).",
       "supportedValues": [
         "px",
         "em",
@@ -1841,12 +1841,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 em/rem resolved against the default 14px font-size (same caveat as fontSize re: single-level cascade). normal -> 0 per CSS spec.",
+      "notes": "Wave 2 css.2 — em/rem resolved against the default 14px font-size (same caveat as fontSize re: single-level cascade). normal -> 0 per CSS spec.",
       "issue": ""
     },
     "css/lineClamp": {
       "status": "supported",
-      "mapsTo": "parseInt -> setLineClamp(id, n) \u2014 Label paint emits at most N lines + U+2026 ellipsis on the last visible line if source lines were dropped",
+      "mapsTo": "parseInt -> setLineClamp(id, n) — Label paint emits at most N lines + U+2026 ellipsis on the last visible line if source lines were dropped",
       "supportedValues": [
         "integer"
       ],
@@ -1862,7 +1862,7 @@
     },
     "css/lineHeight": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js: detects bare-number unitless multiplier (\u00d7 default 14px font-size); resolves em/rem/% against same default; normal = 1.2 \u00d7 14; numeric px path unchanged. -> setLineHeight(id, px).",
+      "mapsTo": "web-compat-style-decl.js: detects bare-number unitless multiplier (× default 14px font-size); resolves em/rem/% against same default; normal = 1.2 × 14; numeric px path unchanged. -> setLineHeight(id, px).",
       "supportedValues": [
         "px",
         "unitless multiplier (e.g. 1.5)",
@@ -1873,12 +1873,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 closes the major-gap unitless-multiplier hole. Resolved against the default 14px font-size (same single-level cascade caveat as fontSize). Multi-level cascade is the follow-up.",
+      "notes": "Wave 2 css.2 — closes the major-gap unitless-multiplier hole. Resolved against the default 14px font-size (same single-level cascade caveat as fontSize). Multi-level cascade is the follow-up.",
       "issue": ""
     },
     "css/listStyle": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js parses the shorthand into the 3 longhands (any order: type / position / image) and dispatches setListStyleType / setListStyleImage / setListStylePosition. Bridge stores values on View::ListStyleType / list_style_image_ / View::ListStylePosition slots. Paint-time marker rendering is deferred \u2014 values are stored but not yet drawn.",
+      "mapsTo": "web-compat-style-decl.js parses the shorthand into the 3 longhands (any order: type / position / image) and dispatches setListStyleType / setListStyleImage / setListStylePosition. Bridge stores values on View::ListStyleType / list_style_image_ / View::ListStylePosition slots. Paint-time marker rendering is deferred — values are stored but not yet drawn.",
       "supportedValues": [
         "shorthand parsing into 3 longhands"
       ],
@@ -1887,7 +1887,7 @@
         "test/test_widget_bridge.cpp::\"setListStyleType maps each keyword to the right enum (issue-1514)\"",
         "packages/pulp-react/test/prop-applier-list-style.test.ts"
       ],
-      "notes": "Wave 2 css.4 \u2014 reclassified partial -> partial-deferred-paint-time (marker glyph painting is the architectural blocker, not a JS-side gap). pulp #1514 \u2014 list-style cluster. Pulp doesn't model <li>/<ul>/<ol> semantics; the bridge stores the values verbatim on the View so a future paint pass (or future semantic-list surface) can honor them. Wave 4 css extensive \u2014 drift cleanup \u2014 value-coverage is complete (the catalog's only 'unsupported' entry was the paint-time marker glyph rendering, which is an arch-paint-deferred follow-up \u2014 moved out of unsupportedValues per the Wave 1 backgroundAttachment precedent).",
+      "notes": "Wave 2 css.4 — reclassified partial -> partial-deferred-paint-time (marker glyph painting is the architectural blocker, not a JS-side gap). pulp #1514 — list-style cluster. Pulp doesn't model <li>/<ul>/<ol> semantics; the bridge stores the values verbatim on the View so a future paint pass (or future semantic-list surface) can honor them. Wave 4 css extensive — drift cleanup — value-coverage is complete (the catalog's only 'unsupported' entry was the paint-time marker glyph rendering, which is an arch-paint-deferred follow-up — moved out of unsupportedValues per the Wave 1 backgroundAttachment precedent).",
       "issue": "1514"
     },
     "css/listStyleImage": {
@@ -1902,7 +1902,7 @@
         "test/test_widget_bridge.cpp::\"setListStyleImage stores url and clears on 'none' (issue-1514)\"",
         "packages/pulp-react/test/prop-applier-list-style.test.ts"
       ],
-      "notes": "Wave 2 css.4 \u2014 reclassified partial -> partial-deferred-paint-time (bullet image paint is the architectural blocker, not a JS-side gap). pulp #1514 \u2014 Bridge round-trips the URL string. Image fetch + decode + paint is the follow-up. Wave 4 css extensive \u2014 drift cleanup \u2014 value-coverage is complete (the catalog's only 'unsupported' entry was the paint-time marker glyph rendering, which is an arch-paint-deferred follow-up \u2014 moved out of unsupportedValues per the Wave 1 backgroundAttachment precedent).",
+      "notes": "Wave 2 css.4 — reclassified partial -> partial-deferred-paint-time (bullet image paint is the architectural blocker, not a JS-side gap). pulp #1514 — Bridge round-trips the URL string. Image fetch + decode + paint is the follow-up. Wave 4 css extensive — drift cleanup — value-coverage is complete (the catalog's only 'unsupported' entry was the paint-time marker glyph rendering, which is an arch-paint-deferred follow-up — moved out of unsupportedValues per the Wave 1 backgroundAttachment precedent).",
       "issue": "1514"
     },
     "css/listStylePosition": {
@@ -1919,12 +1919,12 @@
         "test/test_widget_bridge.cpp::\"setListStylePosition maps each keyword to the right enum (issue-1514)\"",
         "packages/pulp-react/test/prop-applier-list-style.test.ts"
       ],
-      "notes": "pulp #1514 \u2014 Bridge stores the position; marker rendering is the follow-up. Wave 1 drift cleanup \u2014 partial \u2192 supported (harness verifies all 2 spec values).",
+      "notes": "pulp #1514 — Bridge stores the position; marker rendering is the follow-up. Wave 1 drift cleanup — partial → supported (harness verifies all 2 spec values).",
       "issue": "1514"
     },
     "css/listStyleType": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js forwards the keyword to setListStyleType; bridge stores View::ListStyleType (none / disc / circle / square / decimal). Marker glyph paint is deferred \u2014 `decimal` additionally needs sibling-index resolution from the parent's children.",
+      "mapsTo": "web-compat-style-decl.js forwards the keyword to setListStyleType; bridge stores View::ListStyleType (none / disc / circle / square / decimal). Marker glyph paint is deferred — `decimal` additionally needs sibling-index resolution from the parent's children.",
       "supportedValues": [
         "none",
         "disc",
@@ -1939,7 +1939,7 @@
         "test/test_widget_bridge.cpp::\"setListStyleType maps each keyword to the right enum (issue-1514)\"",
         "packages/pulp-react/test/prop-applier-list-style.test.ts"
       ],
-      "notes": "pulp #1514 \u2014 Bridge stores the type keyword; marker glyph rendering is the follow-up. Pulp doesn't model HTML <li> semantics yet. Wave 1 drift cleanup \u2014 decimal sibling-index + marker glyph paint shipped via #1551 catalog hygiene; lower-roman / upper-roman / lower-alpha remain architectural (no View::ListStyleType enum slot today).",
+      "notes": "pulp #1514 — Bridge stores the type keyword; marker glyph rendering is the follow-up. Pulp doesn't model HTML <li> semantics yet. Wave 1 drift cleanup — decimal sibling-index + marker glyph paint shipped via #1551 catalog hygiene; lower-roman / upper-roman / lower-alpha remain architectural (no View::ListStyleType enum slot today).",
       "issue": "1514"
     },
     "css/margin": {
@@ -1953,7 +1953,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 auto + % now honored in the shorthand (parity with the per-edge longhands). Yoga's YGNodeStyleSetMarginAuto centers when both opposing margins are auto.",
+      "notes": "Wave 2 css.2 — auto + % now honored in the shorthand (parity with the per-edge longhands). Yoga's YGNodeStyleSetMarginAuto centers when both opposing margins are auto.",
       "issue": ""
     },
     "css/marginBlock": {
@@ -1969,7 +1969,7 @@
     },
     "css/marginBlockEnd": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js maps `margin-block-end` \u2192 setFlex(margin_bottom) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js maps `margin-block-end` → setFlex(margin_bottom) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges — direction-aware mapping is the follow-up.",
       "supportedValues": [
         "<length>",
         "<percentage>",
@@ -1977,12 +1977,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing → partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/marginBlockStart": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js maps `margin-block-start` \u2192 setFlex(margin_top) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js maps `margin-block-start` → setFlex(margin_top) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges — direction-aware mapping is the follow-up.",
       "supportedValues": [
         "<length>",
         "<percentage>",
@@ -1990,7 +1990,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing → partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/marginBottom": {
@@ -2005,7 +2005,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
+      "notes": "pulp #1434 cross-surface mega-batch — accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
       "issue": ""
     },
     "css/marginHorizontal": {
@@ -2020,7 +2020,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "css/marginInline": {
@@ -2036,7 +2036,7 @@
     },
     "css/marginInlineEnd": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js maps `margin-inline-end` \u2192 setFlex(margin_right) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js maps `margin-inline-end` → setFlex(margin_right) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges — direction-aware mapping is the follow-up.",
       "supportedValues": [
         "<length>",
         "<percentage>",
@@ -2044,7 +2044,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing → partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/marginInlineStart": {
@@ -2053,7 +2053,7 @@
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 batch 1: status flipped missing \u2192 partial. CSS translator at web-compat-style-decl.js:784 maps to setFlex(margin_left) under LTR assumption; RTL not yet wired. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 batch 1: status flipped missing → partial. CSS translator at web-compat-style-decl.js:784 maps to setFlex(margin_left) under LTR assumption; RTL not yet wired. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/marginLeft": {
@@ -2068,7 +2068,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
+      "notes": "pulp #1434 cross-surface mega-batch — accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
       "issue": ""
     },
     "css/marginRight": {
@@ -2083,7 +2083,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
+      "notes": "pulp #1434 cross-surface mega-batch — accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
       "issue": ""
     },
     "css/marginTop": {
@@ -2098,7 +2098,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
+      "notes": "pulp #1434 cross-surface mega-batch — accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
       "issue": ""
     },
     "css/marginVertical": {
@@ -2113,7 +2113,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "css/mask": {
@@ -2127,7 +2127,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 6: status flipped missing \u2192 partial. Storage landed in #1515 / #1540. Wave 4 css extensive \u2014 mask sub-properties (mode/repeat/position/size/origin/clip/composite) are arch-paint-deferred \u2014 the shorthand parser routes mask-image to setMaskImage today; the orchestration of the other sub-properties at paint time is the follow-up. Reclassified as paint-side gap rather than value-coverage gap.",
+      "notes": "pulp #1434 A4 Bundle 6: status flipped missing → partial. Storage landed in #1515 / #1540. Wave 4 css extensive — mask sub-properties (mode/repeat/position/size/origin/clip/composite) are arch-paint-deferred — the shorthand parser routes mask-image to setMaskImage today; the orchestration of the other sub-properties at paint time is the follow-up. Reclassified as paint-side gap rather than value-coverage gap.",
       "issue": ""
     },
     "css/maskImage": {
@@ -2141,12 +2141,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 6: status flipped missing \u2192 partial. Storage landed in #1515. Wave 4 css extensive \u2014 paint-time mask compositing is arch-paint-deferred (the bridge stores the value; SkBlendMode::kSrcIn / SkShader::MakeMask integration at paint time is the follow-up). Reclassified as paint-side gap rather than value-coverage gap.",
+      "notes": "pulp #1434 A4 Bundle 6: status flipped missing → partial. Storage landed in #1515. Wave 4 css extensive — paint-time mask compositing is arch-paint-deferred (the bridge stores the value; SkBlendMode::kSrcIn / SkShader::MakeMask integration at paint time is the follow-up). Reclassified as paint-side gap rather than value-coverage gap.",
       "issue": ""
     },
     "css/maxHeight": {
       "status": "supported",
-      "mapsTo": "setFlex(id, 'max_height', px) for numeric, 'NN%' for percent. Wave 2 css.2 \u2014 calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
+      "mapsTo": "setFlex(id, 'max_height', px) for numeric, 'NN%' for percent. Wave 2 css.2 — calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
       "supportedValues": [
         "px (number)",
         "%",
@@ -2157,12 +2157,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 calc() actually wired in the shim (catalog had previously claimed it shipped; verified + connected). pulp #1434 rn batch C: % values route through FlexStyle::dim_*.unit \u2192 Yoga percent API. min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
+      "notes": "Wave 2 css.2 — calc() actually wired in the shim (catalog had previously claimed it shipped; verified + connected). pulp #1434 rn batch C: % values route through FlexStyle::dim_*.unit → Yoga percent API. min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
       "issue": ""
     },
     "css/maxWidth": {
       "status": "supported",
-      "mapsTo": "setFlex(id, 'max_width', px) for numeric, 'NN%' for percent. Wave 2 css.2 \u2014 calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
+      "mapsTo": "setFlex(id, 'max_width', px) for numeric, 'NN%' for percent. Wave 2 css.2 — calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
       "supportedValues": [
         "px (number)",
         "%",
@@ -2173,12 +2173,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 calc() actually wired in the shim. 0 = no maximum (semantic differs from CSS where unspecified = none). min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
+      "notes": "Wave 2 css.2 — calc() actually wired in the shim. 0 = no maximum (semantic differs from CSS where unspecified = none). min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
       "issue": ""
     },
     "css/minHeight": {
       "status": "supported",
-      "mapsTo": "setFlex(id, 'min_height', px) for numeric, 'NN%' for percent. Wave 2 css.2 \u2014 calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
+      "mapsTo": "setFlex(id, 'min_height', px) for numeric, 'NN%' for percent. Wave 2 css.2 — calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
       "supportedValues": [
         "px (number)",
         "%",
@@ -2189,12 +2189,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 calc() actually wired in the shim. min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
+      "notes": "Wave 2 css.2 — calc() actually wired in the shim. min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
       "issue": ""
     },
     "css/minWidth": {
       "status": "supported",
-      "mapsTo": "setFlex(id, 'min_width', px) for numeric, 'NN%' for percent. Wave 2 css.2 \u2014 calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
+      "mapsTo": "setFlex(id, 'min_width', px) for numeric, 'NN%' for percent. Wave 2 css.2 — calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
       "supportedValues": [
         "px (number)",
         "%",
@@ -2205,7 +2205,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 calc() actually wired in the shim. min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
+      "notes": "Wave 2 css.2 — calc() actually wired in the shim. min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
       "issue": ""
     },
     "css/mixBlendMode": {
@@ -2228,14 +2228,14 @@
         "saturation",
         "color",
         "luminosity",
-        "plus-lighter (additive \u2014 SkBlendMode::kPlus)",
-        "plus-darker (additive \u2014 SkBlendMode::kPlus)"
+        "plus-lighter (additive — SkBlendMode::kPlus)",
+        "plus-darker (additive — SkBlendMode::kPlus)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp::WidgetBridge setMixBlendMode keyword -> BlendMode mapping (issue-1549) [wave2-css]"
       ],
-      "notes": "Wave 2 css.9 \u2014 plus-lighter/plus-darker now map to BlendMode::lighter (Skia's SkBlendMode::kPlus). plus-darker is technically a multiplicative variant in the W3C draft but Skia/Chromium ship the additive kPlus for both; mirroring that is the closest match without a custom SkBlender. pulp #1434 A4 Bundle 6: original wiring (16 W3C modes).",
+      "notes": "Wave 2 css.9 — plus-lighter/plus-darker now map to BlendMode::lighter (Skia's SkBlendMode::kPlus). plus-darker is technically a multiplicative variant in the W3C draft but Skia/Chromium ship the additive kPlus for both; mirroring that is the closest match without a custom SkBlender. pulp #1434 A4 Bundle 6: original wiring (16 W3C modes).",
       "issue": ""
     },
     "css/opacity": {
@@ -2247,7 +2247,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "parseFloat strips the % suffix silently. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 percentage strings are accepted at the JS layer (parsed as 0..1 from 'NN%') \u2014 the JS shim normalizes percent to numeric before calling setOpacity. The bridge slot is numeric only (arch-numeric-only-bridge); authors who pass numeric strings or numbers hit the same setOpacity path today.",
+      "notes": "parseFloat strips the % suffix silently. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — percentage strings are accepted at the JS layer (parsed as 0..1 from 'NN%') — the JS shim normalizes percent to numeric before calling setOpacity. The bridge slot is numeric only (arch-numeric-only-bridge); authors who pass numeric strings or numbers hit the same setOpacity path today.",
       "issue": ""
     },
     "css/order": {
@@ -2266,17 +2266,17 @@
       "mapsTo": "web-compat shorthand parser fans out to setOutlineWidth + setOutlineStyle + setOutlineColor (web-compat-style-decl.js:851 since pulp #1519).",
       "supportedValues": [
         "<width> <style> <color> shorthand",
-        "thin/medium/thick keyword for width (parses; currently falls through to numeric \u2014 keyword expansion deferred)",
+        "thin/medium/thick keyword for width (parses; currently falls through to numeric — keyword expansion deferred)",
         "double/groove/ridge/inset/outset (accepted; rendered as solid per arch-solid-only-pen)"
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1519 \u2014 outline cluster now bridge-backed. Shorthand parses `<width>px <style> <color>` and dispatches to the per-attribute setters. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 outline-style values double/groove/ridge/inset/outset are arch-solid-only-pen (mirrors border-style \u2014 paint pipeline draws a single solid pen by design; outline-width thin/medium/thick are author-named widths and currently fall through to the numeric path \u2014 adding the keyword expansion is queued behind border parity but parses without crashing today).",
+      "notes": "pulp #1519 — outline cluster now bridge-backed. Shorthand parses `<width>px <style> <color>` and dispatches to the per-attribute setters. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — outline-style values double/groove/ridge/inset/outset are arch-solid-only-pen (mirrors border-style — paint pipeline draws a single solid pen by design; outline-width thin/medium/thick are author-named widths and currently fall through to the numeric path — adding the keyword expansion is queued behind border parity but parses without crashing today).",
       "issue": ""
     },
     "css/outlineColor": {
       "status": "supported",
-      "mapsTo": "setOutlineColor(id, color) \u2014 registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js:864 routes through it.",
+      "mapsTo": "setOutlineColor(id, color) — registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js:864 routes through it.",
       "supportedValues": [
         "#hex",
         "#rgba",
@@ -2287,24 +2287,24 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1519 \u2014 outline color now writes to View::outline_color_; Skia paint strokes the inflated rect with this color. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 currentColor keyword is arch-no-cascade-color (the JS shim has no ancestor color resolver; authors pass explicit colors per css/borderColor / css/color precedent \u2014 currentColor parses but resolves to the bridge default).",
+      "notes": "pulp #1519 — outline color now writes to View::outline_color_; Skia paint strokes the inflated rect with this color. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — currentColor keyword is arch-no-cascade-color (the JS shim has no ancestor color resolver; authors pass explicit colors per css/borderColor / css/color precedent — currentColor parses but resolves to the bridge default).",
       "issue": ""
     },
     "css/outlineOffset": {
       "status": "supported",
-      "mapsTo": "setOutlineOffset(id, px) \u2014 registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js routes through it.",
+      "mapsTo": "setOutlineOffset(id, px) — registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js routes through it.",
       "supportedValues": [
         "<length>px",
         "em/rem/% (resolved to px at the JS layer; falls back to the default 14px font-size for em/rem)"
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1519 \u2014 gap between border-box edge and outline. Skia inflates the stroke rect by (offset + width/2). Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 em/rem/% units are arch-paint-px-only (outline is paint-only; the bridge resolves length at the JS boundary and forwards a numeric px to setOutlineOffset \u2014 em/rem/% would require a paint-time resolver hook). Authors precompute at the JS layer.",
+      "notes": "pulp #1519 — gap between border-box edge and outline. Skia inflates the stroke rect by (offset + width/2). Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — em/rem/% units are arch-paint-px-only (outline is paint-only; the bridge resolves length at the JS boundary and forwards a numeric px to setOutlineOffset — em/rem/% would require a paint-time resolver hook). Authors precompute at the JS layer.",
       "issue": ""
     },
     "css/outlineStyle": {
       "status": "supported",
-      "mapsTo": "setOutlineStyle(id, keyword) \u2014 registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js routes through it; keyword set mirrors borderStyle.",
+      "mapsTo": "setOutlineStyle(id, keyword) — registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js routes through it; keyword set mirrors borderStyle.",
       "supportedValues": [
         "solid",
         "dashed",
@@ -2319,19 +2319,19 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1519 \u2014 line-style enum reused from View::BorderStyle (CSS spec is identical). Skia installs SkDashPathEffect for dashed/dotted at outline-stroke time. Other named styles currently degrade to solid (paint-side gap, same as borderStyle).",
+      "notes": "pulp #1519 — line-style enum reused from View::BorderStyle (CSS spec is identical). Skia installs SkDashPathEffect for dashed/dotted at outline-stroke time. Other named styles currently degrade to solid (paint-side gap, same as borderStyle).",
       "issue": ""
     },
     "css/outlineWidth": {
       "status": "supported",
-      "mapsTo": "setOutlineWidth(id, px) \u2014 registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js:859 routes through it.",
+      "mapsTo": "setOutlineWidth(id, px) — registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js:859 routes through it.",
       "supportedValues": [
         "<length>px",
         "thin/medium/thick (parses; rendered as the numeric default per arch-numeric-only)"
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1519 \u2014 outline stroke thickness. width<=0 short-circuits the paint. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 thin/medium/thick keyword forms are arch-numeric-only (the bridge slot is numeric px; the JS shim does not yet expand the keyword set \u2014 authors pass numeric px today, mirrors border-width).",
+      "notes": "pulp #1519 — outline stroke thickness. width<=0 short-circuits the paint. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — thin/medium/thick keyword forms are arch-numeric-only (the bridge slot is numeric px; the JS shim does not yet expand the keyword set — authors pass numeric px today, mirrors border-width).",
       "issue": ""
     },
     "css/overflow": {
@@ -2346,7 +2346,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "View::Overflow enum has only {visible, hidden}. Scroll requires using the ScrollView intrinsic. Wave 4 css extensive \u2014 scroll / auto / clip are arch-scroll-via-scrollview (View::Overflow has only {visible, hidden}; the JS shim parses the keyword without crash and the bridge clamps to the closest behaviour \u2014 `scroll` / `auto` / `overlay` are routed to `hidden` clip, matching the no-scroll-context default). Authors who need true scrolling use the dedicated ScrollView intrinsic, mirrors React Native's split. Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
+      "notes": "View::Overflow enum has only {visible, hidden}. Scroll requires using the ScrollView intrinsic. Wave 4 css extensive — scroll / auto / clip are arch-scroll-via-scrollview (View::Overflow has only {visible, hidden}; the JS shim parses the keyword without crash and the bridge clamps to the closest behaviour — `scroll` / `auto` / `overlay` are routed to `hidden` clip, matching the no-scroll-context default). Authors who need true scrolling use the dedicated ScrollView intrinsic, mirrors React Native's split. Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
       "issue": ""
     },
     "css/overflowWrap": {
@@ -2369,14 +2369,14 @@
         "visible",
         "hidden",
         "per-axis clipping (axis-tied per arch-axis-tied-overflow)",
-        "scroll (arch-scroll-via-scrollview \u2014 use ScrollView)",
-        "auto (arch-scroll-via-scrollview \u2014 use ScrollView)",
-        "clip (arch-scroll-via-scrollview \u2014 clipped at View::overflow_=hidden)",
-        "overlay (arch-scroll-via-scrollview \u2014 use ScrollView)"
+        "scroll (arch-scroll-via-scrollview — use ScrollView)",
+        "auto (arch-scroll-via-scrollview — use ScrollView)",
+        "clip (arch-scroll-via-scrollview — clipped at View::overflow_=hidden)",
+        "overlay (arch-scroll-via-scrollview — use ScrollView)"
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 4: status flipped missing \u2192 partial. Pulp's View::Overflow enum doesn't model per-axis clipping; CSS overflow-x routes to the same single-axis setter as `overflow`. Wave 4 css extensive \u2014 per-axis clipping is arch-axis-tied-overflow (View::overflow_ is a single enum; both axes clip together \u2014 authors who need true per-axis behaviour use the ScrollView intrinsic). scroll/auto/clip/overlay are arch-scroll-via-scrollview (the CSS surface only models visible/hidden \u2014 scrollable containers go through the dedicated ScrollView widget, mirrors React Native's split).",
+      "notes": "pulp #1434 A4 Bundle 4: status flipped missing → partial. Pulp's View::Overflow enum doesn't model per-axis clipping; CSS overflow-x routes to the same single-axis setter as `overflow`. Wave 4 css extensive — per-axis clipping is arch-axis-tied-overflow (View::overflow_ is a single enum; both axes clip together — authors who need true per-axis behaviour use the ScrollView intrinsic). scroll/auto/clip/overlay are arch-scroll-via-scrollview (the CSS surface only models visible/hidden — scrollable containers go through the dedicated ScrollView widget, mirrors React Native's split).",
       "issue": ""
     },
     "css/overflowY": {
@@ -2386,14 +2386,14 @@
         "visible",
         "hidden",
         "per-axis clipping (axis-tied per arch-axis-tied-overflow)",
-        "scroll (arch-scroll-via-scrollview \u2014 use ScrollView)",
-        "auto (arch-scroll-via-scrollview \u2014 use ScrollView)",
-        "clip (arch-scroll-via-scrollview \u2014 clipped at View::overflow_=hidden)",
-        "overlay (arch-scroll-via-scrollview \u2014 use ScrollView)"
+        "scroll (arch-scroll-via-scrollview — use ScrollView)",
+        "auto (arch-scroll-via-scrollview — use ScrollView)",
+        "clip (arch-scroll-via-scrollview — clipped at View::overflow_=hidden)",
+        "overlay (arch-scroll-via-scrollview — use ScrollView)"
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 4: status flipped missing \u2192 partial. See overflowX note. Wave 4 css extensive \u2014 per-axis clipping is arch-axis-tied-overflow (View::overflow_ is a single enum; both axes clip together \u2014 authors who need true per-axis behaviour use the ScrollView intrinsic). scroll/auto/clip/overlay are arch-scroll-via-scrollview (the CSS surface only models visible/hidden \u2014 scrollable containers go through the dedicated ScrollView widget, mirrors React Native's split).",
+      "notes": "pulp #1434 A4 Bundle 4: status flipped missing → partial. See overflowX note. Wave 4 css extensive — per-axis clipping is arch-axis-tied-overflow (View::overflow_ is a single enum; both axes clip together — authors who need true per-axis behaviour use the ScrollView intrinsic). scroll/auto/clip/overlay are arch-scroll-via-scrollview (the CSS surface only models visible/hidden — scrollable containers go through the dedicated ScrollView widget, mirrors React Native's split).",
       "issue": ""
     },
     "css/overscrollBehavior": {
@@ -2416,7 +2416,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 % now honored in the shorthand (parity with the per-edge longhands). auto is intentionally dropped because Yoga padding doesn't support it. Wave 4 css extensive \u2014 auto is arch-yoga-no-padding-auto (Yoga's padding API is scalar / percent only; the spec-asymmetric margin-auto behavior doesn't apply to padding). Cleared from unsupportedValues \u2014 the spec-equivalent default is 0.",
+      "notes": "Wave 2 css.2 — % now honored in the shorthand (parity with the per-edge longhands). auto is intentionally dropped because Yoga padding doesn't support it. Wave 4 css extensive — auto is arch-yoga-no-padding-auto (Yoga's padding API is scalar / percent only; the spec-asymmetric margin-auto behavior doesn't apply to padding). Cleared from unsupportedValues — the spec-equivalent default is 0.",
       "issue": ""
     },
     "css/paddingBlock": {
@@ -2432,7 +2432,7 @@
     },
     "css/paddingBlockEnd": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js maps `padding-block-end` \u2192 setFlex(padding_bottom) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js maps `padding-block-end` → setFlex(padding_bottom) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges — direction-aware mapping is the follow-up.",
       "supportedValues": [
         "<length>",
         "<percentage>",
@@ -2440,12 +2440,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing → partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/paddingBlockStart": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js maps `padding-block-start` \u2192 setFlex(padding_top) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js maps `padding-block-start` → setFlex(padding_top) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges — direction-aware mapping is the follow-up.",
       "supportedValues": [
         "<length>",
         "<percentage>",
@@ -2453,7 +2453,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing → partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/paddingBottom": {
@@ -2467,7 +2467,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
+      "notes": "pulp #1434 cross-surface mega-batch — accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
       "issue": ""
     },
     "css/paddingHorizontal": {
@@ -2481,7 +2481,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "css/paddingInline": {
@@ -2497,7 +2497,7 @@
     },
     "css/paddingInlineEnd": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js maps `padding-inline-end` \u2192 setFlex(padding_right) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js maps `padding-inline-end` → setFlex(padding_right) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges — direction-aware mapping is the follow-up.",
       "supportedValues": [
         "<length>",
         "<percentage>",
@@ -2505,12 +2505,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing → partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/paddingInlineStart": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js maps `padding-inline-start` \u2192 setFlex(padding_left) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js maps `padding-inline-start` → setFlex(padding_left) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges — direction-aware mapping is the follow-up.",
       "supportedValues": [
         "<length>",
         "<percentage>",
@@ -2518,7 +2518,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing → partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/paddingLeft": {
@@ -2532,7 +2532,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
+      "notes": "pulp #1434 cross-surface mega-batch — accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
       "issue": ""
     },
     "css/paddingRight": {
@@ -2546,7 +2546,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
+      "notes": "pulp #1434 cross-surface mega-batch — accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
       "issue": ""
     },
     "css/paddingTop": {
@@ -2560,7 +2560,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
+      "notes": "pulp #1434 cross-surface mega-batch — accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
       "issue": ""
     },
     "css/paddingVertical": {
@@ -2574,7 +2574,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "css/pageBreakAfter": {
@@ -2601,13 +2601,13 @@
     },
     "css/perspective": {
       "status": "noop",
-      "mapsTo": "web-compat-style-decl.js has a `case \"perspective\":` that intentionally no-ops (Pulp's render pipeline is 2D \u2014 no perspective matrix slot on View).",
+      "mapsTo": "web-compat-style-decl.js has a `case \"perspective\":` that intentionally no-ops (Pulp's render pipeline is 2D — no perspective matrix slot on View).",
       "supportedValues": [],
       "unsupportedValues": [
         "all 3D perspective values (Pulp pipeline is 2D)"
       ],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 4: status flipped missing \u2192 noop. Architecturally out of scope \u2014 Pulp uses a 2D Skia/Canvas pipeline; perspective() / matrix3d() / rotate3d would need a 3D transform stack which is not modeled.",
+      "notes": "pulp #1434 A4 Bundle 4: status flipped missing → noop. Architecturally out of scope — Pulp uses a 2D Skia/Canvas pipeline; perspective() / matrix3d() / rotate3d would need a 3D transform stack which is not modeled.",
       "issue": ""
     },
     "css/perspectiveOrigin": {
@@ -2618,7 +2618,7 @@
         "all values (Pulp pipeline is 2D)"
       ],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 4: status flipped missing \u2192 noop. See css/perspective note.",
+      "notes": "pulp #1434 A4 Bundle 4: status flipped missing → noop. See css/perspective note.",
       "issue": ""
     },
     "css/placeContent": {
@@ -2629,7 +2629,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "align_content half is silently dropped (see css/alignContent). Wave 4 css extensive \u2014 shorthand parser fans out to setFlex 'align_content' + 'justify_content' (the only two CSS-spec axes that survive in pulp's flex-only layout). Removed the residual 'all' marker \u2014 not a CSS-spec value.",
+      "notes": "align_content half is silently dropped (see css/alignContent). Wave 4 css extensive — shorthand parser fans out to setFlex 'align_content' + 'justify_content' (the only two CSS-spec axes that survive in pulp's flex-only layout). Removed the residual 'all' marker — not a CSS-spec value.",
       "issue": ""
     },
     "css/placeItems": {
@@ -2640,7 +2640,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Misnamed -- second token is mapped to justify_content rather than justify_items (which Yoga doesn't support). Wave 1 drift cleanup \u2014 partial \u2192 supported (non-enum, wired through web-compat-style-decl.js with no unsupported values listed).",
+      "notes": "Misnamed -- second token is mapped to justify_content rather than justify_items (which Yoga doesn't support). Wave 1 drift cleanup — partial → supported (non-enum, wired through web-compat-style-decl.js with no unsupported values listed).",
       "issue": ""
     },
     "css/pointerEvents": {
@@ -2659,7 +2659,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 Triage #13 \u2014 catalog trim. CSS spec lists SVG-specific values (visible-painted / visible-fill / visible-stroke / painted / fill / stroke); pulp doesn't render SVG via the renderer surface (SVG is layout-leaf via SvgPath widgets), so those values would be no-ops. Trimmed from the catalog. Wave 4 css extensive \u2014 all / visible / visible-painted / visible-fill / visible-stroke are arch-non-svg-renderer (CSS spec defines these for SVG painted regions; pulp doesn't render SVG via the renderer surface \u2014 SVG paths go through the SvgPath layout-leaf widget). The bridge maps unknown keywords to View::PointerEvents::auto.",
+      "notes": "pulp #1434 Triage #13 — catalog trim. CSS spec lists SVG-specific values (visible-painted / visible-fill / visible-stroke / painted / fill / stroke); pulp doesn't render SVG via the renderer surface (SVG is layout-leaf via SvgPath widgets), so those values would be no-ops. Trimmed from the catalog. Wave 4 css extensive — all / visible / visible-painted / visible-fill / visible-stroke are arch-non-svg-renderer (CSS spec defines these for SVG painted regions; pulp doesn't render SVG via the renderer surface — SVG paths go through the SvgPath layout-leaf widget). The bridge maps unknown keywords to View::PointerEvents::auto.",
       "issue": ""
     },
     "css/position": {
@@ -2711,12 +2711,12 @@
         "inline"
       ],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 7: status flipped missing \u2192 noop. Resize handles require a CSS-resize-handle paint primitive that Pulp doesn't model.",
+      "notes": "pulp #1434 A4 Bundle 7: status flipped missing → noop. Resize handles require a CSS-resize-handle paint primitive that Pulp doesn't model.",
       "issue": ""
     },
     "css/right": {
       "status": "supported",
-      "mapsTo": "setRight(id, px); JS shim resolves em/rem (\u00d7 14px default), vh/vw (\u00d7 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
+      "mapsTo": "setRight(id, px); JS shim resolves em/rem (× 14px default), vh/vw (× 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
       "supportedValues": [
         "px",
         "%",
@@ -2727,63 +2727,63 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
+      "notes": "Wave 2 css.2 — em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "css/rowGap": {
       "status": "supported",
-      "mapsTo": "setFlex(id, 'row_gap', px) for numeric, 'NN%' string for percent (best-effort: stored on the scalar FlexStyle.row_gap slot since Yoga has no YGNodeStyleSetGapPercent API yet \u2014 treated as px until upstream Yoga ships percent-aware gap).",
+      "mapsTo": "setFlex(id, 'row_gap', px) for numeric, 'NN%' string for percent (best-effort: stored on the scalar FlexStyle.row_gap slot since Yoga has no YGNodeStyleSetGapPercent API yet — treated as px until upstream Yoga ships percent-aware gap).",
       "supportedValues": [
         "px",
         "% (best-effort scalar)"
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 % accepted at the JS+bridge layer; honest stored-as-scalar caveat documented above. Status stays partial because Yoga doesn't yet honor percent gaps (px-equivalent only). Wave 4 css extensive \u2014 % is best-effort (stored on the scalar slot, treated as px-equivalent) until upstream Yoga ships YGNodeStyleSetGapPercent \u2014 tracked as deferred-yoga-percent-gap. Status flipped partial -> supported because every CSS-spec value (px / %) round-trips through the bridge today; the % honoring is the orthogonal Yoga upstream follow-up.",
+      "notes": "Wave 2 css.2 — % accepted at the JS+bridge layer; honest stored-as-scalar caveat documented above. Status stays partial because Yoga doesn't yet honor percent gaps (px-equivalent only). Wave 4 css extensive — % is best-effort (stored on the scalar slot, treated as px-equivalent) until upstream Yoga ships YGNodeStyleSetGapPercent — tracked as deferred-yoga-percent-gap. Status flipped partial -> supported because every CSS-spec value (px / %) round-trips through the bridge today; the % honoring is the orthogonal Yoga upstream follow-up.",
       "issue": ""
     },
     "css/scrollBehavior": {
       "status": "noop",
-      "mapsTo": "web-compat-style-decl.js has a `case \"scrollBehavior\":` that intentionally no-ops. Pulp doesn't model CSS scroll viewports \u2014 the ScrollView intrinsic owns scroll state; CSS-driven scroll properties have no surface to bind.",
+      "mapsTo": "web-compat-style-decl.js has a `case \"scrollBehavior\":` that intentionally no-ops. Pulp doesn't model CSS scroll viewports — the ScrollView intrinsic owns scroll state; CSS-driven scroll properties have no surface to bind.",
       "supportedValues": [],
       "unsupportedValues": [
         "all values (no CSS scroll-viewport model in Pulp)"
       ],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 5: status flipped missing \u2192 noop. scroll-behavior (smooth / instant) requires a CSS scroll-container model that Pulp does not implement.",
+      "notes": "pulp #1434 A4 Bundle 5: status flipped missing → noop. scroll-behavior (smooth / instant) requires a CSS scroll-container model that Pulp does not implement.",
       "issue": ""
     },
     "css/scrollMargin": {
       "status": "noop",
-      "mapsTo": "web-compat-style-decl.js has a `case \"scrollMargin\":` that intentionally no-ops. Pulp doesn't model CSS scroll viewports \u2014 the ScrollView intrinsic owns scroll state; CSS-driven scroll properties have no surface to bind.",
+      "mapsTo": "web-compat-style-decl.js has a `case \"scrollMargin\":` that intentionally no-ops. Pulp doesn't model CSS scroll viewports — the ScrollView intrinsic owns scroll state; CSS-driven scroll properties have no surface to bind.",
       "supportedValues": [],
       "unsupportedValues": [
         "all values (no CSS scroll-viewport model in Pulp)"
       ],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 5: status flipped missing \u2192 noop. scroll-margin (positions scroll snap target) requires a CSS scroll-container model that Pulp does not implement.",
+      "notes": "pulp #1434 A4 Bundle 5: status flipped missing → noop. scroll-margin (positions scroll snap target) requires a CSS scroll-container model that Pulp does not implement.",
       "issue": ""
     },
     "css/scrollPadding": {
       "status": "noop",
-      "mapsTo": "web-compat-style-decl.js has a `case \"scrollPadding\":` that intentionally no-ops. Pulp doesn't model CSS scroll viewports \u2014 the ScrollView intrinsic owns scroll state; CSS-driven scroll properties have no surface to bind.",
+      "mapsTo": "web-compat-style-decl.js has a `case \"scrollPadding\":` that intentionally no-ops. Pulp doesn't model CSS scroll viewports — the ScrollView intrinsic owns scroll state; CSS-driven scroll properties have no surface to bind.",
       "supportedValues": [],
       "unsupportedValues": [
         "all values (no CSS scroll-viewport model in Pulp)"
       ],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 5: status flipped missing \u2192 noop. scroll-padding (snap-area inset) requires a CSS scroll-container model that Pulp does not implement.",
+      "notes": "pulp #1434 A4 Bundle 5: status flipped missing → noop. scroll-padding (snap-area inset) requires a CSS scroll-container model that Pulp does not implement.",
       "issue": ""
     },
     "css/scrollSnapType": {
       "status": "noop",
-      "mapsTo": "web-compat-style-decl.js has a `case \"scrollSnapType\":` that intentionally no-ops. Pulp doesn't model CSS scroll viewports \u2014 the ScrollView intrinsic owns scroll state; CSS-driven scroll properties have no surface to bind.",
+      "mapsTo": "web-compat-style-decl.js has a `case \"scrollSnapType\":` that intentionally no-ops. Pulp doesn't model CSS scroll viewports — the ScrollView intrinsic owns scroll state; CSS-driven scroll properties have no surface to bind.",
       "supportedValues": [],
       "unsupportedValues": [
         "all values (no CSS scroll-viewport model in Pulp)"
       ],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 5: status flipped missing \u2192 noop. scroll-snap-type (axis + strictness) requires a CSS scroll-container model that Pulp does not implement.",
+      "notes": "pulp #1434 A4 Bundle 5: status flipped missing → noop. scroll-snap-type (axis + strictness) requires a CSS scroll-container model that Pulp does not implement.",
       "issue": ""
     },
     "css/tableLayout": {
@@ -2828,7 +2828,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Single-keyword only. Cannot express 'underline dashed red'. Wave 4 css extensive \u2014 blink is arch-deprecated (CSS Text Decoration L3 explicitly deprecates the keyword; modern browsers no-op it for accessibility). The bridge accepts the keyword and applies no decoration \u2014 matches the spec deprecation path.",
+      "notes": "Single-keyword only. Cannot express 'underline dashed red'. Wave 4 css extensive — blink is arch-deprecated (CSS Text Decoration L3 explicitly deprecates the keyword; modern browsers no-op it for accessibility). The bridge accepts the keyword and applies no decoration — matches the spec deprecation path.",
       "issue": ""
     },
     "css/textDecorationColor": {
@@ -2888,7 +2888,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 5: status flipped missing \u2192 partial. Storage-only with a dedicated bridge fn. Wave 4 css extensive \u2014 <percentage> / each-line / hanging are arch-paint-deferred (SkParagraph::setTextIndent integration at paint time is queued \u2014 the bridge stores the keyword + length on View::text_indent_ today and the paint path applies the stored value as a leading inset, so arbitrary first-line / each-line semantics are pending). Authors can express the leading inset today; per-line dispatch is the follow-up.",
+      "notes": "pulp #1434 A4 Bundle 5: status flipped missing → partial. Storage-only with a dedicated bridge fn. Wave 4 css extensive — <percentage> / each-line / hanging are arch-paint-deferred (SkParagraph::setTextIndent integration at paint time is queued — the bridge stores the keyword + length on View::text_indent_ today and the paint path applies the stored value as a leading inset, so arbitrary first-line / each-line semantics are pending). Authors can express the leading inset today; per-line dispatch is the follow-up.",
       "issue": ""
     },
     "css/textOverflow": {
@@ -2901,18 +2901,18 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 string custom token is accepted at the bridge \u2014 setTextOverflow stores the string verbatim; paint-time application of an arbitrary truncation string (in place of the ellipsis glyph) is queued behind SkParagraph support. The bridge round-trip is complete.",
+      "notes": "Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — string custom token is accepted at the bridge — setTextOverflow stores the string verbatim; paint-time application of an arbitrary truncation string (in place of the ellipsis glyph) is queued behind SkParagraph support. The bridge round-trip is complete.",
       "issue": ""
     },
     "css/textShadow": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js:1356 parses `<dx>px <dy>px <blur>px <color>` and calls setTextShadow(id, dx, dy, blur, color); bridge function is registered (widget_bridge.cpp Wave 5 css.5) and routes into the existing per-attribute slots (text_shadow_offset / text_shadow_radius / text_shadow_color) \u2014 same slots the React-style setTextShadow{Color,Offset,Radius} fan-out uses.",
+      "mapsTo": "web-compat-style-decl.js:1356 parses `<dx>px <dy>px <blur>px <color>` and calls setTextShadow(id, dx, dy, blur, color); bridge function is registered (widget_bridge.cpp Wave 5 css.5) and routes into the existing per-attribute slots (text_shadow_offset / text_shadow_radius / text_shadow_color) — same slots the React-style setTextShadow{Color,Offset,Radius} fan-out uses.",
       "supportedValues": [
         "[inset] <dx>px <dy>px <blur>px [<spread>px] <color> (parsed at the JS shim; bridge fn registration deferred to paint-time)"
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 5 css.5 \u2014 registered the previously-missing setTextShadow bridge fn so the JS shim no longer no-ops. Composes into the existing 3 per-attribute slots that already round-trip through bridge (color / offset / radius). Catalog stays `supported`: the round-trip is honest. Multi-shadow comma-separated lists are arch-single-shadow (Pulp's text-shadow model is one SkPaint::Looper per Label, matching box-shadow's single-shadow architecture). Inset is parsed but is invalid for text-shadow per CSS L3 (text-shadow has no inset variant) \u2014 the JS shim accepts it for shorthand parity but the bridge ignores.",
+      "notes": "Wave 5 css.5 — registered the previously-missing setTextShadow bridge fn so the JS shim no longer no-ops. Composes into the existing 3 per-attribute slots that already round-trip through bridge (color / offset / radius). Catalog stays `supported`: the round-trip is honest. Multi-shadow comma-separated lists are arch-single-shadow (Pulp's text-shadow model is one SkPaint::Looper per Label, matching box-shadow's single-shadow architecture). Inset is parsed but is invalid for text-shadow per CSS L3 (text-shadow has no inset variant) — the JS shim accepts it for shorthand parity but the bridge ignores.",
       "issue": ""
     },
     "css/textTransform": {
@@ -2934,7 +2934,7 @@
     },
     "css/top": {
       "status": "supported",
-      "mapsTo": "setTop(id, px); JS shim resolves em/rem (\u00d7 14px default), vh/vw (\u00d7 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
+      "mapsTo": "setTop(id, px); JS shim resolves em/rem (× 14px default), vh/vw (× 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
       "supportedValues": [
         "px",
         "%",
@@ -2945,7 +2945,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.2 \u2014 em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
+      "notes": "Wave 2 css.2 — em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "css/touchAction": {
@@ -2963,7 +2963,7 @@
     },
     "css/transform": {
       "status": "supported",
-      "mapsTo": "parseTransform (css-parser.js) walks the function set; web-compat-style-decl.js dispatches via setTranslate / setRotation / setScale / setSkew. Walk-once accumulator merges axes (e.g. translateX(10) translateY(20) \u2192 ONE setTranslate(10,20)).",
+      "mapsTo": "parseTransform (css-parser.js) walks the function set; web-compat-style-decl.js dispatches via setTranslate / setRotation / setScale / setSkew. Walk-once accumulator merges axes (e.g. translateX(10) translateY(20) → ONE setTranslate(10,20)).",
       "supportedValues": [
         "translate(x,y)",
         "translateX(x)",
@@ -2976,7 +2976,7 @@
         "scaleY(n)",
         "skewX(deg)",
         "skewY(deg)",
-        "matrix(a,b,c,d,tx,ty) \u2014 decomposed to translate+scale+rotate",
+        "matrix(a,b,c,d,tx,ty) — decomposed to translate+scale+rotate",
         "angle units: deg / rad / turn / grad"
       ],
       "unsupportedValues": [],
@@ -2984,7 +2984,7 @@
         "test/web-compat/test_web_compat_prelude.cpp::\"WebCompat: parseTransform recognizes scaleX\"",
         "test/web-compat/test_web_compat_prelude.cpp::\"WebCompat: setSkew bridge fn registered\""
       ],
-      "notes": "pulp #1434 Triage #9 fan-out \u2014 full CSS transform-function set wired via parseTransform walk-once accumulator. setSkew bridge fn registered; scaleX/scaleY share uniform setScale slot (last-write-wins; bridge gap); matrix() decomposed to translate+scale+rotate. rotateX / rotateY / matrix3d / perspective silently drop (pulp's 2D View has no 3D model). Deferred: rotateX/rotateY/matrix3d/perspective (no 3D model on View \u2014 pulp follow-up).",
+      "notes": "pulp #1434 Triage #9 fan-out — full CSS transform-function set wired via parseTransform walk-once accumulator. setSkew bridge fn registered; scaleX/scaleY share uniform setScale slot (last-write-wins; bridge gap); matrix() decomposed to translate+scale+rotate. rotateX / rotateY / matrix3d / perspective silently drop (pulp's 2D View has no 3D model). Deferred: rotateX/rotateY/matrix3d/perspective (no 3D model on View — pulp follow-up).",
       "issue": ""
     },
     "css/transformOrigin": {
@@ -3003,7 +3003,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Px values are mishandled -- only % and keywords resolve correctly. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 px is supported via the parseCSSLength path (numeric forwards as scalar to setTransformOrigin). third value (z-axis) is arch-2d-only \u2014 pulp's transform pipeline is 2D (Skia matrix is 2D); 3D transforms render in the layer's 2D projection per arch-2d-only.",
+      "notes": "Px values are mishandled -- only % and keywords resolve correctly. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — px is supported via the parseCSSLength path (numeric forwards as scalar to setTransformOrigin). third value (z-axis) is arch-2d-only — pulp's transform pipeline is 2D (Skia matrix is 2D); 3D transforms render in the layer's 2D projection per arch-2d-only.",
       "issue": ""
     },
     "css/transition": {
@@ -3024,7 +3024,7 @@
         "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
         "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\""
       ],
-      "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
+      "notes": "pulp #1434 Phase A2-1 — transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
       "issue": "1323"
     },
     "css/transitionDelay": {
@@ -3045,7 +3045,7 @@
         "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
         "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\""
       ],
-      "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
+      "notes": "pulp #1434 Phase A2-1 — transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
       "issue": ""
     },
     "css/transitionDuration": {
@@ -3066,7 +3066,7 @@
         "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
         "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\""
       ],
-      "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
+      "notes": "pulp #1434 Phase A2-1 — transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
       "issue": ""
     },
     "css/transitionProperty": {
@@ -3087,7 +3087,7 @@
         "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
         "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\""
       ],
-      "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
+      "notes": "pulp #1434 Phase A2-1 — transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
       "issue": ""
     },
     "css/transitionTimingFunction": {
@@ -3108,7 +3108,7 @@
         "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
         "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\""
       ],
-      "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
+      "notes": "pulp #1434 Phase A2-1 — transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
       "issue": ""
     },
     "css/userSelect": {
@@ -3123,7 +3123,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 Triage #12 \u2014 catalog trim. CSS spec also lists `auto` and `contain`; pulp's bridge routes only none/text/all to View::UserSelect. Future bridge expansion can broaden this; for now the catalog is honest about what's wired. Wave 4 css extensive \u2014 auto / contain are arch-default-mapped \u2014 the bridge resolves both to the spec-default (text) which matches the user-selectable behaviour any interactive widget exposes. Catalog claim is keyword-coverage complete.",
+      "notes": "pulp #1434 Triage #12 — catalog trim. CSS spec also lists `auto` and `contain`; pulp's bridge routes only none/text/all to View::UserSelect. Future bridge expansion can broaden this; for now the catalog is honest about what's wired. Wave 4 css extensive — auto / contain are arch-default-mapped — the bridge resolves both to the spec-default (text) which matches the user-selectable behaviour any interactive widget exposes. Catalog claim is keyword-coverage complete.",
       "issue": ""
     },
     "css/verticalAlign": {
@@ -3143,7 +3143,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 5: status flipped missing \u2192 partial. Routes to the existing TextVerticalAlign enum on Label. Wave 4 css extensive \u2014 sub / super / text-top / text-bottom / <length> / <percentage> are arch-paint-deferred \u2014 the bridge stores the keyword on View::vertical_align_ and the paint pipeline today applies the four canonical canvas::TextBaseline values (top / middle / bottom / baseline); the extended set is queued behind SkParagraph baseline shift integration. Round-trip is complete.",
+      "notes": "pulp #1434 A4 Bundle 5: status flipped missing → partial. Routes to the existing TextVerticalAlign enum on Label. Wave 4 css extensive — sub / super / text-top / text-bottom / <length> / <percentage> are arch-paint-deferred — the bridge stores the keyword on View::vertical_align_ and the paint pipeline today applies the four canonical canvas::TextBaseline values (top / middle / bottom / baseline); the extended set is queued behind SkParagraph baseline shift integration. Round-trip is complete.",
       "issue": ""
     },
     "css/visibility": {
@@ -3156,12 +3156,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "setVisibility IS registered (widget_bridge.cpp:1814) so the primary path works. Wave 4 css extensive \u2014 collapse is arch-table-only \u2014 the CSS spec explicitly defines it as equivalent to `hidden` outside of table-row / table-column contexts; pulp's flex-only layout is non-table by design (arch-flex-only) so the spec-equivalent collapse->hidden mapping is the spec-conformant rendering.",
+      "notes": "setVisibility IS registered (widget_bridge.cpp:1814) so the primary path works. Wave 4 css extensive — collapse is arch-table-only — the CSS spec explicitly defines it as equivalent to `hidden` outside of table-row / table-column contexts; pulp's flex-only layout is non-table by design (arch-flex-only) so the spec-equivalent collapse->hidden mapping is the spec-conformant rendering.",
       "issue": ""
     },
     "css/webkitLineClamp": {
       "status": "supported",
-      "mapsTo": "same as lineClamp \u2014 both keys funnel through setLineClamp(id, n)",
+      "mapsTo": "same as lineClamp — both keys funnel through setLineClamp(id, n)",
       "supportedValues": [
         "integer"
       ],
@@ -3188,7 +3188,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 2 css.4 \u2014 pre-line / break-spaces accepted at the JS+bridge layer (no longer dropped); spec-faithful HarfBuzz line-break feature wiring is the paint-time follow-up. Wave 4 css extensive \u2014 label cleanup \u2014 supportedValues now lists the bare keywords (each one round-trips through setWhiteSpace + the JS shim's nowrap/multi-line decision). Spec-faithful collapsing/breaking semantics still arrive via HarfBuzz line-break feature wiring (paint-time follow-up); the keyword coverage claim is complete.",
+      "notes": "Wave 2 css.4 — pre-line / break-spaces accepted at the JS+bridge layer (no longer dropped); spec-faithful HarfBuzz line-break feature wiring is the paint-time follow-up. Wave 4 css extensive — label cleanup — supportedValues now lists the bare keywords (each one round-trips through setWhiteSpace + the JS shim's nowrap/multi-line decision). Spec-faithful collapsing/breaking semantics still arrive via HarfBuzz line-break feature wiring (paint-time follow-up); the keyword coverage claim is complete.",
       "issue": ""
     },
     "css/width": {
@@ -3207,7 +3207,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1423 wired px + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end (CSS translator forwards 'auto' verbatim; bridge populates FlexStyle.dim_width.unit = auto_; yoga_layout.cpp dispatches to YGNodeStyleSetWidthAuto). Relative units (em/rem/calc) remain deferred. Wave 1 architectural reclassification \u2014 min-content / max-content / fit-content are arch-yoga-limit (Yoga doesn't compute content-sized boxes); em/rem/calc() are deferred (relative-unit resolver lands later \u2014 calc() shipped via #1576 for min/max sides only). Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 min-content / max-content / fit-content are arch-yoga-no-intrinsic-sizing (Yoga's flex layout doesn't model intrinsic sizing; use flex / flex-basis for the equivalent shrink-to-fit behaviour). calc() is arch-no-calc-eval (no expression evaluator at the JS shim layer; authors precompute or use JS variables). em/rem resolve against the default 14px font-size at the JS layer (single-level cascade per Wave 2 css.2 fontSize precedent).",
+      "notes": "pulp #1423 wired px + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end (CSS translator forwards 'auto' verbatim; bridge populates FlexStyle.dim_width.unit = auto_; yoga_layout.cpp dispatches to YGNodeStyleSetWidthAuto). Relative units (em/rem/calc) remain deferred. Wave 1 architectural reclassification — min-content / max-content / fit-content are arch-yoga-limit (Yoga doesn't compute content-sized boxes); em/rem/calc() are deferred (relative-unit resolver lands later — calc() shipped via #1576 for min/max sides only). Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — min-content / max-content / fit-content are arch-yoga-no-intrinsic-sizing (Yoga's flex layout doesn't model intrinsic sizing; use flex / flex-basis for the equivalent shrink-to-fit behaviour). calc() is arch-no-calc-eval (no expression evaluator at the JS shim layer; authors precompute or use JS variables). em/rem resolve against the default 14px font-size at the JS layer (single-level cascade per Wave 2 css.2 fontSize precedent).",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "css/willChange": {
@@ -3245,12 +3245,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 batch (catalog hygiene): status flipped missing -> partial. CSS translator at web-compat-style-decl.js:728-729 funnels `wordWrap`, `overflowWrap`, and `wordBreak` through the same setWordBreak case. Bridge function is not yet registered, so values are silently dropped at runtime. Legacy alias of overflow-wrap. Wave 4 css extensive \u2014 stale claim \u2014 break-word/normal/anywhere all reach setWordBreak via the same shared route as wordBreak/overflowWrap (web-compat-style-decl.js funnels three cases into the same call). The bridge fn IS registered (widget_bridge.cpp:4983); HarfBuzz line-break feature integration is the shared paint-side follow-up.",
+      "notes": "pulp #1434 batch (catalog hygiene): status flipped missing -> partial. CSS translator at web-compat-style-decl.js:728-729 funnels `wordWrap`, `overflowWrap`, and `wordBreak` through the same setWordBreak case. Bridge function is not yet registered, so values are silently dropped at runtime. Legacy alias of overflow-wrap. Wave 4 css extensive — stale claim — break-word/normal/anywhere all reach setWordBreak via the same shared route as wordBreak/overflowWrap (web-compat-style-decl.js funnels three cases into the same call). The bridge fn IS registered (widget_bridge.cpp:4983); HarfBuzz line-break feature integration is the shared paint-side follow-up.",
       "issue": ""
     },
     "css/writingMode": {
       "status": "noop",
-      "mapsTo": "web-compat-style-decl.js has a `case \"writingMode\":` that intentionally no-ops (Pulp text flows horizontally only \u2014 no vertical-rl / vertical-lr writing-mode pipeline).",
+      "mapsTo": "web-compat-style-decl.js has a `case \"writingMode\":` that intentionally no-ops (Pulp text flows horizontally only — no vertical-rl / vertical-lr writing-mode pipeline).",
       "supportedValues": [],
       "unsupportedValues": [
         "vertical-rl",
@@ -3259,7 +3259,7 @@
         "sideways-lr"
       ],
       "tests": [],
-      "notes": "pulp #1434 A4 Bundle 5: status flipped missing \u2192 noop. Architecturally out of scope \u2014 Pulp's text shaper is horizontal-tb only.",
+      "notes": "pulp #1434 A4 Bundle 5: status flipped missing → noop. Architecturally out of scope — Pulp's text shaper is horizontal-tb only.",
       "issue": ""
     },
     "css/zIndex": {
@@ -3271,7 +3271,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "'auto' parses as 0. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 `auto` parses as 0 at the JS layer (the integer slot is 0 by default; auto matches the layout-natural ordering). Round-trip is complete.",
+      "notes": "'auto' parses as 0. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — `auto` parses as 0 at the JS layer (the integer slot is 0 by default; auto matches the layout-natural ordering). Round-trip is complete.",
       "issue": ""
     }
   },
@@ -3341,7 +3341,7 @@
         "packages/pulp-react/test/prop-applier-aspect-ratio.test.ts",
         "test/web-compat/test_layout_aspect_ratio.cpp"
       ],
-      "notes": "pulp #1434 \u2014 JSX surface accepts numeric aspectRatio (RN parity per oracle 'kind: number'). String forms ('16/9', 'auto') reach FlexStyle through the CSS shim path (web-compat-style-decl.js), not the @pulp/react TS surface.",
+      "notes": "pulp #1434 — JSX surface accepts numeric aspectRatio (RN parity per oracle 'kind: number'). String forms ('16/9', 'auto') reach FlexStyle through the CSS shim path (web-compat-style-decl.js), not the @pulp/react TS surface.",
       "issue": "1434"
     },
     "rn/backfaceVisibility": {
@@ -3355,7 +3355,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-wires.test.ts"
       ],
-      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) \u2014 bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
+      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) — bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
       "issue": ""
     },
     "rn/backgroundColor": {
@@ -3378,7 +3378,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
       "issue": ""
     },
     "rn/borderBottomColor": {
@@ -3401,7 +3401,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
       "issue": ""
     },
     "rn/borderBottomLeftRadius": {
@@ -3416,7 +3416,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues.",
+      "notes": "Same. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues.",
       "issue": ""
     },
     "rn/borderBottomRightRadius": {
@@ -3431,7 +3431,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues.",
+      "notes": "Same. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues.",
       "issue": ""
     },
     "rn/borderBottomWidth": {
@@ -3442,7 +3442,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "RN prop is flat top-level, Pulp uses object shape. Convert: <View style={{borderBottomWidth: 2}} /> -> <View borderBottom={{color:'#000', width:2}} />. Awkward for RN ports. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
+      "notes": "RN prop is flat top-level, Pulp uses object shape. Convert: <View style={{borderBottomWidth: 2}} /> -> <View borderBottom={{color:'#000', width:2}} />. Awkward for RN ports. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only — em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
       "issue": ""
     },
     "rn/borderColor": {
@@ -3465,7 +3465,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
       "issue": ""
     },
     "rn/borderCurve": {
@@ -3482,7 +3482,7 @@
     },
     "rn/borderEndWidth": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier \u2014 End \u2192 Right under LTR; routes to setBorderRightWidth.",
+      "mapsTo": "@pulp/react prop-applier — End → Right under LTR; routes to setBorderRightWidth.",
       "supportedValues": [
         "number (px)"
       ],
@@ -3490,7 +3490,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/borderLeftColor": {
@@ -3513,7 +3513,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
       "issue": ""
     },
     "rn/borderLeftWidth": {
@@ -3524,7 +3524,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Same as borderBottomWidth. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
+      "notes": "Same as borderBottomWidth. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only — em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
       "issue": ""
     },
     "rn/borderRadius": {
@@ -3539,7 +3539,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "notes": "Workaround: <View border={{color:'transparent', width:0, radius:R}} />. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full elliptical rrect rendering is a deferred paint-side gap).",
+      "notes": "Workaround: <View border={{color:'transparent', width:0, radius:R}} />. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full elliptical rrect rendering is a deferred paint-side gap).",
       "issue": ""
     },
     "rn/borderRightColor": {
@@ -3562,7 +3562,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
       "issue": ""
     },
     "rn/borderRightWidth": {
@@ -3573,12 +3573,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
+      "notes": "Same. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only — em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
       "issue": ""
     },
     "rn/borderStartWidth": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier \u2014 Start \u2192 Left under LTR; routes to setBorderLeftWidth.",
+      "mapsTo": "@pulp/react prop-applier — Start → Left under LTR; routes to setBorderLeftWidth.",
       "supportedValues": [
         "number (px)"
       ],
@@ -3586,7 +3586,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/borderStyle": {
@@ -3608,7 +3608,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-border-style.test.ts"
       ],
-      "notes": "pulp #1434 Triage #10 \u2014 Skia paint installs SkDashPathEffect for dashed/dotted (CG falls through to solid via the canvas-base no-op set_line_dash). View::BorderStyle enum stores the keyword; bridge maps strings; Skia honors at stroke time. Other named styles (double/groove/ridge/inset/outset) currently degrade to solid \u2014 paint-side compositions are a follow-up. none/hidden short-circuit the stroke entirely.",
+      "notes": "pulp #1434 Triage #10 — Skia paint installs SkDashPathEffect for dashed/dotted (CG falls through to solid via the canvas-base no-op set_line_dash). View::BorderStyle enum stores the keyword; bridge maps strings; Skia honors at stroke time. Other named styles (double/groove/ridge/inset/outset) currently degrade to solid — paint-side compositions are a follow-up. none/hidden short-circuit the stroke entirely.",
       "issue": ""
     },
     "rn/borderTopColor": {
@@ -3631,7 +3631,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
       "issue": ""
     },
     "rn/borderTopLeftRadius": {
@@ -3646,7 +3646,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "notes": "Bridge has setBorderTopLeftRadius -- needs prop wiring. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues.",
+      "notes": "Bridge has setBorderTopLeftRadius -- needs prop wiring. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues.",
       "issue": ""
     },
     "rn/borderTopRightRadius": {
@@ -3661,7 +3661,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues.",
+      "notes": "Same. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues.",
       "issue": ""
     },
     "rn/borderTopWidth": {
@@ -3672,7 +3672,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Same as borderBottomWidth. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
+      "notes": "Same as borderBottomWidth. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only — em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
       "issue": ""
     },
     "rn/borderWidth": {
@@ -3683,7 +3683,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "User can call <View border={{color:'#000', width:N}} /> as workaround. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
+      "notes": "User can call <View border={{color:'#000', width:N}} /> as workaround. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only — em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
       "issue": ""
     },
     "rn/bottom": {
@@ -3714,7 +3714,7 @@
         "packages/pulp-react/test/prop-applier-box-shadow.test.ts",
         "packages/pulp-react/test/prop-applier-wave4.test.ts"
       ],
-      "notes": "All forms wired: 'none' (clears), CSS string (single + multi-shadow paren-aware split), object form { offsetX, offsetY, blur?, spread?, color, inset? }, AND RN Fabric BoxShadowValue[] array form (prop-applier.ts:877-894 \u2014 clears first, dispatches one setBoxShadow per shadow with blurRadius/spreadDistance preferred over blur/spread). All 4 forms tested in prop-applier-wave4.test.ts. Closes pulp #1664 \u2014 catalog was stale citing array form as gap when it was actually wired by Wave 4 #1651.",
+      "notes": "All forms wired: 'none' (clears), CSS string (single + multi-shadow paren-aware split), object form { offsetX, offsetY, blur?, spread?, color, inset? }, AND RN Fabric BoxShadowValue[] array form (prop-applier.ts:877-894 — clears first, dispatches one setBoxShadow per shadow with blurRadius/spreadDistance preferred over blur/spread). All 4 forms tested in prop-applier-wave4.test.ts. Closes pulp #1664 — catalog was stale citing array form as gap when it was actually wired by Wave 4 #1651.",
       "issue": ""
     },
     "rn/boxSizing": {
@@ -3751,7 +3751,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
       "issue": ""
     },
     "rn/columnGap": {
@@ -3767,7 +3767,7 @@
     },
     "rn/cursor": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier forwards keyword to setCursor (prop-applier.ts:749 \u2192 widget_bridge.cpp:4007); bridge maps CSS keywords onto View::CursorStyle slots.",
+      "mapsTo": "@pulp/react prop-applier forwards keyword to setCursor (prop-applier.ts:749 → widget_bridge.cpp:4007); bridge maps CSS keywords onto View::CursorStyle slots.",
       "supportedValues": [
         "default",
         "pointer",
@@ -3813,7 +3813,7 @@
         "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
         "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "notes": "pulp #1550 catalog hygiene: flipped partial \u2192 supported. Triage #7 fan-out (#1434 small-wins bundle) wired the CSS cursor keyword set onto View::CursorStyle. RN's spec ViewStyle accepts only {auto, pointer}; Pulp accepts the full CSS cursor enum because the same prop-applier path serves both rn/cursor and css/cursor. Keywords without a dedicated visual (wait / help / progress / alias / copy / zoom-* / cell / context-menu) fall through to `default` \u2014 they're listed in unsupportedValues for catalog accuracy. Wave 1 drift cleanup \u2014 `auto` keyword falls back to default (View::CursorStyle::default_); arch-platform-cursor-set means we don't add a dedicated 'auto' slot. Wave 2 rn \u2014 added 'auto' regression coverage in the wave2 test bundle.",
+      "notes": "pulp #1550 catalog hygiene: flipped partial → supported. Triage #7 fan-out (#1434 small-wins bundle) wired the CSS cursor keyword set onto View::CursorStyle. RN's spec ViewStyle accepts only {auto, pointer}; Pulp accepts the full CSS cursor enum because the same prop-applier path serves both rn/cursor and css/cursor. Keywords without a dedicated visual (wait / help / progress / alias / copy / zoom-* / cell / context-menu) fall through to `default` — they're listed in unsupportedValues for catalog accuracy. Wave 1 drift cleanup — `auto` keyword falls back to default (View::CursorStyle::default_); arch-platform-cursor-set means we don't add a dedicated 'auto' slot. Wave 2 rn — added 'auto' regression coverage in the wave2 test bundle.",
       "issue": ""
     },
     "rn/d": {
@@ -3870,7 +3870,7 @@
     },
     "rn/end": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier \u2014 end \u2192 right under LTR; routes to setRight.",
+      "mapsTo": "@pulp/react prop-applier — end → right under LTR; routes to setRight.",
       "supportedValues": [
         "number",
         "percent string"
@@ -3879,7 +3879,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/experimental_backgroundImage": {
@@ -3906,10 +3906,10 @@
         "CSS color strings"
       ],
       "unsupportedValues": [
-        "url(#gradient) \u2014 gradient fills deferred-pulp-#932 (gated on Skia gradient wiring through SvgPathWidget)"
+        "url(#gradient) — gradient fills deferred-pulp-#932 (gated on Skia gradient wiring through SvgPathWidget)"
       ],
       "tests": [],
-      "notes": "Only on @pulp/react SvgPath. Inline <svg> in DOM-lite still uses createCol (pulp #1147), which means CSS `fill` does NOT route to SVG fill \u2014 it falls into the unknown-prop default switch. Wave 1 architectural reclassification \u2014 url(#gradient) fills are partial-deferred-pulp-#932 (gated on Skia gradient wiring through SvgPathWidget); CSS color strings round-trip end-to-end.",
+      "notes": "Only on @pulp/react SvgPath. Inline <svg> in DOM-lite still uses createCol (pulp #1147), which means CSS `fill` does NOT route to SVG fill — it falls into the unknown-prop default switch. Wave 1 architectural reclassification — url(#gradient) fills are partial-deferred-pulp-#932 (gated on Skia gradient wiring through SvgPathWidget); CSS color strings round-trip end-to-end.",
       "issue": "994"
     },
     "rn/filter": {
@@ -3925,7 +3925,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-wires.test.ts"
       ],
-      "notes": "pulp #1434 Phase A2-4 \u2014 full CSS filter chain. setFilter parses the function-call sequence into View::FilterOp[]; view.cpp paint hands off to canvas.save_layer_with_filters; Skia composes via SkImageFilters::Compose + SkColorFilters::Matrix per filter. CG path falls back to blur-only collapse (no SkColorFilter equivalent yet). Full function set: blur / brightness / contrast / grayscale / hue-rotate / invert / opacity / saturate / sepia / drop-shadow.",
+      "notes": "pulp #1434 Phase A2-4 — full CSS filter chain. setFilter parses the function-call sequence into View::FilterOp[]; view.cpp paint hands off to canvas.save_layer_with_filters; Skia composes via SkImageFilters::Compose + SkColorFilters::Matrix per filter. CG path falls back to blur-only collapse (no SkColorFilter equivalent yet). Full function set: blur / brightness / contrast / grayscale / hue-rotate / invert / opacity / saturate / sepia / drop-shadow.",
       "issue": ""
     },
     "rn/flex": {
@@ -3938,7 +3938,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-flex.test.ts"
       ],
-      "notes": "pulp #1518 closed the gap. Bare-number `flex={n}` is the canonical RN-flavored shorthand; `flex` as an object/string is not a thing in RN, so no further forms are needed. Underlying bridge wires were already stable (flex_grow / flex_shrink / flex_basis) \u2014 this is purely an adapter aliasing.",
+      "notes": "pulp #1518 closed the gap. Bare-number `flex={n}` is the canonical RN-flavored shorthand; `flex` as an object/string is not a thing in RN, so no further forms are needed. Underlying bridge wires were already stable (flex_grow / flex_shrink / flex_basis) — this is purely an adapter aliasing.",
       "issue": "1518"
     },
     "rn/flexBasis": {
@@ -3950,10 +3950,10 @@
         "'auto'"
       ],
       "unsupportedValues": [
-        "content (Yoga doesn't model the content keyword \u2014 arch-yoga-limit)"
+        "content (Yoga doesn't model the content keyword — arch-yoga-limit)"
       ],
       "tests": [],
-      "notes": "TS type is 'number' only. pulp #1434 rn batch C: bridge accepts number / \"NN%\" / \"auto\"; FlexStyle::dim_flex_basis.unit drives YGNodeStyleSetFlexBasis{,Percent,Auto}. Wave 1 architectural reclassification \u2014 `content` keyword is arch-yoga-limit (Yoga has no flex-basis content algorithm); status flipped partial \u2192 wontfix to match the actual ground-truth out-of-scope reason. number / percent / 'auto' all remain fully wired.",
+      "notes": "TS type is 'number' only. pulp #1434 rn batch C: bridge accepts number / \"NN%\" / \"auto\"; FlexStyle::dim_flex_basis.unit drives YGNodeStyleSetFlexBasis{,Percent,Auto}. Wave 1 architectural reclassification — `content` keyword is arch-yoga-limit (Yoga has no flex-basis content algorithm); status flipped partial → wontfix to match the actual ground-truth out-of-scope reason. number / percent / 'auto' all remain fully wired.",
       "issue": ""
     },
     "rn/flexDirection": {
@@ -3994,7 +3994,7 @@
     },
     "rn/flexWrap": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier forwards string ('wrap' / 'wrap-reverse' / 'nowrap') verbatim to setFlex(flex_wrap, ...); legacy boolean still accepted (true \u2192 1, false \u2192 0).",
+      "mapsTo": "@pulp/react prop-applier forwards string ('wrap' / 'wrap-reverse' / 'nowrap') verbatim to setFlex(flex_wrap, ...); legacy boolean still accepted (true → 1, false → 0).",
       "supportedValues": [
         "boolean (legacy)",
         "nowrap",
@@ -4006,22 +4006,22 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-bundle.test.ts"
       ],
-      "notes": "pulp #1434 Triage #14 \u2014 broadened flexWrap type to boolean | string (CSS keywords). RN spec accepts the same string vocabulary; routing same as css/flexWrap.",
+      "notes": "pulp #1434 Triage #14 — broadened flexWrap type to boolean | string (CSS keywords). RN spec accepts the same string vocabulary; routing same as css/flexWrap.",
       "issue": ""
     },
     "rn/fontFamily": {
       "status": "partial",
       "mapsTo": "prop-applier.ts case 'fontFamily' -> setFontFamily(id, value). Bridge parses CSS list (first non-empty family wins). Container Views fall through to inheritable_font_family_ for cascade.",
       "supportedValues": [
-        "string (single family or comma-separated list \u2014 first non-empty wins)"
+        "string (single family or comma-separated list — first non-empty wins)"
       ],
       "unsupportedValues": [
-        "whole-list fallback chain \u2014 gated on pulp #932 SkFontMgr registration"
+        "whole-list fallback chain — gated on pulp #932 SkFontMgr registration"
       ],
       "tests": [
-        "test/test_widget_bridge.cpp \u2014 [issue-1434-fontfamily]"
+        "test/test_widget_bridge.cpp — [issue-1434-fontfamily]"
       ],
-      "notes": "pulp #1434 Phase A2-5 wired the @pulp/react JSX dispatch and the bridge-side list parser. Cross-engine ready: when pulp #932 lands the registry resolution, no consumer change is needed \u2014 the same name flows through.",
+      "notes": "pulp #1434 Phase A2-5 wired the @pulp/react JSX dispatch and the bridge-side list parser. Cross-engine ready: when pulp #932 lands the registry resolution, no consumer change is needed — the same name flows through.",
       "issue": "1434"
     },
     "rn/fontSize": {
@@ -4099,7 +4099,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "notes": "Keyword aliasing not done in prop-applier. Wave 1 drift cleanup \u2014 populated supportedValues with the RN standard weight set (normal / bold / 100..900); wired through prop-applier 'fontWeight' case. Wave 2 rn \u2014 added regression coverage for numeric weights '100'..'900'.",
+      "notes": "Keyword aliasing not done in prop-applier. Wave 1 drift cleanup — populated supportedValues with the RN standard weight set (normal / bold / 100..900); wired through prop-applier 'fontWeight' case. Wave 2 rn — added regression coverage for numeric weights '100'..'900'.",
       "issue": ""
     },
     "rn/gap": {
@@ -4115,7 +4115,7 @@
     },
     "rn/height": {
       "status": "partial",
-      "mapsTo": "setFlex(id, 'height', n) \u2014 number=px, '50%'=percent, 'auto'=hug-contents",
+      "mapsTo": "setFlex(id, 'height', n) — number=px, '50%'=percent, 'auto'=hug-contents",
       "supportedValues": [
         "number (px)",
         "string % (e.g. '50%')",
@@ -4125,7 +4125,7 @@
         "string vh"
       ],
       "tests": [],
-      "notes": "pulp #1434 rn batch C wired number + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end. TS type accepts `number | string`; prop-applier forwards verbatim; bridge dispatches via FlexStyle::dim_height.unit (px / percent / auto_) and yoga_layout.cpp routes to YGNodeStyleSetHeight{,Percent,Auto}. Wave 1 drift cleanup \u2014 supported \u2192 partial (`vh` string unit is a real deferred gap).",
+      "notes": "pulp #1434 rn batch C wired number + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end. TS type accepts `number | string`; prop-applier forwards verbatim; bridge dispatches via FlexStyle::dim_height.unit (px / percent / auto_) and yoga_layout.cpp routes to YGNodeStyleSetHeight{,Percent,Auto}. Wave 1 drift cleanup — supported → partial (`vh` string unit is a real deferred gap).",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "rn/includeFontPadding": {
@@ -4141,7 +4141,7 @@
     },
     "rn/inset": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier \u2014 CSS shorthand fan-out to top/right/bottom/left (1/2/3/4 token expansion).",
+      "mapsTo": "@pulp/react prop-applier — CSS shorthand fan-out to top/right/bottom/left (1/2/3/4 token expansion).",
       "supportedValues": [
         "number",
         "percent string",
@@ -4151,12 +4151,12 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/insetBlock": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier \u2014 top + bottom fan-out.",
+      "mapsTo": "@pulp/react prop-applier — top + bottom fan-out.",
       "supportedValues": [
         "number",
         "percent string"
@@ -4165,12 +4165,12 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/insetInline": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier \u2014 left + right fan-out under LTR.",
+      "mapsTo": "@pulp/react prop-applier — left + right fan-out under LTR.",
       "supportedValues": [
         "number",
         "percent string"
@@ -4179,19 +4179,19 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/isolation": {
       "status": "noop",
-      "mapsTo": "no-op accept \u2014 RN models isolation as enum auto|isolate (rn-viewstyle.json:134, RN New Architecture only). Pulp's box composition doesn't currently honor stacking-context isolation, so the value is accepted silently with no rendered effect (same shape as css/willChange / css/animation noop pattern).",
+      "mapsTo": "no-op accept — RN models isolation as enum auto|isolate (rn-viewstyle.json:134, RN New Architecture only). Pulp's box composition doesn't currently honor stacking-context isolation, so the value is accepted silently with no rendered effect (same shape as css/willChange / css/animation noop pattern).",
       "supportedValues": [],
       "unsupportedValues": [
         "auto",
         "isolate"
       ],
       "tests": [],
-      "notes": "RN's ViewStyle DOES model isolation (oracle defines enum auto|isolate, flagged 'RN New Architecture only'). The earlier wontfix premise ('no RN model') was factually wrong \u2014 corrected per Codex P2 review on PR #1565. Pulp accepts the value but the underlying box composition isn't isolated, which matches the noop vocabulary (consumer can pass, no visual effect; same pattern as css/animation, css/willChange). Reclassified missing \u2192 noop per pulp #1546 (PURE CATALOG: zero implementation, zero behavior change).",
+      "notes": "RN's ViewStyle DOES model isolation (oracle defines enum auto|isolate, flagged 'RN New Architecture only'). The earlier wontfix premise ('no RN model') was factually wrong — corrected per Codex P2 review on PR #1565. Pulp accepts the value but the underlying box composition isn't isolated, which matches the noop vocabulary (consumer can pass, no visual effect; same pattern as css/animation, css/willChange). Reclassified missing → noop per pulp #1546 (PURE CATALOG: zero implementation, zero behavior change).",
       "issue": "https://github.com/danielraffel/pulp/issues/1546"
     },
     "rn/justifyContent": {
@@ -4246,7 +4246,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (unitless multiplier form is a real deferred gap; absolute-px works end-to-end). Wave 2 rn \u2014 unitless-multiplier semantics now resolved at dispatch time. Values <= 8 are treated as a multiplier of the live `fontSize` from props (default 14 if absent); larger values flow through as absolute pixels. Px-suffix strings strip the suffix and treat as absolute.",
+      "notes": "Wave 1 drift cleanup — supported → partial (unitless multiplier form is a real deferred gap; absolute-px works end-to-end). Wave 2 rn — unitless-multiplier semantics now resolved at dispatch time. Values <= 8 are treated as a multiplier of the live `fontSize` from props (default 14 if absent); larger values flow through as absolute pixels. Px-suffix strings strip the suffix and treat as absolute.",
       "issue": ""
     },
     "rn/margin": {
@@ -4262,7 +4262,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (auto + string-form margins are real deferred gaps). Wave 2 rn \u2014 string margin shorthands (`'auto'`, `'5%'`, `'0 auto'`) now fan out to the per-edge bridge keys (which honor Yoga's YGNodeStyleSetMarginAuto for centering and the percent path).",
+      "notes": "Wave 1 drift cleanup — supported → partial (auto + string-form margins are real deferred gaps). Wave 2 rn — string margin shorthands (`'auto'`, `'5%'`, `'0 auto'`) now fan out to the per-edge bridge keys (which honor Yoga's YGNodeStyleSetMarginAuto for centering and the percent path).",
       "issue": ""
     },
     "rn/marginBottom": {
@@ -4277,12 +4277,12 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-edges.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "rn/marginEnd": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier \u2014 End \u2192 Right under LTR.",
+      "mapsTo": "@pulp/react prop-applier — End → Right under LTR.",
       "supportedValues": [
         "number",
         "percent string",
@@ -4292,7 +4292,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/marginHorizontal": {
@@ -4307,7 +4307,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "rn/marginLeft": {
@@ -4322,7 +4322,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-edges.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "rn/marginRight": {
@@ -4337,12 +4337,12 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-edges.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "rn/marginStart": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier \u2014 Start \u2192 Left under LTR.",
+      "mapsTo": "@pulp/react prop-applier — Start → Left under LTR.",
       "supportedValues": [
         "number",
         "percent string",
@@ -4352,7 +4352,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/marginTop": {
@@ -4367,7 +4367,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-edges.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "rn/marginVertical": {
@@ -4382,7 +4382,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "rn/maxHeight": {
@@ -4394,7 +4394,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_height.unit; yoga_layout.cpp routes to YGNodeStyleSetMaxHeightPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_height.unit \u2192 YGNodeStyleSetMaxHeightPercent.",
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_height.unit; yoga_layout.cpp routes to YGNodeStyleSetMaxHeightPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_height.unit → YGNodeStyleSetMaxHeightPercent.",
       "issue": ""
     },
     "rn/maxWidth": {
@@ -4406,7 +4406,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_width.unit; yoga_layout.cpp routes to YGNodeStyleSetMaxWidthPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_width.unit \u2192 YGNodeStyleSetMaxWidthPercent.",
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_width.unit; yoga_layout.cpp routes to YGNodeStyleSetMaxWidthPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_width.unit → YGNodeStyleSetMaxWidthPercent.",
       "issue": ""
     },
     "rn/minHeight": {
@@ -4418,7 +4418,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_height.unit; yoga_layout.cpp routes to YGNodeStyleSetMinHeightPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_height.unit \u2192 YGNodeStyleSetMinHeightPercent.",
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_height.unit; yoga_layout.cpp routes to YGNodeStyleSetMinHeightPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_height.unit → YGNodeStyleSetMinHeightPercent.",
       "issue": ""
     },
     "rn/minWidth": {
@@ -4430,7 +4430,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_width.unit; yoga_layout.cpp routes to YGNodeStyleSetMinWidthPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_width.unit \u2192 YGNodeStyleSetMinWidthPercent.",
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_width.unit; yoga_layout.cpp routes to YGNodeStyleSetMinWidthPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_width.unit → YGNodeStyleSetMinWidthPercent.",
       "issue": ""
     },
     "rn/mixBlendMode": {
@@ -4489,7 +4489,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-outline.test.ts"
       ],
-      "notes": "pulp #1519 \u2014 RN outline cluster. Outline is paint-time only and does NOT affect Yoga layout (parent never reserves space). Skia paint inflates the box by (offset + width/2) and strokes with the parsed color. Wave 1 drift cleanup \u2014 supported \u2192 partial (currentColor keyword resolution deferred; CSS color strings round-trip).",
+      "notes": "pulp #1519 — RN outline cluster. Outline is paint-time only and does NOT affect Yoga layout (parent never reserves space). Skia paint inflates the box by (offset + width/2) and strokes with the parsed color. Wave 1 drift cleanup — supported → partial (currentColor keyword resolution deferred; CSS color strings round-trip).",
       "issue": ""
     },
     "rn/outlineOffset": {
@@ -4502,12 +4502,12 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-outline.test.ts"
       ],
-      "notes": "pulp #1519 \u2014 gap between border-box edge and outline. Paint-only; no Yoga layout impact.",
+      "notes": "pulp #1519 — gap between border-box edge and outline. Paint-only; no Yoga layout impact.",
       "issue": ""
     },
     "rn/outlineStyle": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier dispatches outlineStyle to setOutlineStyle (prop-applier.ts since pulp #1519). Bridge maps the CSS keyword to View::BorderStyle (reused \u2014 CSS spec is identical for outline + border).",
+      "mapsTo": "@pulp/react prop-applier dispatches outlineStyle to setOutlineStyle (prop-applier.ts since pulp #1519). Bridge maps the CSS keyword to View::BorderStyle (reused — CSS spec is identical for outline + border).",
       "supportedValues": [
         "solid",
         "dashed",
@@ -4524,7 +4524,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-outline.test.ts"
       ],
-      "notes": "pulp #1519 \u2014 Skia installs SkDashPathEffect for dashed/dotted at outline-stroke time. Other named styles currently degrade to solid (paint-side gap, same as borderStyle). none/hidden/zero-width short-circuit the stroke.",
+      "notes": "pulp #1519 — Skia installs SkDashPathEffect for dashed/dotted at outline-stroke time. Other named styles currently degrade to solid (paint-side gap, same as borderStyle). none/hidden/zero-width short-circuit the stroke.",
       "issue": ""
     },
     "rn/outlineWidth": {
@@ -4537,7 +4537,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-outline.test.ts"
       ],
-      "notes": "pulp #1519 \u2014 outline stroke thickness. width<=0 short-circuits the paint. Paint-only; no Yoga layout impact.",
+      "notes": "pulp #1519 — outline stroke thickness. width<=0 short-circuits the paint. Paint-only; no Yoga layout impact.",
       "issue": ""
     },
     "rn/overflow": {
@@ -4548,12 +4548,12 @@
         "hidden"
       ],
       "unsupportedValues": [
-        "scroll (Yoga's View::Overflow models visible/hidden only \u2014 arch-yoga-limit; ScrollView is a separate container intrinsic, not a View::Overflow mode)"
+        "scroll (Yoga's View::Overflow models visible/hidden only — arch-yoga-limit; ScrollView is a separate container intrinsic, not a View::Overflow mode)"
       ],
       "tests": [
         "packages/pulp-react/test/prop-applier-pointer.test.ts"
       ],
-      "notes": "pulp #1550 catalog hygiene: flipped partial \u2192 supported. The two RN ViewStyle keywords that View::Overflow models \u2014 `visible` and `hidden` \u2014 both round-trip through the prop-applier and the C++ bridge. `scroll` is intentionally excluded: ScrollView is a separate container intrinsic, not a View::Overflow mode. Spectr dropdowns + Figma overflow:hidden cards now port verbatim (#1387 gap #1). Wave 1 architectural reclassification \u2014 `scroll` is arch-yoga-limit (Yoga's View::Overflow only models visible/hidden); ScrollView container intrinsic is the designed entry point.",
+      "notes": "pulp #1550 catalog hygiene: flipped partial → supported. The two RN ViewStyle keywords that View::Overflow models — `visible` and `hidden` — both round-trip through the prop-applier and the C++ bridge. `scroll` is intentionally excluded: ScrollView is a separate container intrinsic, not a View::Overflow mode. Spectr dropdowns + Figma overflow:hidden cards now port verbatim (#1387 gap #1). Wave 1 architectural reclassification — `scroll` is arch-yoga-limit (Yoga's View::Overflow only models visible/hidden); ScrollView container intrinsic is the designed entry point.",
       "issue": ""
     },
     "rn/overlay": {
@@ -4580,7 +4580,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (% form on padding edges is deferred). Wave 2 rn \u2014 string padding shorthands (`'5%'`, `'10px 20px'`, etc.) now fan out to the per-edge bridge keys (which already accept percent via Yoga's YGNodeStyleSetPaddingPercent). Numeric values still take the single-call shorthand path.",
+      "notes": "Wave 1 drift cleanup — supported → partial (% form on padding edges is deferred). Wave 2 rn — string padding shorthands (`'5%'`, `'10px 20px'`, etc.) now fan out to the per-edge bridge keys (which already accept percent via Yoga's YGNodeStyleSetPaddingPercent). Numeric values still take the single-call shorthand path.",
       "issue": ""
     },
     "rn/paddingBottom": {
@@ -4594,12 +4594,12 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-edges.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
+      "notes": "pulp #1434 cross-surface mega-batch — accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
       "issue": ""
     },
     "rn/paddingEnd": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier \u2014 End \u2192 Right under LTR.",
+      "mapsTo": "@pulp/react prop-applier — End → Right under LTR.",
       "supportedValues": [
         "number",
         "percent string"
@@ -4608,7 +4608,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/paddingHorizontal": {
@@ -4622,7 +4622,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "rn/paddingLeft": {
@@ -4636,7 +4636,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-edges.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
+      "notes": "pulp #1434 cross-surface mega-batch — accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
       "issue": ""
     },
     "rn/paddingRight": {
@@ -4650,12 +4650,12 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-edges.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
+      "notes": "pulp #1434 cross-surface mega-batch — accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
       "issue": ""
     },
     "rn/paddingStart": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier \u2014 Start \u2192 Left under LTR.",
+      "mapsTo": "@pulp/react prop-applier — Start → Left under LTR.",
       "supportedValues": [
         "number",
         "percent string"
@@ -4664,7 +4664,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/paddingTop": {
@@ -4678,7 +4678,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-edges.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
+      "notes": "pulp #1434 cross-surface mega-batch — accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
       "issue": ""
     },
     "rn/paddingVertical": {
@@ -4692,7 +4692,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "rn/pointerEvents": {
@@ -4708,7 +4708,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-wires.test.ts"
       ],
-      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) \u2014 bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
+      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) — bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
       "issue": ""
     },
     "rn/position": {
@@ -4752,51 +4752,51 @@
     },
     "rn/shadowColor": {
       "status": "wontfix",
-      "mapsTo": "n/a \u2014 superseded by `boxShadow` in modern RN (RN 0.71+); pulp implements `boxShadow` (rn/boxShadow=supported). Reclassified per pulp #1546 to drop the iOS-only legacy from the rn denominator.",
+      "mapsTo": "n/a — superseded by `boxShadow` in modern RN (RN 0.71+); pulp implements `boxShadow` (rn/boxShadow=supported). Reclassified per pulp #1546 to drop the iOS-only legacy from the rn denominator.",
       "supportedValues": [],
       "unsupportedValues": [
         "all"
       ],
       "tests": [],
-      "notes": "iOS-only legacy in RN; consumers on modern RN use `boxShadow` (CSS box-shadow syntax) which pulp already supports. Reclassified missing \u2192 wontfix per pulp #1546 (PURE CATALOG: zero implementation, zero behavior change).",
+      "notes": "iOS-only legacy in RN; consumers on modern RN use `boxShadow` (CSS box-shadow syntax) which pulp already supports. Reclassified missing → wontfix per pulp #1546 (PURE CATALOG: zero implementation, zero behavior change).",
       "issue": "https://github.com/danielraffel/pulp/issues/1546"
     },
     "rn/shadowOffset": {
       "status": "wontfix",
-      "mapsTo": "n/a \u2014 superseded by `boxShadow` in modern RN (RN 0.71+); pulp implements `boxShadow` (rn/boxShadow=supported). Reclassified per pulp #1546 to drop the iOS-only legacy from the rn denominator.",
+      "mapsTo": "n/a — superseded by `boxShadow` in modern RN (RN 0.71+); pulp implements `boxShadow` (rn/boxShadow=supported). Reclassified per pulp #1546 to drop the iOS-only legacy from the rn denominator.",
       "supportedValues": [],
       "unsupportedValues": [
         "all"
       ],
       "tests": [],
-      "notes": "iOS-only legacy in RN; consumers on modern RN use `boxShadow` (CSS box-shadow syntax) which pulp already supports. Reclassified missing \u2192 wontfix per pulp #1546 (PURE CATALOG: zero implementation, zero behavior change).",
+      "notes": "iOS-only legacy in RN; consumers on modern RN use `boxShadow` (CSS box-shadow syntax) which pulp already supports. Reclassified missing → wontfix per pulp #1546 (PURE CATALOG: zero implementation, zero behavior change).",
       "issue": "https://github.com/danielraffel/pulp/issues/1546"
     },
     "rn/shadowOpacity": {
       "status": "wontfix",
-      "mapsTo": "n/a \u2014 superseded by `boxShadow` in modern RN (RN 0.71+); pulp implements `boxShadow` (rn/boxShadow=supported). Reclassified per pulp #1546 to drop the iOS-only legacy from the rn denominator.",
+      "mapsTo": "n/a — superseded by `boxShadow` in modern RN (RN 0.71+); pulp implements `boxShadow` (rn/boxShadow=supported). Reclassified per pulp #1546 to drop the iOS-only legacy from the rn denominator.",
       "supportedValues": [],
       "unsupportedValues": [
         "all"
       ],
       "tests": [],
-      "notes": "iOS-only legacy in RN; consumers on modern RN use `boxShadow` (CSS box-shadow syntax) which pulp already supports. Reclassified missing \u2192 wontfix per pulp #1546 (PURE CATALOG: zero implementation, zero behavior change).",
+      "notes": "iOS-only legacy in RN; consumers on modern RN use `boxShadow` (CSS box-shadow syntax) which pulp already supports. Reclassified missing → wontfix per pulp #1546 (PURE CATALOG: zero implementation, zero behavior change).",
       "issue": "https://github.com/danielraffel/pulp/issues/1546"
     },
     "rn/shadowRadius": {
       "status": "wontfix",
-      "mapsTo": "n/a \u2014 superseded by `boxShadow` in modern RN (RN 0.71+); pulp implements `boxShadow` (rn/boxShadow=supported). Reclassified per pulp #1546 to drop the iOS-only legacy from the rn denominator.",
+      "mapsTo": "n/a — superseded by `boxShadow` in modern RN (RN 0.71+); pulp implements `boxShadow` (rn/boxShadow=supported). Reclassified per pulp #1546 to drop the iOS-only legacy from the rn denominator.",
       "supportedValues": [],
       "unsupportedValues": [
         "all"
       ],
       "tests": [],
-      "notes": "iOS-only legacy in RN; consumers on modern RN use `boxShadow` (CSS box-shadow syntax) which pulp already supports. Reclassified missing \u2192 wontfix per pulp #1546 (PURE CATALOG: zero implementation, zero behavior change).",
+      "notes": "iOS-only legacy in RN; consumers on modern RN use `boxShadow` (CSS box-shadow syntax) which pulp already supports. Reclassified missing → wontfix per pulp #1546 (PURE CATALOG: zero implementation, zero behavior change).",
       "issue": "https://github.com/danielraffel/pulp/issues/1546"
     },
     "rn/start": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier \u2014 start \u2192 left under LTR; routes to setLeft.",
+      "mapsTo": "@pulp/react prop-applier — start → left under LTR; routes to setLeft.",
       "supportedValues": [
         "number",
         "percent string"
@@ -4805,7 +4805,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/stroke": {
@@ -4816,7 +4816,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Only on @pulp/react SvgPath. See rn/fill caveat \u2014 no DOM-lite path-prop equivalent.",
+      "notes": "Only on @pulp/react SvgPath. See rn/fill caveat — no DOM-lite path-prop equivalent.",
       "issue": "994"
     },
     "rn/strokeWidth": {
@@ -4856,7 +4856,7 @@
         "center"
       ],
       "tests": [],
-      "notes": "Android-only in RN; could map to flex align. Wave 1 drift cleanup \u2014 missing \u2192 wontfix (platform-only RN prop, OOS for the cross-platform Pulp surface \u2014 see oracle platformOnly flag).",
+      "notes": "Android-only in RN; could map to flex align. Wave 1 drift cleanup — missing → wontfix (platform-only RN prop, OOS for the cross-platform Pulp surface — see oracle platformOnly flag).",
       "issue": ""
     },
     "rn/textDecorationColor": {
@@ -4867,7 +4867,7 @@
         "all"
       ],
       "tests": [],
-      "notes": "Not modeled. Wave 1 drift cleanup \u2014 missing \u2192 wontfix (platform-only RN prop, OOS for the cross-platform Pulp surface \u2014 see oracle platformOnly flag).",
+      "notes": "Not modeled. Wave 1 drift cleanup — missing → wontfix (platform-only RN prop, OOS for the cross-platform Pulp surface — see oracle platformOnly flag).",
       "issue": ""
     },
     "rn/textDecorationLine": {
@@ -4885,7 +4885,7 @@
         "packages/pulp-react/test/prop-applier-rn-not-impl-bundle1.test.ts",
         "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "notes": "pulp #1434 (rn NOT-IMPL bundle 1): the @pulp/react surface aliases RN's `textDecorationLine` to the existing setTextDecoration bridge fn. Single-keyword form is honored by Label::TextDecoration; the RN compound form `'underline line-through'` is forwarded verbatim but only the first keyword takes effect today (same partial gap noted on css/textDecoration). `overline` is a pulp extension over RN spec. Wave 1 drift cleanup \u2014 added 'underline line-through' combined keyword to supportedValues (the prop-applier passes the keyword to the bridge verbatim). Wave 2 rn \u2014 added 'underline line-through' compound regression coverage.",
+      "notes": "pulp #1434 (rn NOT-IMPL bundle 1): the @pulp/react surface aliases RN's `textDecorationLine` to the existing setTextDecoration bridge fn. Single-keyword form is honored by Label::TextDecoration; the RN compound form `'underline line-through'` is forwarded verbatim but only the first keyword takes effect today (same partial gap noted on css/textDecoration). `overline` is a pulp extension over RN spec. Wave 1 drift cleanup — added 'underline line-through' combined keyword to supportedValues (the prop-applier passes the keyword to the bridge verbatim). Wave 2 rn — added 'underline line-through' compound regression coverage.",
       "issue": ""
     },
     "rn/textDecorationStyle": {
@@ -4896,7 +4896,7 @@
         "all"
       ],
       "tests": [],
-      "notes": "Not modeled. Wave 1 drift cleanup \u2014 missing \u2192 wontfix (platform-only RN prop, OOS for the cross-platform Pulp surface \u2014 see oracle platformOnly flag).",
+      "notes": "Not modeled. Wave 1 drift cleanup — missing → wontfix (platform-only RN prop, OOS for the cross-platform Pulp surface — see oracle platformOnly flag).",
       "issue": ""
     },
     "rn/textShadowColor": {
@@ -4909,7 +4909,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-not-impl-bundle1.test.ts"
       ],
-      "notes": "pulp #1548 work shipped: bridge fn registered (widget_bridge.cpp:5010-5017) and prop-applier wired (prop-applier.ts:1280). Earlier catalog note claimed deferred-to-#1548 \u2014 that work landed. CSS color strings flow through to View::set_text_shadow_color_."
+      "notes": "pulp #1548 work shipped: bridge fn registered (widget_bridge.cpp:5010-5017) and prop-applier wired (prop-applier.ts:1280). Earlier catalog note claimed deferred-to-#1548 — that work landed. CSS color strings flow through to View::set_text_shadow_color_."
     },
     "rn/textShadowOffset": {
       "status": "supported",
@@ -4948,7 +4948,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-wires.test.ts"
       ],
-      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) \u2014 bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
+      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) — bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
       "issue": ""
     },
     "rn/top": {
@@ -4978,7 +4978,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-transform.test.ts"
       ],
-      "notes": "pulp #1434 Triage #9 fan-out \u2014 full CSS transform-function set wired via parseTransform walk-once accumulator. setSkew bridge fn registered; scaleX/scaleY share uniform setScale slot (last-write-wins; bridge gap); matrix() decomposed to translate+scale+rotate. rotateX / rotateY / matrix3d / perspective silently drop (pulp's 2D View has no 3D model). rn array surface does not include matrix() (RN spec omits it). independent scaleX != scaleY \u2014 last-write-wins on the uniform bridge.",
+      "notes": "pulp #1434 Triage #9 fan-out — full CSS transform-function set wired via parseTransform walk-once accumulator. setSkew bridge fn registered; scaleX/scaleY share uniform setScale slot (last-write-wins; bridge gap); matrix() decomposed to translate+scale+rotate. rotateX / rotateY / matrix3d / perspective silently drop (pulp's 2D View has no 3D model). rn array surface does not include matrix() (RN spec omits it). independent scaleX != scaleY — last-write-wins on the uniform bridge.",
       "issue": ""
     },
     "rn/transformOrigin": {
@@ -4994,12 +4994,12 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-wires.test.ts"
       ],
-      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) \u2014 bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
+      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) — bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
       "issue": ""
     },
     "rn/userSelect": {
       "status": "noop",
-      "mapsTo": "@pulp/react prop-applier forwards keyword to setUserSelect (prop-applier.ts:753); the bridge currently registers setUserSelect as a no-op stash (widget_bridge.cpp:2267) \u2014 the JSX \u2192 prop-applier \u2192 bridge round-trip is wired but no semantic effect lands until the View::UserSelect path is implemented.",
+      "mapsTo": "@pulp/react prop-applier forwards keyword to setUserSelect (prop-applier.ts:753); the bridge currently registers setUserSelect as a no-op stash (widget_bridge.cpp:2267) — the JSX → prop-applier → bridge round-trip is wired but no semantic effect lands until the View::UserSelect path is implemented.",
       "supportedValues": [],
       "unsupportedValues": [
         "auto",
@@ -5011,7 +5011,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-wires.test.ts"
       ],
-      "notes": "pulp #1550 catalog hygiene: kept partial (does NOT meet the catalog-hygiene supported bar). Bridge fn is a registered no-op \u2014 accepts the value to keep prop-applier dispatch quiet, but there is no View::UserSelect storage and no native text-selection suppression path. Promotion blocked until the bridge actually applies the mode. Tests cover prop-applier dispatch only. Wave 1 drift cleanup \u2014 partial \u2192 noop (the prop-applier forwards the keyword to setUserSelect but the bridge stores-only; selection behavior gated on a future selection-engine subsystem).",
+      "notes": "pulp #1550 catalog hygiene: kept partial (does NOT meet the catalog-hygiene supported bar). Bridge fn is a registered no-op — accepts the value to keep prop-applier dispatch quiet, but there is no View::UserSelect storage and no native text-selection suppression path. Promotion blocked until the bridge actually applies the mode. Tests cover prop-applier dispatch only. Wave 1 drift cleanup — partial → noop (the prop-applier forwards the keyword to setUserSelect but the bridge stores-only; selection behavior gated on a future selection-engine subsystem).",
       "issue": ""
     },
     "rn/verticalAlign": {
@@ -5022,7 +5022,7 @@
         "all"
       ],
       "tests": [],
-      "notes": "Not modeled. Wave 1 drift cleanup \u2014 missing \u2192 wontfix (platform-only RN prop, OOS for the cross-platform Pulp surface \u2014 see oracle platformOnly flag).",
+      "notes": "Not modeled. Wave 1 drift cleanup — missing → wontfix (platform-only RN prop, OOS for the cross-platform Pulp surface — see oracle platformOnly flag).",
       "issue": ""
     },
     "rn/viewBox": {
@@ -5036,12 +5036,12 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "notes": "RN doesn't have a native SVG surface; this is a Pulp-specific @pulp/react intrinsic. CSS-shim consumers don't see this prop today. Wave 1 drift cleanup \u2014 supported \u2192 partial (only the [w,h] tuple is consumed; min-x/min-y prefix is parsed but ignored). Wave 2 rn \u2014 SVG-spec string form `'min-x min-y w h'` (or `'w h'`) now parses at dispatch time. The bridge consumes the trailing two tokens as (width, height); the min-x / min-y origin offset is not yet honored by the SvgPathWidget paint side (separate paint-side follow-up).",
+      "notes": "RN doesn't have a native SVG surface; this is a Pulp-specific @pulp/react intrinsic. CSS-shim consumers don't see this prop today. Wave 1 drift cleanup — supported → partial (only the [w,h] tuple is consumed; min-x/min-y prefix is parsed but ignored). Wave 2 rn — SVG-spec string form `'min-x min-y w h'` (or `'w h'`) now parses at dispatch time. The bridge consumes the trailing two tokens as (width, height); the min-x / min-y origin offset is not yet honored by the SvgPathWidget paint side (separate paint-side follow-up).",
       "issue": "994"
     },
     "rn/width": {
       "status": "supported",
-      "mapsTo": "setFlex(id, 'width', n) \u2014 number=px, '50%'=percent, 'auto'=hug-contents",
+      "mapsTo": "setFlex(id, 'width', n) — number=px, '50%'=percent, 'auto'=hug-contents",
       "supportedValues": [
         "number (px)",
         "string % (e.g. '50%')",
@@ -5062,7 +5062,7 @@
         "rtl"
       ],
       "tests": [],
-      "notes": "RTL not modeled. Wave 1 drift cleanup \u2014 missing \u2192 wontfix (platform-only RN prop, OOS for the cross-platform Pulp surface \u2014 see oracle platformOnly flag).",
+      "notes": "RTL not modeled. Wave 1 drift cleanup — missing → wontfix (platform-only RN prop, OOS for the cross-platform Pulp surface — see oracle platformOnly flag).",
       "issue": ""
     },
     "rn/zIndex": {
@@ -5102,7 +5102,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 Triage #14 \u2014 FlexStyle.flex_wrap is now FlexWrap enum (no_wrap/wrap/wrap_reverse); yoga_layout.cpp dispatches all three through YGNodeStyleSetFlexWrap with YGWrapNoWrap / YGWrapWrap / YGWrapWrapReverse.",
+      "notes": "pulp #1434 Triage #14 — FlexStyle.flex_wrap is now FlexWrap enum (no_wrap/wrap/wrap_reverse); yoga_layout.cpp dispatches all three through YGNodeStyleSetFlexWrap with YGWrapNoWrap / YGWrapWrap / YGWrapWrapReverse.",
       "issue": ""
     },
     "yoga/flexGrow": {
@@ -5133,7 +5133,7 @@
     },
     "yoga/flexBasis": {
       "status": "supported",
-      "mapsTo": "FlexStyle::dim_flex_basis (Dimension { unit, value }) \u2192 YGNodeStyleSetFlexBasis / YGNodeStyleSetFlexBasisPercent / YGNodeStyleSetFlexBasisAuto in build_yoga_subtree (core/view/src/yoga_layout.cpp).",
+      "mapsTo": "FlexStyle::dim_flex_basis (Dimension { unit, value }) → YGNodeStyleSetFlexBasis / YGNodeStyleSetFlexBasisPercent / YGNodeStyleSetFlexBasisAuto in build_yoga_subtree (core/view/src/yoga_layout.cpp).",
       "supportedValues": [
         "px",
         "%",
@@ -5163,7 +5163,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "All 6 modes covered. Bridge accepts both CSS spelling (flex-start/flex-end) and Yoga spelling (start/end) \u2014 CSS translator _cssToFlex maps the former to the latter. pulp #1434 rn batch B: confirmed bridge accepts flex-start/flex-end aliases too via @pulp/react prop-applier path.",
+      "notes": "All 6 modes covered. Bridge accepts both CSS spelling (flex-start/flex-end) and Yoga spelling (start/end) — CSS translator _cssToFlex maps the former to the latter. pulp #1434 rn batch B: confirmed bridge accepts flex-start/flex-end aliases too via @pulp/react prop-applier path.",
       "issue": ""
     },
     "yoga/alignItems": {
@@ -5180,7 +5180,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 rn batch B: bridge accepts both CSS (flex-start/flex-end/baseline) and Yoga (start/end) spellings; FlexAlign extended with baseline \u2192 YGAlignBaseline.",
+      "notes": "pulp #1434 rn batch B: bridge accepts both CSS (flex-start/flex-end/baseline) and Yoga (start/end) spellings; FlexAlign extended with baseline → YGAlignBaseline.",
       "issue": ""
     },
     "yoga/alignSelf": {
@@ -5309,7 +5309,7 @@
         "unit:test/web-compat/test_layout_aspect_ratio.cpp",
         "semantic:yoga/aspect-ratio"
       ],
-      "notes": "pulp #1434 \u2014 added FlexStyle.aspect_ratio + Yoga dispatch + bridge setFlex 'aspect_ratio' branch + @pulp/react aspectRatio prop. CSS shim accepts plain numbers ('1.5'), 'width/height' ratios ('16/9'), and 'auto' (clears slot).",
+      "notes": "pulp #1434 — added FlexStyle.aspect_ratio + Yoga dispatch + bridge setFlex 'aspect_ratio' branch + @pulp/react aspectRatio prop. CSS shim accepts plain numbers ('1.5'), 'width/height' ratios ('16/9'), and 'auto' (clears slot).",
       "issue": "1434"
     },
     "yoga/boxSizing": {
@@ -5329,13 +5329,13 @@
       "mapsTo": "FlexStyle.margin (float) for the uniform shorthand; per-edge `marginTop` / `marginRight` / `marginBottom` / `marginLeft` route through FlexStyle::dim_margin_* to YGNodeStyleSetMargin{,Percent,Auto}. The shorthand is uniform-px today; the per-edge entries already cover px / % / auto.",
       "supportedValues": [
         "px",
-        "auto (per-edge \u2014 see yoga/marginTop etc.)"
+        "auto (per-edge — see yoga/marginTop etc.)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\""
       ],
-      "notes": "Yoga's YGNodeStyleSetMarginAuto is wired through `apply_margin` and `apply_logical_margin` in yoga_layout.cpp \u2014 `auto` works on every edge (top/right/bottom/left/start/end). The uniform shorthand stays px-only because there's no spec-defined `margin: auto` per-edge expansion that requires the shorthand itself to carry the unit; consumers that want centering set the per-edge keys.",
+      "notes": "Yoga's YGNodeStyleSetMarginAuto is wired through `apply_margin` and `apply_logical_margin` in yoga_layout.cpp — `auto` works on every edge (top/right/bottom/left/start/end). The uniform shorthand stays px-only because there's no spec-defined `margin: auto` per-edge expansion that requires the shorthand itself to carry the unit; consumers that want centering set the per-edge keys.",
       "issue": ""
     },
     "yoga/marginTop": {
@@ -5351,7 +5351,7 @@
         "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
         "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "yoga/marginRight": {
@@ -5367,7 +5367,7 @@
         "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
         "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "yoga/marginBottom": {
@@ -5383,7 +5383,7 @@
         "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
         "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "yoga/marginLeft": {
@@ -5399,7 +5399,7 @@
         "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
         "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "yoga/marginStart": {
@@ -5414,7 +5414,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1542]"
       ],
-      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL; the new FlexStyle::writing_direction field plus YGNodeStyleSetDirection drives the flip.",
+      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL; the new FlexStyle::writing_direction field plus YGNodeStyleSetDirection drives the flip.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/marginEnd": {
@@ -5429,7 +5429,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1542]"
       ],
-      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL.",
+      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/marginHorizontal": {
@@ -5444,7 +5444,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "yoga/marginVertical": {
@@ -5459,7 +5459,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "yoga/padding": {
@@ -5467,14 +5467,14 @@
       "mapsTo": "FlexStyle.padding (uniform shorthand, float) plus per-edge FlexStyle::dim_padding_* routing through `apply_padding` / `apply_logical_padding` in yoga_layout.cpp to YGNodeStyleSetPadding{,Percent}.",
       "supportedValues": [
         "px",
-        "% (per-edge \u2014 see yoga/paddingTop etc.)"
+        "% (per-edge — see yoga/paddingTop etc.)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
         "semantic:yoga/box-sizing"
       ],
-      "notes": "% values flow through the per-edge keys (paddingTop/Right/Bottom/Left/Start/End). The uniform `padding` shorthand is px-only by design \u2014 the bridge expands shorthands at the JS layer (web-compat-style-decl.js `padding` case) into per-edge calls that DO carry the unit. CSS spec rejects `padding: auto` (auto is invalid for padding), matching Yoga's lack of a YGNodeStyleSetPaddingAuto API.",
+      "notes": "% values flow through the per-edge keys (paddingTop/Right/Bottom/Left/Start/End). The uniform `padding` shorthand is px-only by design — the bridge expands shorthands at the JS layer (web-compat-style-decl.js `padding` case) into per-edge calls that DO carry the unit. CSS spec rejects `padding: auto` (auto is invalid for padding), matching Yoga's lack of a YGNodeStyleSetPaddingAuto API.",
       "issue": ""
     },
     "yoga/paddingTop": {
@@ -5488,7 +5488,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
+      "notes": "pulp #1434 cross-surface mega-batch — Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
       "issue": ""
     },
     "yoga/paddingRight": {
@@ -5502,7 +5502,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
+      "notes": "pulp #1434 cross-surface mega-batch — Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
       "issue": ""
     },
     "yoga/paddingBottom": {
@@ -5516,7 +5516,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
+      "notes": "pulp #1434 cross-surface mega-batch — Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
       "issue": ""
     },
     "yoga/paddingLeft": {
@@ -5530,7 +5530,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\""
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
+      "notes": "pulp #1434 cross-surface mega-batch — Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
       "issue": ""
     },
     "yoga/paddingStart": {
@@ -5544,7 +5544,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1542]"
       ],
-      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL. `auto` is spec-invalid for padding (CSS rejects `padding: auto`), so it's not listed as a gap \u2014 Yoga matches the spec by not exposing a YGNodeStyleSetPaddingAuto API.",
+      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL. `auto` is spec-invalid for padding (CSS rejects `padding: auto`), so it's not listed as a gap — Yoga matches the spec by not exposing a YGNodeStyleSetPaddingAuto API.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/paddingEnd": {
@@ -5558,7 +5558,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1542]"
       ],
-      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL. `auto` is spec-invalid for padding so it's not listed as a gap.",
+      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL. `auto` is spec-invalid for padding so it's not listed as a gap.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/paddingHorizontal": {
@@ -5572,7 +5572,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "yoga/paddingVertical": {
@@ -5586,7 +5586,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "yoga/borderWidth": {
@@ -5599,7 +5599,7 @@
       "tests": [
         "semantic:yoga/box-sizing"
       ],
-      "notes": "Yoga's BORDER edges contribute to content-box sizing. Before #1543, Pulp's borders were paint-only (Skia stroke) and Yoga saw zero border insets, which made box-sizing math wrong when border-box was active. Wired now \u2014 borders affect both layout AND paint. % is intentionally not listed as an unsupported gap because the CSS spec rejects `border-width: <%>` (invalid value); Yoga matches the spec by not exposing a YGNodeStyleSetBorderPercent API.",
+      "notes": "Yoga's BORDER edges contribute to content-box sizing. Before #1543, Pulp's borders were paint-only (Skia stroke) and Yoga saw zero border insets, which made box-sizing math wrong when border-box was active. Wired now — borders affect both layout AND paint. % is intentionally not listed as an unsupported gap because the CSS spec rejects `border-width: <%>` (invalid value); Yoga matches the spec by not exposing a YGNodeStyleSetBorderPercent API.",
       "issue": ""
     },
     "yoga/borderTopWidth": {
@@ -5610,7 +5610,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Same as borderWidth \u2014 the per-edge variants share the same wiring. Reached from JS via setBorderTopWidth(id, w). % is spec-invalid for border-width so not listed as a gap.",
+      "notes": "Same as borderWidth — the per-edge variants share the same wiring. Reached from JS via setBorderTopWidth(id, w). % is spec-invalid for border-width so not listed as a gap.",
       "issue": ""
     },
     "yoga/borderRightWidth": {
@@ -5728,7 +5728,7 @@
         "test/test_widget_bridge.cpp [issue-1542]",
         "test/test_widget_bridge.cpp::\"setFlex start/end accept 'auto' keyword\""
       ],
-      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL. `auto` (the CSS default \u2014 \"don't anchor to this edge\") routes through Yoga's YGNodeStyleSetPositionAuto via FlexStyle::dim_start.unit = auto_; the bridge accepts `'auto'` verbatim. Wired DIVERGE\u2192PASS sweep.",
+      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL. `auto` (the CSS default — \"don't anchor to this edge\") routes through Yoga's YGNodeStyleSetPositionAuto via FlexStyle::dim_start.unit = auto_; the bridge accepts `'auto'` verbatim. Wired DIVERGE→PASS sweep.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/end": {
@@ -5744,7 +5744,7 @@
         "test/test_widget_bridge.cpp [issue-1542]",
         "test/test_widget_bridge.cpp::\"setFlex start/end accept 'auto' keyword\""
       ],
-      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL. `auto` routes through YGNodeStyleSetPositionAuto. Wired DIVERGE\u2192PASS sweep.",
+      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL. `auto` routes through YGNodeStyleSetPositionAuto. Wired DIVERGE→PASS sweep.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/gap": {
@@ -5807,7 +5807,7 @@
     },
     "yoga/overflow": {
       "status": "supported",
-      "mapsTo": "View::Overflow {visible, hidden, scroll} \u2014 set via setOverflow(id, 'visible'|'hidden'|'scroll') in widget_bridge.cpp; routed through to Yoga via YGNodeStyleSetOverflow in yoga_layout.cpp::build_yoga_subtree. Paint clipping in view.cpp treats `scroll` like `hidden` (no scrollbar UI yet).",
+      "mapsTo": "View::Overflow {visible, hidden, scroll} — set via setOverflow(id, 'visible'|'hidden'|'scroll') in widget_bridge.cpp; routed through to Yoga via YGNodeStyleSetOverflow in yoga_layout.cpp::build_yoga_subtree. Paint clipping in view.cpp treats `scroll` like `hidden` (no scrollbar UI yet).",
       "supportedValues": [
         "visible",
         "hidden",
@@ -5817,7 +5817,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"setOverflow accepts scroll keyword\""
       ],
-      "notes": "DIVERGE\u2192PASS sweep \u2014 `scroll` is now accepted as a third keyword and propagates through both the layout engine (Yoga's overflow:scroll affects descendant-overflow contribution) and the paint clip path (matches CSS spec where `scroll` clips the painted box like `hidden`). Scrollbar UI / actual scroll-position state remains a roadmap item; the harness gap was about *layout-side* keyword acceptance, which is now covered.",
+      "notes": "DIVERGE→PASS sweep — `scroll` is now accepted as a third keyword and propagates through both the layout engine (Yoga's overflow:scroll affects descendant-overflow contribution) and the paint clip path (matches CSS spec where `scroll` clips the painted box like `hidden`). Scrollbar UI / actual scroll-position state remains a roadmap item; the harness gap was about *layout-side* keyword acceptance, which is now covered.",
       "issue": ""
     },
     "yoga/direction": {
@@ -5832,26 +5832,26 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1542]"
       ],
-      "notes": "pulp #1542 \u2014 bridge accepts `direction_writing` sub-key on setFlex (distinct from `direction` for flex-direction). FlexStyle::writing_direction { inherit, ltr, rtl } drives both YGNodeStyleSetDirection on the per-node call and the root's YGNodeCalculateLayout direction argument. Required for yoga's logical-edge resolution (start/end, marginStart, etc.).",
+      "notes": "pulp #1542 — bridge accepts `direction_writing` sub-key on setFlex (distinct from `direction` for flex-direction). FlexStyle::writing_direction { inherit, ltr, rtl } drives both YGNodeStyleSetDirection on the per-node call and the root's YGNodeCalculateLayout direction argument. Required for yoga's logical-edge resolution (start/end, marginStart, etc.).",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/flex": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js case 'flex' shorthand parser splits on whitespace and dispatches setFlex(id, 'flex_grow', ...) + optional setFlex(id, 'flex_shrink', ...) + optional setFlex(id, 'flex_basis', ...) onto FlexStyle.flex_grow/flex_shrink/flex_basis. Keyword forms route through the same setFlex calls \u2014 see notes for spec expansions.",
+      "mapsTo": "web-compat-style-decl.js case 'flex' shorthand parser splits on whitespace and dispatches setFlex(id, 'flex_grow', ...) + optional setFlex(id, 'flex_shrink', ...) + optional setFlex(id, 'flex_basis', ...) onto FlexStyle.flex_grow/flex_shrink/flex_basis. Keyword forms route through the same setFlex calls — see notes for spec expansions.",
       "supportedValues": [
         "<grow>",
         "<grow> <shrink>",
         "<grow> <shrink> <basis>",
-        "'auto' (\u2261 1 1 auto)",
-        "'none' (\u2261 0 0 auto)",
-        "'initial' (\u2261 0 1 auto)"
+        "'auto' (≡ 1 1 auto)",
+        "'none' (≡ 0 0 auto)",
+        "'initial' (≡ 0 1 auto)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/web-compat/test_popover_row_template_1147.cpp",
         "test/test_widget_bridge.cpp::\"flex shorthand keyword forms\""
       ],
-      "notes": "pulp #1544 \u2014 catalog promotion. Already wired through `web-compat-style-decl.js` shorthand parser; mirrors `css/flex`. DIVERGE\u2192PASS sweep \u2014 keyword forms (`flex: auto`/`none`/`initial`) now expand per the CSS Flexible Box spec instead of silently zeroing flex_grow.",
+      "notes": "pulp #1544 — catalog promotion. Already wired through `web-compat-style-decl.js` shorthand parser; mirrors `css/flex`. DIVERGE→PASS sweep — keyword forms (`flex: auto`/`none`/`initial`) now expand per the CSS Flexible Box spec instead of silently zeroing flex_grow.",
       "issue": ""
     },
     "yoga/flexFlow": {
@@ -5866,7 +5866,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"flex-flow shorthand recognizes wrap-reverse\""
       ],
-      "notes": "pulp #1544 \u2014 catalog promotion. Already wired through `web-compat-style-decl.js` shorthand parser (pulp #1434 Triage #14 extended it to cover `-reverse` modes); mirrors `css/flexFlow`.",
+      "notes": "pulp #1544 — catalog promotion. Already wired through `web-compat-style-decl.js` shorthand parser (pulp #1434 Triage #14 extended it to cover `-reverse` modes); mirrors `css/flexFlow`.",
       "issue": ""
     }
   },
@@ -5874,7 +5874,7 @@
     "_note": "The @pulp/react reconciler surface (host-config.ts, prop-applier.ts) is captured under rn/* above (prop-applier covers ~70 props). This section is reserved for React-specific features that aren't single-prop entries: Suspense, ConcurrentMode, Profiler, error boundaries, refs, portals, hooks edge cases (useTransition, useDeferredValue, useId, useSyncExternalStore). As of 2026-05-04 the renderer is built on react-reconciler@0.31 and supports the basic function-component + useState + useEffect + useRef + useMemo / useCallback set; concurrent features are not exercised. File-issue follow-up: enumerate observed React features end-to-end and populate per-feature entries. Currently empty pending that audit."
   },
   "html": {
-    "_note": "Populated 2026-05-04 from web-compat-element.js (~836 LOC) and web-compat-document.js (~1527 LOC). Tracks the DOM-lite consumer surface: createElement / setAttribute / appendChild / addEventListener / Element / HTMLElement attributes / dataset / classList / events / style sheet support. Spec source: https://developer.mozilla.org/en-US/docs/Web/API/Element + HTMLElement subclasses. Recent additions since 2026-04-30: html/svg width/height attribute replay (#1347 / pulp #1147), html/span/p/label widget mapping confirmed (Label widget, not View), html/style :hover stylesheet support (#1345 / pulp #1149 part b). 2026-05-05 hygiene (pulp #1434): html/ARIA flipped missing \u2192 partial \u2014 storage works (parallel to html/Element_disabled); platform-bridge routing tracked under #1476.",
+    "_note": "Populated 2026-05-04 from web-compat-element.js (~836 LOC) and web-compat-document.js (~1527 LOC). Tracks the DOM-lite consumer surface: createElement / setAttribute / appendChild / addEventListener / Element / HTMLElement attributes / dataset / classList / events / style sheet support. Spec source: https://developer.mozilla.org/en-US/docs/Web/API/Element + HTMLElement subclasses. Recent additions since 2026-04-30: html/svg width/height attribute replay (#1347 / pulp #1147), html/span/p/label widget mapping confirmed (Label widget, not View), html/style :hover stylesheet support (#1345 / pulp #1149 part b). 2026-05-05 hygiene (pulp #1434): html/ARIA flipped missing → partial — storage works (parallel to html/Element_disabled); platform-bridge routing tracked under #1476.",
     "html/ARIA": {
       "status": "supported",
       "mapsTo": "Element.setAttribute('aria-label', ...) -> bridge.setAccessibilityLabel(id, value) -> View::set_access_label(); Element.setAttribute('role', ...) -> bridge.setAccessibilityRole(id, role) -> View::set_access_role() with ARIA->AccessRole bucket mapping (slider/checkbox/switch/radio/img/progressbar/meter/heading/label collapse onto Pulp's enum; the long ARIA tail collapses to AccessRole::group). Storage round-trips through getAttribute either way. macOS NSAccessibility bridge in core/view/platform/mac/accessibility_mac.mm reads these slots directly; AccessibilityTree snapshot picks them up cross-platform.",
@@ -5887,7 +5887,7 @@
       "tests": [
         "test/test_widget_bridge.cpp: HTML aria-label + role attributes route to View access slots [wave3-html]"
       ],
-      "notes": "Wave 3 (PR #1641) html.2 \u2014 setAccessibilityLabel / setAccessibilityRole bridge fns wired; web-compat-element.js setAttribute() fast-paths aria-label and role. Replay path on _ensureNative + _reparentNative covers the React/JSX setAttribute-before-mount commit order. macOS NSAccessibility wired; Linux AT-SPI / Windows UIA platform routing remains storage-only (tracked under #217). Wave 4 cleanup \u2014 catalog flip from PR #1641 was clobbered by the Wave 3 css PR rebase (#1640); restored to status=supported + emptied unsupportedValues so the harness reflects the wired surface. aria-pressed / aria-checked / aria-disabled / aria-hidden state routing is a follow-on (the View doesn't have a state slot today \u2014 partial-deferred-access-state); not part of the supported surface claim.",
+      "notes": "Wave 3 (PR #1641) html.2 — setAccessibilityLabel / setAccessibilityRole bridge fns wired; web-compat-element.js setAttribute() fast-paths aria-label and role. Replay path on _ensureNative + _reparentNative covers the React/JSX setAttribute-before-mount commit order. macOS NSAccessibility wired; Linux AT-SPI / Windows UIA platform routing remains storage-only (tracked under #217). Wave 4 cleanup — catalog flip from PR #1641 was clobbered by the Wave 3 css PR rebase (#1640); restored to status=supported + emptied unsupportedValues so the harness reflects the wired surface. aria-pressed / aria-checked / aria-disabled / aria-hidden state routing is a follow-on (the View doesn't have a state slot today — partial-deferred-access-state); not part of the supported surface claim.",
       "issue": "1476"
     },
     "html/DocumentFragment": {
@@ -5900,12 +5900,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Wave 1 architectural reclassification \u2014 full Range / Selection API is arch-text-editor-owns-selection (Pulp's text editor has its own selection model; the W3C Range/Selection API is not modeled by design). Wave 4 cleanup \u2014 status partial \u2192 supported + emptied unsupportedValues so the harness reflects the wired DocumentFragment surface (the React reconciler path); the Range/Selection API is an explicit arch non-goal, not a partial-deferred gap.",
+      "notes": "Wave 1 architectural reclassification — full Range / Selection API is arch-text-editor-owns-selection (Pulp's text editor has its own selection model; the W3C Range/Selection API is not modeled by design). Wave 4 cleanup — status partial → supported + emptied unsupportedValues so the harness reflects the wired DocumentFragment surface (the React reconciler path); the Range/Selection API is an explicit arch non-goal, not a partial-deferred gap.",
       "issue": ""
     },
     "html/Element_addEventListener": {
       "status": "supported",
-      "mapsTo": "Element.addEventListener \u2014 registers click / mousedown / mouseup / mouseenter / mouseleave / pointerenter / pointerleave / pointerdown / pointermove / pointerup / pointercancel / gesturestart / gesturechange / gestureend / input / change / focus / blur / wheel / dragstart / drag / dragend / dragenter / dragover / dragleave / drop with the bridge. registerHover/registerClick/registerPointer/registerGesture/registerWheel/registerDrop are called lazily as needed; drop events synthesize a DragEvent-shaped object with `_dropData`.",
+      "mapsTo": "Element.addEventListener — registers click / mousedown / mouseup / mouseenter / mouseleave / pointerenter / pointerleave / pointerdown / pointermove / pointerup / pointercancel / gesturestart / gesturechange / gestureend / input / change / focus / blur / wheel / dragstart / drag / dragend / dragenter / dragover / dragleave / drop with the bridge. registerHover/registerClick/registerPointer/registerGesture/registerWheel/registerDrop are called lazily as needed; drop events synthesize a DragEvent-shaped object with `_dropData`.",
       "supportedValues": [
         "click",
         "mousedown",
@@ -5942,7 +5942,7 @@
         "test/test_widget_bridge.cpp::\"addEventListener('wheel', fn) routes through registerWheel\"",
         "test/test_widget_bridge.cpp::\"addEventListener('drop', fn) routes through registerDrop\""
       ],
-      "notes": "DIVERGE\u2192PASS sweep \u2014 `wheel` and `drag*`/`drop` event types are now routed through `registerWheel` / `registerDrop` from inside `_registerNativeEvent`, so DOM consumers no longer need to call the platform-specific bridge fns directly. The full multi-stage drag lifecycle (native drag-image rendering, dragstart/drag/dragend on the source element) remains a roadmap item \u2014 the bridge fires a single `drop` callback at completion and we synthesize a DragEvent-shaped object for the target element. Hover events fixed earlier in PR #1173 (pulp #1149 part a).",
+      "notes": "DIVERGE→PASS sweep — `wheel` and `drag*`/`drop` event types are now routed through `registerWheel` / `registerDrop` from inside `_registerNativeEvent`, so DOM consumers no longer need to call the platform-specific bridge fns directly. The full multi-stage drag lifecycle (native drag-image rendering, dragstart/drag/dragend on the source element) remains a roadmap item — the bridge fires a single `drop` callback at completion and we synthesize a DragEvent-shaped object for the target element. Hover events fixed earlier in PR #1173 (pulp #1149 part a).",
       "issue": "1149"
     },
     "html/Element_appendChild": {
@@ -5956,7 +5956,7 @@
     },
     "html/Element_classList": {
       "status": "supported",
-      "mapsTo": "Element.classList \u2014 add/remove/toggle/contains/length/item, mirrors className. Triggers stylesheet re-application on change.",
+      "mapsTo": "Element.classList — add/remove/toggle/contains/length/item, mirrors className. Triggers stylesheet re-application on change.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -5965,7 +5965,7 @@
     },
     "html/Element_cloneNode": {
       "status": "supported",
-      "mapsTo": "Element.cloneNode(deep) \u2014 replicates className, textContent, type, value, style props; recursive when deep.",
+      "mapsTo": "Element.cloneNode(deep) — replicates className, textContent, type, value, style props; recursive when deep.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -5974,7 +5974,7 @@
     },
     "html/Element_dataset": {
       "status": "supported",
-      "mapsTo": "Element.dataset \u2014 kebab-cased data-* attrs surface as camelCase JS properties. Includes the data-overlay='true' hint (#1148).",
+      "mapsTo": "Element.dataset — kebab-cased data-* attrs surface as camelCase JS properties. Includes the data-overlay='true' hint (#1148).",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -5983,7 +5983,7 @@
     },
     "html/Element_disabled": {
       "status": "supported",
-      "mapsTo": "Element.disabled property accessor in web-compat-element.js \u2014 set re-applies stylesheets (so `:disabled` selectors react) AND calls bridge `setEnabled(id, !disabled)` so the underlying View flips its enabled flag and stops handling pointer events / dispatching change.",
+      "mapsTo": "Element.disabled property accessor in web-compat-element.js — set re-applies stylesheets (so `:disabled` selectors react) AND calls bridge `setEnabled(id, !disabled)` so the underlying View flips its enabled flag and stops handling pointer events / dispatching change.",
       "supportedValues": [
         "true / false (round-trips through el.disabled getter; both stylesheet and native widget state stay in sync)"
       ],
@@ -5991,12 +5991,12 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"Element.disabled wires to setEnabled\""
       ],
-      "notes": "DIVERGE\u2192PASS sweep \u2014 previously the setter only flipped the stylesheet flag, leaving the native widget interactive even though `:disabled` styles applied. Now wired end-to-end via setEnabled.",
+      "notes": "DIVERGE→PASS sweep — previously the setter only flipped the stylesheet flag, leaving the native widget interactive even though `:disabled` styles applied. Now wired end-to-end via setEnabled.",
       "issue": ""
     },
     "html/Element_dispatchEvent": {
       "status": "supported",
-      "mapsTo": "Element.dispatchEvent \u2014 capture + target + bubble phases; honors stopPropagation / preventDefault / _noBubble.",
+      "mapsTo": "Element.dispatchEvent — capture + target + bubble phases; honors stopPropagation / preventDefault / _noBubble.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6068,7 +6068,7 @@
     },
     "html/Element_removeAttribute": {
       "status": "supported",
-      "mapsTo": "Element.removeAttribute \u2014 also clears data-* dataset entries and re-evaluates overlay heuristic if data-overlay was set.",
+      "mapsTo": "Element.removeAttribute — also clears data-* dataset entries and re-evaluates overlay heuristic if data-overlay was set.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6095,7 +6095,7 @@
     },
     "html/Element_setAttribute": {
       "status": "supported",
-      "mapsTo": "Element.setAttribute(name, value) \u2014 handles id, class, data-*, plus presentational width/height for media tags (replay path).",
+      "mapsTo": "Element.setAttribute(name, value) — handles id, class, data-*, plus presentational width/height for media tags (replay path).",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6113,7 +6113,7 @@
     },
     "html/Element_textContent": {
       "status": "supported",
-      "mapsTo": "Element.textContent \u2014 special-cased for <style>: routes through _processStyleElement instead of setText.",
+      "mapsTo": "Element.textContent — special-cased for <style>: routes through _processStyleElement instead of setText.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6122,7 +6122,7 @@
     },
     "html/Element_value": {
       "status": "supported",
-      "mapsTo": "Element.value \u2014 type-aware (range -> normalized, checkbox -> 0/1, progress -> setProgress, default -> setText).",
+      "mapsTo": "Element.value — type-aware (range -> normalized, checkbox -> 0/1, progress -> setProgress, default -> setText).",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6131,7 +6131,7 @@
     },
     "html/Event_constructor": {
       "status": "supported",
-      "mapsTo": "Event(type, init) and CustomEvent(type, init) constructor functions in web-compat-element.js \u2014 produce objects shaped like the DOM Event interface (type / bubbles / cancelable / composed / target / currentTarget / timeStamp / defaultPrevented / stopPropagation / stopImmediatePropagation / preventDefault). Round-trips through Element.dispatchEvent. The bridge-synthesized `_makeEvent` factory remains the canonical path for native-originated events (it carries the position / pointer / gesture fields).",
+      "mapsTo": "Event(type, init) and CustomEvent(type, init) constructor functions in web-compat-element.js — produce objects shaped like the DOM Event interface (type / bubbles / cancelable / composed / target / currentTarget / timeStamp / defaultPrevented / stopPropagation / stopImmediatePropagation / preventDefault). Round-trips through Element.dispatchEvent. The bridge-synthesized `_makeEvent` factory remains the canonical path for native-originated events (it carries the position / pointer / gesture fields).",
       "supportedValues": [
         "new Event('foo')",
         "new Event('foo', { bubbles, cancelable, composed })",
@@ -6141,7 +6141,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"new Event() round-trips through dispatchEvent\""
       ],
-      "notes": "DIVERGE\u2192PASS sweep \u2014 userland `new Event(...)` previously was a TypeError because no Event class was exposed. Now exposed as a global constructor (plus CustomEvent for parity). Type-only events are sufficient for the harness gap; full DOM event class hierarchy (UIEvent / MouseEvent / KeyboardEvent etc.) remains a roadmap follow-up.",
+      "notes": "DIVERGE→PASS sweep — userland `new Event(...)` previously was a TypeError because no Event class was exposed. Now exposed as a global constructor (plus CustomEvent for parity). Type-only events are sufficient for the harness gap; full DOM event class hierarchy (UIEvent / MouseEvent / KeyboardEvent etc.) remains a roadmap follow-up.",
       "issue": ""
     },
     "html/StyleSheet_inline": {
@@ -6156,12 +6156,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "PR #1345 added :hover; PR #1641 (Wave 3 html.3) extended selector engine with [attr] / descendant / child / compound. Wave 1 architectural reclassification \u2014 @media / @keyframes / @import / @font-face / @supports / complex selectors are arch-no-cascade-engine (Pulp doesn't model the CSS cascade by design; selector evaluation is single-pass tag/.class/#id/[attr]/combinator). Wave 4 cleanup \u2014 status partial \u2192 supported + emptied unsupportedValues; the inline-style surface that IS implemented is the supported claim, the at-rule + cascade-engine extensions are explicit arch non-goals (consumers reach for @pulp/react state-dependent components for media-query / keyframe needs).",
+      "notes": "PR #1345 added :hover; PR #1641 (Wave 3 html.3) extended selector engine with [attr] / descendant / child / compound. Wave 1 architectural reclassification — @media / @keyframes / @import / @font-face / @supports / complex selectors are arch-no-cascade-engine (Pulp doesn't model the CSS cascade by design; selector evaluation is single-pass tag/.class/#id/[attr]/combinator). Wave 4 cleanup — status partial → supported + emptied unsupportedValues; the inline-style surface that IS implemented is the supported claim, the at-rule + cascade-engine extensions are explicit arch non-goals (consumers reach for @pulp/react state-dependent components for media-query / keyframe needs).",
       "issue": ""
     },
     "html/article": {
       "status": "supported",
-      "mapsTo": "createCol \u2014 same as div.",
+      "mapsTo": "createCol — same as div.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6170,7 +6170,7 @@
     },
     "html/aside": {
       "status": "supported",
-      "mapsTo": "createCol \u2014 same as div.",
+      "mapsTo": "createCol — same as div.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6183,7 +6183,7 @@
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Inherits ToggleButton widget \u2014 toggleable by default.",
+      "notes": "Inherits ToggleButton widget — toggleable by default.",
       "issue": ""
     },
     "html/canvas": {
@@ -6207,16 +6207,16 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"<details> open setter dispatches toggle event\""
       ],
-      "notes": "DIVERGE\u2192PASS sweep \u2014 open/closed toggle behavior wired through Element.open setter. <summary>-driven children hiding when closed is a paint-side concern that remains roadmap; the harness gap was about JS-side toggle semantics.",
+      "notes": "DIVERGE→PASS sweep — open/closed toggle behavior wired through Element.open setter. <summary>-driven children hiding when closed is a paint-side concern that remains roadmap; the harness gap was about JS-side toggle semantics.",
       "issue": ""
     },
     "html/dialog": {
       "status": "noop",
-      "mapsTo": "createPanel(id, parent) + setVisible(false). Element.show() / showModal() / close() methods on Element.prototype (tag-guarded \u2014 no-op on non-DIALOG elements) flip setVisible and the `open` HTML attribute, dispatch a `close` event, and round-trip `el.returnValue`. showModal() degrades to show() because Pulp doesn't yet have a native modal-input-trap layer; the ::backdrop pseudo-element remains a separate paint-side roadmap item.",
+      "mapsTo": "createPanel(id, parent) + setVisible(false). Element.show() / showModal() / close() methods on Element.prototype (tag-guarded — no-op on non-DIALOG elements) flip setVisible and the `open` HTML attribute, dispatch a `close` event, and round-trip `el.returnValue`. showModal() degrades to show() because Pulp doesn't yet have a native modal-input-trap layer; the ::backdrop pseudo-element remains a separate paint-side roadmap item.",
       "supportedValues": [
         "dialog as a hidden Panel",
         "el.show()",
-        "el.showModal() (degrades to show() \u2014 no native modal trap layer yet)",
+        "el.showModal() (degrades to show() — no native modal trap layer yet)",
         "el.close(returnValue) + 'close' event",
         "el.open getter (reflects open attribute)",
         "el.returnValue"
@@ -6225,7 +6225,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::\"<dialog> show/close round-trips visibility and dispatches close\""
       ],
-      "notes": "DIVERGE\u2192PASS sweep \u2014 show/showModal/close methods exposed. Modal input-trap + ::backdrop remain a roadmap paint-side concern; the harness gap was about JS-side state-machine vocabulary. Wave 1 drift cleanup \u2014 supported \u2192 noop (Element.show() / showModal() / close() are stored-only; modal dialog rendering not in pipeline today).",
+      "notes": "DIVERGE→PASS sweep — show/showModal/close methods exposed. Modal input-trap + ::backdrop remain a roadmap paint-side concern; the harness gap was about JS-side state-machine vocabulary. Wave 1 drift cleanup — supported → noop (Element.show() / showModal() / close() are stored-only; modal dialog rendering not in pipeline today).",
       "issue": ""
     },
     "html/div": {
@@ -6236,7 +6236,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Generic container \u2014 Yoga column flex by default.",
+      "notes": "Generic container — Yoga column flex by default.",
       "issue": ""
     },
     "html/document_addEventListener": {
@@ -6277,7 +6277,7 @@
     },
     "html/document_querySelector": {
       "status": "supported",
-      "mapsTo": "document.querySelector / querySelectorAll \u2014 _parseSelector + _matchesSelector in web-compat-document.js. Tokenizes the rightmost simple selector (tag / #id / .class / [attr] / [attr=value] / [attr^=v] / [attr$=v] / [attr*=v] / [attr|=v] / [attr~=v]) plus descendant (`a b`) and child (`a > b`) combinators, walking left to right with bracket-aware splitting.",
+      "mapsTo": "document.querySelector / querySelectorAll — _parseSelector + _matchesSelector in web-compat-document.js. Tokenizes the rightmost simple selector (tag / #id / .class / [attr] / [attr=value] / [attr^=v] / [attr$=v] / [attr*=v] / [attr|=v] / [attr~=v]) plus descendant (`a b`) and child (`a > b`) combinators, walking left to right with bracket-aware splitting.",
       "supportedValues": [
         "#id",
         ".class",
@@ -6297,12 +6297,12 @@
       "tests": [
         "test/test_widget_bridge.cpp: querySelector minimal selector engine [wave3-html]"
       ],
-      "notes": "Wave 3 (PR #1641) html.3 \u2014 tag/.class/#id/[attr]/[attr=value]/descendant/child wired; pseudo-classes (:hover, :nth-child) and sibling combinators not implemented (parser tolerates trailing `:pseudo` for forward compat \u2014 it's stored but unmatched). Selectors that include unsupported features fall through to no-match rather than throwing. CSS StyleSheet `_applyTo` rides the same code path. Wave 4 cleanup \u2014 catalog flip from PR #1641 was clobbered by Wave 3 css PR rebase (#1640); restored to status=supported + emptied unsupportedValues. Pseudo-classes / pseudo-elements / sibling combinators / selector-lists / case-insensitive flag are arch-no-cascade-engine (Pulp's selector engine is single-pass tag/.class/#id/[attr]/combinator; the full CSS Selectors Level 4 cascade is an explicit non-goal \u2014 use @pulp/react components for state-dependent styling).",
+      "notes": "Wave 3 (PR #1641) html.3 — tag/.class/#id/[attr]/[attr=value]/descendant/child wired; pseudo-classes (:hover, :nth-child) and sibling combinators not implemented (parser tolerates trailing `:pseudo` for forward compat — it's stored but unmatched). Selectors that include unsupported features fall through to no-match rather than throwing. CSS StyleSheet `_applyTo` rides the same code path. Wave 4 cleanup — catalog flip from PR #1641 was clobbered by Wave 3 css PR rebase (#1640); restored to status=supported + emptied unsupportedValues. Pseudo-classes / pseudo-elements / sibling combinators / selector-lists / case-insensitive flag are arch-no-cascade-engine (Pulp's selector engine is single-pass tag/.class/#id/[attr]/combinator; the full CSS Selectors Level 4 cascade is an explicit non-goal — use @pulp/react components for state-dependent styling).",
       "issue": ""
     },
     "html/footer": {
       "status": "supported",
-      "mapsTo": "createCol \u2014 same as div.",
+      "mapsTo": "createCol — same as div.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6365,7 +6365,7 @@
     },
     "html/header": {
       "status": "supported",
-      "mapsTo": "createCol \u2014 same as div.",
+      "mapsTo": "createCol — same as div.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6399,35 +6399,35 @@
     },
     "html/input": {
       "status": "supported",
-      "mapsTo": "createTextEditor by default; createFader for type=range, createCheckbox for type=checkbox. Other `type=` values fall through to text-editor \u2014 a deliberate design choice that matches how the same DOM element is rendered in environments without specialized native widgets (the value-bearing semantics are uniform, only the chrome differs).",
+      "mapsTo": "createTextEditor by default; createFader for type=range, createCheckbox for type=checkbox. Other `type=` values fall through to text-editor — a deliberate design choice that matches how the same DOM element is rendered in environments without specialized native widgets (the value-bearing semantics are uniform, only the chrome differs).",
       "supportedValues": [
         "type=text / type=password / type=email / type=number / type=range / type=checkbox",
-        "type=date / type=time / type=datetime-local / type=month / type=week (fall through to text-editor \u2014 value typed as ISO-8601 string)",
-        "type=file / type=color (fall through to text-editor \u2014 placeholder; native pickers are a roadmap item)",
+        "type=date / type=time / type=datetime-local / type=month / type=week (fall through to text-editor — value typed as ISO-8601 string)",
+        "type=file / type=color (fall through to text-editor — placeholder; native pickers are a roadmap item)",
         "type=url / type=search (fall through to text-editor)"
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "DIVERGE\u2192PASS sweep \u2014 fall-through to text-editor is the SUPPORTED behavior for these input types in Pulp's render surface; the catalog previously listed them as gaps but they accept input correctly (the value is just a string typed by the user). Specialized chrome \u2014 date pickers, color wheels, file pickers \u2014 remains a roadmap item; that's a separate UX concern from compat. Wave 1 drift cleanup \u2014 partial \u2192 supported (wired through _ensureNative -> bridge createTextEditor / createFader / createCheckbox).",
+      "notes": "DIVERGE→PASS sweep — fall-through to text-editor is the SUPPORTED behavior for these input types in Pulp's render surface; the catalog previously listed them as gaps but they accept input correctly (the value is just a string typed by the user). Specialized chrome — date pickers, color wheels, file pickers — remains a roadmap item; that's a separate UX concern from compat. Wave 1 drift cleanup — partial → supported (wired through _ensureNative -> bridge createTextEditor / createFader / createCheckbox).",
       "issue": ""
     },
     "html/label": {
       "status": "supported",
-      "mapsTo": "createLabel + lazy `_installLabelForRouting` in web-compat-element.js \u2014 clicking the label inspects the `for` attribute and, if it matches an Element id, routes activation to that target (focus via setFocus when wired; checkbox/radio toggle plus dispatched 'input' event always).",
+      "mapsTo": "createLabel + lazy `_installLabelForRouting` in web-compat-element.js — clicking the label inspects the `for` attribute and, if it matches an Element id, routes activation to that target (focus via setFocus when wired; checkbox/radio toggle plus dispatched 'input' event always).",
       "supportedValues": [
         "createLabel rendering",
-        "for attribute \u2192 click activation routing (toggle on checkbox/radio; setFocus when bridge fn available)"
+        "for attribute → click activation routing (toggle on checkbox/radio; setFocus when bridge fn available)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp::\"<label for=...> click toggles labeled checkbox\""
       ],
-      "notes": "DIVERGE\u2192PASS sweep \u2014 `for` attribute click-routing wired in JS. Full focus-pull (currently bridge has no setFocus) remains a roadmap follow-up; the harness gap was about the wired vs. silently-dropped distinction.",
+      "notes": "DIVERGE→PASS sweep — `for` attribute click-routing wired in JS. Full focus-pull (currently bridge has no setFocus) remains a roadmap follow-up; the harness gap was about the wired vs. silently-dropped distinction.",
       "issue": ""
     },
     "html/main": {
       "status": "supported",
-      "mapsTo": "createCol \u2014 same as div.",
+      "mapsTo": "createCol — same as div.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6436,7 +6436,7 @@
     },
     "html/nav": {
       "status": "supported",
-      "mapsTo": "createCol \u2014 same as div.",
+      "mapsTo": "createCol — same as div.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6445,7 +6445,7 @@
     },
     "html/p": {
       "status": "supported",
-      "mapsTo": "createLabel \u2014 same as span.",
+      "mapsTo": "createLabel — same as span.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6463,7 +6463,7 @@
     },
     "html/section": {
       "status": "supported",
-      "mapsTo": "createCol \u2014 same as div.",
+      "mapsTo": "createCol — same as div.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6498,7 +6498,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "PR #1345 / pulp #1149 part b added :hover; PR #1641 (Wave 3 html.3) extended selector engine. Wave 1 architectural reclassification \u2014 @media / @keyframes / complex selectors are arch-no-cascade-engine (Pulp's inline <style> parser is single-pass; the cascade engine is an explicit non-goal). Wave 4 cleanup \u2014 status partial \u2192 supported + emptied unsupportedValues so the harness reflects the wired surface; rides the StyleSheet_inline catalog claim.",
+      "notes": "PR #1345 / pulp #1149 part b added :hover; PR #1641 (Wave 3 html.3) extended selector engine. Wave 1 architectural reclassification — @media / @keyframes / complex selectors are arch-no-cascade-engine (Pulp's inline <style> parser is single-pass; the cascade engine is an explicit non-goal). Wave 4 cleanup — status partial → supported + emptied unsupportedValues so the harness reflects the wired surface; rides the StyleSheet_inline catalog claim.",
       "issue": "1149"
     },
     "html/svg": {
@@ -6510,7 +6510,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "PR #1347 (pulp #1147): <svg> is a leaf container that reserves layout space. For rendered SVG paths use the @pulp/react SvgPath intrinsic. Wave 1 architectural reclassification \u2014 full SVG rasterization of children is arch-explicit-non-goal (createCol shim reserves layout space; @pulp/react SvgPath intrinsic is the canonical rendered-path API \u2014 the layout-shim surface IS the supported surface). Wave 4 cleanup \u2014 status partial \u2192 supported + emptied unsupportedValues; child path/rect/circle/text rasterization is arch-non-goal, not a partial-deferred gap.",
+      "notes": "PR #1347 (pulp #1147): <svg> is a leaf container that reserves layout space. For rendered SVG paths use the @pulp/react SvgPath intrinsic. Wave 1 architectural reclassification — full SVG rasterization of children is arch-explicit-non-goal (createCol shim reserves layout space; @pulp/react SvgPath intrinsic is the canonical rendered-path API — the layout-shim surface IS the supported surface). Wave 4 cleanup — status partial → supported + emptied unsupportedValues; child path/rect/circle/text rasterization is arch-non-goal, not a partial-deferred gap.",
       "issue": "1147"
     },
     "html/textarea": {
@@ -6533,7 +6533,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "PR #1348 fixed a typo where the JS was calling canvasFillRect (which never existed) \u2014 now correctly calls canvasRect.",
+      "notes": "PR #1348 fixed a typo where the JS was calling canvasFillRect (which never existed) — now correctly calls canvasRect.",
       "issue": "1346"
     },
     "canvas2d/strokeRect": {
@@ -6596,7 +6596,7 @@
     },
     "canvas2d/rect": {
       "status": "supported",
-      "mapsTo": "ctx.rect(x,y,w,h) -> moveTo + 4\u00d7 lineTo back to start (composes a closed subpath).",
+      "mapsTo": "ctx.rect(x,y,w,h) -> moveTo + 4× lineTo back to start (composes a closed subpath).",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6617,7 +6617,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [wave2-canvas2d]"
       ],
-      "notes": "PR #1348 + Wave 2 cheap wiring \u2014 confirmed all five radii forms thread through to SkRRect::setRectRadii with 4 distinct SkVector corners.",
+      "notes": "PR #1348 + Wave 2 cheap wiring — confirmed all five radii forms thread through to SkRRect::setRectRadii with 4 distinct SkVector corners.",
       "issue": "1346"
     },
     "canvas2d/arc": {
@@ -6630,18 +6630,18 @@
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1526]"
       ],
-      "notes": "PR #1348. The bezier approximation is per-quadrant (k = (4/3)\u00b7tan(\u03b8/4)); fidelity is visually exact for fill/stroke/clip use cases. Wave 1 drift cleanup \u2014 partial \u2192 supported (PR #1348 wired path-mode arc as cubic-bezier segments via canvasPathArc; bezier approximation is per-quadrant, visually exact for fill/stroke/clip use cases).",
+      "notes": "PR #1348. The bezier approximation is per-quadrant (k = (4/3)·tan(θ/4)); fidelity is visually exact for fill/stroke/clip use cases. Wave 1 drift cleanup — partial → supported (PR #1348 wired path-mode arc as cubic-bezier segments via canvasPathArc; bezier approximation is per-quadrant, visually exact for fill/stroke/clip use cases).",
       "issue": "1346"
     },
     "canvas2d/arcTo": {
       "status": "supported",
-      "mapsTo": "ctx.arcTo(x1,y1,x2,y2,r) -> canvasPathArcTo. Skia: SkPath::arcTo(p1, p2, radius) \u2014 closed-form tangent-arc geometry. CG: CGPathAddArcToPoint(p1, p2, radius). pulp #1521 replaced the conservative lineTo-only fallback with the spec-compliant radius-tangent computation.",
+      "mapsTo": "ctx.arcTo(x1,y1,x2,y2,r) -> canvasPathArcTo. Skia: SkPath::arcTo(p1, p2, radius) — closed-form tangent-arc geometry. CG: CGPathAddArcToPoint(p1, p2, radius). pulp #1521 replaced the conservative lineTo-only fallback with the spec-compliant radius-tangent computation.",
       "supportedValues": [
-        "arcTo(x1, y1, x2, y2, radius) \u2014 geometrically correct on Skia + CG"
+        "arcTo(x1, y1, x2, y2, radius) — geometrically correct on Skia + CG"
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1521 \u2014 native SkPath::arcTo (Skia) / CGPathAddArcToPoint (CG). Wave 4 c2d cleanup: catalog reconciled to match wired implementation (prior PR #1348 lineTo fallback was replaced by #1521).",
+      "notes": "pulp #1521 — native SkPath::arcTo (Skia) / CGPathAddArcToPoint (CG). Wave 4 c2d cleanup: catalog reconciled to match wired implementation (prior PR #1348 lineTo fallback was replaced by #1521).",
       "issue": ""
     },
     "canvas2d/bezierCurveTo": {
@@ -6678,7 +6678,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [wave2-canvas2d]"
       ],
-      "notes": "PR #1521 + Wave 2 cheap wiring \u2014 confirmed rotation threads through SkMatrix and CGAffineTransform.",
+      "notes": "PR #1521 + Wave 2 cheap wiring — confirmed rotation threads through SkMatrix and CGAffineTransform.",
       "issue": "1346"
     },
     "canvas2d/fill": {
@@ -6692,7 +6692,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [wave2-canvas2d]"
       ],
-      "notes": "Wave 2 cheap wiring \u2014 added FillRule enum to canvas.hpp, plumbed cmd.int_val from widget_bridge through CanvasWidget::paint into both Skia (SkPathFillType::kEvenOdd) and CG (CGContextEOFillPath) backends. Pre-Wave-2 the rule was read by widget_bridge but discarded by canvas_widget.",
+      "notes": "Wave 2 cheap wiring — added FillRule enum to canvas.hpp, plumbed cmd.int_val from widget_bridge through CanvasWidget::paint into both Skia (SkPathFillType::kEvenOdd) and CG (CGContextEOFillPath) backends. Pre-Wave-2 the rule was read by widget_bridge but discarded by canvas_widget.",
       "issue": ""
     },
     "canvas2d/stroke": {
@@ -6715,37 +6715,37 @@
       "tests": [
         "test/test_widget_bridge.cpp [wave2-canvas2d]"
       ],
-      "notes": "Backed by SkCanvas::clipPath. (issue-896 added canvasClip; older canvasClipRect is the rect-only path.) Wave 2 cheap wiring \u2014 added FillRule enum to canvas.hpp, plumbed cmd.int_val from widget_bridge through CanvasWidget::paint into both Skia (SkPathFillType::kEvenOdd) and CG (CGContextEOClip) backends.",
+      "notes": "Backed by SkCanvas::clipPath. (issue-896 added canvasClip; older canvasClipRect is the rect-only path.) Wave 2 cheap wiring — added FillRule enum to canvas.hpp, plumbed cmd.int_val from widget_bridge through CanvasWidget::paint into both Skia (SkPathFillType::kEvenOdd) and CG (CGContextEOClip) backends.",
       "issue": ""
     },
     "canvas2d/isPointInPath": {
       "status": "partial",
-      "mapsTo": "ctx.isPointInPath(x, y[, fillRule]) -> JS-side ray-cast against the path mirror. Each path-construction method (moveTo / lineTo / rect / roundRect / arc / arcTo / ellipse / bezierCurveTo / quadraticCurveTo / closePath) appends to `_pathSubpaths` in addition to forwarding to the bridge. Curve segments sample to ~16 line pieces \u2014 accurate enough for spec-compliant hit testing.",
+      "mapsTo": "ctx.isPointInPath(x, y[, fillRule]) -> JS-side ray-cast against the path mirror. Each path-construction method (moveTo / lineTo / rect / roundRect / arc / arcTo / ellipse / bezierCurveTo / quadraticCurveTo / closePath) appends to `_pathSubpaths` in addition to forwarding to the bridge. Curve segments sample to ~16 line pieces — accurate enough for spec-compliant hit testing.",
       "supportedValues": [
         "isPointInPath(x, y) on rect / lineTo polygon / arc / curve paths",
         "rolls back across save / restore via the path-mirror snapshot"
       ],
       "unsupportedValues": [
         "Path2D-object first argument (shim returns a 2-arg form result; standalone Path2D not yet modeled)",
-        "fillRule difference for self-intersecting paths \u2014 the JS ray-cast returns the same answer for 'nonzero' and 'evenodd'"
+        "fillRule difference for self-intersecting paths — the JS ray-cast returns the same answer for 'nonzero' and 'evenodd'"
       ],
       "tests": [],
-      "notes": "pulp #1527 bridge-thin gap-fill. Synchronous return \u2014 no bridge round-trip; the bridge owns the canonical SkPath but it's not queryable from JS until paint time. Wave 1 paperwork \u2014 synchronous return; no bridge round-trip; bridge-thin gap-fill (pulp #1527).",
+      "notes": "pulp #1527 bridge-thin gap-fill. Synchronous return — no bridge round-trip; the bridge owns the canonical SkPath but it's not queryable from JS until paint time. Wave 1 paperwork — synchronous return; no bridge round-trip; bridge-thin gap-fill (pulp #1527).",
       "issue": "1527"
     },
     "canvas2d/isPointInStroke": {
       "status": "partial",
-      "mapsTo": "ctx.isPointInStroke(x, y) -> JS-side closest-point-on-segment distance check against `_pathSubpaths`. Returns true when the test point's distance to any path segment is \u2264 lineWidth / 2.",
+      "mapsTo": "ctx.isPointInStroke(x, y) -> JS-side closest-point-on-segment distance check against `_pathSubpaths`. Returns true when the test point's distance to any path segment is ≤ lineWidth / 2.",
       "supportedValues": [
         "lineWidth-aware hit test on straight + curve segments",
         "respects later assignments to ctx.lineWidth"
       ],
       "unsupportedValues": [
-        "lineCap / lineJoin geometry (square caps, miter spikes \u2014 approximated as round caps because we test distance to the segment)",
+        "lineCap / lineJoin geometry (square caps, miter spikes — approximated as round caps because we test distance to the segment)",
         "Path2D-object first argument"
       ],
       "tests": [],
-      "notes": "pulp #1527 bridge-thin gap-fill. Pairs with isPointInPath; uses the same JS path mirror. Wave 1 paperwork \u2014 pairs with isPointInPath; same JS path mirror (pulp #1527).",
+      "notes": "pulp #1527 bridge-thin gap-fill. Pairs with isPointInPath; uses the same JS path mirror. Wave 1 paperwork — pairs with isPointInPath; same JS path mirror (pulp #1527).",
       "issue": "1527"
     },
     "canvas2d/save": {
@@ -6795,7 +6795,7 @@
     },
     "canvas2d/setTransform": {
       "status": "supported",
-      "mapsTo": "ctx.setTransform(a,b,c,d,e,f) \u2014 also accepts a single DOMMatrix-like arg, shim unpacks. -> canvasSetTransform.",
+      "mapsTo": "ctx.setTransform(a,b,c,d,e,f) — also accepts a single DOMMatrix-like arg, shim unpacks. -> canvasSetTransform.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6813,7 +6813,7 @@
     },
     "canvas2d/getTransform": {
       "status": "supported",
-      "mapsTo": "ctx.getTransform() -> returns a DOMMatrix-shaped object reflecting the JS-mirrored 2D affine transform. The shim tracks `_currentTransform` via translate / scale / rotate / setTransform / transform / save / restore so the read is synchronous (no bridge round-trip; the bridge replays draws at paint time and has no queryable 'current matrix' from JS). Per HTML5 Canvas spec, getTransform() returns a NEW DOMMatrix per call (a snapshot \u2014 mutating it does not affect the live ctx). DOMMatrix mutation methods (multiplySelf, scaleSelf, etc.) on the returned object are not exposed because they would only mutate the snapshot, not the canvas \u2014 same outcome as on the standard browser surface.",
+      "mapsTo": "ctx.getTransform() -> returns a DOMMatrix-shaped object reflecting the JS-mirrored 2D affine transform. The shim tracks `_currentTransform` via translate / scale / rotate / setTransform / transform / save / restore so the read is synchronous (no bridge round-trip; the bridge replays draws at paint time and has no queryable 'current matrix' from JS). Per HTML5 Canvas spec, getTransform() returns a NEW DOMMatrix per call (a snapshot — mutating it does not affect the live ctx). DOMMatrix mutation methods (multiplySelf, scaleSelf, etc.) on the returned object are not exposed because they would only mutate the snapshot, not the canvas — same outcome as on the standard browser surface.",
       "supportedValues": [
         "a, b, c, d, e, f (live)",
         "m11/m12/m21/m22/m41/m42 DOMMatrix aliases",
@@ -6822,12 +6822,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "DIVERGE\u2192PASS sweep \u2014 clarified that snapshot semantics are spec-compliant (HTML5 Canvas spec: getTransform() returns a NEW DOMMatrix); DOMMatrix mutation methods on a snapshot wouldn't affect the canvas anyway. pulp #1527 bridge-thin gap-fill.",
+      "notes": "DIVERGE→PASS sweep — clarified that snapshot semantics are spec-compliant (HTML5 Canvas spec: getTransform() returns a NEW DOMMatrix); DOMMatrix mutation methods on a snapshot wouldn't affect the canvas anyway. pulp #1527 bridge-thin gap-fill.",
       "issue": "1527"
     },
     "canvas2d/transform": {
       "status": "partial",
-      "mapsTo": "ctx.transform(a,b,c,d,e,f) \u2014 multiplies CURRENT transform; bridge only exposes replace (setTransform), not concat. Pure-translation matrices (a===1, b===0, c===0, d===1) fall through to canvasTranslate; everything else is a no-op.",
+      "mapsTo": "ctx.transform(a,b,c,d,e,f) — multiplies CURRENT transform; bridge only exposes replace (setTransform), not concat. Pure-translation matrices (a===1, b===0, c===0, d===1) fall through to canvasTranslate; everything else is a no-op.",
       "supportedValues": [
         "pure-translation matrices"
       ],
@@ -6835,21 +6835,21 @@
         "arbitrary concat (rotate/scale/skew + existing transform)"
       ],
       "tests": [],
-      "notes": "PR #1348. File a follow-up if a plugin needs strict concat. Wave 1 paperwork \u2014 strict concat semantics deferred (PR #1348); pure-translation fast path covers the common case.",
+      "notes": "PR #1348. File a follow-up if a plugin needs strict concat. Wave 1 paperwork — strict concat semantics deferred (PR #1348); pure-translation fast path covers the common case.",
       "issue": "1346"
     },
     "canvas2d/fillText": {
       "status": "supported",
       "mapsTo": "ctx.fillText(text,x,y,maxWidth) -> _syncGlobalState + _syncShadowState + _syncFilterState + _syncDirectionState + _syncTextState + _applyFillStyle + canvasFillText(id, text, x, y, size, color, maxWidth). pulp #1525 plumbed maxWidth end-to-end (Skia: SkMatrix::Scale around the origin; CG: CGContextScaleCTM). pulp Wave 3 c2d.6 routes gradient/pattern fillStyle through current_fill_paint() so glyphs honour the active gradient_shader_.",
       "supportedValues": [
-        "fillText(text, x, y) \u2014 solid colour fillStyle",
-        "fillText(text, x, y, maxWidth) \u2014 squeezed via SkMatrix::Scale (Skia) / CGContextScaleCTM (CG)",
+        "fillText(text, x, y) — solid colour fillStyle",
+        "fillText(text, x, y, maxWidth) — squeezed via SkMatrix::Scale (Skia) / CGContextScaleCTM (CG)",
         "gradient fillStyle (shader flows onto glyph paint via current_fill_paint)",
         "CanvasPattern fillStyle on Skia (SkShader::MakeImage)"
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1525 \u2014 maxWidth plumbed end-to-end. pulp Wave 3 c2d.6 \u2014 gradient/pattern fillStyle routes through current_fill_paint() so the shader applies to glyphs. Wave 4 c2d cleanup: catalog reconciled to match wired implementation.",
+      "notes": "pulp #1525 — maxWidth plumbed end-to-end. pulp Wave 3 c2d.6 — gradient/pattern fillStyle routes through current_fill_paint() so the shader applies to glyphs. Wave 4 c2d cleanup: catalog reconciled to match wired implementation.",
       "issue": ""
     },
     "canvas2d/strokeText": {
@@ -6865,12 +6865,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [wave2-canvas2d]"
       ],
-      "notes": "PR #1525 + Codex P2 follow-up \u2014 make_stroke_paint() sets kStroke_Style and apply_stroke_state() propagates sticky stroke state. Wave 2 cheap wiring \u2014 confirmed end-to-end and bumped from partial -> supported.",
+      "notes": "PR #1525 + Codex P2 follow-up — make_stroke_paint() sets kStroke_Style and apply_stroke_state() propagates sticky stroke state. Wave 2 cheap wiring — confirmed end-to-end and bumped from partial -> supported.",
       "issue": ""
     },
     "canvas2d/measureText": {
       "status": "supported",
-      "mapsTo": "ctx.measureText(text) \u2014 when canvasMeasureText is available returns the bridge-side TextMetrics; else returns a coarse char-width estimate.",
+      "mapsTo": "ctx.measureText(text) — when canvasMeasureText is available returns the bridge-side TextMetrics; else returns a coarse char-width estimate.",
       "supportedValues": [
         "width",
         "actualBoundingBoxLeft/Right/Ascent/Descent",
@@ -6889,10 +6889,10 @@
         "drawImage(img, dx, dy, dw, dh)"
       ],
       "unsupportedValues": [
-        "drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh) \u2014 sprite-sheet slicing not yet wired"
+        "drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh) — sprite-sheet slicing not yet wired"
       ],
       "tests": [],
-      "notes": "issue-916. File a follow-up if a Pulp plugin needs sprite-sheet slicing. Wave 1 paperwork \u2014 sprite-sheet 9-arg form deferred (issue-916); file follow-up if a Pulp plugin needs sprite-sheet slicing.",
+      "notes": "issue-916. File a follow-up if a Pulp plugin needs sprite-sheet slicing. Wave 1 paperwork — sprite-sheet 9-arg form deferred (issue-916); file follow-up if a Pulp plugin needs sprite-sheet slicing.",
       "issue": ""
     },
     "canvas2d/getImageData": {
@@ -6905,7 +6905,7 @@
         "non-rasterized RecordingCanvas (returns zero-filled)"
       ],
       "tests": [],
-      "notes": "issue-916. The base64 round-trip avoids passing typed arrays across the JS bridge. Wave 1 paperwork \u2014 base64 round-trip avoids typed-array bridge cost (issue-916).",
+      "notes": "issue-916. The base64 round-trip avoids passing typed arrays across the JS bridge. Wave 1 paperwork — base64 round-trip avoids typed-array bridge cost (issue-916).",
       "issue": ""
     },
     "canvas2d/putImageData": {
@@ -6915,10 +6915,10 @@
         "putImageData(img, dx, dy)"
       ],
       "unsupportedValues": [
-        "putImageData(img, dx, dy, dirtyX, dirtyY, dirtyW, dirtyH) \u2014 sub-rect form treated as no-rect"
+        "putImageData(img, dx, dy, dirtyX, dirtyY, dirtyW, dirtyH) — sub-rect form treated as no-rect"
       ],
       "tests": [],
-      "notes": "issue-916. File a follow-up if sub-rect updates become a hot path. Wave 1 paperwork \u2014 sub-rect form deferred (issue-916); file follow-up if it becomes a hot path.",
+      "notes": "issue-916. File a follow-up if sub-rect updates become a hot path. Wave 1 paperwork — sub-rect form deferred (issue-916); file follow-up if it becomes a hot path.",
       "issue": ""
     },
     "canvas2d/createLinearGradient": {
@@ -6974,12 +6974,12 @@
         "test/test_canvas.cpp [canvas][cg][issue-1524]",
         "test/test_canvas2d_shim.cpp [issue-1434][bridge-thin]"
       ],
-      "notes": "pulp #1524. Skia uses SkShader::MakeImage; CG uses CGPatternCreate with a draw callback that emits one tile via CGContextDrawImage. `no_repeat` axes blow up the tile step beyond the clip bbox so only the seed tile lands. Image source decoded via ImageIO (CGImageSourceCreateWithData / WithURL) for both file paths and `data:` URLs. Note: CG stroke patterns are still a no-op (strokes continue with stroke_color_) \u2014 file a follow-up if a CG-targeted plugin needs tiled stroke patterns; this entry is for the createPattern fill surface.",
+      "notes": "pulp #1524. Skia uses SkShader::MakeImage; CG uses CGPatternCreate with a draw callback that emits one tile via CGContextDrawImage. `no_repeat` axes blow up the tile step beyond the clip bbox so only the seed tile lands. Image source decoded via ImageIO (CGImageSourceCreateWithData / WithURL) for both file paths and `data:` URLs. Note: CG stroke patterns are still a no-op (strokes continue with stroke_color_) — file a follow-up if a CG-targeted plugin needs tiled stroke patterns; this entry is for the createPattern fill surface.",
       "issue": "1524"
     },
     "canvas2d/addColorStop": {
       "status": "supported",
-      "mapsTo": "CanvasGradient.addColorStop(offset, color) \u2014 accumulates stops on the JS-side gradient object; flushed to bridge via canvasSetLinearGradient / canvasSetRadialGradient when the gradient is assigned to fillStyle.",
+      "mapsTo": "CanvasGradient.addColorStop(offset, color) — accumulates stops on the JS-side gradient object; flushed to bridge via canvasSetLinearGradient / canvasSetRadialGradient when the gradient is assigned to fillStyle.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
@@ -6988,7 +6988,7 @@
     },
     "canvas2d/setLineDash": {
       "status": "supported",
-      "mapsTo": "ctx.setLineDash(pattern) -> canvasSetLineDash(id, pattern, lineDashOffset). Bridge does the HTML5-spec odd-length array doubling (`[5, 10, 15]` \u2192 `[5, 10, 15, 5, 10, 15]`) in widget_bridge.cpp::canvasSetLineDash before recording the command. Negative / non-finite values drop the pattern (graceful solid-stroke fallback per spec's implementation-defined clause).",
+      "mapsTo": "ctx.setLineDash(pattern) -> canvasSetLineDash(id, pattern, lineDashOffset). Bridge does the HTML5-spec odd-length array doubling (`[5, 10, 15]` → `[5, 10, 15, 5, 10, 15]`) in widget_bridge.cpp::canvasSetLineDash before recording the command. Negative / non-finite values drop the pattern (graceful solid-stroke fallback per spec's implementation-defined clause).",
       "supportedValues": [
         "even-length pattern arrays",
         "odd-length pattern arrays (spec-doubled by the bridge)",
@@ -6996,7 +6996,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "DIVERGE\u2192PASS sweep \u2014 the catalog note about \"shim takes pattern verbatim; bridge handles the spec-doubling\" was describing the architecture, not a gap. The end-to-end behavior is spec-compliant. Wave 1 paperwork \u2014 see SKILL canvas2d gotchas; HTML5-spec odd-length doubling is performed internally by canvasSetLineDash before recording.",
+      "notes": "DIVERGE→PASS sweep — the catalog note about \"shim takes pattern verbatim; bridge handles the spec-doubling\" was describing the architecture, not a gap. The end-to-end behavior is spec-compliant. Wave 1 paperwork — see SKILL canvas2d gotchas; HTML5-spec odd-length doubling is performed internally by canvasSetLineDash before recording.",
       "issue": ""
     },
     "canvas2d/getLineDash": {
@@ -7019,7 +7019,7 @@
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1526]"
       ],
-      "notes": "Wave 4 c2d cleanup \u2014 defineProperty getter/setter pair re-flushes dash on assignment. Pre-Wave-4 the field tracked locally but only sent on the next setLineDash, so phase mutations between draws were silently dropped.",
+      "notes": "Wave 4 c2d cleanup — defineProperty getter/setter pair re-flushes dash on assignment. Pre-Wave-4 the field tracked locally but only sent on the next setLineDash, so phase mutations between draws were silently dropped.",
       "issue": ""
     },
     "canvas2d/fillStyle": {
@@ -7032,12 +7032,12 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "DIVERGE\u2192PASS sweep \u2014 pattern path was already wired (createPattern in PASS list, _applyFillStyle dispatches canvasSetFillPattern); the catalog had a stale gap entry from before pulp #1434's createPattern bridge work. Wave 1 paperwork \u2014 CanvasPattern wiring confirmed via createPattern + _applyFillStyle / canvasSetFillPattern (#1625 finding).",
+      "notes": "DIVERGE→PASS sweep — pattern path was already wired (createPattern in PASS list, _applyFillStyle dispatches canvasSetFillPattern); the catalog had a stale gap entry from before pulp #1434's createPattern bridge work. Wave 1 paperwork — CanvasPattern wiring confirmed via createPattern + _applyFillStyle / canvasSetFillPattern (#1625 finding).",
       "issue": ""
     },
     "canvas2d/strokeStyle": {
       "status": "supported",
-      "mapsTo": "Settable to a CSS-color string OR a CanvasGradient OR a CanvasPattern. pulp Wave 3 c2d.7 \u2014 bridge exposes canvasSetStrokeLinearGradient / canvasSetStrokeRadialGradient / canvasSetStrokeRadialGradientTwoCircles / canvasSetStrokeConicGradient / canvasSetStrokePattern; the JS shim routes gradients per kind in _applyStrokeStyle. Skia populates stroke_shader_; apply_stroke_state attaches it to SkPaint via setShader.",
+      "mapsTo": "Settable to a CSS-color string OR a CanvasGradient OR a CanvasPattern. pulp Wave 3 c2d.7 — bridge exposes canvasSetStrokeLinearGradient / canvasSetStrokeRadialGradient / canvasSetStrokeRadialGradientTwoCircles / canvasSetStrokeConicGradient / canvasSetStrokePattern; the JS shim routes gradients per kind in _applyStrokeStyle. Skia populates stroke_shader_; apply_stroke_state attaches it to SkPaint via setShader.",
       "supportedValues": [
         "CSS color strings",
         "CanvasGradient (linear, radial, two-circle radial, conic) on stroke",
@@ -7045,7 +7045,7 @@
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp Wave 3 c2d.7 \u2014 stroke gradients wired through dedicated setters. Wave 4 c2d cleanup: catalog reconciled to match wired implementation.",
+      "notes": "pulp Wave 3 c2d.7 — stroke gradients wired through dedicated setters. Wave 4 c2d cleanup: catalog reconciled to match wired implementation.",
       "issue": ""
     },
     "canvas2d/lineWidth": {
@@ -7089,7 +7089,7 @@
     },
     "canvas2d/miterLimit": {
       "status": "supported",
-      "mapsTo": "ctx.miterLimit -> canvasSetMiterLimit (web-compat-canvas.js _syncLineState). Sticky stroke state. Skia honours via SkPaint::setStrokeMiter; CG via CGContextSetMiterLimit. Spec: assigning \u2264 0 / NaN / Infinity is silently ignored (validated at the shim level).",
+      "mapsTo": "ctx.miterLimit -> canvasSetMiterLimit (web-compat-canvas.js _syncLineState). Sticky stroke state. Skia honours via SkPaint::setStrokeMiter; CG via CGContextSetMiterLimit. Spec: assigning ≤ 0 / NaN / Infinity is silently ignored (validated at the shim level).",
       "supportedValues": [
         "any positive finite number",
         "spec default = 10"
@@ -7098,7 +7098,7 @@
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1434][bridge-thin]"
       ],
-      "notes": "pulp #1434 bridge-thin gap-fill. Side note: this PR also wired SkPaint::setStrokeJoin + setStrokeCap from line_join_/line_cap_ \u2014 those were stored but never applied on Skia before.",
+      "notes": "pulp #1434 bridge-thin gap-fill. Side note: this PR also wired SkPaint::setStrokeJoin + setStrokeCap from line_join_/line_cap_ — those were stored but never applied on Skia before.",
       "issue": "1434"
     },
     "canvas2d/globalAlpha": {
@@ -7165,13 +7165,13 @@
         "weight numerics: 100..900 (3-digit)",
         "style keywords: normal/italic/oblique",
         "stretch keywords: ultra-condensed..ultra-expanded (parsed, dropped)",
-        "lineHeight: number / length / 'normal' (parsed, ignored per Canvas2D spec \u2014 canvas uses the font's own line metrics)"
+        "lineHeight: number / length / 'normal' (parsed, ignored per Canvas2D spec — canvas uses the font's own line metrics)"
       ],
       "unsupportedValues": [
-        "font-variant 'small-caps' (parsed and tracked, but Skia/CG fonts in the canvas pipeline don't honour it \u2014 Canvas::set_font_full has no variant field)"
+        "font-variant 'small-caps' (parsed and tracked, but Skia/CG fonts in the canvas pipeline don't honour it — Canvas::set_font_full has no variant field)"
       ],
       "tests": [],
-      "notes": "pulp #1434 expanded shim parser to full CSS font shorthand. Family names quoted as 'Inter' or \"Inter\" are unwrapped; comma-separated lists are passed verbatim. font-variant 'small-caps' is the ONLY genuine gap and is architecturally tied: Canvas::set_font_full has no variant field and Skia/CG canvas font pipelines don't expose OpenType variation axes at this layer. Per #1657 discipline this stays as DIVERGE (honest signal of a real value-gap) rather than being moved to notes \u2014 the gap IS real and consumers should know. Reclassification would require either (a) extending Canvas::set_font to carry variant flags, or (b) adapter-level architectural-exclusion support.",
+      "notes": "pulp #1434 expanded shim parser to full CSS font shorthand. Family names quoted as 'Inter' or \"Inter\" are unwrapped; comma-separated lists are passed verbatim. font-variant 'small-caps' is the ONLY genuine gap and is architecturally tied: Canvas::set_font_full has no variant field and Skia/CG canvas font pipelines don't expose OpenType variation axes at this layer. Per #1657 discipline this stays as DIVERGE (honest signal of a real value-gap) rather than being moved to notes — the gap IS real and consumers should know. Reclassification would require either (a) extending Canvas::set_font to carry variant flags, or (b) adapter-level architectural-exclusion support.",
       "issue": "1434"
     },
     "canvas2d/textAlign": {
@@ -7252,12 +7252,12 @@
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1520]"
       ],
-      "notes": "pulp #1520 \u2014 JS shim + bridge + SkShaper direction flag. Real bidi (mixed LTR/RTL paragraphs) shares plumbing with #1506.",
+      "notes": "pulp #1520 — JS shim + bridge + SkShaper direction flag. Real bidi (mixed LTR/RTL paragraphs) shares plumbing with #1506.",
       "issue": "1520"
     },
     "canvas2d/filter": {
       "status": "partial",
-      "mapsTo": "ctx.filter -> canvasSetFilter (web-compat-canvas.js _syncFilterState, flushed before fill/stroke/text/image draws). Skia parses CSS <filter-function-list> into an SkImageFilter chain (Blur + ColorFilter::Matrix combinations) applied via SkPaint::setImageFilter. Distinct from CSS `filter` on the View element (#1503) \u2014 this is per-2D-context state and stacks with save()/restore().",
+      "mapsTo": "ctx.filter -> canvasSetFilter (web-compat-canvas.js _syncFilterState, flushed before fill/stroke/text/image draws). Skia parses CSS <filter-function-list> into an SkImageFilter chain (Blur + ColorFilter::Matrix combinations) applied via SkPaint::setImageFilter. Distinct from CSS `filter` on the View element (#1503) — this is per-2D-context state and stacks with save()/restore().",
       "supportedValues": [
         "blur(<length>)",
         "brightness(<num|%>)",
@@ -7279,15 +7279,7 @@
         "test/test_canvas.cpp [skia][filter-chain][drop-shadow]",
         "test/test_canvas2d_shim.cpp [issue-1520]"
       ],
-      "unsupportedValues": [
-        "drop-shadow(...) (deferred \u2014 needs offset+blur+color tuple parsing)",
-        "url(#filter-id) (SVG filter references)",
-        "CG backend renders unfiltered (Skia-only today)"
-      ],
-      "tests": [
-        "test/test_canvas2d_shim.cpp [issue-1520]"
-      ],
-      "notes": "pulp #1520 \u2014 JS shim + bridge + Skia parser/chain. Parser is local to skia_canvas.cpp; #1503's CSS filter on View elements is a parallel parser to be unified in a follow-up.",
+      "notes": "pulp #1520 — JS shim + bridge + Skia parser/chain. Parser is local to skia_canvas.cpp; #1503's CSS filter on View elements is a parallel parser to be unified in a follow-up.",
       "issue": "1520"
     },
     "canvas2d/shadowColor": {
@@ -7352,7 +7344,7 @@
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "Tracked in detail under canvas2d/* by convention even though WebGPU is not strictly Canvas2D \u2014 the shim co-locates them. See planning/research/three-js* for the Three.js end-to-end story.",
+      "notes": "Tracked in detail under canvas2d/* by convention even though WebGPU is not strictly Canvas2D — the shim co-locates them. See planning/research/three-js* for the Three.js end-to-end story.",
       "issue": ""
     },
     "canvas2d/getContext_2d": {
@@ -7407,7 +7399,7 @@
               "value": "__bundler/template"
             }
           ],
-          "notes": "Anthropic Labs Claude Design \u2014 manually-exported standalone HTML. Detect via the inline bundler script tag inserted by the Claude Design export. Loader-shell HTML wraps the bundled React app; the static parser sees ~9 elements until the bundle is executed."
+          "notes": "Anthropic Labs Claude Design — manually-exported standalone HTML. Detect via the inline bundler script tag inserted by the Claude Design export. Loader-shell HTML wraps the bundled React app; the static parser sees ~9 elements until the bundle is executed."
         }
       ]
     },

--- a/compat.json
+++ b/compat.json
@@ -2,6 +2,7 @@
   "compat-schema-version": "0.3",
   "_comment": "Compat matrix per #1027. This file is the spec-driven inventory of every prop / style / API surface Pulp's React + DOM-lite consumers might use, mapped to its current implementation status. Status values: supported | partial | missing | wontfix. The 'mapsTo' field names the bridge / Yoga / Skia path the prop lowers to. The 'tests' field records validation references; legacy free-form test paths may coexist with typed routes such as semantic:<fixture-id>, visual:<fixture-id>, dom:<fixture-id>, behavior:<fixture-id>, unit:<test-id>, or cannot-validate:<tracking-id>. The audit was generated 2026-04-30 by walking three reference specs (Yoga via React Native Layout Props, React Native View / Text / Transform Style Props, and the most-used MDN CSS reference) and cross-referencing against four implementation surfaces: packages/pulp-react/src/prop-applier.ts (the @pulp/react switch), core/view/js/web-compat-style-decl.js (the DOM-lite CSS adapter), core/view/src/widget_bridge.cpp (the C++ bridge \u2014 251 register_function entries), and core/view/include/pulp/view/{view,geometry}.hpp (the Flex / View widget surface).",
   "_audit": {
+    "_evidence_grace_until": "2026-05-22",
     "generated": "2026-05-04",
     "main_sha": "a5f4f5ac",
     "spec_sources": {
@@ -7261,6 +7262,7 @@
         "blur(<length>)",
         "brightness(<num|%>)",
         "contrast(<num|%>)",
+        "drop-shadow(<dx> <dy> <blur> <color>)",
         "grayscale(<num|%>)",
         "hue-rotate(<angle>)",
         "invert(<num|%>)",
@@ -7268,6 +7270,14 @@
         "saturate(<num|%>)",
         "sepia(<num|%>)",
         "none (default; clears any active chain)"
+      ],
+      "unsupportedValues": [
+        "url(#filter-id) (SVG filter references)",
+        "CG backend renders unfiltered (Skia-only today)"
+      ],
+      "tests": [
+        "test/test_canvas.cpp [skia][filter-chain][drop-shadow]",
+        "test/test_canvas2d_shim.cpp [issue-1520]"
       ],
       "unsupportedValues": [
         "drop-shadow(...) (deferred \u2014 needs offset+blur+color tuple parsing)",

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -1,5 +1,7 @@
 #include <algorithm>
+#include <cctype>
 #include <cmath>
+#include <sstream>
 #include <unordered_map>
 #include <pulp/canvas/skia_canvas.hpp>
 #include <pulp/canvas/bundled_fonts.hpp>
@@ -510,6 +512,141 @@ double parse_filter_arg(const std::string& body, FilterArgKind kind) {
     return v;
 }
 
+// Split space-separated arguments from a filter function's body.
+// Handles parenthesised sub-expressions (e.g. `rgb(1,2,3)`) so color
+// functions are kept as a single token.
+std::vector<std::string> parse_filter_args(const std::string& body) {
+    std::vector<std::string> tokens;
+    std::string tok;
+    int paren = 0;
+    for (char c : body) {
+        if (c == '(') { ++paren; tok += c; continue; }
+        if (c == ')') { --paren; tok += c; continue; }
+        if (paren == 0 && std::isspace(static_cast<unsigned char>(c))) {
+            if (!tok.empty()) { tokens.push_back(std::move(tok)); tok.clear(); }
+            continue;
+        }
+        tok += c;
+    }
+    if (!tok.empty()) tokens.push_back(std::move(tok));
+    return tokens;
+}
+
+// Parse a single CSS length token to a numeric pixel value.
+// "12px" → 12.0, "12" → 12.0, "invalid" → NaN.
+double parse_filter_arg_length(const std::string& tok) {
+    if (tok.empty()) return std::nan("");
+    size_t end = 0;
+    while (end < tok.size() &&
+           (std::isdigit(static_cast<unsigned char>(tok[end])) ||
+            tok[end] == '.' || tok[end] == '-' || tok[end] == '+' ||
+            tok[end] == 'e' || tok[end] == 'E')) {
+        ++end;
+    }
+    if (end == 0) return std::nan("");
+    double v = 0;
+    try { v = std::stod(tok.substr(0, end)); }
+    catch (...) { return std::nan(""); }
+    return v; // bare number or "px" suffix both treated as pixels
+}
+
+// Parse a CSS color string into SkColor. Supports #hex, rgb()/rgba(),
+// hsl()/hsla(), "transparent", and a subset of named colors.
+// Defaults to black on parse failure.
+SkColor parse_css_color_to_skcolor(const std::string& str) {
+    if (str == "transparent") return SK_ColorTRANSPARENT;
+
+    if (!str.empty() && str[0] == '#') {
+        if (str.size() == 4) { // #RGB
+            uint8_t r = static_cast<uint8_t>(std::stoul(std::string(2, str[1]), nullptr, 16));
+            uint8_t g = static_cast<uint8_t>(std::stoul(std::string(2, str[2]), nullptr, 16));
+            uint8_t b = static_cast<uint8_t>(std::stoul(std::string(2, str[3]), nullptr, 16));
+            return SkColorSetRGB(r * 17, g * 17, b * 17);
+        }
+        if (str.size() >= 7) { // #RRGGBB[AA]
+            uint8_t r = static_cast<uint8_t>(std::stoul(str.substr(1, 2), nullptr, 16));
+            uint8_t g = static_cast<uint8_t>(std::stoul(str.substr(3, 2), nullptr, 16));
+            uint8_t b = static_cast<uint8_t>(std::stoul(str.substr(5, 2), nullptr, 16));
+            uint8_t a = 255;
+            if (str.size() >= 9)
+                a = static_cast<uint8_t>(std::stoul(str.substr(7, 2), nullptr, 16));
+            return SkColorSetARGB(a, r, g, b);
+        }
+        return SK_ColorBLACK;
+    }
+
+    // rgb(r, g, b) / rgba(r, g, b, a)
+    if (str.substr(0, 4) == "rgb(" || str.substr(0, 5) == "rgba(") {
+        auto inner = str.substr(str.find('(') + 1);
+        inner = inner.substr(0, inner.find(')'));
+        float vals[4] = {0, 0, 0, 1};
+        int n = 0;
+        std::istringstream ss(inner);
+        std::string tok;
+        while (std::getline(ss, tok, ',') && n < 4) {
+            while (!tok.empty() && tok[0] == ' ') tok.erase(0, 1);
+            vals[n++] = std::stof(tok);
+        }
+        uint8_t r = static_cast<uint8_t>(std::clamp(vals[0] / 255.0f, 0.0f, 1.0f) * 255.0f + 0.5f);
+        uint8_t g = static_cast<uint8_t>(std::clamp(vals[1] / 255.0f, 0.0f, 1.0f) * 255.0f + 0.5f);
+        uint8_t b = static_cast<uint8_t>(std::clamp(vals[2] / 255.0f, 0.0f, 1.0f) * 255.0f + 0.5f);
+        uint8_t a = static_cast<uint8_t>(std::clamp(vals[3], 0.0f, 1.0f) * 255.0f + 0.5f);
+        return SkColorSetARGB(a, r, g, b);
+    }
+
+    // hsl(h, s%, l%) / hsla(h, s%, l%, a)
+    if (str.substr(0, 4) == "hsl(" || str.substr(0, 5) == "hsla(") {
+        auto inner = str.substr(str.find('(') + 1);
+        inner = inner.substr(0, inner.find(')'));
+        float vals[4] = {0, 0, 0, 1};
+        int n = 0;
+        std::istringstream ss(inner);
+        std::string tok;
+        while (std::getline(ss, tok, ',') && n < 4) {
+            while (!tok.empty() && tok[0] == ' ') tok.erase(0, 1);
+            if (tok.back() == '%') tok.pop_back();
+            vals[n++] = std::stof(tok);
+        }
+        float h = std::fmod(vals[0], 360.0f) / 360.0f;
+        float s = vals[1] / 100.0f;
+        float l = vals[2] / 100.0f;
+        auto hue2rgb = [](float p, float q, float t) {
+            if (t < 0) t += 1; if (t > 1) t -= 1;
+            if (t < 1.0f / 6) return p + (q - p) * 6 * t;
+            if (t < 1.0f / 2) return q;
+            if (t < 2.0f / 3) return p + (q - p) * (2.0f / 3 - t) * 6;
+            return p;
+        };
+        float r, g, b;
+        if (s == 0) { r = g = b = l; }
+        else {
+            float q = l < 0.5f ? l * (1 + s) : l + s - l * s;
+            float p = 2 * l - q;
+            r = hue2rgb(p, q, h + 1.0f / 3);
+            g = hue2rgb(p, q, h);
+            b = hue2rgb(p, q, h - 1.0f / 3);
+        }
+        return SkColorSetARGB(
+            static_cast<uint8_t>(vals[3] * 255.0f + 0.5f),
+            static_cast<uint8_t>(r * 255.0f + 0.5f),
+            static_cast<uint8_t>(g * 255.0f + 0.5f),
+            static_cast<uint8_t>(b * 255.0f + 0.5f));
+    }
+
+    // Named colors (subset matching test expectations).
+    static const std::unordered_map<std::string, SkColor> named = {
+        {"black", SK_ColorBLACK}, {"white", SK_ColorWHITE},
+        {"red", SK_ColorRED}, {"green", SK_ColorGREEN},
+        {"blue", SK_ColorBLUE}, {"yellow", SK_ColorYELLOW},
+        {"cyan", SK_ColorCYAN}, {"magenta", SK_ColorMAGENTA},
+        {"gray", 0xFF808080}, {"grey", 0xFF808080},
+    };
+    auto it = named.find(str);
+    if (it != named.end()) return it->second;
+
+    return SK_ColorBLACK;
+}
+
 // Build a saturation SkColorMatrix. s=1 is identity, s=0 is grayscale,
 // s>1 boosts saturation. Standard luminance weights match the CSS spec.
 SkColorMatrix make_saturation_matrix(double s) {
@@ -719,10 +856,25 @@ sk_sp<SkImageFilter> parse_filter_chain(const std::string& src) {
                 if (amt < 0.0) amt = 0.0;
                 step = color_matrix_filter(make_sepia_matrix(amt));
             }
+        } else if (name == "drop-shadow") {
+            // drop-shadow(<dx> <dy> <blur-radius> <color>)
+            // dx, dy, blur-radius are lengths (px); color is optional
+            // (defaults to black per CSS spec § filter-effects).
+            auto tokens = parse_filter_args(body);
+            if (tokens.size() >= 3) {
+                float dx   = static_cast<float>(parse_filter_arg_length(tokens[0]));
+                float dy   = static_cast<float>(parse_filter_arg_length(tokens[1]));
+                float blur = static_cast<float>(parse_filter_arg_length(tokens[2]));
+                if (blur < 0) blur = 0; // CSS spec: negative blur → 0
+                SkColor color = SK_ColorBLACK;
+                if (tokens.size() >= 4) {
+                    std::string cs = tokens[3];
+                    for (size_t k = 4; k < tokens.size(); ++k) cs += " " + tokens[k];
+                    color = parse_css_color_to_skcolor(cs);
+                }
+                step = SkImageFilters::DropShadow(dx, dy, blur, blur, color, nullptr, nullptr);
+            }
         }
-        // drop-shadow could be added here as SkImageFilters::DropShadow
-        // — deferred to a follow-up since the parser would also need to
-        // consume up to four arguments (offset-x offset-y blur-radius color).
         chain = compose(std::move(step), std::move(chain));
         // Skip optional comma between functions (spec is whitespace-only,
         // but tolerate ",").

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <optional>
 #include <sstream>
 #include <unordered_map>
 #include <pulp/canvas/skia_canvas.hpp>
@@ -557,20 +558,29 @@ SkColor parse_css_color_to_skcolor(const std::string& str) {
     if (str == "transparent") return SK_ColorTRANSPARENT;
 
     if (!str.empty() && str[0] == '#') {
-        if (str.size() == 4) { // #RGB
-            uint8_t r = static_cast<uint8_t>(std::stoul(std::string(2, str[1]), nullptr, 16));
-            uint8_t g = static_cast<uint8_t>(std::stoul(std::string(2, str[2]), nullptr, 16));
-            uint8_t b = static_cast<uint8_t>(std::stoul(std::string(2, str[3]), nullptr, 16));
-            return SkColorSetRGB(r * 17, g * 17, b * 17);
+        auto parse_hex = [](const std::string& s) -> std::optional<uint8_t> {
+            try { return static_cast<uint8_t>(std::stoul(s, nullptr, 16)); }
+            catch (...) { return std::nullopt; }
+        };
+        if (str.size() == 4) { // #RGB — each nibble doubled
+            auto r = parse_hex(std::string(2, str[1]));
+            auto g = parse_hex(std::string(2, str[2]));
+            auto b = parse_hex(std::string(2, str[3]));
+            if (r && g && b) return SkColorSetRGB(*r, *g, *b);
+            return SK_ColorBLACK;
         }
         if (str.size() >= 7) { // #RRGGBB[AA]
-            uint8_t r = static_cast<uint8_t>(std::stoul(str.substr(1, 2), nullptr, 16));
-            uint8_t g = static_cast<uint8_t>(std::stoul(str.substr(3, 2), nullptr, 16));
-            uint8_t b = static_cast<uint8_t>(std::stoul(str.substr(5, 2), nullptr, 16));
+            auto r = parse_hex(str.substr(1, 2));
+            auto g = parse_hex(str.substr(3, 2));
+            auto b = parse_hex(str.substr(5, 2));
+            if (!r || !g || !b) return SK_ColorBLACK;
             uint8_t a = 255;
-            if (str.size() >= 9)
-                a = static_cast<uint8_t>(std::stoul(str.substr(7, 2), nullptr, 16));
-            return SkColorSetARGB(a, r, g, b);
+            if (str.size() >= 9) {
+                auto parsed = parse_hex(str.substr(7, 2));
+                if (!parsed) return SK_ColorBLACK;
+                a = *parsed;
+            }
+            return SkColorSetARGB(a, *r, *g, *b);
         }
         return SK_ColorBLACK;
     }

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -1221,6 +1221,80 @@ TEST_CASE("SkiaCanvas filter chain: opacity ordering changes pixel output "
     REQUIRE(any_channel_differs);
 }
 
+// Regression test: `parse_filter_chain("drop-shadow(dx dy blur color)")`
+// must return non-null and the resulting SkImageFilter must produce a
+// visible offset shadow when rendered through SkiaCanvas::set_filter().
+TEST_CASE("SkiaCanvas set_filter parses drop-shadow and renders shadow",
+          "[canvas][skia][filter-chain][drop-shadow][wave6-canvas2d]") {
+    constexpr int kW = 32;
+    constexpr int kH = 32;
+    SkImageInfo info = SkImageInfo::Make(kW, kH, kN32_SkColorType,
+                                         kPremul_SkAlphaType,
+                                         SkColorSpace::MakeSRGB());
+    auto surface = SkSurfaces::Raster(info);
+    REQUIRE(surface != nullptr);
+    auto* sk_canvas = surface->getCanvas();
+    REQUIRE(sk_canvas != nullptr);
+    sk_canvas->clear(SK_ColorWHITE);
+
+    SkiaCanvas canvas(sk_canvas);
+    canvas.set_filter("drop-shadow(4px 4px 0px black)");
+
+    SkPaint paint;
+    canvas.apply_filter(paint);
+    REQUIRE(paint.getImageFilter() != nullptr);
+
+    // Render a 16x16 filled rect at (8,8). The drop-shadow should
+    // produce a black pixel at the shadow offset position (8+16+4, 8+16+4)
+    // = (28,28) that is NOT fully white.
+    sk_canvas->saveLayer(nullptr, &paint);
+    SkPaint rect_paint;
+    rect_paint.setColor(SK_ColorRED);
+    rect_paint.setAntiAlias(false);
+    sk_canvas->drawRect(SkRect::MakeXYWH(8, 8, 16, 16), rect_paint);
+    sk_canvas->restore();
+
+    SkPixmap pm;
+    REQUIRE(surface->peekPixels(&pm));
+    SkColor shadow_pixel = pm.getColor(28, 28);
+    // Black drop-shadow on white → at least one channel < 200.
+    bool has_shadow =
+        SkColorGetR(shadow_pixel) < 200 ||
+        SkColorGetG(shadow_pixel) < 200 ||
+        SkColorGetB(shadow_pixel) < 200;
+    REQUIRE(has_shadow);
+}
+
+TEST_CASE("SkiaCanvas set_filter parsers drop-shadow with hex color",
+          "[canvas][skia][filter-chain][drop-shadow][wave6-canvas2d]") {
+    constexpr int kW = 32;
+    constexpr int kH = 32;
+    SkImageInfo info = SkImageInfo::Make(kW, kH, kN32_SkColorType,
+                                         kPremul_SkAlphaType,
+                                         SkColorSpace::MakeSRGB());
+    auto surface = SkSurfaces::Raster(info);
+    REQUIRE(surface != nullptr);
+    auto* sk_canvas = surface->getCanvas();
+    REQUIRE(sk_canvas != nullptr);
+    sk_canvas->clear(SK_ColorWHITE);
+
+    SkiaCanvas canvas(sk_canvas);
+    canvas.set_filter("drop-shadow(2px 2px 2px #ff0000)");
+
+    SkPaint paint;
+    canvas.apply_filter(paint);
+    REQUIRE(paint.getImageFilter() != nullptr);
+}
+
+TEST_CASE("SkiaCanvas set_filter non-existent filter returns null",
+          "[canvas][skia][filter-chain][wave6-canvas2d]") {
+    SkiaCanvas canvas(nullptr);  // null canvas for this test
+    canvas.set_filter("none");
+    SkPaint paint;
+    canvas.apply_filter(paint);
+    REQUIRE(paint.getImageFilter() == nullptr);
+}
+
 #endif  // PULP_HAS_SKIA
 
 // ── pulp #1434 Phase A2-4 — portable filter-chain matrix math ──────────

--- a/tools/harness/status.py
+++ b/tools/harness/status.py
@@ -21,6 +21,7 @@ class Status(str, Enum):
     """
 
     PASS = "PASS"
+    SUPPORTED_NO_EVIDENCE = "SUPPORTED-NO-EVIDENCE"
     DIVERGE = "DIVERGE"
     NO_OP = "NO-OP"
     NOT_IMPL = "NOT-IMPL"
@@ -39,6 +40,7 @@ class Status(str, Enum):
 # Canonical ordering for table rendering.
 STATUS_ORDER = [
     Status.PASS,
+    Status.SUPPORTED_NO_EVIDENCE,
     Status.DIVERGE,
     Status.NO_OP,
     Status.NOT_IMPL,
@@ -51,6 +53,7 @@ class StatusCounts:
     """Aggregated counts across one surface (or the whole run)."""
 
     pass_: int = 0
+    supported_no_evidence: int = 0
     diverge: int = 0
     no_op: int = 0
     not_impl: int = 0
@@ -58,7 +61,8 @@ class StatusCounts:
 
     @property
     def total(self) -> int:
-        return self.pass_ + self.diverge + self.no_op + self.not_impl + self.oos
+        return (self.pass_ + self.supported_no_evidence + self.diverge +
+                self.no_op + self.not_impl + self.oos)
 
     @property
     def pass_pct(self) -> float:
@@ -71,12 +75,13 @@ class StatusCounts:
         """PASS+DIVERGE / total."""
         if self.total == 0:
             return 0.0
-        return 100.0 * (self.pass_ + self.diverge) / self.total
+        return 100.0 * (self.pass_ + self.supported_no_evidence + self.diverge) / self.total
 
     @classmethod
     def from_results(cls, statuses: list[Status]) -> "StatusCounts":
         return cls(
             pass_=sum(1 for s in statuses if s is Status.PASS),
+            supported_no_evidence=sum(1 for s in statuses if s is Status.SUPPORTED_NO_EVIDENCE),
             diverge=sum(1 for s in statuses if s is Status.DIVERGE),
             no_op=sum(1 for s in statuses if s is Status.NO_OP),
             not_impl=sum(1 for s in statuses if s is Status.NOT_IMPL),

--- a/tools/harness/tests/test_evidence_check.py
+++ b/tools/harness/tests/test_evidence_check.py
@@ -1,0 +1,159 @@
+"""Tests for the evidence.tests gate (pulp #1657 control #1).
+
+Verifies:
+* `check_evidence()` demotes PASS→SUPPORTED_NO_EVIDENCE when
+  ``entry.tests`` is empty after the grace period.
+* During the grace period, PASS is retained with a warning.
+* Entries with an existing test file stay PASS.
+* `partial` entries are not affected.
+* `_audit._evidence_grace_until` controls the grace window.
+
+Invocation::
+
+    python3 -m unittest tools.harness.tests.test_evidence_check
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from datetime import date, timedelta
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.harness.adapters.base import CatalogEntry, Result  # noqa: E402
+from tools.harness.status import Status  # noqa: E402
+from tools.harness.verifier import check_evidence, _grace_active  # noqa: E402
+
+
+def _make_entry(
+    surface: str = "css",
+    name: str = "css/prop",
+    status: str = "supported",
+    tests: list | None = None,
+) -> CatalogEntry:
+    return CatalogEntry(
+        surface=surface,
+        name=name,
+        status=status,
+        tests=tests or [],
+    )
+
+
+def _make_result(entry: CatalogEntry, status: Status = Status.PASS) -> Result:
+    return Result(entry=entry, status=status)
+
+
+class GraceActiveTests(unittest.TestCase):
+    def test_no_grace_when_none(self) -> None:
+        self.assertFalse(_grace_active(None))
+
+    def test_no_grace_when_empty(self) -> None:
+        self.assertFalse(_grace_active(""))
+
+    def test_grace_active_before_deadline(self) -> None:
+        future = (date.today() + timedelta(days=30)).isoformat()
+        self.assertTrue(_grace_active(future))
+
+    def test_grace_inactive_after_deadline(self) -> None:
+        past = (date.today() - timedelta(days=1)).isoformat()
+        self.assertFalse(_grace_active(past))
+
+    def test_grace_active_on_deadline(self) -> None:
+        today_str = date.today().isoformat()
+        self.assertTrue(_grace_active(today_str))
+
+    def test_invalid_date_no_grace(self) -> None:
+        self.assertFalse(_grace_active("not-a-date"))
+
+
+class EvidenceCheckTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = TemporaryDirectory()
+        self.repo_root = Path(self.tmp.name)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _compat(self, grace_until: str | None = None) -> dict:
+        compat: dict = {}
+        if grace_until:
+            compat["_audit"] = {"_evidence_grace_until": grace_until}
+        return compat
+
+    def test_supported_with_valid_test_stays_pass(self) -> None:
+        test_path = self.repo_root / "test/test_foo.cpp"
+        test_path.parent.mkdir(parents=True, exist_ok=True)
+        test_path.write_text("// test")
+        entry = _make_entry(name="css/foo", tests=["test/test_foo.cpp [tag]"])
+        results = [_make_result(entry, Status.PASS)]
+        updated = check_evidence(self.repo_root, results, self._compat())
+        self.assertEqual(updated[0].status, Status.PASS)
+
+    def test_supported_without_tests_during_grace_stays_pass(self) -> None:
+        future = (date.today() + timedelta(days=30)).isoformat()
+        entry = _make_entry(name="css/noTests", tests=[])  # empty tests
+        results = [_make_result(entry, Status.PASS)]
+        updated = check_evidence(self.repo_root, results, self._compat(future))
+        self.assertEqual(updated[0].status, Status.PASS)
+
+    def test_supported_without_tests_after_grace_demotes(self) -> None:
+        # Use a grace date that is definitely in the past.
+        past_grace = "2020-01-01"
+        entry = _make_entry(name="css/noTests", tests=[])
+        results = [_make_result(entry, Status.PASS)]
+        updated = check_evidence(self.repo_root, results, self._compat(past_grace))
+        self.assertEqual(updated[0].status, Status.SUPPORTED_NO_EVIDENCE)
+        self.assertIn("evidence.tests is empty", updated[0].detail or "")
+
+    def test_supported_with_nonexistent_test_file_after_grace_demotes(self) -> None:
+        past = (date.today() - timedelta(days=1)).isoformat()
+        entry = _make_entry(name="css/missingTests",
+                            tests=["test/nonexistent.cpp [tag]"])
+        results = [_make_result(entry, Status.PASS)]
+        updated = check_evidence(self.repo_root, results, self._compat(past))
+        self.assertEqual(updated[0].status, Status.SUPPORTED_NO_EVIDENCE)
+
+    def test_partial_without_tests_not_affected(self) -> None:
+        past = (date.today() - timedelta(days=1)).isoformat()
+        entry = _make_entry(name="css/partial", status="partial", tests=[])
+        results = [_make_result(entry, Status.DIVERGE)]
+        updated = check_evidence(self.repo_root, results, self._compat(past))
+        self.assertEqual(updated[0].status, Status.DIVERGE)
+
+    def test_mixed_results_handled_correctly(self) -> None:
+        test_path = self.repo_root / "test/test_good.cpp"
+        test_path.parent.mkdir(parents=True, exist_ok=True)
+        test_path.write_text("// test")
+        past = (date.today() - timedelta(days=1)).isoformat()
+
+        good = _make_entry(name="css/good", tests=["test/test_good.cpp [tag]"])
+        bad = _make_entry(name="css/bad", tests=[])
+        partial = _make_entry(name="css/partial", status="partial", tests=[])
+
+        results = [
+            _make_result(good, Status.PASS),
+            _make_result(bad, Status.PASS),
+            _make_result(partial, Status.DIVERGE),
+        ]
+        updated = check_evidence(self.repo_root, results, self._compat(past))
+
+        self.assertEqual(updated[0].status, Status.PASS)
+        self.assertEqual(updated[1].status, Status.SUPPORTED_NO_EVIDENCE)
+        self.assertEqual(updated[2].status, Status.DIVERGE)
+
+    def test_no_audit_section_treats_as_no_grace(self) -> None:
+        entry = _make_entry(name="css/foo", tests=[])
+        results = [_make_result(entry, Status.PASS)]
+        updated = check_evidence(self.repo_root, results, {})
+        self.assertEqual(updated[0].status, Status.SUPPORTED_NO_EVIDENCE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/harness/verifier.py
+++ b/tools/harness/verifier.py
@@ -142,6 +142,72 @@ def collect_entries(compat: dict, surface: str) -> list[CatalogEntry]:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Evidence check (#1657 control #1) — requires runtime tests for supported claims
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _get_grace_until(compat: dict) -> Optional[str]:
+    audit = compat.get("_audit") or {}
+    return audit.get("_evidence_grace_until")  # e.g. "2026-05-22"
+
+
+def _grace_active(grace_until: Optional[str]) -> bool:
+    if not grace_until:
+        return False
+    from datetime import date
+
+    try:
+        deadline = date.fromisoformat(grace_until)
+        return date.today() <= deadline
+    except (ValueError, TypeError):
+        return False
+
+
+def check_evidence(repo_root: Path, results: list[Result], compat: dict) -> list[Result]:
+    """Post-process PASS results: demote to SUPPORTED_NO_EVIDENCE when the
+    catalog entry claims ``supported`` but has no ``tests`` paths that exist in
+    the repo. During a grace period the result stays PASS with a warning;
+    after the grace period it becomes SUPPORTED_NO_EVIDENCE.
+    """
+    grace_until = _get_grace_until(compat)
+    in_grace = _grace_active(grace_until)
+    updated: list[Result] = []
+    for r in results:
+        if r.status is not Status.PASS:
+            updated.append(r)
+            continue
+        if r.entry.status != "supported":
+            updated.append(r)
+            continue
+        # Check for evidence: at least one test path that exists.
+        valid_tests = [
+            t for t in r.entry.tests
+            if (repo_root / t.split("[")[0].strip()).exists()
+        ]
+        if valid_tests:
+            updated.append(r)
+            continue
+        # No evidence.
+        if in_grace:
+            logger.warning(
+                "evidence: `%s` claims supported but has no tests — "
+                "grace period until %s, will fail after",
+                r.entry.name,
+                grace_until,
+            )
+            updated.append(r)
+        else:
+            updated.append(
+                Result(
+                    entry=r.entry,
+                    status=Status.SUPPORTED_NO_EVIDENCE,
+                    detail="catalog claims supported but evidence.tests is empty",
+                )
+            )
+    return updated
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Run
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -152,15 +218,20 @@ def run_surface(repo_root: Path, surface: str) -> list[Result]:
     compat = load_compat(repo_root)
     entries = collect_entries(compat, surface)
     adapter = ADAPTERS[surface](repo_root)
-    return [adapter.run(e) for e in entries]
+    results = [adapter.run(e) for e in entries]
+    return check_evidence(repo_root, results, compat)
 
 
 def run_all(repo_root: Path) -> dict[str, list[Result]]:
     out: dict[str, list[Result]] = {}
+    compat = load_compat(repo_root)
     for surface in KNOWN_SURFACES:
         if surface not in ADAPTERS:
             continue
-        out[surface] = run_surface(repo_root, surface)
+        entries = collect_entries(compat, surface)
+        adapter = ADAPTERS[surface](repo_root)
+        results = [adapter.run(e) for e in entries]
+        out[surface] = check_evidence(repo_root, results, compat)
     return out
 
 
@@ -207,18 +278,19 @@ def render_markdown(
     )
     lines.append("## Summary")
     lines.append("")
-    lines.append("| Surface | Total | PASS | DIVERGE | NO-OP | NOT-IMPL | OOS | PASS % | Progress % | Drift | Validation route | Visual covered |")
-    lines.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+    lines.append("| Surface | Total | PASS | NO-EV | DIVERGE | NO-OP | NOT-IMPL | OOS | PASS % | Progress % | Drift | Validation route | Visual covered |")
+    lines.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
     for surface, results in results_by_surface.items():
         counts = StatusCounts.from_results([r.status for r in results])
         drifts = sum(1 for r in results if r.drifts)
         visual = visual_counts.get(surface, {"label": "0/0"})
         validation = validation_counts.get(surface, {"label": "0/0"})
         lines.append(
-            "| `{}/` | {} | {} | {} | {} | {} | {} | {:.1f}% | {:.1f}% | {} | {} | {} |".format(
+            "| `{}/` | {} | {} | {} | {} | {} | {} | {} | {:.1f}% | {:.1f}% | {} | {} | {} |".format(
                 surface,
                 counts.total,
                 counts.pass_,
+                counts.supported_no_evidence,
                 counts.diverge,
                 counts.no_op,
                 counts.not_impl,
@@ -242,9 +314,10 @@ def render_markdown(
         validation_pass = sum(int(v.get("pass", 0)) for v in validation_counts.values())
         validation_total = sum(int(v.get("total", 0)) for v in validation_counts.values())
         lines.append(
-            "| **TOTAL** | {} | {} | {} | {} | {} | {} | {:.1f}% | {:.1f}% | {} | {}/{} | {}/{} |".format(
+            "| **TOTAL** | {} | {} | {} | {} | {} | {} | {} | {:.1f}% | {:.1f}% | {} | {}/{} | {}/{} |".format(
                 total_counts.total,
                 total_counts.pass_,
+                total_counts.supported_no_evidence,
                 total_counts.diverge,
                 total_counts.no_op,
                 total_counts.not_impl,
@@ -319,6 +392,7 @@ def render_json(
         out_surfaces[surface] = {
             "total": counts.total,
             "pass": counts.pass_,
+            "supported_no_evidence": counts.supported_no_evidence,
             "diverge": counts.diverge,
             "no_op": counts.no_op,
             "not_impl": counts.not_impl,
@@ -355,6 +429,7 @@ def render_json(
         "totals": {
             "total": total_counts.total,
             "pass": total_counts.pass_,
+            "supported_no_evidence": total_counts.supported_no_evidence,
             "diverge": total_counts.diverge,
             "no_op": total_counts.no_op,
             "not_impl": total_counts.not_impl,
@@ -513,7 +588,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     )
     print(f"# pulp harness coverage @ {sha}")
     print(f"")
-    print(f"{'surface':<10} {'total':>6} {'PASS':>6} {'DIVERGE':>8} {'NO-OP':>6} "
+    print(f"{'surface':<10} {'total':>6} {'PASS':>6} {'NO-EV':>6} {'DIVERGE':>8} {'NO-OP':>6} "
           f"{'NOT-IMPL':>9} {'OOS':>5} {'PASS%':>7} {'drift':>6} {'valid':>8} {'visual':>8}")
     for surface, results in results_by_surface.items():
         c = StatusCounts.from_results([r.status for r in results])
@@ -521,7 +596,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         visual = visual_counts.get(surface, {"label": "0/0"})
         validation = validation_counts.get(surface, {"label": "0/0"})
         print(
-            f"{surface:<10} {c.total:>6} {c.pass_:>6} {c.diverge:>8} "
+            f"{surface:<10} {c.total:>6} {c.pass_:>6} {c.supported_no_evidence:>6} {c.diverge:>8} "
             f"{c.no_op:>6} {c.not_impl:>9} {c.oos:>5} {c.pass_pct:>6.1f}% "
             f"{drifts:>6} {validation['label']:>8} {visual['label']:>8}"
         )
@@ -538,7 +613,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         validation_pass = sum(int(v.get("pass", 0)) for v in validation_counts.values())
         validation_total = sum(int(v.get("total", 0)) for v in validation_counts.values())
         print(
-            f"{'TOTAL':<10} {c.total:>6} {c.pass_:>6} {c.diverge:>8} "
+            f"{'TOTAL':<10} {c.total:>6} {c.pass_:>6} {c.supported_no_evidence:>6} {c.diverge:>8} "
             f"{c.no_op:>6} {c.not_impl:>9} {c.oos:>5} {c.pass_pct:>6.1f}% "
             f"{all_drifts:>6} {f'{validation_pass}/{validation_total}':>8} "
             f"{f'{visual_pass}/{visual_total}':>8}"


### PR DESCRIPTION
## Summary

Three inter-related changes from the SESSION-2026-05-08 foreground work:

### 1. canvas2d/filter drop-shadow wiring
- Extended `parse_filter_chain()` in `skia_canvas.cpp` to parse `drop-shadow(<dx> <dy> <blur> <color>)`
- Added helpers: `parse_filter_args()`, `parse_filter_arg_length()`, `parse_css_color_to_skcolor()` (supports #hex, rgb/rgba, hsl/hsla, named colors, transparent)
- Creates `SkImageFilters::DropShadow(dx, dy, blur, blur, color, nullptr, nullptr)`
- Moved `drop-shadow(...)` from unsupported→supported in `compat.json` canvas2d/filter
- Added 3 Catch2 tests (Skia-guarded, `[drop-shadow][wave6-canvas2d]` tags)

### 2. #1657 control #1 — verifier `evidence.tests` requirement  
- Added `Status.SUPPORTED_NO_EVIDENCE` to harness taxonomy
- `check_evidence()` post-processing: demotes PASS→SUPPORTED_NO_EVIDENCE when `supported` claims lack real test paths; grace via `_audit._evidence_grace_until: "2026-05-22"`
- Added 13 unittest tests covering grace/expiry/edge cases and all status transitions
- Updated renderers (markdown, JSON, stdout) to display NO-EV column

### 3. #1657 control #2 — pre-push status-flip gate
- Added `check_compat_status_flips()` to `.githooks/pre-push`
- Blocks push when `compat.json` flips `partial→supported` without test file coverage
- Integrated with existing `PULP_DISABLE_PREPUSH_GATES` demotion

**Total**: 6 files modified, 1 new file, 16 tests