### PR TITLE
fix(html): restore :root pseudo-class for stylesheet matching (Codex P2 on #1773)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
+<a id="v0811"></a>
+## [0.81.1] - 2026-05-10
+
+- fix(html): restore :root pseudo-class for stylesheet matching (Codex P2 on #1773) ([#1777](https://github.com/danielraffel/pulp/pull/1777))
+
 <a id="v100"></a>
 ## [1.0.0] - 2026-05-10
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.81.0
+    VERSION 0.81.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/js/web-compat-document.js
+++ b/core/view/js/web-compat-document.js
@@ -577,14 +577,16 @@ function _matchesPseudoClass(el, pseudo) {
         return !!parent && parent._children && parent._children.length === 1
             && parent._children[0] === el;
     }
-    // pulp #1737 followup (Codex P2 on #1759): `:root` removed from the
-    // supported set. _findMatch starts traversal from root._children, so
-    // even an "el with no parent" check can't reach the body element
-    // (every element in the BFS queue is by construction a descendant
-    // of root). Implementing :root would require either pushing `root`
-    // into the queue or special-casing :root at the document.querySelector
-    // level — out of scope for this shim. The matcher returns false for
-    // :root rather than advertising support that doesn't work end-to-end.
+    // pulp #1737 followup (Codex P2 on #1773): `:root` must match the
+    // document root in stylesheet evaluation (StyleSheet._applyTo iterates
+    // every registered element including __bodyElement__, so :root rules
+    // for CSS custom-property themes can land). querySelector traversal
+    // still won't see :root because _findMatch starts at root._children
+    // and never visits root itself — but spec-conformant matching of the
+    // pseudo-class itself is the primitive both call sites need.
+    if (lower === "root") {
+        return el === __bodyElement__ || el === __documentElement__;
+    }
     if (lower === "empty") {
         return !el._children || el._children.length === 0;
     }

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -10372,6 +10372,47 @@ TEST_CASE("querySelector :first-child / :last-child / :nth-child / :only-child /
     REQUIRE(engine.evaluate("__emptyCount").getWithDefault<int64_t>(0) == 5);
 }
 
+// pulp #1773 — `:root` regression. PR #1759 removed `:root` from the
+// pseudo-class evaluator entirely (it was unsupported in the
+// querySelector BFS), but stylesheet evaluation (StyleSheet._applyTo)
+// uses the same `_matchesPseudoClass` and visits __bodyElement__, so
+// CSS custom-property themes like `:root { --accent: red; }` silently
+// stopped applying. The fix re-adds `:root` matching at the primitive
+// level (body or documentElement), restoring the stylesheet path.
+TEST_CASE(":root pseudo-class matches body/documentElement for stylesheet themes",
+          "[view][bridge][wave3-html][html-stylesheet][issue-1773]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        // `:root` should match document.body (the stylesheet iteration
+        // root in this shim) and document.documentElement (real <html>).
+        // A non-root element must NOT match.
+        var d = document.createElement('div');
+        d.id = 'inner';
+        document.body.appendChild(d);
+
+        // Round-trip via the StyleSheet/_matchesSelector path: a
+        // :root rule must apply to document.body even though body is
+        // the only element __elements__ has from this fixture.
+        // Use width because it's a numeric Yoga slot we can read back.
+        var sheet = new StyleSheet({ ':root': { width: '321px' } });
+        sheet.attach();
+
+        // Body width should now be 321px from the stylesheet pass.
+        globalThis.__bodyWidth = document.body.style.width;
+        // The inner div must NOT have been styled by the :root rule.
+        globalThis.__innerWidth = d.style.width || '';
+    )");
+
+    REQUIRE(std::string(engine.evaluate("__bodyWidth")
+        .getWithDefault<std::string_view>("")) == "321px");
+    REQUIRE(std::string(engine.evaluate("__innerWidth")
+        .getWithDefault<std::string_view>("")).empty());
+}
+
 // ──────────────────────────────────────────────────────────────────────
 // Wave 5 css.5 — audit of the 49 entries flipped by PR #1649 from
 // `partial`/DIVERGE to `supported`. These tests exercise the *runtime*


### PR DESCRIPTION
## Summary

Closes Codex P2 finding on #1773. PR #1759 removed `:root` from `_matchesPseudoClass` entirely — but the same evaluator is called from `StyleSheet._applyTo`, not just from `document.querySelector`. So `:root { ... }` rules silently stopped applying. The most common casualty is CSS custom-property themes: `:root { --accent: red; }` no longer styled `document.body`.

The fix re-adds `:root` matching at the primitive level. An element matches when it's `__bodyElement__` (the stylesheet iteration root in this shim) or `__documentElement__` (real `<html>` semantics). The `querySelector` BFS path is unchanged — `:root` still can't be reached there because root isn't enqueued — but the primitive is now spec-conformant for both call sites.

## Why this matters

The Codex review on #1759 correctly flagged that the wholesale removal was too aggressive. The right level to disable `:root` was at the BFS traversal (which we never actually changed), not at the pseudo-class evaluator (which is shared between traversal and stylesheet application).

## Test plan

- [x] New regression test `:root pseudo-class matches body/documentElement for stylesheet themes [issue-1773]` in `test/test_widget_bridge.cpp` — creates a `StyleSheet({':root': {width: '321px'}})`, asserts body picks up the style and an inner div does NOT.
- [x] Re-ran existing `[issue-1737]` pseudo-class suite (8 cases, 59 assertions) — no regression.
- [ ] CI macOS local smoke + sanitizers (run on push)