### PR TITLE
fix(view): paint honors percent corner-radius + Panel uses View slot (Codex P1×2 on #1731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0873"></a>
+## [0.88.0]
+
 ## [0.87.3] - 2026-05-10
 
 - fix(canvas2d): DOMMatrix scaleSelf/rotateSelf/inverse spec conformance (Codex P1×2 + P2 on #1730) ([#1754](https://github.com/danielraffel/pulp/pull/1754))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.87.3
+    VERSION 0.88.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -714,16 +714,22 @@ private:
 
 class Panel : public View {
 public:
-    Panel() = default;
+    // pulp #1731 Codex P1 — Panel used to shadow View::corner_radius_
+    // with its own field that paint() never read. Constructor now seeds
+    // the View-side slot so the default 8px rounding actually paints.
+    Panel() { View::set_border_radius(8.0f); }
 
     void set_background_token(std::string token) { bg_token_ = std::move(token); }
     void set_border_token(std::string token) { border_token_ = std::move(token); }
-    void set_corner_radius(float r) { corner_radius_ = r; }
+    // pulp #1731 Codex P1 — route through View::set_border_radius so the
+    // px slot painter actually reads is updated (and the pct slot is
+    // cleared, matching documented semantics).
+    void set_corner_radius(float r) { View::set_border_radius(r); }
     void set_border_width(float w) { border_width_ = w; }
 
     const std::string& background_token() const { return bg_token_; }
     const std::string& border_token() const { return border_token_; }
-    float corner_radius() const { return corner_radius_; }
+    float corner_radius() const { return View::corner_radius(); }
     float border_width() const { return border_width_; }
 
     void paint(canvas::Canvas& canvas) override;
@@ -731,7 +737,6 @@ public:
 private:
     std::string bg_token_ = "bg.surface";
     std::string border_token_ = "control.border";
-    float corner_radius_ = 8.0f;
     float border_width_ = 1.0f;
 };
 

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -239,7 +239,7 @@ void View::paint_all(canvas::Canvas& canvas) {
                                shadow_.offset_x, shadow_.offset_y,
                                shadow_.blur, shadow_.spread,
                                shadow_.color, /*inset=*/false,
-                               corner_radius_);
+                               effective_corner_radius(bounds_.width, bounds_.height));
     }
 
     // Clip only when overflow:hidden / overflow:scroll is explicitly
