### PR TITLE
feat(view): rn/outlineColor supports currentColor keyword (closes pulp #1710)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.79.18
+    VERSION 0.79.19
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/compat.json
+++ b/compat.json
@@ -4900,22 +4900,22 @@
       "issue": ""
     },
     "rn/outlineColor": {
-      "status": "partial",
+      "status": "supported",
       "mapsTo": "@pulp/react prop-applier dispatches outlineColor to setOutlineColor (prop-applier.ts since pulp #1519). Bridge writes to View::outline_color_.",
       "supportedValues": [
         "#hex",
         "#rgba",
         "rgb()",
         "rgba()",
-        "named colors"
+        "named colors",
+        "currentColor (resolves to View::inheritable_text_color() with theme text fallback)"
       ],
-      "unsupportedValues": [
-        "currentColor keyword"
-      ],
+      "unsupportedValues": [],
       "tests": [
-        "packages/pulp-react/test/prop-applier-outline.test.ts"
+        "packages/pulp-react/test/prop-applier-outline.test.ts",
+        "test/test_widget_bridge.cpp [issue-1710][outline-currentcolor]"
       ],
-      "notes": "pulp #1519 — RN outline cluster. Outline is paint-time only and does NOT affect Yoga layout (parent never reserves space). Skia paint inflates the box by (offset + width/2) and strokes with the parsed color. Wave 1 drift cleanup — supported → partial (currentColor keyword resolution deferred; CSS color strings round-trip).",
+      "notes": "pulp #1519 — RN outline cluster. Outline is paint-time only and does NOT affect Yoga layout (parent never reserves space). Skia paint inflates the box by (offset + width/2) and strokes with the parsed color. Wave 1 drift cleanup — supported → partial (currentColor keyword resolution deferred; CSS color strings round-trip). Wired in pulp #1710 — `currentColor` keyword resolves to the View's inheritable text color (walks parent chain via View::inheritable_text_color), falling back to theme `text.primary` token when no ancestor set the text color explicitly. Test [view][bridge][rn][issue-1710][outline-currentcolor] proves the resolution.",
       "issue": ""
     },
     "rn/outlineOffset": {

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -3327,12 +3327,31 @@ void WidgetBridge::register_api() {
     // — same paint-side gap as borderStyle.
     //
     // setOutlineColor(id, hex) — accepts the same color forms as
-    // setBackground / setBorderColor (#hex / rgb() / named).
+    // setBackground / setBorderColor (#hex / rgb() / named), plus the
+    // CSS `currentColor` keyword which resolves to the View's text
+    // color via the inheritable cascade (#1710).
     engine_.register_function("setOutlineColor", [this, parseHexColor](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "");
         auto* v = id.empty() ? &root_ : widget(id);
-        if (v && !hex.empty()) v->set_outline_color(parseHexColor(hex));
+        if (!v || hex.empty()) return choc::value::Value();
+        // CSS `currentColor`: resolve from the View's inheritable text
+        // color (walks the parent chain), falling back to the theme
+        // text token if no ancestor set one explicitly.
+        std::string lower;
+        lower.reserve(hex.size());
+        for (char c : hex) lower += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        if (lower == "currentcolor") {
+            auto inherited = v->inheritable_text_color();
+            if (inherited) {
+                v->set_outline_color(*inherited);
+            } else {
+                v->set_outline_color(v->resolve_color("text.primary",
+                                                      canvas::Color::rgba8(220, 220, 220)));
+            }
+        } else {
+            v->set_outline_color(parseHexColor(hex));
+        }
         return choc::value::Value();
     });
 

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -10974,3 +10974,47 @@ TEST_CASE("Catalog flips: canvas2d/transform concat + css/grid shorthand support
     // harness-anchor that proves the catalog-flip claim.
     SUCCEED("canvas2d/transform composed matrix coverage in test_canvas2d_shim.cpp [issue-1348][codex-p1]");
 }
+
+// pulp #1710 — rn/outlineColor `currentColor` keyword resolves via the
+// View's inheritable text color cascade. Catalog flip partial→supported
+// requires evidence per #1657 control #2.
+TEST_CASE("setOutlineColor resolves currentColor from inheritable text color",
+          "[view][bridge][rn][issue-1710][outline-currentcolor]") {
+    using namespace pulp::view;
+    using namespace pulp::canvas;
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.load_script("createPanel('p', '')");
+    auto* panel = bridge.widget("p");
+    REQUIRE(panel != nullptr);
+
+    // Set inheritable text color on root → child inherits via cascade.
+    // Color uses normalized float channels [0,1].
+    root.set_inheritable_text_color(Color::rgba8(255, 100, 50));
+
+    bridge.load_script("setOutlineColor('p', 'currentColor')");
+    auto oc = panel->outline_color();
+    REQUIRE_THAT(oc.r, WithinAbs(1.0f, 0.01f));
+    REQUIRE_THAT(oc.g, WithinAbs(100.0f / 255.0f, 0.01f));
+    REQUIRE_THAT(oc.b, WithinAbs(50.0f / 255.0f, 0.01f));
+
+    // Case-insensitive: CURRENTCOLOR + CurrentColor work the same.
+    root.set_inheritable_text_color(Color::rgba8(10, 200, 40));
+    bridge.load_script("setOutlineColor('p', 'CURRENTCOLOR')");
+    REQUIRE_THAT(panel->outline_color().g, WithinAbs(200.0f / 255.0f, 0.01f));
+
+    bridge.load_script("setOutlineColor('p', 'CurrentColor')");
+    REQUIRE_THAT(panel->outline_color().g, WithinAbs(200.0f / 255.0f, 0.01f));
+
+    // Non-keyword colors still parse normally.
+    bridge.load_script("setOutlineColor('p', '#0080ff')");
+    REQUIRE_THAT(panel->outline_color().b, WithinAbs(1.0f, 0.01f));
+
+    // No inheritable text → falls back to theme text.primary token (non-zero).
+    root.clear_inheritable_text_color();
+    bridge.load_script("setOutlineColor('p', 'currentColor')");
+    auto fallback = panel->outline_color();
+    REQUIRE(fallback.a > 0.0f);
+}


### PR DESCRIPTION
## Summary

Closes pulp #1710. CSS / RN spec value `currentColor` was the only unsupported value on rn/outlineColor — kept the entry at `partial`.

**Fix**: setOutlineColor bridge fn case-folds the keyword and detects `currentcolor` before the standard hex/rgb/named color parser. Resolution: `View::inheritable_text_color()` (walks parent chain) → theme `text.primary` fallback.

**Catalog**: rn/outlineColor `partial → supported`.

## Test plan

- [x] `[view][bridge][rn][issue-1710][outline-currentcolor]`: 8 assertions covering case-insensitive keyword (`currentColor` / `CURRENTCOLOR` / `CurrentColor`), inheritable cascade resolution, non-keyword color parse-through, no-inheritable fallback path.

## Net catalog impact

- rn: 10 → 9 DIVERGE (after this lands)
- TOTAL DIVERGE: 28 → 27

## Refs

- Closes pulp #1710
- pulp #1657 (no-metric-games gate — partial→supported flip ships with test evidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)