### PR TITLE
fix(view/css): single-token gap clears per-axis row_gap/column_gap (Codex P1, pulp #1638 followup)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.79.0
+    VERSION 0.79.4
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/js/web-compat-style-decl.js
+++ b/core/view/js/web-compat-style-decl.js
@@ -202,8 +202,13 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             // pulp Wave 2 css.2 — CSS shorthand `gap: <row-gap> [<col-gap>]`.
             // When two tokens are present, fan out to setRowGap +
             // setColumnGap so each axis gets its own value (matching the
-            // CSS spec). Single-token form falls through to the legacy
-            // shared `gap` slot for backwards compatibility.
+            // CSS spec). Single-token form writes the shared `gap` slot.
+            //
+            // Codex #1616 P1 on #1638 — single-token writes were ignoring
+            // any prior 2-token state, leaving stale row_gap/column_gap
+            // (which FlexStyle::effective_gap prefers when ≥0). The fix
+            // resets per-axis to the -1 sentinel before writing the
+            // shared slot so the new shorthand value actually wins.
             var gapToks = String(resolved).trim().split(/\s+/);
             if (gapToks.length >= 2) {
                 var grRow = parseCSSLength(gapToks[0]);
@@ -213,6 +218,11 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
                 if (grCol) setFlex(id, "column_gap",
                     grCol.unit === "%" ? (grCol.value + "%") : grCol.value);
             } else {
+                // Reset per-axis (-1 = "consult shared gap") so the new
+                // single-token value isn't shadowed by a prior 2-token
+                // write.
+                setFlex(id, "row_gap", -1);
+                setFlex(id, "column_gap", -1);
                 var g = parseCSSLength(resolved);
                 if (g) setFlex(id, "gap",
                     g.unit === "%" ? (g.value + "%") : g.value);

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -8698,6 +8698,43 @@ TEST_CASE("CSSStyleDeclaration gap two-value fans out to row + column",
     REQUIRE_THAT(f.column_gap, WithinAbs(20.0f, 0.001f));
 }
 
+// Codex #1616 P1 on #1638 — single-token `gap` was leaving prior
+// row_gap/column_gap intact; FlexStyle::effective_gap prefers per-axis
+// when ≥0, so `gap: 5px` after `gap: 10px 20px` was reading 10/20
+// instead of 5/5. The fix resets per-axis to the -1 sentinel before
+// writing the shared slot.
+TEST_CASE("CSSStyleDeclaration single-token gap clears per-axis (no shadowing)",
+          "[view][bridge][css][issue-1638][codex-p1]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('p', '');
+        var s = new CSSStyleDeclaration({ _id: 'p', _nativeCreated: true });
+        s._applyProperty('gap', '10px 20px');
+    )");
+    const auto& f = bridge.widget("p")->flex();
+    REQUIRE_THAT(f.row_gap,    WithinAbs(10.0f, 0.001f));
+    REQUIRE_THAT(f.column_gap, WithinAbs(20.0f, 0.001f));
+
+    // Now overwrite with single-token gap. Per-axis must reset (-1)
+    // so the shared `gap` value is consulted by effective_gap.
+    bridge.load_script(R"(
+        var s2 = new CSSStyleDeclaration({ _id: 'p', _nativeCreated: true });
+        s2._applyProperty('gap', '5px');
+    )");
+    REQUIRE_THAT(f.gap,        WithinAbs(5.0f,  0.001f));
+    REQUIRE(f.row_gap    < 0.0f);  // -1 sentinel = "consult shared gap"
+    REQUIRE(f.column_gap < 0.0f);
+    // effective_gap on either axis should now resolve to 5.0
+    REQUIRE_THAT(f.effective_gap(pulp::view::FlexDirection::row),
+                 WithinAbs(5.0f, 0.001f));
+    REQUIRE_THAT(f.effective_gap(pulp::view::FlexDirection::column),
+                 WithinAbs(5.0f, 0.001f));
+}
+
 // pulp #1638 baseline-corruption: this TEST_CASE body got truncated
 // during the bad merge — it set up `using BM = ...; ScriptEngine
 // engine; View root; root.set_bounds(...);` but never wrapped the


### PR DESCRIPTION
## Summary

Fixes Codex P1 finding from #1616 sweep on PR #1638.

**Bug**: Single-token `gap` writes only the shared `gap` slot, but `FlexStyle::effective_gap` prefers `row_gap`/`column_gap` when ≥0. So `gap: 10px 20px` followed by `gap: 5px` left `row_gap=10/column_gap=20` stale and the new shorthand silently lost — observed layout was `10/20`, not `5/5`.

**Fix** in `web-compat-style-decl.js` single-token branch: write `row_gap = -1` and `column_gap = -1` (the FlexStyle "unset" sentinel that `effective_gap` interprets as "consult shared gap") before writing the new shared `gap` value. The two-token branch was already correct (its explicit per-axis writes always win over `gap`).

## Test plan

- [x] New test `[view][bridge][css][issue-1638][codex-p1]`: 7 assertions walking the full state transition — set 2-token, observe 10/20, set 1-token, observe `gap=5 / row_gap=-1 / column_gap=-1 / effective_gap(row)=5 / effective_gap(column)=5`.
- [x] Existing `[wave2-css]` tests still pass (64 assertions, 17 cases).

## Refs

- pulp #1616 (Codex post-merge sweep P1 list)
- pulp #1638 (original PR that introduced the bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)