@@ -274,6 +274,16 @@ void View::paint_all(canvas::Canvas& canvas) {
     // uniform corner_radius_.
     const bool use_per_corner = has_corner_radii_;
 
+    // pulp #1731 Codex P1 — paint sites must read effective_* which honor
+    // the percent slots (corner_radius_pct_, corner_radii_pct_[]). Reading
+    // the raw px slots makes `setBorderRadius('50%')` and per-corner
+    // percent setters silently no-op.
+    const float eff_r = effective_corner_radius(bounds_.width, bounds_.height);
+    const float eff_tl = effective_corner_radius_tl(bounds_.width, bounds_.height);
+    const float eff_tr = effective_corner_radius_tr(bounds_.width, bounds_.height);
+    const float eff_bl = effective_corner_radius_bl(bounds_.width, bounds_.height);
+    const float eff_br = effective_corner_radius_br(bounds_.width, bounds_.height);
+
     // Paint background gradient if set (CSS background: linear-gradient)
     if (bg_gradient_type_ > 0 && !bg_gradient_colors_.empty()) {
         canvas.set_fill_gradient_linear(
@@ -283,11 +293,10 @@ void View::paint_all(canvas::Canvas& canvas) {
             static_cast<int>(bg_gradient_colors_.size()));
         if (use_per_corner) {
             build_per_corner_rounded_rect_path(canvas, bounds_.width, bounds_.height,
-                                               corner_radii_[0], corner_radii_[1],
-                                               corner_radii_[2], corner_radii_[3]);
+                                               eff_tl, eff_tr, eff_bl, eff_br);
             canvas.fill_current_path();
-        } else if (corner_radius_ > 0) {
-            canvas.fill_rounded_rect(0, 0, bounds_.width, bounds_.height, corner_radius_);
+        } else if (eff_r > 0) {
+            canvas.fill_rounded_rect(0, 0, bounds_.width, bounds_.height, eff_r);
         } else {
             canvas.fill_rect(0, 0, bounds_.width, bounds_.height);
         }
@@ -299,11 +308,10 @@ void View::paint_all(canvas::Canvas& canvas) {
         canvas.set_fill_color(bg_color_);
         if (use_per_corner) {
             build_per_corner_rounded_rect_path(canvas, bounds_.width, bounds_.height,
-                                               corner_radii_[0], corner_radii_[1],
-                                               corner_radii_[2], corner_radii_[3]);
+                                               eff_tl, eff_tr, eff_bl, eff_br);
             canvas.fill_current_path();
-        } else if (corner_radius_ > 0) {
-            canvas.fill_rounded_rect(0, 0, bounds_.width, bounds_.height, corner_radius_);
+        } else if (eff_r > 0) {
+            canvas.fill_rounded_rect(0, 0, bounds_.width, bounds_.height, eff_r);
         } else {
             canvas.fill_rect(0, 0, bounds_.width, bounds_.height);
         }
@@ -336,11 +344,10 @@ void View::paint_all(canvas::Canvas& canvas) {
 
         if (use_per_corner) {
             build_per_corner_rounded_rect_path(canvas, bounds_.width, bounds_.height,
-                                               corner_radii_[0], corner_radii_[1],
-                                               corner_radii_[2], corner_radii_[3]);
+                                               eff_tl, eff_tr, eff_bl, eff_br);
             canvas.stroke_current_path();
-        } else if (corner_radius_ > 0) {
-            canvas.stroke_rounded_rect(0, 0, bounds_.width, bounds_.height, corner_radius_);
+        } else if (eff_r > 0) {
+            canvas.stroke_rounded_rect(0, 0, bounds_.width, bounds_.height, eff_r);
         } else {
             canvas.stroke_rect(0, 0, bounds_.width, bounds_.height);
         }
@@ -378,7 +385,7 @@ void View::paint_all(canvas::Canvas& canvas) {
                                shadow_.offset_x, shadow_.offset_y,
                                shadow_.blur, shadow_.spread,
                                shadow_.color, /*inset=*/true,
-                               corner_radius_);
+                               eff_r);
     }
 
     // CSS / RN outline (pulp #1519). Paints OUTSIDE the border-box and
