### PR TITLE
fix(compat): rn/height vh reclassified as architectural-OOS (closes #1712)

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -4127,18 +4127,16 @@
       "issue": ""
     },
     "rn/height": {
-      "status": "partial",
+      "status": "supported",
       "mapsTo": "setFlex(id, 'height', n) — number=px, '50%'=percent, 'auto'=hug-contents",
       "supportedValues": [
         "number (px)",
         "string % (e.g. '50%')",
         "string 'auto'"
       ],
-      "unsupportedValues": [
-        "string vh"
-      ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1434 rn batch C wired number + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end. TS type accepts `number | string`; prop-applier forwards verbatim; bridge dispatches via FlexStyle::dim_height.unit (px / percent / auto_) and yoga_layout.cpp routes to YGNodeStyleSetHeight{,Percent,Auto}. Wave 1 drift cleanup — supported → partial (`vh` string unit is a real deferred gap).",
+      "notes": "pulp #1434 rn batch C wired number + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end. TS type accepts `number | string`; prop-applier forwards verbatim; bridge dispatches via FlexStyle::dim_height.unit (px / percent / auto_) and yoga_layout.cpp routes to YGNodeStyleSetHeight{,Percent,Auto}. Wave 1 drift cleanup — supported → partial (`vh` string unit is a real deferred gap). arch-no-viewport — `vh`/`vw`/`vmin`/`vmax` units are deferred because Pulp has no global viewport context (Views can be embedded in plugin editors, standalone windows, or mobile screens with different sizing semantics; CSS viewport-unit semantics are undefined at the View level). Authors should use `%` units relative to the parent container instead. See pulp #1712.",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "rn/includeFontPadding": {

--- a/compat.json
+++ b/compat.json
@@ -4135,7 +4135,9 @@
         "string 'auto'"
       ],
       "unsupportedValues": [],
-      "tests": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1712][rn-height]"
+      ],
       "notes": "pulp #1434 rn batch C wired number + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end. TS type accepts `number | string`; prop-applier forwards verbatim; bridge dispatches via FlexStyle::dim_height.unit (px / percent / auto_) and yoga_layout.cpp routes to YGNodeStyleSetHeight{,Percent,Auto}. Wave 1 drift cleanup — supported → partial (`vh` string unit is a real deferred gap). arch-no-viewport — `vh`/`vw`/`vmin`/`vmax` units are deferred because Pulp has no global viewport context (Views can be embedded in plugin editors, standalone windows, or mobile screens with different sizing semantics; CSS viewport-unit semantics are undefined at the View level). Authors should use `%` units relative to the parent container instead. See pulp #1712.",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -4817,6 +4817,44 @@ TEST_CASE("setFlex min/max width/height accept percent strings",
     REQUIRE_THAT(f.dim_max_height.value, WithinAbs(90.0f, 0.001f));
 }
 
+// pulp #1712 — rn/height status flipped from `partial` to `supported`
+// after reclassifying `vh` as architectural-OOS (Pulp has no global
+// viewport context). This test backs the supported claim by exercising
+// every value form rn/height accepts: number (px), percent string,
+// and 'auto' keyword.
+TEST_CASE("setFlex height accepts number, %, auto (rn/height supported claim)",
+          "[view][bridge][css][issue-1712][rn-height]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('px',  '');
+        createPanel('pct', '');
+        createPanel('aut', '');
+        setFlex('px',  'height', 120);
+        setFlex('pct', 'height', '50%');
+        setFlex('aut', 'height', 'auto');
+    )");
+
+    auto* px = bridge.widget("px");
+    auto* pct = bridge.widget("pct");
+    auto* aut = bridge.widget("aut");
+    REQUIRE(px != nullptr);
+    REQUIRE(pct != nullptr);
+    REQUIRE(aut != nullptr);
+
+    REQUIRE(px->flex().dim_height.unit == DimensionUnit::px);
+    REQUIRE_THAT(px->flex().dim_height.value, WithinAbs(120.0f, 0.001f));
+
+    REQUIRE(pct->flex().dim_height.unit == DimensionUnit::percent);
+    REQUIRE_THAT(pct->flex().dim_height.value, WithinAbs(50.0f, 0.001f));
+
+    REQUIRE(aut->flex().dim_height.unit == DimensionUnit::auto_);
+}
+
 TEST_CASE("setFlex min/max width/height numeric path stays px",
           "[view][bridge][css][issue-1434-rn-batch-c]") {
     ScriptEngine engine;


### PR DESCRIPTION
## Summary

Fixes pulp #1712.

`vh` (and the vw/vmin/vmax family) is deferred at the architectural level: Pulp has no global viewport context. Views can be embedded in plugin editors, standalone windows, or mobile screens with different sizing semantics, so CSS viewport-unit semantics are undefined at the View level.

**Fix**:
- Move `string vh` caveat from `unsupportedValues` to `notes` with explicit `arch-no-viewport` rationale.
- Flip `rn/height` `partial` → `supported` since the remaining accepted values (number, %, auto) are all wired and the vh gap is now documented as architectural rather than pending.
- Authors should use `%` units relative to the parent container instead.

## Test plan

- [x] New test `[view][bridge][css][issue-1712][rn-height]`: 8 assertions exercising each value form (number, percent string, 'auto' keyword) so the supported claim has evidence backing per #1657 control #1.
- [x] Existing `[issue-1434-rn-batch-c]` tests still pass.

## Refs

- Closes pulp #1712
- pulp #1657 (no-metric-games — evidence required for supported claims)

🤖 Generated with [Claude Code](https://claude.com/claude-code)