### PR TITLE
fix(canvas2d): rotated ellipse extends current contour (Codex P1, pulp #1556 followup)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.79.6
+    VERSION 0.79.7
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -1963,9 +1963,15 @@ void SkiaCanvas::ellipse(float cx, float cy, float rx, float ry,
     SkPath rotated = tmp.detach();
     rotated.transform(m);
     // Append rotated path into the live builder, preserving the current
-    // subpath. addPath with kAppend_AddPathMode joins the new path to
-    // any existing pen position via a moveTo on the first verb.
-    path_builder_->addPath(rotated);
+    // subpath. kExtend connects the rotated arc's first point to the
+    // existing pen position with an implicit lineTo (matching CSS
+    // Canvas2D semantics for ellipse: "If the current point is not at
+    // the start of the arc, a straight line is added."). The earlier
+    // kAppend default replaced that with a moveTo, breaking contour
+    // continuity for fills (Codex #1616 P1 on #1556). When the builder
+    // is empty kExtend degrades to kAppend, so unrotated standalone
+    // ellipses still work.
+    path_builder_->addPath(rotated, SkPath::kExtend_AddPathMode);
 }
 
 void SkiaCanvas::round_rect(float x, float y, float w, float h,

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -2893,41 +2893,49 @@ TEST_CASE("SkiaCanvas::round_rect renders 4 distinct corner radii",
 TEST_CASE("SkiaCanvas::ellipse with rotation extends current contour (no gap)",
           "[canvas][skia][issue-1556][codex-p1]") {
     const int W = 200, H = 200;
+    // STROKE (not fill) the path so the bridge segment between the
+    // initial move_to and the rotated ellipse's start point is
+    // observable. A moveTo (the kAppend bug) leaves no rendered
+    // bridge — the stroke jumps to the ellipse start without drawing.
+    // A lineTo (the kExtend fix) renders the bridge as a stroked line
+    // along y=100 from x=20 toward the ellipse start. Sampling a
+    // pixel on that bridge line is the regression-catching probe.
     auto pixels = render_to_pixels_for_arc_test(W, H,
         [](pulp::canvas::SkiaCanvas& canvas) {
             canvas.begin_path();
-            // Move to a point clearly OFF the rotated ellipse center.
             canvas.move_to(20.0f, 100.0f);
-            // Rotated ellipse — same call shape as the existing #1521
-            // RecordingCanvas test, but exercising the SkiaCanvas
-            // path-builder graft.
+            // Rotated ellipse at (140,100) — far enough from the moveTo
+            // that the bridge segment must traverse at least 80px.
             canvas.ellipse(140.0f, 100.0f,
                            40.0f, 20.0f,
                            /*rotation=*/0.785398f, // 45 deg
                            0.0f, 6.283185307f,
                            /*anticlockwise=*/false);
-            canvas.set_fill_color(pulp::canvas::Color::hex(0x000000));
-            canvas.fill_current_path();
+            canvas.set_stroke_color(pulp::canvas::Color::hex(0x000000));
+            canvas.set_line_width(3.0f);
+            canvas.stroke_current_path();
         });
     REQUIRE(pixels.size() == static_cast<size_t>(W * H * 4));
     auto sample_r = [&](int x, int y) -> int {
         size_t off = (static_cast<size_t>(y) * W + x) * 4;
-        return pixels[off + 0]; // red channel
+        return pixels[off + 0]; // red channel; near-white = unfilled
     };
-    // The rotated ellipse spans roughly x∈[100,180], y∈[60,140].
-    // Center (140,100) must be filled (< 200 = not white).
-    REQUIRE(sample_r(140, 100) < 200);
-    // The connecting segment (move_to(20,100) → ellipse start) must
-    // produce a fill-region that crosses the line y=100 between x=20
-    // and the ellipse boundary. With the old kAppend bug the ellipse
-    // appears as a separate shape and the rendering of the unclosed
-    // path (move + ellipse with a fresh moveTo) does not create a
-    // visible bridge, so a sample just inside the ellipse-near edge
-    // should still be filled either way (we use the center as a
-    // robust signal). The regression we want to catch is: with the
-    // bug, fill_current_path produces non-deterministic gap pixels.
-    // Cross-check by sampling a point well inside the rotated bbox.
-    REQUIRE(sample_r(140, 100) < 200);
-    REQUIRE(sample_r(150, 100) < 200);
+    // Probe along the y=100 line in the bridge region (x∈[40,80]),
+    // well clear of both the move_to point and any rotated-ellipse
+    // edge. With the fix this line is stroked (channel < 200); with
+    // the kAppend bug there's no draw command and the pixel stays
+    // near-white (channel ≥ 200). Try multiple x to be robust against
+    // anti-alias / line-width rounding.
+    bool any_bridge_pixel_drawn = false;
+    for (int x = 40; x <= 80 && !any_bridge_pixel_drawn; x += 5) {
+        for (int dy = -1; dy <= 1; ++dy) {
+            if (sample_r(x, 100 + dy) < 200) {
+                any_bridge_pixel_drawn = true;
+                break;
+            }
+        }
+    }
+    INFO("Bridge segment pixels along y=100, x in [40,80] should be stroked.");
+    REQUIRE(any_bridge_pixel_drawn);
 }
 #endif // PULP_HAS_SKIA

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -2882,4 +2882,52 @@ TEST_CASE("SkiaCanvas::round_rect renders 4 distinct corner radii",
     REQUIRE(sample(pixels_uniform, 187, 87) < 200);
     REQUIRE(sample(pixels_top_left_big, 187, 87) < 200);
 }
+
+// Codex #1616 P1 — rotated ellipse() previously used kAppend_AddPathMode
+// when grafting the rotated arc onto the live path builder, replacing the
+// implicit lineTo (CSS Canvas2D semantics) with a moveTo. Fills with a
+// preceding moveTo + a rotated arc would render with a visible gap
+// because the new contour did not connect back to the moveTo pen
+// position. With kExtend_AddPathMode, the connect-via-lineTo behavior
+// is restored.
+TEST_CASE("SkiaCanvas::ellipse with rotation extends current contour (no gap)",
+          "[canvas][skia][issue-1556][codex-p1]") {
+    const int W = 200, H = 200;
+    auto pixels = render_to_pixels_for_arc_test(W, H,
+        [](pulp::canvas::SkiaCanvas& canvas) {
+            canvas.begin_path();
+            // Move to a point clearly OFF the rotated ellipse center.
+            canvas.move_to(20.0f, 100.0f);
+            // Rotated ellipse — same call shape as the existing #1521
+            // RecordingCanvas test, but exercising the SkiaCanvas
+            // path-builder graft.
+            canvas.ellipse(140.0f, 100.0f,
+                           40.0f, 20.0f,
+                           /*rotation=*/0.785398f, // 45 deg
+                           0.0f, 6.283185307f,
+                           /*anticlockwise=*/false);
+            canvas.set_fill_color(pulp::canvas::Color::hex(0x000000));
+            canvas.fill_current_path();
+        });
+    REQUIRE(pixels.size() == static_cast<size_t>(W * H * 4));
+    auto sample_r = [&](int x, int y) -> int {
+        size_t off = (static_cast<size_t>(y) * W + x) * 4;
+        return pixels[off + 0]; // red channel
+    };
+    // The rotated ellipse spans roughly x∈[100,180], y∈[60,140].
+    // Center (140,100) must be filled (< 200 = not white).
+    REQUIRE(sample_r(140, 100) < 200);
+    // The connecting segment (move_to(20,100) → ellipse start) must
+    // produce a fill-region that crosses the line y=100 between x=20
+    // and the ellipse boundary. With the old kAppend bug the ellipse
+    // appears as a separate shape and the rendering of the unclosed
+    // path (move + ellipse with a fresh moveTo) does not create a
+    // visible bridge, so a sample just inside the ellipse-near edge
+    // should still be filled either way (we use the center as a
+    // robust signal). The regression we want to catch is: with the
+    // bug, fill_current_path produces non-deterministic gap pixels.
+    // Cross-check by sampling a point well inside the rotated bbox.
+    REQUIRE(sample_r(140, 100) < 200);
+    REQUIRE(sample_r(150, 100) < 200);
+}
 #endif // PULP_HAS_SKIA


### PR DESCRIPTION
## Summary

Fixes Codex P1 finding from #1616 sweep on PR #1556.

**Bug**: Rotated `ellipse()` in `SkiaCanvas` builds the arc into a temp `SkPathBuilder` with `forceMoveTo=true`, then grafts it onto the live `path_builder_` via `addPath(rotated)` which uses `kAppend_AddPathMode` by default. kAppend keeps the temp path's initial `moveTo`, starting a new contour and breaking continuity from any prior `moveTo` / `lineTo` already on the live builder. CSS Canvas2D semantics: "If the current point is not at the start of the arc, a straight line is added" — i.e. implicit `lineTo`, not `moveTo`. Visible gaps in fills.

**Fix**: Pass `SkPath::kExtend_AddPathMode` so the rotated arc connects via `lineTo` when there's a prior pen position, and degrades to kAppend when the live builder is empty (so unrotated standalone ellipses still work).

## Test plan

- [x] New test `[canvas][skia][issue-1556][codex-p1]`: `moveTo(20,100)` then a rotated ellipse at `(140,100)` — rendered fill must include the ellipse interior.
- [x] Existing `[issue-1521]` tests still pass (25 assertions, 4 cases).

## Refs

- pulp #1616 (Codex post-merge sweep P1 list)
- pulp #1556 (original PR that introduced the bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)