### PR TITLE
chore: bump versions to v0.82.0 (recover SDK release pipeline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,40 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
-<a id="v100"></a>
-## [1.0.0] - 2026-05-10
+<a id="v0820"></a>
+## [0.82.0] - 2026-05-10
 
-- feat(css): consume object-fit + object-position in ImageView::paint (closes pulp #1707) ([#1755](https://github.com/danielraffel/pulp/pull/1755))
-- feat(catalog): hygiene PR — yoga 100%, 5 grace saves, 5 test-ref backfills ([#1752](https://github.com/danielraffel/pulp/pull/1752))
-- fix(canvas): restore text CTM before stroke gradients (Codex P1 on #1736) ([#1750](https://github.com/danielraffel/pulp/pull/1750))
-- feat(rn): catalog flip — rn/userSelect noop → supported (matches wired impl) ([#1746](https://github.com/danielraffel/pulp/pull/1746))
-- feat(rn): catalog flip — rn/overflow lists all 3 RN keywords incl. scroll ([#1745](https://github.com/danielraffel/pulp/pull/1745))
-- feat(canvas2d): wire putImageData 7-arg sub-rect form (issue-916) ([#1741](https://github.com/danielraffel/pulp/pull/1741))
+This release recovers the SDK release pipeline. PR #1755 corrupted CMakeLists.txt VERSION (Clock test fixture leak → 1.0.0); the file was hot-fixed in #1757 but the CHANGELOG retained a bogus `## [1.0.0]` heading and 16 subsequent merges accumulated on main without a tag because `auto-release.yml` saw `CMakeLists.txt VERSION` unchanged. The bogus heading is removed here and v0.82.0 is the proper iterative successor to v0.81.0; the unreleased work below is consolidated into this single minor bump.
+
+Surface changes (canvas2d / css / rn / html):
+
+- feat(css): full white-space enum (normal/nowrap/pre/pre-wrap/pre-line/break-spaces) wired through bridge + Label ([#1786](https://github.com/danielraffel/pulp/pull/1786), [#1788](https://github.com/danielraffel/pulp/pull/1788))
+- feat(rn): SkFontMgr fallback chain — fontFamily comma-list now walks all families instead of only the first ([#1781](https://github.com/danielraffel/pulp/pull/1781))
+- feat(html): querySelector evaluates pseudo-classes spec-correctly (state, DOM-position, :not, :nth-child) ([#1759](https://github.com/danielraffel/pulp/pull/1759), [#1779](https://github.com/danielraffel/pulp/pull/1779), [#1783](https://github.com/danielraffel/pulp/pull/1783))
+- feat(html): aria-pressed/checked/disabled/hidden state attributes wired end-to-end through NSAccessibility + AccessibilityTree ([#1766](https://github.com/danielraffel/pulp/pull/1766), [#1771](https://github.com/danielraffel/pulp/pull/1771))
+- feat(html): catalog flip — html/dialog noop → supported (html surface 100%) ([#1775](https://github.com/danielraffel/pulp/pull/1775))
+- feat(css): object-fit + object-position consumed in ImageView::paint (closes pulp #1707) ([#1755](https://github.com/danielraffel/pulp/pull/1755))
+- feat(canvas2d): putImageData 7-arg sub-rect form (issue-916) ([#1741](https://github.com/danielraffel/pulp/pull/1741))
+- feat(rn): catalog flips — rn/overflow with `scroll`, rn/userSelect noop → supported ([#1745](https://github.com/danielraffel/pulp/pull/1745), [#1746](https://github.com/danielraffel/pulp/pull/1746))
+- fix(canvas): stroke text gradient CTM restored before gradient eval ([#1750](https://github.com/danielraffel/pulp/pull/1750))
+- fix(css): white-space pre keeps multi_line=true so newlines are preserved ([#1788](https://github.com/danielraffel/pulp/pull/1788))
+
+Catalog hygiene + tooling:
+
+- feat(catalog): yoga surface to 100%; 5 grace saves + 5 test-ref backfills ([#1752](https://github.com/danielraffel/pulp/pull/1752))
+- chore(catalog): rn/isolation noop → wontfix (architectural — no stacking-context engine) ([#1785](https://github.com/danielraffel/pulp/pull/1785))
+- chore(catalog): 9 css NO-OPs → wontfix (architectural per flex+grid layout-model contract) ([#1790](https://github.com/danielraffel/pulp/pull/1790))
+- feat(harness): verify-tests step grepping TEST_CASE tags + names against catalog refs ([#1768](https://github.com/danielraffel/pulp/pull/1768))
+- test(canvas): direct unit tests for draw_image_from_*_rect (PR #1739 codecov backfill) ([#1770](https://github.com/danielraffel/pulp/pull/1770))
+
+Release-engineering + guards:
+
+- fix: restore CMakeLists.txt + drop pulp.toml after #1755 corruption ([#1757](https://github.com/danielraffel/pulp/pull/1757))
+- guard: source-tree pollution check (prevents #1755-class CMakeLists corruption) ([#1761](https://github.com/danielraffel/pulp/pull/1761), [#1763](https://github.com/danielraffel/pulp/pull/1763))
+- feat(release): drop example plugin .pkg artifacts from GitHub release page ([#1764](https://github.com/danielraffel/pulp/pull/1764))
+- fix: 4 Codex sweep findings on #1759/#1761/#1763/#1768 ([#1773](https://github.com/danielraffel/pulp/pull/1773))
+
+Surface coverage at v0.82.0: yoga 100%, canvas2d 100%, html 100%, css 82.9%, rn 87.5%, **TOTAL 90.0%**.
 
 <a id="v0810"></a>
 ## [0.81.0] - 2026-05-10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.81.0
+    VERSION 0.82.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
## Summary

Recovery PR for the stranded SDK release pipeline. Main has been frozen at v0.81.0 in CMakeLists.txt VERSION (and on the GitHub releases page) despite ~16 PRs landing since the v0.81.0 tag, including 6+ user-facing `feat:` slices.

**Root cause** (three compounding bugs):

1. **Bogus v1.0.0 changelog entry from #1755 corruption.** PR #1755 (object-fit) leaked a Clock test-fixture file into the repo root, overwriting CMakeLists.txt with `project(Clock VERSION 1.0.0 ...)`. PR #1757 hot-fixed the CMakeLists.txt back to 0.81.0, but `regenerate_changelog.py` had already written a `## [1.0.0]` heading into CHANGELOG.md (no v1.0.0 tag was actually published — verified `git tag --list 'v1*'` returns empty). The bogus heading is removed here.

2. **Direct `gh pr create` bypassed the bump-commit step.** Subsequent PRs (#1759, #1764, #1766, #1768, #1781, #1786, plus their fixes) all merged via direct `gh pr create` rather than `shipyard pr`. None of them carried the `chore: bump versions` commit on the PR branch (verified via API on each PR — exactly one commit per branch). `version-skill-check.yml` ran and FAILED on those PRs (per check-run conclusion = `failure`), but...

3. **Branch protection didn't enforce the bump gate.** Only the `macos` context is required on `main`; `Enforce version & skill sync` runs but is advisory in practice. Failed bump checks did not block merges.

Result: every push to main hit `auto-release.yml` with `sdk decision: {"should_tag": 0, "reason": "sdk v0.81.0 already tagged — no-op"}` because main's `CMakeLists.txt VERSION` never moved. No `release-cli.yml` build fired. SDK release-page binaries are still v0.81.0.

## What this PR does

- **CMakeLists.txt VERSION 0.81.0 → 0.82.0** (single iterative minor bump per CLAUDE.md / user direction — explicitly NOT another v1.0.0 jump; iterative small bumps are the contract).
- **CHANGELOG.md**: removes the bogus `## [1.0.0]` heading; replaces with `## [0.82.0] - 2026-05-10` consolidating all 16 merged PRs grouped by surface / catalog-tooling / release-engineering.

The commit subject `chore: bump versions to v0.82.0` matches `BUMP_COMMIT_SUBJECT_PREFIXES = ("chore: bump versions",)` in `tools/scripts/version_bump_check.py` so the version-bump gate is satisfied.

On merge:
- `auto-release.yml` sees CMakeLists.txt VERSION moved 0.81.0 → 0.82.0 vs latest tag → creates `v0.82.0` tag.
- `release-cli.yml` + `sign-and-release.yml` fire on the new tag → build + publish v0.82.0 SDK binaries.

## Structural follow-up (not in this PR)

`Enforce version & skill sync` should be a **required** status check on `main` so future unbumped feat:/fix: PRs can't merge. Today only `macos` is required (verified via branch protection API). Once that's gated, any PR using direct `gh pr create` without a bump commit will be blocked at merge time, removing the failure mode that caused this freeze.

## Test plan

- [x] CMakeLists.txt VERSION delta verified (0.81.0 → 0.82.0)
- [x] CHANGELOG.md `## [1.0.0]` heading removed
- [x] Commit subject matches `chore: bump versions` prefix → version-bump-check passes the bump-marker gate
- [x] No code changes (release-engineering only) — diff-cover lane irrelevant

🤖 Generated with [Claude Code](https://claude.com/claude-code)