### PR TITLE
feat(canvas2d): DOMMatrix mutator methods on getTransform snapshot (closes pulp #1527 followup)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.79.20
+    VERSION 0.79.21
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/compat.json
+++ b/compat.json
@@ -7490,19 +7490,24 @@
       "issue": "1346"
     },
     "canvas2d/getTransform": {
-      "status": "partial",
+      "status": "supported",
       "mapsTo": "ctx.getTransform() -> returns a DOMMatrix-shaped object reflecting the JS-mirrored 2D affine transform. The shim tracks `_currentTransform` via translate / scale / rotate / setTransform / transform / save / restore so the read is synchronous (no bridge round-trip; the bridge replays draws at paint time and has no queryable 'current matrix' from JS). Per HTML5 Canvas spec, getTransform() returns a NEW DOMMatrix per call (a snapshot — mutating it does not affect the live ctx). DOMMatrix mutation methods (multiplySelf, scaleSelf, etc.) on the returned object are not exposed because they would only mutate the snapshot, not the canvas — same outcome as on the standard browser surface.",
       "supportedValues": [
         "a, b, c, d, e, f (live)",
         "m11/m12/m21/m22/m41/m42 DOMMatrix aliases",
         "is2D, isIdentity flags",
-        "toFloat32Array / toFloat64Array readers"
+        "toFloat32Array / toFloat64Array readers",
+        "multiplySelf(other) — right-multiply + chain",
+        "scaleSelf(sx, sy?) — post-multiply scale",
+        "rotateSelf(angle) — post-multiply rotation (radians)",
+        "translateSelf(tx, ty) — post-multiply translation",
+        "inverse() — return inverted copy (throws on singular)"
       ],
-      "unsupportedValues": [
-        "DOMMatrix mutator methods (multiplySelf/scaleSelf/rotateSelf/translateSelf/inverse/etc. — getTransform returns the lightweight _PulpCanvasMatrix shim with read-only fields, not a spec DOMMatrix)"
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1527][dommatrix-mutators]"
       ],
-      "tests": [],
-      "notes": "DIVERGE→PASS sweep — clarified that snapshot semantics are spec-compliant (HTML5 Canvas spec: getTransform() returns a NEW DOMMatrix); DOMMatrix mutation methods on a snapshot wouldn't affect the canvas anyway. pulp #1527 bridge-thin gap-fill. Wave-5 follow-up audit (post-PR #1616 sweep): walked back to partial. `_PulpCanvasMatrix` (web-compat-canvas.js) has `a/b/c/d/e/f` getters and `is2D`/`isIdentity` flags but does NOT implement DOMMatrix mutators like `multiplySelf` / `scaleSelf` / `inverse()`. Standard DOM code that does `ctx.getTransform().multiplySelf(other)` will throw at runtime.",
+      "notes": "DIVERGE→PASS sweep — clarified that snapshot semantics are spec-compliant (HTML5 Canvas spec: getTransform() returns a NEW DOMMatrix); DOMMatrix mutation methods on a snapshot wouldn't affect the canvas anyway. pulp #1527 bridge-thin gap-fill. Wave-5 follow-up audit (post-PR #1616 sweep): walked back to partial. `_PulpCanvasMatrix` (web-compat-canvas.js) has `a/b/c/d/e/f` getters and `is2D`/`isIdentity` flags but does NOT implement DOMMatrix mutators like `multiplySelf` / `scaleSelf` / `inverse()`. Standard DOM code that does `ctx.getTransform().multiplySelf(other)` will throw at runtime. PR #1527 followup: DOMMatrix mutator methods (multiplySelf / scaleSelf / rotateSelf / translateSelf / inverse) now implemented on the snapshot. Snapshot semantics preserved per HTML5 spec — mutating the returned matrix does NOT affect the live ctx; mutators return `this` for chaining; inverse() returns a NEW matrix (throws TypeError on singular).",
       "issue": "1527"
     },
     "canvas2d/transform": {

--- a/core/view/js/web-compat-canvas.js
+++ b/core/view/js/web-compat-canvas.js
@@ -187,6 +187,73 @@ _PulpCanvasMatrix.prototype.toJSON = function() {
              e: this.e, f: this.f, is2D: true, isIdentity: this.isIdentity };
 };
 
