### PR TITLE
fix(view): setClipPath unwraps path() + skips deferred shapes (Codex P1, pulp #1540 followup)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.79.5
+    VERSION 0.79.6
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -4850,18 +4850,48 @@ void WidgetBridge::register_api() {
             return choc::value::Value();
         });
 
-    // setClipPath(id, svg_path_d) — CSS `clip-path: path("...")` (pulp
-    // #1515). Stores the SVG-path-d string on the View; paint_all()
-    // installs it as a canvas clip via Canvas::clip_path_svg. Empty
-    // string clears the slot. URL refs (`url(#id)`) and named shapes
-    // (`circle()`, `inset()`, `polygon()`) are deferred — only
-    // `path("...")` form is honored today.
+    // setClipPath(id, value) — CSS `clip-path` (pulp #1515). The paint
+    // side feeds the stored slot to `Canvas::clip_path_svg` which calls
+    // `SkPath::FromSVGString` — that parser only accepts raw SVG path
+    // "d" data, so we must unwrap `path("...")` here and explicitly
+    // skip shapes / URL refs that the paint side cannot honor (they
+    // remain documented as deferred). Forwarding the verbatim value
+    // produced silent paint failures on every non-path() form (Codex
+    // #1616 P1 on #1540).
     engine_.register_function("setClipPath",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
             auto value = args.get<std::string>(1, "");
             auto* v = id.empty() ? &root_ : widget(id);
-            if (v) v->set_clip_path(value);
+            if (!v) return choc::value::Value();
+            auto trim = [](std::string s) {
+                auto a = s.find_first_not_of(" \t\n\r");
+                if (a == std::string::npos) return std::string{};
+                auto b = s.find_last_not_of(" \t\n\r");
+                return s.substr(a, b - a + 1);
+            };
+            std::string t = trim(value);
+            if (t.empty() || t == "none") {
+                v->set_clip_path("");
+            } else if (t.size() > 6 && t.rfind("path(", 0) == 0 && t.back() == ')') {
+                std::string inner = trim(t.substr(5, t.size() - 6));
+                if (inner.size() >= 2 && (inner.front() == '"' || inner.front() == '\'')
+                    && inner.back() == inner.front()) {
+                    inner = inner.substr(1, inner.size() - 2);
+                }
+                v->set_clip_path(inner);
+            } else {
+                bool deferred_shape = false;
+                for (const char* p : {"circle(", "ellipse(", "inset(", "polygon(",
+                                       "rect(", "xywh(", "url("}) {
+                    if (t.rfind(p, 0) == 0) { deferred_shape = true; break; }
+                }
+                if (deferred_shape) {
+                    v->set_clip_path("");
+                } else {
+                    v->set_clip_path(t);
+                }
+            }
             return choc::value::Value();
         });
 

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -4871,9 +4871,16 @@ void WidgetBridge::register_api() {
                 return s.substr(a, b - a + 1);
             };
             std::string t = trim(value);
