### PR TITLE
fix(view): removeAttribute(role)/(aria-label) resets View slot (Codex P1 on #1641)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.79.23
+    VERSION 0.79.24
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/compat.json
+++ b/compat.json
@@ -6423,13 +6423,13 @@
         "aria-disabled state routing to native AT (storage-only)",
         "aria-hidden state routing to native AT (storage-only)",
         "Linux AT-SPI bridge (storage-only)",
-        "Windows UIA bridge (storage-only)",
-        "removeAttribute('role') / removeAttribute('aria-label') don't reset View::access_role_ — stale until next set"
+        "Windows UIA bridge (storage-only)"
       ],
       "tests": [
-        "test/test_widget_bridge.cpp: HTML aria-label + role attributes route to View access slots [wave3-html]"
+        "test/test_widget_bridge.cpp: HTML aria-label + role attributes route to View access slots [wave3-html]",
+        "test/test_widget_bridge.cpp [issue-1641-followup-aria-removeattribute]"
       ],
-      "notes": "Wave 3 (PR #1641) html.2 — setAccessibilityLabel / setAccessibilityRole bridge fns wired; web-compat-element.js setAttribute() fast-paths aria-label and role. Replay path on _ensureNative + _reparentNative covers the React/JSX setAttribute-before-mount commit order. macOS NSAccessibility wired; Linux AT-SPI / Windows UIA platform routing remains storage-only (tracked under #217). Wave 4 cleanup — catalog flip from PR #1641 was clobbered by the Wave 3 css PR rebase (#1640); restored to status=supported + emptied unsupportedValues so the harness reflects the wired surface. aria-pressed / aria-checked / aria-disabled / aria-hidden state routing is a follow-on (the View doesn't have a state slot today — partial-deferred-access-state); not part of the supported surface claim. Wave-5 follow-up audit (post-PR #1616 sweep): walked back to partial. PR #1641 added setters that mirror role/aria-label into View::access_role_ / access_label_, but the platform-AT side is only wired on macOS NSAccessibility. State attributes (aria-pressed/checked/disabled/hidden) and Linux/Windows platform routing are still storage-only. Removal also doesn't reset state.",
+      "notes": "Wave 3 (PR #1641) html.2 — setAccessibilityLabel / setAccessibilityRole bridge fns wired; web-compat-element.js setAttribute() fast-paths aria-label and role. Replay path on _ensureNative + _reparentNative covers the React/JSX setAttribute-before-mount commit order. macOS NSAccessibility wired; Linux AT-SPI / Windows UIA platform routing remains storage-only (tracked under #217). Wave 4 cleanup — catalog flip from PR #1641 was clobbered by the Wave 3 css PR rebase (#1640); restored to status=supported + emptied unsupportedValues so the harness reflects the wired surface. aria-pressed / aria-checked / aria-disabled / aria-hidden state routing is a follow-on (the View doesn't have a state slot today — partial-deferred-access-state); not part of the supported surface claim. Wave-5 follow-up audit (post-PR #1616 sweep): walked back to partial. PR #1641 added setters that mirror role/aria-label into View::access_role_ / access_label_, but the platform-AT side is only wired on macOS NSAccessibility. State attributes (aria-pressed/checked/disabled/hidden) and Linux/Windows platform routing are still storage-only. Removal also doesn't reset state. pulp #1641 followup — removeAttribute(role)/(aria-label) now resets the View slot via bridge calls. Test [view][bridge][html][issue-1641-followup-aria-removeattribute] proves the reset.",
       "issue": "1476"
     },
     "html/DocumentFragment": {

--- a/core/view/js/web-compat-element.js
+++ b/core/view/js/web-compat-element.js
@@ -704,6 +704,18 @@ Element.prototype.removeAttribute = function(name) {
             this.style._reevaluateOverlay();
         }
     }
+    // pulp #1641 followup — reset View::access_role_ / access_label_
+    // when role / aria-label are removed. Without this the slot stayed
+    // populated even after the author detached the attribute (a user-
+    // observable bug for assistive tech that reads stale state).
+    else if (name === "role" && this._nativeCreated &&
+             typeof setAccessibilityRole === "function") {
+        setAccessibilityRole(this._id, "");
+    }
+    else if (name === "aria-label" && this._nativeCreated &&
+             typeof setAccessibilityLabel === "function") {
+        setAccessibilityLabel(this._id, "");
+    }
 };
 
 Element.prototype.hasAttribute = function(name) {

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -9783,6 +9783,42 @@ TEST_CASE("HTML setAttribute before mount replays ARIA on appendChild",
     REQUIRE(v->access_role() == View::AccessRole::slider);
 }
 
+// pulp #1641 followup — `removeAttribute('role')` /
+// `removeAttribute('aria-label')` must reset View::access_role_ /
+// access_label_. The earlier shim only deleted the JS-side
+// `_attributes[name]` entry, leaving the bridge slot stale (a
+// user-observable bug for assistive tech that reads stale state).
+TEST_CASE("HTML removeAttribute resets View accessibility slots",
+          "[view][bridge][html][issue-1641-followup-aria-removeattribute]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var d = document.createElement('div');
+        d.id = 'aria-rm';
+        document.body.appendChild(d);
+        d.setAttribute('aria-label', 'Mute toggle');
+        d.setAttribute('role', 'switch');
+    )");
+    auto idVal = engine.evaluate("document.getElementById('aria-rm')._id");
+    auto id = std::string(idVal.getWithDefault<std::string_view>(""));
+    auto* v = bridge.widget(id);
+    REQUIRE(v != nullptr);
+    REQUIRE(v->access_label() == "Mute toggle");
+    REQUIRE(v->access_role() == View::AccessRole::toggle);
+
+    // removeAttribute should reset the bridge slot (was the bug).
+    bridge.load_script(R"(
+        var d = document.getElementById('aria-rm');
+        d.removeAttribute('aria-label');
+        d.removeAttribute('role');
+    )");
+    REQUIRE(v->access_label().empty());
+    REQUIRE(v->access_role() == View::AccessRole::none);
+}
+
 TEST_CASE("querySelector matches tag / .class / #id forms",
           "[view][bridge][wave3-html][html-querySelector]") {
     ScriptEngine engine;


### PR DESCRIPTION
## Summary

Fixes Codex P1 followup on #1641 — `Element.prototype.removeAttribute` only deleted the JS-side `_attributes[name]` entry; the corresponding bridge slot stayed populated, leaving stale state visible to assistive tech (NSAccessibility on macOS).

**Fix**: when removeAttribute is called for `role` or `aria-label` on a native-mounted element, call `setAccessibilityRole/Label` with empty string. Mirrors the existing setAttribute fast path.

## Test plan

- [x] `[view][bridge][html][issue-1641-followup-aria-removeattribute]`: 5 assertions covering role + aria-label set → removeAttribute → verify View::access_role_ === none + access_label_ empty.
- [x] Existing `[wave3-html][html-aria]` tests still pass.

## Catalog

`html/ARIA` keeps `partial` (Linux AT-SPI / Windows UIA + 4 aria-* state routing entries still storage-only), but unsupportedValues drops the removeAttribute reset entry.

## Refs

- pulp #1641 (Codex P1), pulp #1616 (Codex sweep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)