### PR TITLE
fix(canvas2d): DOMMatrix scaleSelf/rotateSelf/inverse spec conformance (Codex P1×2 + P2 on #1730)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.87.2
+    VERSION 0.87.3
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/js/web-compat-canvas.js
+++ b/core/view/js/web-compat-canvas.js
@@ -216,6 +216,10 @@ _PulpCanvasMatrix.prototype.multiplySelf = function(other) {
     return this;
 };
 _PulpCanvasMatrix.prototype.scaleSelf = function(sx, sy) {
+    // Codex P2 on #1730: spec says scaleX defaults to 1 when omitted,
+    // and scaleY defaults to scaleX when omitted. Without this, the
+    // bare scaleSelf() call multiplies by undefined and produces NaN.
+    if (sx === undefined) sx = 1;
     if (sy === undefined) sy = sx;
     this.a *= sx;
     this.b *= sx;
@@ -225,7 +229,14 @@ _PulpCanvasMatrix.prototype.scaleSelf = function(sx, sy) {
     return this;
 };
 _PulpCanvasMatrix.prototype.rotateSelf = function(angle) {
-    var cos = Math.cos(angle), sin = Math.sin(angle);
+    // Codex P1 on #1730: DOMMatrix.rotateSelf() takes degrees per spec
+    // (https://drafts.fxtf.org/geometry/#dom-dommatrix-rotateself). The
+    // previous implementation fed `angle` directly into Math.cos/sin
+    // (radians), so callers ported from browsers (e.g. rotateSelf(90)
+    // expecting a quarter turn) got the wrong rotation.
+    if (angle === undefined) angle = 0;
+    var rad = angle * Math.PI / 180;
+    var cos = Math.cos(rad), sin = Math.sin(rad);
     var a = this.a, b = this.b, c = this.c, d = this.d;
     this.a =  a * cos + c * sin;
     this.b =  b * cos + d * sin;
@@ -235,6 +246,7 @@ _PulpCanvasMatrix.prototype.rotateSelf = function(angle) {
     return this;
 };
 _PulpCanvasMatrix.prototype.translateSelf = function(tx, ty) {
+    if (tx === undefined) tx = 0;
     if (ty === undefined) ty = 0;
     this.e += this.a * tx + this.c * ty;
     this.f += this.b * tx + this.d * ty;
@@ -242,10 +254,17 @@ _PulpCanvasMatrix.prototype.translateSelf = function(tx, ty) {
     return this;
 };
 _PulpCanvasMatrix.prototype.inverse = function() {
+    // Codex P1 on #1730: spec says non-invertible matrices yield a
+    // matrix with NaN components and `is2D = false` — they do NOT
+    // throw. Throwing here breaks compat for callers that rely on
+    // the standard non-throwing inverse contract.
+    // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-inverse
     var a = this.a, b = this.b, c = this.c, d = this.d, e = this.e, f = this.f;
     var det = a * d - b * c;
-    if (det === 0) {
-        throw new TypeError("DOMMatrix.inverse() called on a singular matrix");
+    if (det === 0 || !isFinite(det)) {
+        var nan = new _PulpCanvasMatrix(NaN, NaN, NaN, NaN, NaN, NaN);
+        nan.is2D = false;
+        return nan;
     }
     var ia =  d / det, ib = -b / det;
     var ic = -c / det, id =  a / det;

--- a/core/view/js/web-compat-canvas.js
+++ b/core/view/js/web-compat-canvas.js
@@ -183,8 +183,13 @@ _PulpCanvasMatrix.prototype.toFloat64Array = function() {
     return this.toFloat32Array();
 };
 _PulpCanvasMatrix.prototype.toJSON = function() {
+    // Codex P2 follow-up on #1754: honor the actual is2D state. A
+    // singular-inverse result has is2D=false; if toJSON hardcodes
+    // true, JSON consumers can't distinguish inversion failure from
+    // a successful 2D inverse.
     return { a: this.a, b: this.b, c: this.c, d: this.d,
-             e: this.e, f: this.f, is2D: true, isIdentity: this.isIdentity };
+             e: this.e, f: this.f, is2D: this.is2D !== false,
+             isIdentity: this.isIdentity };
 };
 
 // pulp #1527 — DOMMatrix mutator methods. Snapshot semantics
@@ -262,7 +267,17 @@ _PulpCanvasMatrix.prototype.inverse = function() {
     var a = this.a, b = this.b, c = this.c, d = this.d, e = this.e, f = this.f;
     var det = a * d - b * c;
     if (det === 0 || !isFinite(det)) {
+        // Codex P2 follow-up: spec says ALL 16 components become NaN
+        // for a non-invertible matrix. The constructor only NaNs the
+        // 2D aliases (m11..m22, m41..m42); m13, m14, m23, m24,
+        // m31..m34, m43, m44 stay at constructor-default identity.
+        // toFloat32Array() / toFloat64Array() would then return
+        // mixed finite/NaN data, violating the contract.
         var nan = new _PulpCanvasMatrix(NaN, NaN, NaN, NaN, NaN, NaN);
+        nan.m13 = NaN; nan.m14 = NaN;
+        nan.m23 = NaN; nan.m24 = NaN;
+        nan.m31 = NaN; nan.m32 = NaN; nan.m33 = NaN; nan.m34 = NaN;
+        nan.m43 = NaN; nan.m44 = NaN;
         nan.is2D = false;
         return nan;
     }

--- a/test/test_canvas2d_shim.cpp
+++ b/test/test_canvas2d_shim.cpp
@@ -3031,6 +3031,50 @@ TEST_CASE("Canvas2D getTransform DOMMatrix translateSelf affine compose",
     REQUIRE(result == "2,1,10,3");
 }
 
+TEST_CASE("Canvas2D DOMMatrix singular inverse: all 16 components are NaN [issue-1730]",
+          "[view][canvas2d][issue-1730][dommatrix-mutators]") {
+    // Codex P2 follow-up on #1754: spec says ALL 16 matrix components
+    // become NaN for a non-invertible inverse. Constructor only NaN'd
+    // the 2D aliases; m13/m14/m23/m24/m31..m34/m43/m44 stayed at
+    // constructor-default identity. toFloat32Array/toFloat64Array
+    // would return mixed finite/NaN, violating the contract.
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        c.id = 'probe'; document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        ctx.setTransform(1, 1, 1, 1, 0, 0);  // det=0
+        var ninv = ctx.getTransform().inverse();
+        var arr = ninv.toFloat32Array();
+        var allNaN = true;
+        for (var i = 0; i < arr.length; ++i) {
+            if (!isNaN(arr[i])) { allNaN = false; break; }
+        }
+        return [allNaN, arr.length].join(',');
+    )");
+    REQUIRE(result == "true,16");
+}
+
+TEST_CASE("Canvas2D DOMMatrix toJSON honors actual is2D [issue-1730]",
+          "[view][canvas2d][issue-1730][dommatrix-mutators]") {
+    // Codex P2 follow-up on #1754: toJSON used to hardcode is2D=true;
+    // a singular-inverse result has is2D=false but JSON serialization
+    // would lose the inversion-failure indicator.
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        c.id = 'probe'; document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        // Identity → is2D=true should serialize true.
+        var j_ok = ctx.getTransform().toJSON();
+        var ok1 = (j_ok.is2D === true);
+        // Singular → is2D=false should serialize false.
+        ctx.setTransform(1, 1, 1, 1, 0, 0);
+        var j_bad = ctx.getTransform().inverse().toJSON();
+        var ok2 = (j_bad.is2D === false);
+        return [ok1, ok2].join(',');
+    )");
+    REQUIRE(result == "true,true");
+}
+
 TEST_CASE("Canvas2D DOMMatrix inverse round-trips identity; singular yields NaN matrix [issue-1730]",
           "[view][canvas2d][issue-1527][issue-1730][dommatrix-mutators]") {
     // Codex P1 on #1730: per spec

--- a/test/test_canvas2d_shim.cpp
+++ b/test/test_canvas2d_shim.cpp
@@ -2943,14 +2943,18 @@ TEST_CASE("Canvas2D getTransform DOMMatrix scaleSelf + isIdentity recompute",
     REQUIRE(result == "true,2,3,false,true");
 }
 
-TEST_CASE("Canvas2D getTransform DOMMatrix rotateSelf 90deg",
-          "[view][canvas2d][issue-1527][dommatrix-mutators]") {
+TEST_CASE("Canvas2D getTransform DOMMatrix rotateSelf takes degrees [issue-1730]",
+          "[view][canvas2d][issue-1527][issue-1730][dommatrix-mutators]") {
+    // Codex P1 on #1730: rotateSelf() input is DEGREES per the
+    // DOMMatrix spec (https://drafts.fxtf.org/geometry/#dom-dommatrix-rotateself).
+    // Previously this test passed Math.PI/2 and expected a 90deg
+    // rotation — that documented the BUG. Now we pass 90 (degrees).
     auto result = run_in_bridge(R"(
         var c = document.createElement('canvas');
         c.id = 'probe'; document.body.appendChild(c);
         var ctx = c.getContext('2d');
         var m = ctx.getTransform();
-        m.rotateSelf(Math.PI / 2);
+        m.rotateSelf(90);
         // identity rotated 90deg: a≈0, b≈1, c≈-1, d≈0
         return [Math.abs(m.a) < 1e-10,
                 Math.abs(m.b - 1) < 1e-10,
@@ -2958,6 +2962,58 @@ TEST_CASE("Canvas2D getTransform DOMMatrix rotateSelf 90deg",
                 Math.abs(m.d) < 1e-10].join(',');
     )");
     REQUIRE(result == "true,true,true,true");
+}
+
+TEST_CASE("Canvas2D DOMMatrix rotateSelf(180) flips signs [issue-1730]",
+          "[view][canvas2d][issue-1730][dommatrix-mutators]") {
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        c.id = 'probe'; document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        var m = ctx.getTransform();
+        m.rotateSelf(180);
+        // identity rotated 180deg: a=-1, b=0, c=0, d=-1
+        return [Math.abs(m.a + 1) < 1e-10,
+                Math.abs(m.b) < 1e-10,
+                Math.abs(m.c) < 1e-10,
+                Math.abs(m.d + 1) < 1e-10].join(',');
+    )");
+    REQUIRE(result == "true,true,true,true");
+}
+
+TEST_CASE("Canvas2D DOMMatrix rotateSelf() omitted arg defaults to 0 [issue-1730]",
+          "[view][canvas2d][issue-1730][dommatrix-mutators]") {
+    // Codex P1 on #1730: omitted angle defaults to 0 — must not be NaN.
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        c.id = 'probe'; document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        var m = ctx.getTransform();
+        m.rotateSelf();
+        return [m.a, m.b, m.c, m.d].join(',');
+    )");
+    REQUIRE(result == "1,0,0,1");
+}
+
+TEST_CASE("Canvas2D DOMMatrix scaleSelf() omitted args default to identity [issue-1730]",
+          "[view][canvas2d][issue-1730][dommatrix-mutators]") {
+    // Codex P2 on #1730: spec says scaleX defaults to 1 when omitted,
+    // scaleY defaults to scaleX when omitted. Was producing NaN before.
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        c.id = 'probe'; document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        ctx.setTransform(2, 0, 0, 3, 0, 0);
+        var m = ctx.getTransform();
+        // Bare scaleSelf() — should be a no-op.
+        m.scaleSelf();
+        var noop_ok = (m.a === 2 && m.d === 3);
+        // scaleSelf(4) — applies 4x to BOTH axes.
+        m.scaleSelf(4);
+        var single_arg_ok = (m.a === 8 && m.d === 12);
+        return [noop_ok, single_arg_ok].join(',');
+    )");
+    REQUIRE(result == "true,true");
 }
 
 TEST_CASE("Canvas2D getTransform DOMMatrix translateSelf affine compose",
@@ -2975,25 +3031,34 @@ TEST_CASE("Canvas2D getTransform DOMMatrix translateSelf affine compose",
     REQUIRE(result == "2,1,10,3");
 }
 
-TEST_CASE("Canvas2D getTransform DOMMatrix inverse round-trips identity; singular throws",
-          "[view][canvas2d][issue-1527][dommatrix-mutators]") {
+TEST_CASE("Canvas2D DOMMatrix inverse round-trips identity; singular yields NaN matrix [issue-1730]",
+          "[view][canvas2d][issue-1527][issue-1730][dommatrix-mutators]") {
+    // Codex P1 on #1730: per spec
+    // (https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-inverse),
+    // a non-invertible matrix produces a matrix with NaN components and
+    // is2D=false. It does NOT throw. The previous test asserted "throws
+    // TypeError" — that was documenting the BUG.
     auto result = run_in_bridge(R"(
         var c = document.createElement('canvas');
         c.id = 'probe'; document.body.appendChild(c);
         var ctx = c.getContext('2d');
-        // Inverse of identity is identity
+        // Inverse of identity is identity.
         var inv = ctx.getTransform().inverse();
         var ok1 = (inv.a === 1 && inv.b === 0 && inv.c === 0 &&
                    inv.d === 1 && inv.e === 0 && inv.f === 0);
-        // Singular throws TypeError
+        // Singular: does NOT throw, returns NaN matrix with is2D=false.
+        ctx.setTransform(1, 1, 1, 1, 0, 0);  // det = 1*1 - 1*1 = 0
         var threw = false;
+        var ninv;
         try {
-            ctx.setTransform(1, 1, 1, 1, 0, 0);  // det=0
-            ctx.getTransform().inverse();
+            ninv = ctx.getTransform().inverse();
         } catch (e) {
             threw = true;
         }
-        return [ok1, threw].join(',');
+        var ok2 = !threw && isNaN(ninv.a) && isNaN(ninv.b) && isNaN(ninv.c) &&
+                  isNaN(ninv.d) && isNaN(ninv.e) && isNaN(ninv.f) &&
+                  ninv.is2D === false;
+        return [ok1, ok2].join(',');
     )");
     REQUIRE(result == "true,true");
 }


### PR DESCRIPTION
## Summary

Three spec divergences in `_PulpCanvasMatrix` shim flagged by Codex review on PR #1730:

**P1 — `rotateSelf` takes degrees, not radians.** Per the [DOMMatrix spec](https://drafts.fxtf.org/geometry/#dom-dommatrix-rotateself), browser code calling `m.rotateSelf(90)` expects a quarter turn. Previous code treated the arg as radians. Now converts degrees → radians at the boundary. Omitted angle defaults to 0.

**P1 — `inverse()` returns NaN matrix for singular, not throw.** Per the [DOMMatrixReadOnly spec](https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-inverse), non-invertible matrices yield NaN components and `is2D = false`; they do **not** throw. Previous `TypeError` broke compat with callers relying on the standard non-throwing contract.

**P2 — `scaleSelf()` omitted args default to identity, not NaN.** Bare `scaleSelf()` now no-ops instead of producing NaN.

## Test plan
- [x] Rewrote 2 existing tests that documented the buggy behavior:
  - `rotateSelf 90deg` previously passed `Math.PI/2` — now passes `90` (degrees, per spec)
  - `inverse... singular throws` previously asserted throw — now asserts NaN matrix with `is2D=false`
- [x] 4 new spec-conformance tests:
  - `rotateSelf takes degrees` (90deg, 180deg)
  - `rotateSelf()` omitted defaults to 0 (no-op, not NaN)
  - `scaleSelf()` / `scaleSelf(N)` honor spec defaults
  - `inverse()` of singular returns NaN matrix with `is2D=false`
- [x] 96 cases in `pulp-test-canvas2d-shim` pass (273 assertions)

Co-ordinated via `planning/coverage-coordination.md`.