-            if (t.empty() || t == "none") {
+            // CSS keywords (`none`, `path(...)`, `circle(...)`, etc.) are
+            // case-insensitive per spec. Build a lowercased copy of the
+            // prefix-bearing portion for comparison; preserve the original
+            // case for the SVG path "d" data inside path("...") (Codex
+            // #1616 P2 on #1540 follow-up #1698).
+            std::string t_lower = t;
+            for (auto& c : t_lower) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+            if (t_lower.empty() || t_lower == "none") {
                 v->set_clip_path("");
-            } else if (t.size() > 6 && t.rfind("path(", 0) == 0 && t.back() == ')') {
+            } else if (t_lower.size() > 6 && t_lower.rfind("path(", 0) == 0 && t.back() == ')') {
                 std::string inner = trim(t.substr(5, t.size() - 6));
                 if (inner.size() >= 2 && (inner.front() == '"' || inner.front() == '\'')
                     && inner.back() == inner.front()) {
@@ -4884,7 +4891,7 @@ void WidgetBridge::register_api() {
                 bool deferred_shape = false;
                 for (const char* p : {"circle(", "ellipse(", "inset(", "polygon(",
                                        "rect(", "xywh(", "url("}) {
-                    if (t.rfind(p, 0) == 0) { deferred_shape = true; break; }
+                    if (t_lower.rfind(p, 0) == 0) { deferred_shape = true; break; }
                 }
                 if (deferred_shape) {
                     v->set_clip_path("");

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -7229,6 +7229,61 @@ TEST_CASE("WidgetBridge setClipPath stores SVG-path-d on the View",
     REQUIRE_FALSE(panel->has_clip_path());
 }
 
+// Codex #1616 P1 — `setClipPath` was forwarding the verbatim CSS value
+// (e.g. `path("M ...")`, `none`, `circle(...)`) to `SkPath::FromSVGString`,
+// which only accepts raw "d" data. The unwrap path below is the bridge-side
+// fix; non-path() shapes are deferred per #1515.
+TEST_CASE("WidgetBridge setClipPath unwraps path() and rejects non-path forms",
+          "[view][bridge][issue-1540][codex-p1]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.load_script("createPanel('p', '')");
+    auto* panel = bridge.widget("p");
+    REQUIRE(panel != nullptr);
+
+    // path("...") — quoted, double-quote
+    bridge.load_script(R"(setClipPath('p', 'path("M 0 0 L 50 0 L 50 50 Z")'))");
+    REQUIRE(panel->has_clip_path());
+    REQUIRE(panel->clip_path() == "M 0 0 L 50 0 L 50 50 Z");
+
+    // path('...') — single-quote variant
+    bridge.load_script("setClipPath('p', \"path('M 1 1 L 9 1')\")");
+    REQUIRE(panel->clip_path() == "M 1 1 L 9 1");
+
+    // path("...") with surrounding whitespace and inner trim
+    bridge.load_script(R"(setClipPath('p', '  path( "M 0 0 H 10"  )  '))");
+    REQUIRE(panel->clip_path() == "M 0 0 H 10");
+
+    // `none` clears the slot per CSS spec.
+    bridge.load_script("setClipPath('p', 'none')");
+    REQUIRE_FALSE(panel->has_clip_path());
+
+    // Re-set then pass a non-path shape: slot must clear (deferred form).
+    bridge.load_script(R"(setClipPath('p', 'path("M 0 0 H 5")'))");
+    REQUIRE(panel->has_clip_path());
+    bridge.load_script("setClipPath('p', 'circle(50% at 50% 50%)')");
+    REQUIRE_FALSE(panel->has_clip_path());
+
+    // url(#ref) — also deferred form, slot must clear (no bogus forward).
+    bridge.load_script(R"(setClipPath('p', 'path("M 0 0 H 5")'))");
+    bridge.load_script("setClipPath('p', 'url(#someId)')");
+    REQUIRE_FALSE(panel->has_clip_path());
+
+    // polygon(...) — also deferred form.
+    bridge.load_script(R"(setClipPath('p', 'path("M 0 0 H 5")'))");
+    bridge.load_script("setClipPath('p', 'polygon(0 0, 10 0, 5 10)')");
+    REQUIRE_FALSE(panel->has_clip_path());
+
+    // Bare SVG-path "d" data (no wrapper): the original pre-#1540
+    // form. Still passes through verbatim for legacy callers and the
+    // existing [issue-1515] round-trip test.
+    bridge.load_script("setClipPath('p', 'M 0 0 L 20 0 L 20 20 Z')");
+    REQUIRE(panel->has_clip_path());
+    REQUIRE(panel->clip_path() == "M 0 0 L 20 0 L 20 20 Z");
+}
+
 TEST_CASE("WidgetBridge setMaskImage / setMask round-trip on the View",
           "[view][bridge][issue-1515]") {
     ScriptEngine engine;

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -7282,6 +7282,24 @@ TEST_CASE("WidgetBridge setClipPath unwraps path() and rejects non-path forms",
     bridge.load_script("setClipPath('p', 'M 0 0 L 20 0 L 20 20 Z')");
     REQUIRE(panel->has_clip_path());
     REQUIRE(panel->clip_path() == "M 0 0 L 20 0 L 20 20 Z");
+
+    // Codex #1616 P2 — CSS keywords are case-insensitive. Verify the
+    // bridge normalizes case before dispatch (NONE clears, PATH(...)
+    // unwraps, URL(#id) is treated as deferred).
+    bridge.load_script("setClipPath('p', 'M 1 1 L 9 1')");  // pre-set
+    REQUIRE(panel->has_clip_path());
+    bridge.load_script("setClipPath('p', 'NONE')");
+    REQUIRE_FALSE(panel->has_clip_path());
+
+    bridge.load_script(R"(setClipPath('p', 'PATH("M 5 5 L 6 6")'))");
+    REQUIRE(panel->has_clip_path());
+    REQUIRE(panel->clip_path() == "M 5 5 L 6 6");
+
+    bridge.load_script(R"(setClipPath('p', 'Path("M 7 7")'))"); // mixed-case
+    REQUIRE(panel->clip_path() == "M 7 7");
+
+    bridge.load_script("setClipPath('p', 'URL(#someId)')");  // deferred
+    REQUIRE_FALSE(panel->has_clip_path());
 }
 
 TEST_CASE("WidgetBridge setMaskImage / setMask round-trip on the View",


### PR DESCRIPTION
## Summary

Fixes Codex P1 finding from #1616 sweep on PR #1540.

**Bug**: `setClipPath` was forwarding the verbatim CSS value to `SkPath::FromSVGString` (via `Canvas::clip_path_svg`), which only accepts raw SVG path "d" data. Common forms silently failed:

- `clip-path: path("M 0 0 L 10 10")` — wrapper not unwrapped
- `clip-path: none` — written as a path string, then non-empty so `has_clip_path()` reported true
- `clip-path: circle(...)` / `inset(...)` / `polygon(...)` / `url(#...)` — forwarded as bogus path strings

**Fix at the bridge**:
- Trim outer whitespace
- Unwrap `path("...")` and `path('...')` (both quote styles plus inner whitespace) → store bare d-data
- `none` (and empty) clear the slot
- Recognized-but-deferred shapes (circle/ellipse/inset/polygon/rect/xywh/url) clear the slot
- Bare-d input (legacy pre-#1540 form, used by `[issue-1515]` round-trip test) still passes through verbatim

## Test plan

- [x] New test `[view][bridge][issue-1540][codex-p1]`: 12 assertions covering 4 quote/wrapper variants, deferred shapes, bare-d backward compat
- [x] Existing `[issue-1515]` tests still pass (24 assertions, 7 cases)

## Refs

- pulp #1616 (Codex post-merge sweep P1 list)
- pulp #1540 (original PR that introduced the bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)