### PR TITLE
fix(view): currentColor honors element's own text color (Codex P2 on #1728)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.82.0
+    VERSION 0.82.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -3369,15 +3369,22 @@ void WidgetBridge::register_api() {
         auto hex = args.get<std::string>(1, "");
         auto* v = id.empty() ? &root_ : widget(id);
         if (!v || hex.empty()) return choc::value::Value();
-        // CSS `currentColor`: resolve from the View's inheritable text
-        // color (walks the parent chain), falling back to the theme
-        // text token if no ancestor set one explicitly.
+        // CSS `currentColor`: resolve to the element's own computed text
+        // color first, then the inheritable cascade, then theme fallback.
+        // Order matters — pulp #1728 Codex P2: a Label that set its own
+        // `color` via setTextColor stores it in `Label::text_color_`
+        // (`has_own_text_color_=true`) and does NOT touch the inheritable
+        // slot, so `inheritable_text_color()` would skip the Label and
+        // climb to the parent's inheritable color. CSS semantics: an
+        // element's own `color` always wins over inheritance for that
+        // element's `currentColor`.
         std::string lower;
         lower.reserve(hex.size());
         for (char c : hex) lower += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
         if (lower == "currentcolor") {
-            auto inherited = v->inheritable_text_color();
-            if (inherited) {
+            if (auto* l = dynamic_cast<Label*>(v); l && l->has_own_text_color()) {
+                v->set_outline_color(l->text_color());
+            } else if (auto inherited = v->inheritable_text_color()) {
                 v->set_outline_color(*inherited);
             } else {
                 v->set_outline_color(v->resolve_color("text.primary",

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -11582,6 +11582,53 @@ TEST_CASE("setOutlineColor resolves currentColor from inheritable text color",
     REQUIRE(fallback.a > 0.0f);
 }
 
+// pulp #1728 (Codex P2) — `currentColor` must honor an element's own
+// computed `color` before climbing the inheritable cascade. A Label
+// that set its own text color via setTextColor stores it in
+// Label::text_color_ (has_own_text_color_=true) and does NOT touch the
+// inheritable slot. Pre-fix, the resolver called inheritable_text_color()
+// which skipped the Label and climbed to the parent's inheritable color
+// — so setOutlineColor(label, 'currentColor') resolved to the parent's
+// color, contradicting CSS (own color always wins for currentColor on
+// that element) AND contradicting Label::paint() which prefers
+// has_own_text_color_ first.
+TEST_CASE("setOutlineColor currentColor honors Label's own text color over parent inheritance",
+          "[view][bridge][rn][issue-1728][outline-currentcolor]") {
+    using namespace pulp::view;
+    using namespace pulp::canvas;
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // Set up: root carries inheritable blue text; the Label sits under
+    // root (createLabel attaches to root by default in this bridge).
+    root.set_inheritable_text_color(Color::rgba8(20, 50, 220));  // blue
+
+    bridge.load_script("createLabel('lbl', 'hi')");
+    auto* lbl = bridge.widget("lbl");
+    REQUIRE(lbl != nullptr);
+    REQUIRE(dynamic_cast<Label*>(lbl) != nullptr);
+
+    // Pre-condition: Label has no own color yet → currentColor resolves
+    // from root's inheritable blue.
+    bridge.load_script("setOutlineColor('lbl', 'currentColor')");
+    REQUIRE_THAT(lbl->outline_color().b, WithinAbs(220.0f / 255.0f, 0.01f));
+
+    // Give Label its own red text color via setTextColor (which sets
+    // Label::text_color_ + has_own_text_color_, NOT the inheritable slot).
+    bridge.load_script("setTextColor('lbl', '#ff3322')");
+
+    // The Label's own red MUST now win over root's inheritable blue.
+    bridge.load_script("setOutlineColor('lbl', 'currentColor')");
+    auto oc = lbl->outline_color();
+    REQUIRE_THAT(oc.r, WithinAbs(1.0f, 0.01f));            // 0xff
+    REQUIRE_THAT(oc.g, WithinAbs(0x33 / 255.0f, 0.02f));   // 0x33
+    REQUIRE_THAT(oc.b, WithinAbs(0x22 / 255.0f, 0.02f));   // 0x22
+    // Specifically NOT the root's blue (b=220/255 ≈ 0.86).
+    REQUIRE(oc.b < 0.5f);
+}
+
 // pulp #1663 — rn/borderRadius % family (5 entries) supports percent
 // values via paint-time bounds resolution. Bridge stores percent in
 // View::corner_radius_pct_ / corner_radii_pct_[4]; paint code calls


### PR DESCRIPTION
## Summary

Closes Codex P2 finding on #1728. CSS spec says `currentColor` on element X resolves to **X's own** computed `color`, falling back to inheritance only when X has no own value. Pre-fix, `setOutlineColor(id, 'currentColor')` always called `View::inheritable_text_color()`, which walks `inh_text_color_` up the parent chain.

But `setTextColor` on a Label stores the color in `Label::text_color_` + `has_own_text_color_`, **not** in `inh_text_color_`. So a Label whose own color was set via JS `setTextColor` had its outline `currentColor` silently snap to the parent's inheritable color instead. This also contradicted `Label::paint()`, which already prefers `has_own_text_color_` first.

## Fix

setOutlineColor's currentColor branch now checks `Label::has_own_text_color()` first, then falls through to `inheritable_text_color()`, then the theme fallback. Order matches what `Label::paint()` already does.

## Test plan

- [x] New `[issue-1728]` regression test in `test/test_widget_bridge.cpp`: parent has inheritable blue (b=220/255 ≈ 0.86); child Label gets own red via `setTextColor('#ff3322')`; outline `currentColor` must resolve to red (r=1.0, b<0.5).
- [x] Re-ran existing `[issue-1710]` outline-currentcolor tests — no regression (8 assertions still pass).
- [ ] CI macOS local smoke + sanitizers (run on push)