+// pulp #1527 — DOMMatrix mutator methods. Snapshot semantics
+// (mutating the returned matrix does NOT affect the live ctx — that
+// matches HTML5 Canvas spec). The mutators are useful for offline
+// transform calculations like
+// `ctx.getTransform().translateSelf(x, y).inverse()` and are widely
+// used in plugin code adapted from web canvas libraries (Three.js
+// canvas adapter, Skia-canvas, etc.). Each *Self method mutates this
+// matrix in place and returns this for chaining; inverse() returns a
+// NEW matrix (or throws on singular).
+_PulpCanvasMatrix.prototype._refreshAliases = function() {
+    this.m11 = this.a; this.m12 = this.b;
+    this.m21 = this.c; this.m22 = this.d;
+    this.m41 = this.e; this.m42 = this.f;
+    this.isIdentity = (this.a === 1 && this.b === 0 && this.c === 0 &&
+                       this.d === 1 && this.e === 0 && this.f === 0);
+};
+_PulpCanvasMatrix.prototype.multiplySelf = function(other) {
+    var a = this.a, b = this.b, c = this.c, d = this.d, e = this.e, f = this.f;
+    var oa = other.a, ob = other.b, oc = other.c, od = other.d, oe = other.e, of = other.f;
+    this.a = a * oa + c * ob;
+    this.b = b * oa + d * ob;
+    this.c = a * oc + c * od;
+    this.d = b * oc + d * od;
+    this.e = a * oe + c * of + e;
+    this.f = b * oe + d * of + f;
+    this._refreshAliases();
+    return this;
+};
+_PulpCanvasMatrix.prototype.scaleSelf = function(sx, sy) {
+    if (sy === undefined) sy = sx;
+    this.a *= sx;
+    this.b *= sx;
+    this.c *= sy;
+    this.d *= sy;
+    this._refreshAliases();
+    return this;
+};
+_PulpCanvasMatrix.prototype.rotateSelf = function(angle) {
+    var cos = Math.cos(angle), sin = Math.sin(angle);
+    var a = this.a, b = this.b, c = this.c, d = this.d;
+    this.a =  a * cos + c * sin;
+    this.b =  b * cos + d * sin;
+    this.c = -a * sin + c * cos;
+    this.d = -b * sin + d * cos;
+    this._refreshAliases();
+    return this;
+};
+_PulpCanvasMatrix.prototype.translateSelf = function(tx, ty) {
+    if (ty === undefined) ty = 0;
+    this.e += this.a * tx + this.c * ty;
+    this.f += this.b * tx + this.d * ty;
+    this._refreshAliases();
+    return this;
+};
+_PulpCanvasMatrix.prototype.inverse = function() {
+    var a = this.a, b = this.b, c = this.c, d = this.d, e = this.e, f = this.f;
+    var det = a * d - b * c;
+    if (det === 0) {
+        throw new TypeError("DOMMatrix.inverse() called on a singular matrix");
+    }
+    var ia =  d / det, ib = -b / det;
+    var ic = -c / det, id =  a / det;
+    var ie = (c * f - d * e) / det;
+    var ifv = (b * e - a * f) / det;
+    return new _PulpCanvasMatrix(ia, ib, ic, id, ie, ifv);
+};
+
 CanvasRenderingContext2D.prototype._applyFillStyle = function() {
     var fs = this.fillStyle;
     if (fs && fs._kind === "linear" && typeof canvasSetLinearGradient === "function") {

--- a/test/test_canvas2d_shim.cpp
+++ b/test/test_canvas2d_shim.cpp
@@ -2902,3 +2902,111 @@ TEST_CASE("Canvas2D isPointInPath / isPointInStroke survive save/restore",
     )");
     REQUIRE(result == "true,false");
 }
+
+
+// pulp #1527 — DOMMatrix mutator methods on _PulpCanvasMatrix.
+// Snapshot semantics preserved per HTML5 spec: mutating the returned
+// matrix does NOT affect the live ctx. This proves the 5 mutator
+// methods (multiplySelf, scaleSelf, rotateSelf, translateSelf, inverse).
+TEST_CASE("Canvas2D getTransform DOMMatrix mutator chains + snapshot semantics",
+          "[view][canvas2d][issue-1527][dommatrix-mutators]") {
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        c.id = 'probe'; document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        ctx.setTransform(2, 0, 0, 3, 4, 5);  // [[2,0,4],[0,3,5]]
+        var m = ctx.getTransform();
+        // multiplySelf with translation matrix [[1,0,10],[0,1,20]]
+        var tr = ctx.getTransform();
+        tr.a = 1; tr.b = 0; tr.c = 0; tr.d = 1; tr.e = 10; tr.f = 20;
+        m.multiplySelf(tr);
+        // After: a=2, b=0, c=0, d=3, e=2*10+4=24, f=3*20+5=65
+        // Live ctx unaffected (snapshot semantics)
+        var live = ctx.getTransform();
+        return [m.a, m.b, m.c, m.d, m.e, m.f,
+                live.a, live.e, live.f].join(',');
+    )");
+    REQUIRE(result == "2,0,0,3,24,65,2,4,5");
+}
+
+TEST_CASE("Canvas2D getTransform DOMMatrix scaleSelf + isIdentity recompute",
+          "[view][canvas2d][issue-1527][dommatrix-mutators]") {
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        c.id = 'probe'; document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        var m = ctx.getTransform();
+        var was_identity = m.isIdentity;
+        var same = (m.scaleSelf(2, 3) === m);
+        return [was_identity, m.a, m.d, m.isIdentity, same].join(',');
+    )");
+    REQUIRE(result == "true,2,3,false,true");
+}
+
+TEST_CASE("Canvas2D getTransform DOMMatrix rotateSelf 90deg",
+          "[view][canvas2d][issue-1527][dommatrix-mutators]") {
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        c.id = 'probe'; document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        var m = ctx.getTransform();
+        m.rotateSelf(Math.PI / 2);
+        // identity rotated 90deg: a≈0, b≈1, c≈-1, d≈0
+        return [Math.abs(m.a) < 1e-10,
+                Math.abs(m.b - 1) < 1e-10,
+                Math.abs(m.c + 1) < 1e-10,
+                Math.abs(m.d) < 1e-10].join(',');
+    )");
+    REQUIRE(result == "true,true,true,true");
+}
+
+TEST_CASE("Canvas2D getTransform DOMMatrix translateSelf affine compose",
+          "[view][canvas2d][issue-1527][dommatrix-mutators]") {
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        c.id = 'probe'; document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        ctx.setTransform(2, 0, 0, 1, 0, 0);
+        var m = ctx.getTransform();
+        m.translateSelf(5, 3);
+        // e = 0 + 2*5 + 0*3 = 10; f = 0 + 0*5 + 1*3 = 3
+        return [m.a, m.d, m.e, m.f].join(',');
+    )");
+    REQUIRE(result == "2,1,10,3");
+}
+
+TEST_CASE("Canvas2D getTransform DOMMatrix inverse round-trips identity; singular throws",
+          "[view][canvas2d][issue-1527][dommatrix-mutators]") {
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        c.id = 'probe'; document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        // Inverse of identity is identity
+        var inv = ctx.getTransform().inverse();
+        var ok1 = (inv.a === 1 && inv.b === 0 && inv.c === 0 &&
+                   inv.d === 1 && inv.e === 0 && inv.f === 0);
+        // Singular throws TypeError
+        var threw = false;
+        try {
+            ctx.setTransform(1, 1, 1, 1, 0, 0);  // det=0
+            ctx.getTransform().inverse();
+        } catch (e) {
+            threw = true;
+        }
+        return [ok1, threw].join(',');
+    )");
+    REQUIRE(result == "true,true");
+}
+
+TEST_CASE("Canvas2D getTransform DOMMatrix method chaining returns this",
+          "[view][canvas2d][issue-1527][dommatrix-mutators]") {
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        c.id = 'probe'; document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        var m = ctx.getTransform();
+        var same = (m.scaleSelf(2).rotateSelf(0).translateSelf(0, 0) === m);
+        return same ? '1' : '0';
+    )");
+    REQUIRE(result == "1");
+}


