### PR TITLE
fix(harness): canvas2d transform oracle validates canvasSetTransform (Codex P2 on #1729)

### DIFF
--- a/tools/harness/oracles/canvas2d/canvas2d-supported.json
+++ b/tools/harness/oracles/canvas2d/canvas2d-supported.json
@@ -233,10 +233,10 @@
     "transform": {
       "kind": "method",
       "bridge": [
-        "canvasTranslate"
+        "canvasSetTransform"
       ],
       "expectedStatus": "supported",
-      "notes": "PR #1701: arbitrary concat now wired (forwards composed matrix via canvasSetTransform)"
+      "notes": "PR #1701: arbitrary concat wired via canvasSetTransform — composes M' = M * given on the JS-side mirror, forwards the FULL composed matrix to the bridge (see web-compat-canvas.js:899). Pre-#1701 oracle listed canvasTranslate (the deprecated pure-translation fast path); Codex P2 on #1729 corrected the bridge ref so a regression in canvasSetTransform wiring would now be caught."
     },
     "createLinearGradient": {
       "kind": "method",


### PR DESCRIPTION
## Summary

PR #1701 wired arbitrary `ctx.transform()` concat through `canvasSetTransform` (composes M' = M * given on the JS-side mirror, forwards the FULL composed matrix to the bridge — `core/view/js/web-compat-canvas.js:899`). The oracle entry for `transform` was still inherited from the pre-#1701 era and listed `canvasTranslate` (the deprecated pure-translation fast path), so a regression in the `canvasSetTransform` wiring would NOT be caught by the oracle's bridge-binding check (`tools/harness/adapters/canvas2d.py`).

Fix: list `canvasSetTransform` — the actual bridge `ctx.transform` uses now. Notes updated to point future readers at the JS impl + record the Codex finding.

## Test plan

- [x] `python3 -m tools.harness.verifier --surface canvas2d` → canvas2d 66/66 = 100.0% PASS (unchanged; hygiene-only fix).
- [x] No SDK / plugin version bump needed (JSON-only oracle change).

Closes the open #1729 P2 row in `planning/coverage-coordination.md`.