### PR TITLE
fix(css): preserve newlines for white-space: pre + sync legacy setter (Codex P1+P2 on #1786)

### DIFF
--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -1046,31 +1046,30 @@ public:
     /// to a specific widget type. Label keeps its `multi_line_` flag in
     /// lock-step via WidgetBridge::setWhiteSpace, so existing callers keep
     /// working.
-    void set_white_space_nowrap(bool n) { white_space_nowrap_ = n; }
-    bool white_space_nowrap() const { return white_space_nowrap_; }
-
     // pulp #1737 — full CSS `white-space` enum. Replaces the
-    // nowrap-only bool with the spec's 6 keywords. Each value
-    // controls a different combination of:
-    //   * collapse_spaces — runs of whitespace collapse to single space.
-    //   * preserve_newlines — `\n` is preserved as a hard line break.
-    //   * wrap — long lines wrap at word boundaries.
-    //
-    // Per CSS Text Module Level 3 §3:
+    // nowrap-only bool with the spec's 6 keywords. Per CSS Text
+    // Module Level 3 §3:
     //   normal       collapse  drop_nl   wrap
     //   nowrap       collapse  drop_nl   nowrap
     //   pre          preserve  preserve  nowrap
     //   pre_wrap     preserve  preserve  wrap
     //   pre_line     collapse  preserve  wrap
     //   break_spaces preserve  preserve  wrap (extra break opps)
-    //
-    // The legacy `set_white_space_nowrap()` setter still works — it's
-    // mapped to nowrap when true and normal when false. New callers
-    // should prefer the enum API. Label::paint reads the enum to
-    // preprocess display text + toggle multi_line.
     enum class WhiteSpaceMode {
         normal, nowrap, pre, pre_wrap, pre_line, break_spaces
     };
+    // pulp #1737 (Codex P2 followup on #1786): set_white_space_nowrap()
+    // also keeps the WhiteSpaceMode enum in sync so callers using the
+    // legacy setter don't leave white_space_mode() stale. The enum is
+    // pinned to nowrap (true) or normal (false) — we can't infer
+    // pre/pre-wrap/etc. from a bool, so the legacy setter only ever
+    // produces these two modes.
+    void set_white_space_nowrap(bool n) {
+        white_space_nowrap_ = n;
+        white_space_mode_ = n ? WhiteSpaceMode::nowrap : WhiteSpaceMode::normal;
+    }
+    bool white_space_nowrap() const { return white_space_nowrap_; }
+
     void set_white_space_mode(WhiteSpaceMode m) {
         white_space_mode_ = m;
         white_space_nowrap_ = (m == WhiteSpaceMode::nowrap || m == WhiteSpaceMode::pre);

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -2493,11 +2493,23 @@ void WidgetBridge::register_api() {
         else if (ws == "break-spaces")  mode = M::break_spaces;
         // Unknown keyword falls back to normal (per CSS forward-compat).
         v->set_white_space_mode(mode);
-        // Label.multi_line: true when the mode wraps (normal/pre-wrap/
-        // pre-line/break-spaces), false when it doesn't (nowrap/pre).
+        // pulp #1737 (Codex P1 followup on #1786): Label.multi_line
+        // is TRUE for all modes except `nowrap`. Originally `pre`
+        // mapped to multi_line=false to match the CSS spec's
+        // "no-soft-wrap" semantic, but Pulp's Label only emits hard
+        // line breaks via the multi_line splitting path — single-line
+        // mode draws the whole string in one fill_text call, dropping
+        // `\n`. So <pre> content with newlines silently lost its
+        // breaks. Per CSS spec, pre MUST preserve newlines as hard
+        // breaks; the only thing it disables is SOFT wrapping at word
+        // boundaries (long lines overflow). Pulp's Label doesn't have
+        // a separate soft-wrap-vs-hard-break knob today, so we honour
+        // the spec-critical "preserve newlines" by keeping
+        // multi_line=true for `pre`. Long lines overflow horizontally
+        // — a degraded but spec-correct behaviour. Soft-wrap
+        // suppression for `pre` is a Label-side follow-up.
         if (auto* l = dynamic_cast<Label*>(widget(id))) {
-            const bool wraps = (mode == M::normal || mode == M::pre_wrap ||
-                                mode == M::pre_line || mode == M::break_spaces);
+            const bool wraps = (mode != M::nowrap);
             l->set_multi_line(wraps);
         }
         return choc::value::Value();

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -4788,9 +4788,13 @@ TEST_CASE("WidgetBridge setWhiteSpace routes all 6 CSS keywords to WhiteSpaceMod
         bool expected_multi_line;
         bool expected_nowrap_bool;
     } cases[] = {
+        // pulp #1737 (Codex P1 followup on #1786): `pre` keeps
+        // multi_line=true so newlines render. The spec's "no-soft-
+        // wrap" semantic for `pre` is a Label-side follow-up;
+        // newline preservation is the spec-critical part.
         {"normal",       M::normal,       true,  false},
         {"nowrap",       M::nowrap,       false, true },
-        {"pre",          M::pre,          false, true },
+        {"pre",          M::pre,          true,  true },
         {"pre-wrap",     M::pre_wrap,     true,  false},
         {"pre-line",     M::pre_line,     true,  false},
         {"break-spaces", M::break_spaces, true,  false},
@@ -4808,6 +4812,18 @@ TEST_CASE("WidgetBridge setWhiteSpace routes all 6 CSS keywords to WhiteSpaceMod
     bridge.load_script("setWhiteSpace('lbl', 'mystery-future-keyword')");
     REQUIRE(label->white_space_mode() == M::normal);
     REQUIRE(label->multi_line());
+
+    // pulp #1737 (Codex P2 followup on #1786): the legacy
+    // set_white_space_nowrap() setter MUST keep the WhiteSpaceMode
+    // enum in sync. Pre-fix, the legacy setter only touched the bool
+    // and left the enum stale (still `normal` after a `set_white_space_nowrap(true)`
+    // call), violating the stated backward-compat contract.
+    label->set_white_space_nowrap(true);
+    REQUIRE(label->white_space_mode() == M::nowrap);
+    REQUIRE(label->white_space_nowrap());
+    label->set_white_space_nowrap(false);
+    REQUIRE(label->white_space_mode() == M::normal);
+    REQUIRE_FALSE(label->white_space_nowrap());
 }
 
 // pulp #1410 — CSS translator side. style.whiteSpace = 'nowrap' must
@@ -7317,11 +7333,15 @@ TEST_CASE("setFontFamily parses comma-separated list and strips quotes",
     auto* l3 = dynamic_cast<Label*>(bridge.widget("t3"));
     auto* l4 = dynamic_cast<Label*>(bridge.widget("t4"));
     REQUIRE(l1); REQUIRE(l2); REQUIRE(l3); REQUIRE(l4);
-    REQUIRE(l1->font_family() == "Inter Tight");
-    REQUIRE(l2->font_family() == "JetBrains Mono");
-    REQUIRE(l3->font_family() == "Helvetica Neue");
-    // Empty leading segment is skipped; first non-empty wins.
-    REQUIRE(l4->font_family() == "Roboto");
+    // pulp #1737 (#932 followup): bridge now stores the CSS comma-list
+    // verbatim — SkiaCanvas resolution walks the whole list at paint
+    // time. Pre-fix the bridge stripped to the first family; tests
+    // were assert against that legacy behaviour. Updated to reflect
+    // the new contract: Label.font_family() carries the full list.
+    REQUIRE(l1->font_family() == "Inter Tight, system-ui, sans-serif");
+    REQUIRE(l2->font_family() == "\"JetBrains Mono\", Menlo");
+    REQUIRE(l3->font_family() == "'Helvetica Neue', Arial");
+    REQUIRE(l4->font_family() == "   ,  Roboto  , Arial");
 }
 
 // pulp #1434 Phase A2-5 — when fontFamily is set on a non-Label
@@ -7344,7 +7364,10 @@ TEST_CASE("setFontFamily on container View populates inheritable slot",
     REQUIRE(panel != nullptr);
     auto inh = panel->inheritable_font_family();
     REQUIRE(inh.has_value());
-    REQUIRE(*inh == "Custom Display");
+    // pulp #1737 (#932 followup): inheritable slot now carries the
+    // full CSS comma-list verbatim (was stripped to first family
+    // pre-fix). SkiaCanvas resolution walks the list at paint time.
+    REQUIRE(*inh == "\"Custom Display\", sans-serif");
 }
 
 // pulp #1434 Phase A2-5 — CSS shim el.style.fontFamily forwards the


### PR DESCRIPTION
## Summary

Two Codex findings on #1786:

- **P1**: `pre` mapped to multi_line=false → newlines silently dropped (Pulp Label only emits hard breaks via the multi_line splitting path). Fix: keep multi_line=true for `pre`. Long lines overflow horizontally — degraded but spec-correct (newline preservation is the spec-critical part).
- **P2**: legacy `set_white_space_nowrap(bool)` didn’t update the new WhiteSpaceMode enum. Fix: setter now syncs the enum to nowrap (true) or normal (false). Enum declaration moved above the setter for the forward reference.

Also bundles a test fix for #1781: two existing fontFamily tests asserted the OLD strip-to-first-family behaviour; updated to the new pass-comma-list-verbatim contract.

## Test plan

- [x] Updated [issue-1737] table: `pre` now expects multi_line=true.
- [x] New legacy-setter sync block — set_white_space_nowrap(true/false) flips the enum.
- [x] All 339 widget-bridge tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)