### PR TITLE
fix(view): clear input-focus slot on widget destruction (#1708)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.82.1
+    VERSION 0.82.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -30,6 +30,12 @@ public:
         // pointer that the platform window host would dereference on
         // the next click.
         if (active_overlay_ == this) active_overlay_ = nullptr;
+        // pulp #1708 — clear the input-focus slot if this dying View holds
+        // it. Without this, a React unmount of the focused widget (e.g.,
+        // closing a Settings modal) leaves the platform host's focused-
+        // view pointer dangling; the next keypress crashes via
+        // dynamic_cast on freed memory in -[PulpView focusedTextEditor].
+        if (focused_input_ == this) focused_input_ = nullptr;
     }
 
     View(const View&) = delete;
@@ -599,6 +605,19 @@ public:
     // The ComboBox path remains untouched and has its own state.
     static View* active_overlay_;
     void claim_overlay() { active_overlay_ = this; }
+    /// pulp #1708 — global input-focus slot. The platform window host
+    /// (PulpView on mac, equivalent on other platforms) calls
+    /// `claim_input_focus()` when a click sets focus to a widget, and
+    /// reads `focused_input_` for text-input dispatch. The View destructor
+    /// auto-clears the slot if the focused widget is destroyed before
+    /// focus is moved off it (e.g., React unmount of an open modal).
+    /// Without this, the host's raw View* pointer dangles and the next
+    /// keypress segfaults inside dynamic_cast<TextEditor*>(focused).
+    static View* focused_input_;
+    void claim_input_focus() { focused_input_ = this; }
+    void release_input_focus() {
+        if (focused_input_ == this) focused_input_ = nullptr;
+    }
     /// Clear the global overlay if (and only if) `this` currently holds it.
     /// Idempotent — safe to call on unmount even if claim never happened.
     /// Does NOT fire `on_overlay_dismissed` — used by JSX unmount and the

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -486,8 +486,10 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                     _focusedView->on_focus_changed(false);
                 _focusedView = _dragTarget;
                 _focusedView->on_focus_changed(true);
+                _focusedView->claim_input_focus();
             } else if (_focusedView) {
                 _focusedView->on_focus_changed(false);
+                _focusedView->release_input_focus();
                 _focusedView = nullptr;
             }
 
@@ -677,9 +679,13 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             else
                 next = pulp::view::View::focus_next(*self.rootView, _focusedView);
             if (next && next != old) {
-                if (old) old->on_focus_changed(false);
+                if (old) {
+                    old->on_focus_changed(false);
+                    old->release_input_focus();
+                }
                 _focusedView = next;
                 _focusedView->on_focus_changed(true);
+                _focusedView->claim_input_focus();
             }
             [self setNeedsDisplay:YES];
             return;

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -235,6 +235,7 @@ static std::vector<uint8_t> capture_window_screencapture_png(NSWindow* window) {
 
 - (void)clearInteractionState {
     _dragTarget = nullptr;
+    if (_focusedView) _focusedView->release_input_focus();
     _focusedView = nullptr;
 }
 
@@ -434,8 +435,10 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                             _focusedView->on_focus_changed(false);
                         _focusedView = _dragTarget;
                         _focusedView->on_focus_changed(true);
+                        _focusedView->claim_input_focus();
                     } else if (_focusedView) {
                         _focusedView->on_focus_changed(false);
+                        _focusedView->release_input_focus();
                         _focusedView = nullptr;
                     }
 
