### PR TITLE
fix(view): setBoxSizing 'inherit' walks parent chain (Codex P1, pulp #1538 followup)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.79.4
+    VERSION 0.79.5
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -3613,7 +3613,14 @@ void WidgetBridge::register_api() {
         auto* v = id.empty() ? &root_ : widget(id);
         if (!v) return choc::value::Value();
         auto& f = v->flex();
-        f.box_sizing = (kw == "border-box") ? BoxSizing::border_box : BoxSizing::content_box;
+        if (kw == "border-box") {
+            f.box_sizing = BoxSizing::border_box;
+        } else if (kw == "inherit") {
+            f.box_sizing = v->parent() ? v->parent()->flex().box_sizing
+                                       : BoxSizing::content_box;
+        } else {
+            f.box_sizing = BoxSizing::content_box;
+        }
         return choc::value::Value();
     });
 

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -7390,6 +7390,33 @@ TEST_CASE("setBoxSizing border-box / content-box round-trips onto FlexStyle",
     REQUIRE(bridge.widget("a")->flex().box_sizing == BoxSizing::content_box);
 }
 
+// Codex #1616 P1 — `box-sizing: inherit` must walk the parent chain
+// instead of silently coercing to content-box. Reproduces the common
+// reset pattern `html { box-sizing: border-box }` + descendants
+// `* { box-sizing: inherit }` that gets imported from web designs.
+TEST_CASE("setBoxSizing 'inherit' resolves to parent's box_sizing",
+          "[view][bridge][css][issue-1538][codex-p1]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.load_script(R"(
+        createPanel('parent', '');
+        createPanel('child', 'parent');
+        createPanel('grandchild', 'child');
+        setBoxSizing('parent', 'border-box');
+        setBoxSizing('child', 'inherit');
+        setBoxSizing('grandchild', 'inherit');
+    )");
+    REQUIRE(bridge.widget("parent")->flex().box_sizing == BoxSizing::border_box);
+    REQUIRE(bridge.widget("child")->flex().box_sizing == BoxSizing::border_box);
+    REQUIRE(bridge.widget("grandchild")->flex().box_sizing == BoxSizing::border_box);
+
+    // inherit on a detached/root node falls back to the CSS default content-box.
+    bridge.load_script("setBoxSizing('', 'inherit');");
+    REQUIRE(root.flex().box_sizing == BoxSizing::content_box);
+}
+
 // pulp #1516 — CSSStyleDeclaration shim forwards camelCase boxSizing.
 TEST_CASE("CSSStyleDeclaration forwards box-sizing to bridge",
           "[view][bridge][css][issue-1516]") {


### PR DESCRIPTION
## Summary

Fixes the Codex P1 finding from #1616 sweep on PR #1538.

**Bug**: `setBoxSizing(id, kw)` coerced every value other than `border-box` to `content-box`, including `inherit` and `unset`. The common reset `html { box-sizing: border-box }` + descendants `* { box-sizing: inherit }` (extremely common in imported web designs) silently regressed every descendant to `content-box`.

**Fix**: handle `inherit` explicitly by reading the parent's resolved `box_sizing`. With no parent, fall through to the CSS default (`content-box`). All other inputs (`content-box`, `unset`, `initial`, unknown keywords) keep the existing "→ content-box" fallback so the existing #1516 contract holds.

## Test plan

- [x] New test `[view][bridge][css][issue-1538][codex-p1]`: 3-level panel hierarchy (parent / child / grandchild). Parent set to `border-box`, child + grandchild set to `inherit`. All three resolve to `border-box`. Detached/root case with `inherit` falls back to `content-box`.
- [x] Existing `[issue-1516]` tests still pass (10 assertions, 3 cases).

## Refs

- pulp #1616 (Codex post-merge sweep P1 list)
- pulp #1538 (original PR that introduced the bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)