### PR DESCRIPTION
## Summary

Canvas2D spec DOMMatrix supports mutator methods on the matrix returned by `getTransform()`. The previous `_PulpCanvasMatrix` shim was read-only, leaving `canvas2d/getTransform` at `partial`.

**Adds the 5 spec-required mutator methods**:
- `multiplySelf(other)` — right-multiply + chain
- `scaleSelf(sx, sy?)` — post-multiply scale (sy defaults to sx)
- `rotateSelf(angle)` — post-multiply rotation (radians)
- `translateSelf(tx, ty?)` — post-multiply translation
- `inverse()` — return NEW inverted matrix (throws TypeError on singular)

**Snapshot semantics preserved** per HTML5 spec — mutating the returned matrix does NOT affect the live ctx (each call to `getTransform()` returns an independent object). Mutators return `this` for idiomatic chaining like `getTransform().translateSelf(x,y).inverse()`.

## Test plan

- [x] `[view][canvas2d][issue-1527][dommatrix-mutators]`: 6 test cases covering chaining + snapshot semantics + scaleSelf isIdentity recompute + rotateSelf 90deg + translateSelf affine compose + inverse round-trip + singular throws (6 assertions in 6 cases).

## Net catalog impact

- canvas2d/getTransform `partial → supported`
- canvas2d: 5 → 4 DIVERGE
- TOTAL DIVERGE: 22 → 21

## Refs

- Closes pulp #1527 followup
- pulp #1657 (no-metric-games gate — partial→supported flip ships with test evidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)