### PR TITLE
feat(text-shaper): add BreakMode for CSS overflow-wrap (PR-1 of 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
 - chore(catalog): css/touchAction noop → wontfix (architectural — pointerEvents covers hit-test contract) ([#1794](https://github.com/danielraffel/pulp/pull/1794))
 
 <a id="v0821"></a>
+## [0.83.0]
+
 ## [0.82.1] - 2026-05-10
 
 - fix(view): currentColor honors element's own text color (Codex P2 on #1728) ([#1778](https://github.com/danielraffel/pulp/pull/1778))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.82.2
+    VERSION 0.83.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/include/pulp/canvas/text_shaper.hpp
+++ b/core/canvas/include/pulp/canvas/text_shaper.hpp
@@ -70,6 +70,33 @@ struct ShapedLayout {
     int line_count = 0;
 };
 
+/// pulp #1737 — CSS overflow-wrap / word-break break opportunity mode.
+/// Default is `normal` so existing callers keep word-boundary-only wrapping.
+///
+/// CSS Text Module Level 3 §6.1 maps to:
+///   normal      → break only at word boundaries (whitespace). A word
+///                 wider than max_width overflows the box.
+///   break_word  → CSS `overflow-wrap: break-word`. Same as normal, but
+///                 if a word is wider than max_width AND no whitespace
+///                 break is available on the current line, allow a
+///                 break inside the word at the codepoint that fits.
+///   anywhere    → CSS `overflow-wrap: anywhere` (and CSS
+///                 `word-break: break-all`). Treat every codepoint as
+///                 a break opportunity. Used for narrow CJK / mono
+///                 columns where word boundaries don't apply.
+///
+/// The implementation uses a proportional split inside a segment
+/// (`seg.width / utf8_codepoints(seg.text)` per codepoint) — CSS doesn't
+/// require pixel-perfect break positions for soft-wrap; the contract
+/// is "do not overflow when a break opportunity exists." Re-shaping
+/// individual fragments would be more accurate but the cost defeats
+/// PreText's measure-once-reflow-forever invariant.
+enum class BreakMode {
+    normal,
+    break_word,
+    anywhere,
+};
+
 /// Text shaper — the PreText-style measure-once-reflow-forever engine.
 ///
 /// Usage:
@@ -102,11 +129,13 @@ public:
     /// that pair this with #1407's ellipsis truncation can see they
     /// overflow). 0 = unlimited (default).
     ShapedLayout layout(const PreparedText& prepared, float max_width,
-                        float line_height = 0, int max_lines = 0) const;
+                        float line_height = 0, int max_lines = 0,
+                        BreakMode break_mode = BreakMode::normal) const;
 
     /// Layout and materialize line text (slightly more expensive than layout())
     ShapedLayout layout_with_lines(const PreparedText& prepared, float max_width,
-                                    float line_height = 0, int max_lines = 0) const;
+                                    float line_height = 0, int max_lines = 0,
+                                    BreakMode break_mode = BreakMode::normal) const;
 
     /// Quick height calculation (fastest path — just returns height, no line details)
     float measure_height(const PreparedText& prepared, float max_width,

--- a/core/canvas/src/text_shaper.cpp
+++ b/core/canvas/src/text_shaper.cpp
@@ -46,9 +46,41 @@ namespace pulp::canvas {
 // This is the "cheap" path — just arithmetic over cached segment widths.
 // Works identically regardless of how segments were measured.
 
+// Count UTF-8 codepoints in `text`. Used by the BreakMode::break_word /
+// BreakMode::anywhere paths to compute a proportional per-codepoint
+// advance for in-segment splits. Skips continuation bytes (0x80–0xBF)
+// so multi-byte sequences count as a single codepoint.
+static int utf8_codepoint_count(const std::string& text) {
+    int n = 0;
+    for (unsigned char b : text) {
+        if ((b & 0xC0) != 0x80) ++n;
+    }
+    return n;
+}
+
+// Walk `text` to the codepoint boundary that contains at most
+// `target_count` codepoints (returns the byte offset of the first byte
+// AFTER the Nth codepoint, clamped to text.size()). Used to slice a
+// segment without breaking inside a multi-byte UTF-8 sequence.
+static size_t utf8_byte_offset_for_codepoints(const std::string& text, int target_count) {
+    if (target_count <= 0) return 0;
+    int seen = 0;
+    size_t i = 0;
+    while (i < text.size()) {
+        unsigned char b = static_cast<unsigned char>(text[i]);
+        if ((b & 0xC0) != 0x80) {
+            if (seen == target_count) return i;
+            ++seen;
+        }
+        ++i;
+    }
+    return text.size();
+}
+
 static ShapedLayout layout_from_segments(const std::vector<ShapedSegment>& segments,
                                           float max_width, float line_height, bool materialize,
-                                          int max_lines = 0) {
+                                          int max_lines = 0,
+                                          BreakMode break_mode = BreakMode::normal) {
     ShapedLayout result;
     if (segments.empty()) return result;
 
@@ -137,10 +169,158 @@ static ShapedLayout layout_from_segments(const std::vector<ShapedSegment>& segme
             width_at_break = current_width;
         }
 
-        if (current_width + seg.width > max_width && current_width > 0) {
-            // Wrap: break at last whitespace or force break here
-            int break_at = (last_break > line_start) ? last_break : i;
-            float break_width = (last_break > line_start) ? width_at_break : current_width;
+        // pulp #1737 — break-word / anywhere also need to fire when the
+        // over-wide segment is the FIRST on an empty line (current_width
+        // == 0, but seg.width alone exceeds max_width). The legacy
+        // `normal` path lets that overflow on its own line; break-word
+        // and anywhere are supposed to slice it. Without this, e.g.
+        // a single Lorem-style word longer than the column would render
+        // identically to `normal`.
+        const bool first_seg_overflows =
+            (current_width == 0 && seg.width > max_width &&
+             (break_mode == BreakMode::break_word ||
+              break_mode == BreakMode::anywhere));
+
+        if ((current_width + seg.width > max_width && current_width > 0) ||
+            first_seg_overflows) {
+            // pulp #1737 — overflow-wrap / word-break decision point.
+            // CSS Text Module Level 3 §6.1:
+            //   - If a whitespace break opportunity exists on the current
+            //     line, ALWAYS prefer it (matches `normal`, `break-word`,
+            //     and `anywhere` — none of them split words when a soft
+            //     break is available).
+            //   - Otherwise, the segment-boundary fallback (current
+            //     behavior) takes over for `normal`.
+            //   - For `break-word` / `anywhere`, split THIS segment at
+            //     the codepoint boundary that fits before max_width
+            //     instead of overflowing whole-segment-wise. `anywhere`
+            //     additionally allows mid-segment breaks even when
+            //     subsequent segments would have fit a clean boundary;
+            //     here the two modes coincide because we only enter this
+            //     branch on actual overflow.
+            const bool has_ws_break = (last_break > line_start);
+            const bool allow_inside_segment =
+                !has_ws_break && (break_mode == BreakMode::break_word ||
+                                  break_mode == BreakMode::anywhere);
+
+            if (allow_inside_segment && seg.width > 0) {
+                // Proportional split: assume uniform per-codepoint
+                // advance within this segment. The contract is "do not
+                // overflow when a break opportunity exists" — CSS does
+                // not require pixel-perfect break positions for soft-
+                // wrap. Re-shaping each fragment would be more accurate
+                // but defeats PreText's measure-once-reflow-forever
+                // invariant. Browsers themselves use simplified
+                // heuristics for this case.
+                const float remain = max_width - current_width;
+                const int cps = utf8_codepoint_count(seg.text);
+                if (cps > 0 && remain > 0) {
+                    const float per_cp = seg.width / static_cast<float>(cps);
+                    int fit_cps = static_cast<int>(remain / per_cp);
+                    // Always advance at least one codepoint so an
+                    // unconditional infinite loop is impossible (e.g.
+                    // current_width already at max_width with a wide
+                    // glyph). The next iteration will start a new line.
+                    if (fit_cps < 1) fit_cps = 1;
+                    if (fit_cps > cps) fit_cps = cps;
+                    const size_t cut = utf8_byte_offset_for_codepoints(seg.text, fit_cps);
+                    const std::string head = seg.text.substr(0, cut);
+                    const std::string tail = seg.text.substr(cut);
+                    const float head_w = per_cp * static_cast<float>(fit_cps);
+                    const float tail_w = seg.width - head_w;
+
+                    ShapedLayout::Line line;
+                    line.width = current_width + head_w;
+                    line.y = y;
+                    line.first_segment = line_start;
+                    line.segment_count = i - line_start;  // segments BEFORE this one stay grouped
+                    if (materialize) {
+                        for (int j = line_start; j < i; ++j)
+                            line.text += segments[j].text;
+                        line.text += head;
+                    }
+                    result.lines.push_back(std::move(line));
+                    max_line_width = std::max(max_line_width, current_width + head_w);
+
+                    y += line_height;
+
+                    // Emit the tail in repeated max_width chunks until
+                    // what remains fits on a single line. For a segment
+                    // many multiples wider than max_width (pathological
+                    // input — Lorem-style or non-spaced CJK runs), this
+                    // produces N - 1 max-width-wide intermediate lines
+                    // followed by one trailing line for the remnant.
+                    // `normal` mode would just overflow the entire
+                    // tail on one line; break-word/anywhere have to do
+                    // better than that to honor the CSS contract.
+                    std::string remaining_text = tail;
+                    float remaining_w = tail_w;
+                    int safety = 0;
+                    while (remaining_w > max_width && per_cp > 0 && safety < 1024) {
+                        int chunk_cps = static_cast<int>(max_width / per_cp);
+                        if (chunk_cps < 1) chunk_cps = 1;
+                        const size_t chunk_cut = utf8_byte_offset_for_codepoints(remaining_text, chunk_cps);
+                        const std::string chunk = remaining_text.substr(0, chunk_cut);
+                        const float chunk_w = per_cp * static_cast<float>(chunk_cps);
+                        ShapedLayout::Line chunk_line;
+                        chunk_line.width = chunk_w;
+                        chunk_line.y = y;
+                        chunk_line.first_segment = i;
+                        chunk_line.segment_count = 1;
+                        if (materialize) chunk_line.text = chunk;
+                        result.lines.push_back(std::move(chunk_line));
+                        max_line_width = std::max(max_line_width, chunk_w);
+                        y += line_height;
+                        remaining_text = remaining_text.substr(chunk_cut);
+                        remaining_w -= chunk_w;
+                        ++safety;
+                    }
+
+                    // Final remnant of this segment becomes the start
+                    // of the next "in-progress" line. It fits within
+                    // max_width by construction (loop exit condition);
+                    // accumulate it into current_width so the next
+                    // segment can extend the line if it also fits.
+                    line_start = i + 1;
+                    current_width = remaining_w;
+                    last_break = -1;
+                    // If the segments vector ends here, the final-line
+                    // emit code at the bottom of layout_from_segments
+                    // will materialize the remnant alongside any
+                    // following segments. Otherwise the next iteration
+                    // continues with current_width pre-loaded.
+                    //
+                    // The remnant materialization, however, is a gap:
+                    // the final-line code reads segments[j].text for
+                    // j in [line_start, end), so the remnant itself
+                    // (which logically belongs to segment i, not
+                    // segment line_start) is not in any segment. If no
+                    // following segments materialize, we'd lose the
+                    // remnant. Cover that here by emitting the remnant
+                    // as a single-segment line directly when this is
+                    // the last segment.
+                    if (i == static_cast<int>(segments.size()) - 1) {
+                        ShapedLayout::Line tail_line;
+                        tail_line.width = remaining_w;
+                        tail_line.y = y;
+                        tail_line.first_segment = i;
+                        tail_line.segment_count = 1;
+                        if (materialize) tail_line.text = remaining_text;
+                        result.lines.push_back(std::move(tail_line));
+                        max_line_width = std::max(max_line_width, remaining_w);
+                        y += line_height;
+                        current_width = 0;
+                    }
+                    continue;
+                }
+                // cps == 0 falls through to legacy whole-segment path
+            }
+
+            // Legacy `normal`-mode behavior: break at last whitespace or
+            // segment boundary (no inside-word breaks). Same path as
+            // pre-#1737.
+            int break_at = has_ws_break ? last_break : i;
+            float break_width = has_ws_break ? width_at_break : current_width;
 
             ShapedLayout::Line line;
             line.width = break_width;
@@ -157,7 +337,7 @@ static ShapedLayout layout_from_segments(const std::vector<ShapedSegment>& segme
             y += line_height;
 
             // Skip whitespace at break point
-            line_start = (last_break > line_start) ? last_break + 1 : i;
+            line_start = has_ws_break ? last_break + 1 : i;
             current_width = 0;
             for (int j = line_start; j <= i; ++j)
                 current_width += segments[j].width;
@@ -423,15 +603,17 @@ PreparedText TextShaper::prepare(const AttributedString& text) {
 }
 
 ShapedLayout TextShaper::layout(const PreparedText& prepared, float max_width,
-                                 float line_height, int max_lines) const {
+                                 float line_height, int max_lines,
+                                 BreakMode break_mode) const {
     float lh = line_height > 0 ? line_height : prepared.line_height();
-    return layout_from_segments(prepared.segments(), max_width, lh, false, max_lines);
+    return layout_from_segments(prepared.segments(), max_width, lh, false, max_lines, break_mode);
 }
 
 ShapedLayout TextShaper::layout_with_lines(const PreparedText& prepared, float max_width,
-                                            float line_height, int max_lines) const {
+                                            float line_height, int max_lines,
+                                            BreakMode break_mode) const {
     float lh = line_height > 0 ? line_height : prepared.line_height();
-    return layout_from_segments(prepared.segments(), max_width, lh, true, max_lines);
+    return layout_from_segments(prepared.segments(), max_width, lh, true, max_lines, break_mode);
 }
 
 float TextShaper::measure_height(const PreparedText& prepared, float max_width,

--- a/core/canvas/src/text_shaper.cpp
+++ b/core/canvas/src/text_shaper.cpp
@@ -276,30 +276,26 @@ static ShapedLayout layout_from_segments(const std::vector<ShapedSegment>& segme
                         ++safety;
                     }
 
-                    // Final remnant of this segment becomes the start
-                    // of the next "in-progress" line. It fits within
-                    // max_width by construction (loop exit condition);
-                    // accumulate it into current_width so the next
-                    // segment can extend the line if it also fits.
-                    line_start = i + 1;
-                    current_width = remaining_w;
-                    last_break = -1;
-                    // If the segments vector ends here, the final-line
-                    // emit code at the bottom of layout_from_segments
-                    // will materialize the remnant alongside any
-                    // following segments. Otherwise the next iteration
-                    // continues with current_width pre-loaded.
+                    // Final remnant of this segment must be emitted as
+                    // its own line right now — `current_width` would
+                    // preserve the numeric width into the next iteration
+                    // but the textual content (remaining_text) belongs
+                    // to segment `i`, not to any of segments[i+1..end).
+                    // The materialization loops downstream only walk
+                    // `segments[j].text`, so leaving the remnant in
+                    // current_width would silently drop the characters
+                    // when followed by ANY further segments (Codex P1
+                    // on #1795 / pulp #1737: "Preserve split-word
+                    // remainder before subsequent segments"). The
+                    // tradeoff: the remnant gets its own line instead
+                    // of combining with the following segment on the
+                    // same visual line — minor cosmetic vs. data loss.
                     //
-                    // The remnant materialization, however, is a gap:
-                    // the final-line code reads segments[j].text for
-                    // j in [line_start, end), so the remnant itself
-                    // (which logically belongs to segment i, not
-                    // segment line_start) is not in any segment. If no
-                    // following segments materialize, we'd lose the
-                    // remnant. Cover that here by emitting the remnant
-                    // as a single-segment line directly when this is
-                    // the last segment.
-                    if (i == static_cast<int>(segments.size()) - 1) {
+                    // Also handles the last-segment case correctly: an
+                    // unconditional emit means we always materialize
+                    // the remnant, regardless of whether more segments
+                    // follow.
+                    {
                         ShapedLayout::Line tail_line;
                         tail_line.width = remaining_w;
                         tail_line.y = y;
@@ -309,8 +305,10 @@ static ShapedLayout layout_from_segments(const std::vector<ShapedSegment>& segme
                         result.lines.push_back(std::move(tail_line));
                         max_line_width = std::max(max_line_width, remaining_w);
                         y += line_height;
-                        current_width = 0;
                     }
+                    line_start = i + 1;
+                    current_width = 0;
+                    last_break = -1;
                     continue;
                 }
                 // cps == 0 falls through to legacy whole-segment path

--- a/test/test_text_shaper.cpp
+++ b/test/test_text_shaper.cpp
@@ -296,3 +296,147 @@ TEST_CASE("Parallelogram contains accepts interior and edge points",
     REQUIRE_FALSE(para.contains(9.0f, 25.0f));
     REQUIRE_FALSE(para.contains(46.0f, 20.0f));
 }
+
+// ── pulp #1737 — CSS overflow-wrap / word-break BreakMode ───────────────
+// PR-1 of 2 in the css/overflowWrap roadmap slice. PR-1 ships the
+// TextShaper API for honoring break-word + anywhere break opportunities;
+// PR-2 wires Label::paint to call this through View::word_break_ and
+// flips the catalog. These tests anchor the contract for PR-2's
+// integration step.
+//
+// Approach: proportional in-segment split (`seg.width / utf8_codepoints`
+// per codepoint) at the codepoint boundary that fits before max_width.
+// CSS Text Module Level 3 §6.1 does not require pixel-perfect break
+// positions for soft-wrap — the contract is "do not overflow when a
+// break opportunity exists." Re-shaping individual fragments would be
+// more accurate but defeats PreText's measure-once-reflow-forever
+// invariant. Browsers themselves use simplified heuristics for this case.
+
+TEST_CASE("TextShaper BreakMode::normal preserves legacy whole-word overflow",
+          "[canvas][text_shaper][issue-1737]") {
+    TextShaper shaper;
+    // A single long unbroken word wider than max_width must overflow on
+    // one line under `normal` mode. This pins the legacy behavior so
+    // the BreakMode plumbing is purely additive — existing consumers
+    // see zero change at the API boundary.
+    auto prepared = shaper.prepare("Supercalifragilisticexpialidocious", "system", 14);
+    auto layout = shaper.layout(prepared, 30.0f, 0, 0, BreakMode::normal);
+    REQUIRE(layout.line_count == 1);
+    REQUIRE(layout.lines[0].width > 30.0f);
+}
+
+TEST_CASE("TextShaper BreakMode::break_word splits inside an over-wide word",
+          "[canvas][text_shaper][issue-1737]") {
+    TextShaper shaper;
+    auto prepared = shaper.prepare("Supercalifragilisticexpialidocious", "system", 14);
+    auto layout = shaper.layout_with_lines(prepared, 30.0f, 0, 0, BreakMode::break_word);
+    // Must produce at least two lines (one would mean overflow, which
+    // is exactly what break-word is supposed to prevent).
+    REQUIRE(layout.line_count >= 2);
+    // Each emitted line must be at most max_width wide (within the
+    // proportional-split rounding tolerance — one codepoint of slop).
+    for (const auto& line : layout.lines) {
+        REQUIRE(line.width <= 30.0f + 5.0f);  // 5px slop = ~one wide char
+    }
+    // First line's text plus all subsequent lines' text must reconstruct
+    // the original. The shaper materializes line text exactly; no chars
+    // dropped, no chars duplicated.
+    std::string reconstructed;
+    for (const auto& line : layout.lines) reconstructed += line.text;
+    REQUIRE(reconstructed == "Supercalifragilisticexpialidocious");
+}
+
+TEST_CASE("TextShaper BreakMode::break_word still prefers whitespace breaks",
+          "[canvas][text_shaper][issue-1737]") {
+    TextShaper shaper;
+    // Probe text chosen so each individual word fits comfortably within
+    // max_width — break-word only diverges from `normal` when a word is
+    // ALSO over-wide (CSS Text Module §6.1: prefer the best break
+    // opportunity; inside-word breaks only fire on actual overflow with
+    // no whitespace break available).
+    //
+    // "ab cd ef gh" with 14px estimate: each 2-char word ≈ 17px. With
+    // max_width=40, "ab cd" fits (~39px) then "ef gh" wraps to a new
+    // line. NEITHER mode should split a word.
+    auto prepared = shaper.prepare("ab cd ef gh", "system", 14);
+    auto wide_layout = shaper.layout_with_lines(prepared, 1000.0f, 0, 0, BreakMode::break_word);
+    REQUIRE(wide_layout.line_count == 1);
+
+    auto narrow_layout = shaper.layout_with_lines(prepared, 40.0f, 0, 0, BreakMode::break_word);
+    // The break_word verdict here MUST match `normal`'s verdict —
+    // whitespace breaks only.
+    auto narrow_normal = shaper.layout_with_lines(prepared, 40.0f, 0, 0, BreakMode::normal);
+    REQUIRE(narrow_layout.line_count == narrow_normal.line_count);
+    for (size_t k = 0; k < narrow_layout.lines.size(); ++k) {
+        REQUIRE(narrow_layout.lines[k].text == narrow_normal.lines[k].text);
+    }
+}
+
+TEST_CASE("TextShaper BreakMode::anywhere splits at codepoint boundaries",
+          "[canvas][text_shaper][issue-1737]") {
+    TextShaper shaper;
+    // anywhere is a stricter version of break_word: the contract still
+    // applies (don't overflow when a break opportunity exists), but
+    // ALL codepoints are break candidates. In our implementation,
+    // break_word and anywhere coincide on the overflow branch — this
+    // test pins that they both round-trip the same way for an
+    // over-wide single word.
+    auto prepared = shaper.prepare("Antidisestablishmentarianism", "system", 14);
+    auto layout = shaper.layout_with_lines(prepared, 25.0f, 0, 0, BreakMode::anywhere);
+    REQUIRE(layout.line_count >= 2);
+    std::string reconstructed;
+    for (const auto& line : layout.lines) reconstructed += line.text;
+    REQUIRE(reconstructed == "Antidisestablishmentarianism");
+}
+
+TEST_CASE("TextShaper BreakMode never breaks inside a UTF-8 codepoint",
+          "[canvas][text_shaper][issue-1737]") {
+    TextShaper shaper;
+    // Mixed ASCII + multibyte UTF-8 (here: U+00E9 LATIN SMALL LETTER E
+    // WITH ACUTE, encoded as 0xC3 0xA9 — 2 bytes, 1 codepoint).
+    // Splitting inside a multibyte sequence would corrupt the output;
+    // utf8_byte_offset_for_codepoints must always land on a codepoint
+    // boundary. Verify by checking each emitted line's bytes are
+    // valid UTF-8 (no orphan continuation bytes at start/end).
+    // U+00E9 = 0xC3 0xA9. Use string-literal concatenation so each \x
+    // escape doesn't greedily consume subsequent hex characters.
+    auto prepared = shaper.prepare("aaaaa" "\xc3\xa9" "\xc3\xa9" "\xc3\xa9" "aaaaa",
+                                    "system", 14);
+    auto layout = shaper.layout_with_lines(prepared, 20.0f, 0, 0, BreakMode::break_word);
+    for (const auto& line : layout.lines) {
+        if (line.text.empty()) continue;
+        // First byte must NOT be a continuation byte (0x80-0xBF)
+        const unsigned char first = static_cast<unsigned char>(line.text.front());
+        REQUIRE((first & 0xC0) != 0x80);
+        // Last byte either ASCII (top bit 0) or a complete sequence —
+        // walk the string and verify the final codepoint terminates
+        // before end-of-string.
+        size_t i = 0;
+        while (i < line.text.size()) {
+            unsigned char b = static_cast<unsigned char>(line.text[i]);
+            int len = 1;
+            if      ((b & 0x80) == 0)    len = 1;
+            else if ((b & 0xE0) == 0xC0) len = 2;
+            else if ((b & 0xF0) == 0xE0) len = 3;
+            else if ((b & 0xF8) == 0xF0) len = 4;
+            REQUIRE(i + len <= line.text.size());
+            i += len;
+        }
+    }
+}
+
+TEST_CASE("TextShaper BreakMode::normal default-arg matches the no-arg overload",
+          "[canvas][text_shaper][issue-1737]") {
+    TextShaper shaper;
+    auto prepared = shaper.prepare("hello world how are you", "system", 14);
+    auto without_mode = shaper.layout(prepared, 50.0f);
+    auto with_normal  = shaper.layout(prepared, 50.0f, 0, 0, BreakMode::normal);
+    // The default value of BreakMode must be `normal`. If anyone changes
+    // the default in the header, this test fires before any consumer
+    // notices a behavior change.
+    REQUIRE(without_mode.line_count == with_normal.line_count);
+    for (size_t k = 0; k < without_mode.lines.size(); ++k) {
+        REQUIRE_THAT(without_mode.lines[k].width,
+                     WithinAbs(with_normal.lines[k].width, 0.001f));
+    }
+}

--- a/test/test_text_shaper.cpp
+++ b/test/test_text_shaper.cpp
@@ -440,3 +440,30 @@ TEST_CASE("TextShaper BreakMode::normal default-arg matches the no-arg overload"
                      WithinAbs(with_normal.lines[k].width, 0.001f));
     }
 }
+
+TEST_CASE("TextShaper BreakMode preserves remnant when the over-wide segment is followed by more text",
+          "[canvas][text_shaper][issue-1737]") {
+    TextShaper shaper;
+    // Codex P1 on PR #1795: when break_word splits an over-wide segment
+    // mid-segment AND that segment is NOT the last one, the remainder
+    // characters were silently dropped. The fix emits the remnant as
+    // its own line unconditionally so materialization downstream sees
+    // every character. Probe: a long unbroken token, then whitespace,
+    // then a normal word — verify reconstruction is bit-exact.
+    auto prepared = shaper.prepare(
+        "Antidisestablishmentarianism follows", "system", 14);
+    auto layout = shaper.layout_with_lines(prepared, 30.0f, 0, 0, BreakMode::break_word);
+
+    std::string reconstructed;
+    for (const auto& line : layout.lines) reconstructed += line.text;
+    // Whitespace handling: the legacy break-at-whitespace code path
+    // skips the whitespace segment when emitting (line_start advances
+    // past it), so the reconstructed string drops the inter-word space.
+    // Accept the canonical "no spaces" reconstruction OR the spaced one
+    // — what matters is that NO non-whitespace characters are lost.
+    std::string canonical = "Antidisestablishmentarianismfollows";
+    std::string with_space = "Antidisestablishmentarianism follows";
+    bool ok = (reconstructed == canonical) || (reconstructed == with_space);
+    INFO("reconstructed='" << reconstructed << "'");
+    REQUIRE(ok);
+}


### PR DESCRIPTION
PR-1 of the css/overflowWrap roadmap slice. PR-1 ships the
TextShaper API for honoring CSS Text Module Level 3 §6.1
break-word + anywhere break opportunities; PR-2 (next session)
wires Label::paint to call this through View::word_break_ and
flips the catalog. Splitting into two PRs keeps each session-
sized and ensures the new layout logic is tested in isolation
before integration.

Public API addition:

    enum class BreakMode { normal, break_word, anywhere };

    layout(prepared, max_w, lh, max_lines, BreakMode = normal)
    layout_with_lines(prepared, max_w, lh, max_lines, BreakMode = normal)

The default value of `normal` keeps every existing caller's
behavior bit-identical — verified by the new
`BreakMode::normal default-arg matches the no-arg overload`
test case. Plus all 24 pre-existing TextShaper tests pass
unchanged.

Implementation:

- `layout_from_segments` gains a BreakMode parameter and a
  proportional in-segment split path. When the overflow branch
  fires AND no whitespace break opportunity exists on the
  current line AND mode != normal, the over-wide segment is
  sliced at the codepoint boundary that fits before max_width.
  Per-codepoint advance is approximated as `seg.width /
  utf8_codepoints(seg.text)` — CSS does not require pixel-
  perfect break positions for soft-wrap, only the contract
  "do not overflow when a break opportunity exists." Re-shaping
  individual fragments would be more accurate but defeats
  PreText's measure-once-reflow-forever invariant.
- A separate `first_seg_overflows` trigger covers the case
  where the over-wide segment is the FIRST on a fresh line
  (current_width == 0). The legacy `normal` path lets that
  overflow on its own line; break-word/anywhere have to
  slice it.
- Pathological case (single segment many multiples wider than
  max_width — Lorem-style or non-spaced CJK runs): the in-
  segment split loops to chunk the tail into N - 1 max-width
  intermediate lines plus one trailing remnant line. `safety`
  counter (1024) caps the loop so a degenerate per_cp == 0
  cannot infinite-loop.
- UTF-8 safety: `utf8_byte_offset_for_codepoints` walks the
  string skipping continuation bytes (0x80–0xBF) so split
  positions always land on a codepoint boundary. Probed by
  `BreakMode never breaks inside a UTF-8 codepoint` against a
  mixed ASCII + U+00E9 (LATIN SMALL LETTER E WITH ACUTE)
  string.

Tests (test_text_shaper, [issue-1737] tag, 6 new cases / 30
assertions):

- `BreakMode::normal preserves legacy whole-word overflow` —
  pins that an over-wide single word still overflows on one
  line under normal mode (regression guard for the additive
  contract).
- `BreakMode::break_word splits inside an over-wide word` —
  Supercalifragilisticexpialidocious at max_width 30 produces
  multiple lines, each within max_width + 5px slop, and the
  concatenated lines reconstruct the original string exactly
  (no chars dropped or duplicated).
- `BreakMode::break_word still prefers whitespace breaks` —
  when each individual word fits, break_word's verdict matches
  normal's verdict line-by-line (whitespace-only breaks; no
  partial words emitted).
- `BreakMode::anywhere splits at codepoint boundaries` — same
  as break_word for the over-wide-single-word case (the two
  modes coincide on the overflow branch; they differ in CSS at
  the policy level for word-boundary preference, which only
  matters when whitespace IS available — covered by the
  preceding case).
- `BreakMode never breaks inside a UTF-8 codepoint` — verifies
  every emitted line starts with a non-continuation byte and
  ends on a complete UTF-8 sequence.
- `BreakMode::normal default-arg matches the no-arg overload` —
  guards the default value so future signature changes can't
  silently shift behavior for existing callers.

Followups for PR-2 (next session):

- Migrate Label::paint multi-line path from the current
  `\n`-only split to TextShaper::layout_with_lines.
- Wire View::word_break_ → BreakMode mapping ("normal" /
  "break-word" / "anywhere").
- Preserve line-clamp + ellipsis + vertical-align integration
  (the existing visible_lines / text_h / baseline_y math
  carries over; just iterate shaped Lines instead of \n-splits).
- Catalog flip: css/overflowWrap partial → supported with
  paint-time honoring claim. css/wordBreak gains the same
  treatment since both forward to View::word_break_.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>