### PR TITLE
fix(view/css): parse gap before clearing per-axis (Codex P2 followup on #1700, closes #1707)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.79.9
+    VERSION 0.79.10
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/js/web-compat-style-decl.js
+++ b/core/view/js/web-compat-style-decl.js
@@ -218,14 +218,21 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
                 if (grCol) setFlex(id, "column_gap",
                     grCol.unit === "%" ? (grCol.value + "%") : grCol.value);
             } else {
-                // Reset per-axis (-1 = "consult shared gap") so the new
-                // single-token value isn't shadowed by a prior 2-token
-                // write.
-                setFlex(id, "row_gap", -1);
-                setFlex(id, "column_gap", -1);
+                // Codex P2 followup on #1700 (#1707): parse FIRST,
+                // then reset per-axis only if the new value is valid.
+                // The earlier ordering cleared row_gap/column_gap
+                // unconditionally, which silently nuked prior 2-token
+                // state when the new value was malformed.
                 var g = parseCSSLength(resolved);
-                if (g) setFlex(id, "gap",
-                    g.unit === "%" ? (g.value + "%") : g.value);
+                if (g) {
+                    // Reset per-axis (-1 = "consult shared gap") so
+                    // the new single-token value isn't shadowed by a
+                    // prior 2-token write.
+                    setFlex(id, "row_gap", -1);
+                    setFlex(id, "column_gap", -1);
+                    setFlex(id, "gap",
+                        g.unit === "%" ? (g.value + "%") : g.value);
+                }
             }
             break;
         }

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -8814,6 +8814,53 @@ TEST_CASE("CSSStyleDeclaration single-token gap clears per-axis (no shadowing)",
                  WithinAbs(5.0f, 0.001f));
 }
 
+// Codex P2 followup on #1700 (#1707) — single-token gap with invalid
+// input must NOT clobber prior 2-token state. The earlier ordering
+// reset row_gap/column_gap before parsing; if the parse failed, the
+// per-axis slots were nuked silently. Fix parses first, only resets
+// per-axis if the new value is valid.
+TEST_CASE("CSSStyleDeclaration single-token gap with invalid input preserves prior 2-token state",
+          "[view][bridge][css][issue-1707]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.load_script(R"(
+        createPanel('p', '');
+        var s = new CSSStyleDeclaration({ _id: 'p', _nativeCreated: true });
+        s._applyProperty('gap', '10px 20px');
+    )");
+    const auto& f = bridge.widget("p")->flex();
+    REQUIRE_THAT(f.row_gap, WithinAbs(10.0f, 0.001f));
+    REQUIRE_THAT(f.column_gap, WithinAbs(20.0f, 0.001f));
+
+    // Now apply invalid single-token gap: must be a no-op (per-axis
+    // values must REMAIN 10/20, not reset to -1).
+    bridge.load_script(R"(
+        var s2 = new CSSStyleDeclaration({ _id: 'p', _nativeCreated: true });
+        s2._applyProperty('gap', 'foo');
+    )");
+    REQUIRE_THAT(f.row_gap, WithinAbs(10.0f, 0.001f));
+    REQUIRE_THAT(f.column_gap, WithinAbs(20.0f, 0.001f));
+
+    // Empty string also a no-op (parseCSSLength returns null).
+    bridge.load_script(R"(
+        var s3 = new CSSStyleDeclaration({ _id: 'p', _nativeCreated: true });
+        s3._applyProperty('gap', '');
+    )");
+    REQUIRE_THAT(f.row_gap, WithinAbs(10.0f, 0.001f));
+    REQUIRE_THAT(f.column_gap, WithinAbs(20.0f, 0.001f));
+
+    // Valid single-token gap still resets per-axis (existing #1638 behavior).
+    bridge.load_script(R"(
+        var s4 = new CSSStyleDeclaration({ _id: 'p', _nativeCreated: true });
+        s4._applyProperty('gap', '7px');
+    )");
+    REQUIRE_THAT(f.gap, WithinAbs(7.0f, 0.001f));
+    REQUIRE(f.row_gap < 0.0f);
+    REQUIRE(f.column_gap < 0.0f);
+}
+
 // pulp #1638 baseline-corruption: this TEST_CASE body got truncated
 // during the bad merge — it set up `using BM = ...; ScriptEngine
 // engine; View root; root.set_bounds(...);` but never wrapped the


### PR DESCRIPTION
## Summary

Fixes pulp #1707 (Codex P2 followup on PR #1700).

**Bug**: PR #1700 reset `row_gap` and `column_gap` to `-1` BEFORE attempting to parse the new single-token gap value. If the parse failed (e.g. `gap: foo`), the per-axis slots had already been cleared but the shared gap slot was never written — silently nuking prior 2-token state for any malformed input.

**Fix**: parse first, then clear per-axis only if the new value is valid. Invalid input is now a no-op as it was pre-#1700.

## Test plan

- [x] New test `[view][bridge][css][issue-1707]`: 9 assertions verifying invalid inputs preserve prior 2-token state, valid inputs still reset per-axis.
- [x] Existing `[issue-1638]` tests still pass (7 assertions).
- [x] Existing `[wave2-css]` tests still pass (64 assertions, 17 cases).

## Refs

- Closes pulp #1707
- pulp #1700 (the fix that introduced the issue)
- pulp #1616 (Codex sweep tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)