@@ -413,9 +420,9 @@ void View::paint_all(canvas::Canvas& canvas) {
         // Outline corner radius mirrors the border-box corner radius
         // expanded by the same inflate distance — matches CSS UA
         // behavior where the outline follows the box's corner curvature.
-        if (corner_radius_ > 0) {
+        if (eff_r > 0) {
             canvas.stroke_rounded_rect(ox, oy, ow, oh,
-                                       corner_radius_ + inflate);
+                                       eff_r + inflate);
         } else {
             canvas.stroke_rect(ox, oy, ow, oh);
         }

--- a/test/test_view.cpp
+++ b/test/test_view.cpp
@@ -1775,3 +1775,141 @@ TEST_CASE("View::paint_all does NOT route through save_layer_with_mask when mask
     // treated as if no mask were set (no layer overhead, no composite).
     REQUIRE(canvas.mask_calls.empty());
 }
+
+// ── pulp #1731 — Panel & View paint must honor effective_corner_radius ─────
+// Codex P1 #1: Panel had its own corner_radius_ field that paint() never
+// read (it called View::effective_corner_radius which only sees View's
+// slot). Codex P1 #2: View::paint_all used corner_radius_/corner_radii_[]
+// directly, silently ignoring corner_radius_pct_ / corner_radii_pct_[].
+
+TEST_CASE("pulp #1731 P1 — Panel default 8px corner radius actually paints",
+          "[view][issue-1731][panel-radius]") {
+    pulp::view::Panel p;
+    p.set_bounds({0, 0, 100, 50});
+
+    pulp::canvas::RecordingCanvas rc;
+    p.paint(rc);
+
+    // Panel always paints a filled background, so we expect at least one
+    // fill_rounded_rect with the default 8.0f radius.
+    bool saw_default = false;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::fill_rounded_rect
+                && std::abs(cmd.f[4] - 8.0f) < 1e-4f) {
+            saw_default = true;
+            break;
+        }
+    }
+    REQUIRE(saw_default);
+}
+
+TEST_CASE("pulp #1731 P1 — Panel::set_corner_radius writes the View slot paint reads",
+          "[view][issue-1731][panel-radius]") {
+    pulp::view::Panel p;
+    p.set_bounds({0, 0, 100, 50});
+    p.set_corner_radius(16.0f);
+
+    pulp::canvas::RecordingCanvas rc;
+    p.paint(rc);
+
+    bool saw_16 = false;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::fill_rounded_rect
+                && std::abs(cmd.f[4] - 16.0f) < 1e-4f) {
+            saw_16 = true;
+            break;
+        }
+    }
+    REQUIRE(saw_16);
+    REQUIRE_THAT(p.corner_radius(), WithinAbs(16.0f, 1e-4f));
+}
+
+TEST_CASE("pulp #1731 P1 — View::paint_all honors percent uniform border-radius",
+          "[view][issue-1731][percent-radius]") {
+    pulp::view::View v;
+    v.set_bounds({0, 0, 100, 100});
+    v.set_background_color(pulp::canvas::Color::rgba8(10, 20, 30));
+    v.set_border_radius_pct(50.0f);  // 50% of min(100,100) = 50px → circle
+
+    pulp::canvas::RecordingCanvas rc;
+    v.paint_all(rc);
+
+    bool saw_50 = false;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::fill_rounded_rect
+                && std::abs(cmd.f[4] - 50.0f) < 1e-4f) {
+            saw_50 = true;
+            break;
+        }
+    }
+    REQUIRE(saw_50);
+}
+
+TEST_CASE("pulp #1731 P1 — View border stroke honors percent radius",
+          "[view][issue-1731][percent-radius]") {
+    pulp::view::View v;
+    v.set_bounds({0, 0, 80, 80});
+    v.set_border(pulp::canvas::Color::rgba8(255, 255, 255), 2.0f);
+    v.set_border_radius_pct(50.0f);  // 50% of min(80,80) = 40px
+
+    pulp::canvas::RecordingCanvas rc;
+    v.paint_all(rc);
+
+    bool saw_40 = false;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::stroke_rounded_rect
+                && std::abs(cmd.f[4] - 40.0f) < 1e-4f) {
+            saw_40 = true;
+            break;
+        }
+    }
+    REQUIRE(saw_40);
+}
+
+TEST_CASE("pulp #1731 P1 — View outline honors percent radius",
+          "[view][issue-1731][percent-radius]") {
+    pulp::view::View v;
+    v.set_bounds({0, 0, 60, 60});
+    v.set_border_radius_pct(50.0f);  // 50% of min(60,60) = 30px
+    v.set_outline_width(2.0f);
+    v.set_outline_color(pulp::canvas::Color::rgba8(255, 0, 0));
+    v.set_outline_style(pulp::view::View::BorderStyle::solid);
+    // Outline uses outline_offset + outline_width * 0.5f = 0 + 1 = 1 inflate.
+    // Expected stroked radius = 30 + 1 = 31.
+
+    pulp::canvas::RecordingCanvas rc;
+    v.paint_all(rc);
+
+    bool saw_31 = false;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::stroke_rounded_rect
+                && std::abs(cmd.f[4] - 31.0f) < 1e-4f) {
+            saw_31 = true;
+            break;
+        }
+    }
+    REQUIRE(saw_31);
+}
+
+TEST_CASE("pulp #1731 P1 — px radius still wins when pct is 0 (default)",
+          "[view][issue-1731][regression-guard]") {
+    // Make sure the percent-resolving paint path doesn't silently regress
+    // the px-only case for views that never set a percent.
+    pulp::view::View v;
+    v.set_bounds({0, 0, 200, 200});
+    v.set_background_color(pulp::canvas::Color::rgba8(0, 0, 0));
+    v.set_border_radius(12.0f);
+
+    pulp::canvas::RecordingCanvas rc;
+    v.paint_all(rc);
+
+    bool saw_12 = false;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::fill_rounded_rect
+                && std::abs(cmd.f[4] - 12.0f) < 1e-4f) {
+            saw_12 = true;
+            break;
+        }
+    }
+    REQUIRE(saw_12);
+}

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -947,7 +947,12 @@ TEST_CASE("WidgetBridge style and layout setters update native view state",
     REQUIRE_FALSE(panel->hit_testable());
     REQUIRE(panel->background_token() == "bg.raised");
     REQUIRE(panel->border_token() == "accent.primary");
-    REQUIRE_THAT(panel->corner_radius(), WithinAbs(9.0f, 0.001f));
+    // pulp #1731 P1 — Panel::set_corner_radius now routes through the
+    // same View slot setBorder() writes to. setPanelStyle(..., 9, ...)
+    // on JS line 90 was followed by setBorder(..., 2, 6) on line 92, so
+    // last-write-wins yields 6. Previously Panel kept a shadowed 9 that
+    // paint() never read — the on-screen radius was always the View slot.
+    REQUIRE_THAT(panel->corner_radius(), WithinAbs(6.0f, 0.001f));
     REQUIRE_THAT(panel->border_width(), WithinAbs(2.0f, 0.001f));
     REQUIRE(panel->has_background_color());
     REQUIRE(panel->has_border());


### PR DESCRIPTION
## Summary

Two P1 Codex findings on the merged #1731 (rn/borderRadius % paint-time):

### P1 #1 — Panel rendered flat because its `corner_radius_` field was shadowed
`Panel::paint()` calls `effective_corner_radius()` which only reads `View::corner_radius_`, but `Panel` kept its own private `corner_radius_` field (default 8.0f) that paint never saw. Result: every Panel rendered with whatever was last written to **View**'s slot (0 by default, or whatever `setBorderRadius()` wrote), ignoring the Panel-specific `set_corner_radius()` setter.

**Fix**: removed the shadowed field; `Panel::set_corner_radius()` now routes to `View::set_border_radius()`; constructor seeds the View slot to 8.0f so the documented default actually paints.

### P1 #2 — `View::paint_all()` ignored percent corner-radius slots
PR #1731 added `corner_radius_pct_` + `corner_radii_pct_[]` slots and `effective_corner_radius*()` helpers, but the **6 paint sites** in `View::paint_all()` (bg gradient, bg color, border stroke, outset shadow, inset shadow, outline) still read the raw px slots. `setBorderRadius('50%')` and per-corner percent setters silently had zero visible effect.

**Fix**: every paint-site read now goes through `effective_corner_radius()` / `effective_corner_radius_tl/tr/bl/br()`, which already encapsulates the px-vs-pct cascade.

## Test plan

6 new TEST_CASEs in `test/test_view.cpp` (tags `[issue-1731][panel-radius]` and `[issue-1731][percent-radius]`):
- [x] Panel default 8px corner radius actually paints (was: silently 0)
- [x] `Panel::set_corner_radius()` writes the View slot that paint reads
- [x] `View::paint_all` background honors `set_border_radius_pct()`
- [x] `View::paint_all` border stroke honors `set_border_radius_pct()`
- [x] `View::paint_all` outline honors `set_border_radius_pct()`
- [x] Regression guard: px radius still wins when pct is 0

One existing test in `test/test_widget_bridge.cpp` asserted the OLD buggy behavior (`panel->corner_radius() == 9` while paint actually rendered 6). Updated to the now-coherent 6 (matches what the user always saw on screen), with a comment explaining the history.

- [x] `ctest --test-dir build --exclude-regex AudioWorkgroup -j10` → 4729 tests, all pass on this branch.
- [x] `test/pulp-test-view "[issue-1731]"` — all 6 new tests pass.
- [x] `test/pulp-test-widget-bridge` — 2052 assertions / 348 cases pass.

Closes the open P1×2 rows on #1731 in `planning/coverage-coordination.md`.