@@ -749,18 +752,29 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
 
 - (void)insertText:(id)string replacementRange:(NSRange)range {
     (void)range;
-    if (_focusedView) {
+    // pulp #1708 — read from View::focused_input_ rather than the raw
+    // _focusedView ivar. The static is auto-cleared by ~View() when the
+    // focused widget is destroyed (e.g., React unmount of an open modal),
+    // so we never dispatch text-input on freed memory.
+    auto* fv = pulp::view::View::focused_input_;
+    if (fv) {
         NSString* str = [string isKindOfClass:[NSAttributedString class]]
             ? [(NSAttributedString*)string string] : (NSString*)string;
         pulp::view::TextInputEvent te;
         te.text = [str UTF8String];
-        _focusedView->on_text_input(te);
+        fv->on_text_input(te);
         [self setNeedsDisplay:YES];
     }
 }
 
 - (pulp::view::TextEditor*)focusedTextEditor {
-    auto* te = dynamic_cast<pulp::view::TextEditor*>(_focusedView);
+    // pulp #1708 — use the auto-clearing static slot. Without this, the
+    // raw _focusedView ivar dangles after the focused widget is freed
+    // (React unmount of an open modal) and dynamic_cast on freed memory
+    // segfaults inside libc++abi during -[NSTextInputContext
+    // hasMarkedTextWithCompletionHandler:] on the next keypress.
+    auto* fv = pulp::view::View::focused_input_;
+    auto* te = dynamic_cast<pulp::view::TextEditor*>(fv);
     return te;
 }
 

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -672,6 +672,11 @@ bool View::call_inspector_mouse_hook(const MouseEvent& e) {
 // pulp #1148 — generalized overlay-click routing.
 View* View::active_overlay_ = nullptr;
 
+// pulp #1708 — global input-focus slot. Auto-cleared by ~View() when the
+// focused widget is destroyed, preventing use-after-free in the platform
+// window host's keyDown handler.
+View* View::focused_input_ = nullptr;
+
 // pulp #1361 — dismiss-path release. Pulls the slot, then fires the
 // dismissed View's `on_overlay_dismissed` callback so React state can
 // sync. Order matters: clear the slot FIRST so a callback that calls

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1620,6 +1620,11 @@ add_executable(pulp-test-overlay-routing test_overlay_routing.cpp)
 target_link_libraries(pulp-test-overlay-routing PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-overlay-routing)
 
+# pulp #1708 — auto-clearing input-focus slot (View::focused_input_)
+add_executable(pulp-test-focused-input test_focused_input.cpp)
+target_link_libraries(pulp-test-focused-input PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-focused-input)
+
 # pulp #1148 (slice b) — auto-claim active_overlay_ from CSS shape
 # (`position:absolute` + `z-index >= 10`) or `data-overlay` author hint
 # detected by the web-compat layer (web-compat-style-decl.js +

--- a/test/test_focused_input.cpp
+++ b/test/test_focused_input.cpp
@@ -1,0 +1,92 @@
+// pulp #1708 — global input-focus slot, auto-cleared on destruction.
+//
+// Pins the `View::focused_input_` mechanism that the macOS PulpView's
+// keyDown / text-input dispatch consults instead of its own raw
+// `_focusedView` pointer. Without auto-clear on destruction, a React
+// unmount of the focused widget (e.g., closing a Settings modal)
+// leaves a dangling pointer that the next keypress dereferences via
+// dynamic_cast<TextEditor*> inside libc++abi — segfault.
+//
+// Contract under test:
+//   1. focused_input_ defaults to nullptr.
+//   2. claim_input_focus() / release_input_focus() toggle the slot
+//      and don't null a third party's hold.
+//   3. View destructor releases the slot if it currently holds it.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/view/view.hpp>
+
+using pulp::view::View;
+
+namespace {
+
+class TestView : public View {
+public:
+    void paint(pulp::canvas::Canvas&) override {}
+};
+
+struct FocusGuard {
+    FocusGuard() { View::focused_input_ = nullptr; }
+    ~FocusGuard() { View::focused_input_ = nullptr; }
+};
+
+}  // namespace
+
+TEST_CASE("View::focused_input_ defaults to nullptr [issue-1708]",
+          "[view][focus]") {
+    FocusGuard g;
+    REQUIRE(View::focused_input_ == nullptr);
+}
+
+TEST_CASE("View::claim_input_focus sets focused_input_ to this [issue-1708]",
+          "[view][focus]") {
+    FocusGuard g;
+    TestView v;
+    v.claim_input_focus();
+    REQUIRE(View::focused_input_ == &v);
+}
+
+TEST_CASE("View::release_input_focus clears only if this holds it [issue-1708]",
+          "[view][focus]") {
+    FocusGuard g;
+    TestView a;
+    TestView b;
+
+    a.claim_input_focus();
+    REQUIRE(View::focused_input_ == &a);
+
+    // Releasing a non-holder must NOT null a third party's slot.
+    b.release_input_focus();
+    REQUIRE(View::focused_input_ == &a);
+
+    a.release_input_focus();
+    REQUIRE(View::focused_input_ == nullptr);
+}
+
+// THE crash regression: destroying the focused widget must clear the
+// global slot so the platform host's next text-input dispatch reads
+// nullptr instead of a freed View*.
+TEST_CASE("~View() clears focused_input_ if this holds it [issue-1708]",
+          "[view][focus]") {
+    FocusGuard g;
+    {
+        TestView v;
+        v.claim_input_focus();
+        REQUIRE(View::focused_input_ == &v);
+    }  // v destructed here
+    REQUIRE(View::focused_input_ == nullptr);
+}
+
+TEST_CASE("~View() does not clear focused_input_ if a sibling holds it [issue-1708]",
+          "[view][focus]") {
+    FocusGuard g;
+    TestView holder;
+    holder.claim_input_focus();
+    REQUIRE(View::focused_input_ == &holder);
+    {
+        TestView sibling;
+        // sibling never claimed focus
+    }
+    REQUIRE(View::focused_input_ == &holder);
+    holder.release_input_focus();
+}


### PR DESCRIPTION
Use-after-free in -[PulpView keyDown:] -> -[PulpView focusedTextEditor]
when the focused widget is destroyed by a tree update (e.g., a React
unmount of an open Settings modal). PulpView held a raw View* in
_focusedView; the next keypress dynamic_cast<TextEditor*> on the freed
memory segfaulted inside libc++abi.

Mirror the pulp #1148 active_overlay_ pattern: add a static
View::focused_input_ slot that the destructor auto-clears, and route
the macOS window host's keyDown / text-input dispatch through it
instead of its own raw ivar.

- View::focused_input_ static, claim_input_focus() / release_input_focus()
- ~View() clears the slot if this == focused_input_
- PulpView calls claim/release on focus changes and on
  clearInteractionState; reads focused_input_ for hasMarkedText,
  selectedRange, setMarkedText, unmarkText, attributedSubstring,
  insertText, focusedTextEditor

Verified end-to-end via Spectr's native-react editor: Settings can
now be opened, dismissed via Esc/click-outside, and typed into without
crashing. Repro path (close modal -> press any key -> segfault) now
exits cleanly through the auto-cleared slot.

5 regression tests in test/test_focused_input.cpp cover: default
nullptr, claim, mutual release, swap-on-destruct (the actual UAF
guard), and sibling destruct doesn't clear holder.