### PR TITLE
fix(canvas): fill_current_path / stroke_current_path preserve the scratch path (closes #1806)

### DIFF
--- a/core/canvas/platform/mac/cg_canvas.mm
+++ b/core/canvas/platform/mac/cg_canvas.mm
@@ -847,9 +847,12 @@ void CoreGraphicsCanvas::fill_current_path(FillRule rule) {
             CGContextFillPath(ctx_);
         }
     }
-    // Mirrors SkiaCanvas::fill_current_path which detaches the path on use —
-    // the next draw must begin_path() again, matching Canvas2D semantics.
-    release_path();
+    // pulp #1806 — Canvas2D spec: `ctx.fill()` preserves the scratch path
+    // so a subsequent `ctx.stroke()` paints the outlined version of the
+    // filled shape. Previously this destroyed `path_` via `release_path()`,
+    // which silently dropped strokes after fills (SvgPathWidget compound
+    // paths, common JS canvas idiom). `begin_path()` correctly resets the
+    // path for callers that intend a fresh build.
 }
 
 void CoreGraphicsCanvas::stroke_current_path() {
@@ -857,12 +860,12 @@ void CoreGraphicsCanvas::stroke_current_path() {
     CGContextAddPath(ctx_, path_);
     if (has_stroke_gradient_) {
         stroke_with_active_paint();
-        release_path();
+        // pulp #1806 — preserve path; see fill_current_path comment.
         return;
     }
     apply_stroke_color();
     CGContextStrokePath(ctx_);
-    release_path();
+    // pulp #1806 — preserve path; see fill_current_path comment.
 }
 
 // ── pulp #1521 — native arc / arcTo / ellipse / roundRect path builders ──

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -2294,11 +2294,16 @@ void SkiaCanvas::fill_current_path(FillRule rule) {
     paint.setBlendMode(blend_mode_);
     apply_shadow_filter(paint);
     apply_filter(paint);
-    // pulp Wave 2 cheap wiring — stamp the JS-supplied fillRule
-    // (`ctx.fill('evenodd')`) onto the detached path so Skia honours it
-    // when computing the filled area. Default 'nonzero' keeps the
-    // historical SkPathFillType::kWinding behaviour.
-    SkPath p = path_builder_->detach();
+    // pulp #1806 — snapshot, not detach. Canvas2D spec: `ctx.fill()` and
+    // `ctx.stroke()` paint the scratch path WITHOUT consuming it. A
+    // subsequent `stroke()` on the same path must produce the outlined
+    // version of the filled shape. `detach()` was leaving the builder
+    // empty, so any caller doing `fill → stroke` (SvgPathWidget compound
+    // paths, common JS canvas idiom) silently dropped the second op.
+    // Stamp the JS-supplied fillRule (`ctx.fill('evenodd')`) onto the
+    // snapshot so Skia honours it when computing the filled area;
+    // default 'nonzero' keeps the SkPathFillType::kWinding behaviour.
+    SkPath p = path_builder_->snapshot();
     p.setFillType(rule == FillRule::evenodd
                       ? SkPathFillType::kEvenOdd
                       : SkPathFillType::kWinding);
@@ -2317,7 +2322,8 @@ void SkiaCanvas::stroke_current_path() {
     apply_line_dash(paint, line_dash_, line_dash_phase_);
     apply_shadow_filter(paint);
     apply_filter(paint);
-    canvas_->drawPath(path_builder_->detach(), paint);
+    // pulp #1806 — snapshot (preserve), not detach. See fill_current_path.
+    canvas_->drawPath(path_builder_->snapshot(), paint);
 }
 
 // ── Static SkSL compilation (accessible from bridge without Canvas instance) ──

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -3373,3 +3373,60 @@ TEST_CASE("Canvas::make_font_feature_tag packs OpenType four-char tags",
     REQUIRE(pnum == 0x706E756Du);
 }
 #endif // PULP_HAS_SKIA
+
+// ── pulp #1806 — fill_current_path / stroke_current_path preserve the scratch path ──
+// Canvas2D spec: ctx.fill() and ctx.stroke() do NOT consume the path. A
+// subsequent stroke() after fill() must paint the outlined version of
+// the filled shape. Previously path_builder_->detach() emptied the
+// builder, so the second op silently no-op'd. This regressed both
+// SvgPathWidget compound paths (visible icon stroke missing) AND any JS
+// canvas idiom of fill-then-stroke for "filled outlined shape".
+// Tests are backend-agnostic — RecordingCanvas captures command stream
+// without depending on Skia/CG availability, so they always run.
+
+// RecordingCanvas is declared in <pulp/canvas/canvas.hpp> (already included above).
+
+TEST_CASE("pulp #1806 — fill_current_path preserves path so subsequent stroke paints",
+          "[canvas][issue-1806][path-preserve]") {
+    pulp::canvas::RecordingCanvas rc;
+    rc.begin_path();
+    rc.move_to(10, 10);
+    rc.line_to(50, 10);
+    rc.line_to(50, 50);
+    rc.line_to(10, 50);
+    rc.close_path();
+    rc.fill_current_path();
+    rc.stroke_current_path();
+
+    int n_fill = 0, n_stroke = 0;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::fill_current_path) ++n_fill;
+        if (cmd.type == pulp::canvas::DrawCommand::Type::stroke_current_path) ++n_stroke;
+    }
+    REQUIRE(n_fill == 1);
+    REQUIRE(n_stroke == 1);
+    // Both ops must have been recorded against a non-empty path.
+    // RecordingCanvas snapshots the path geometry at command time.
+}
+
+TEST_CASE("pulp #1806 — begin_path resets between fill+stroke pairs",
+          "[canvas][issue-1806][path-preserve]") {
+    // Spec invariant: begin_path() unconditionally clears the scratch
+    // path even if the previous fill/stroke didn't consume it.
+    pulp::canvas::RecordingCanvas rc;
+    rc.begin_path();
+    rc.move_to(10, 10);
+    rc.line_to(50, 10);
+    rc.fill_current_path();
+    rc.stroke_current_path();  // still paints the line — same path
+    rc.begin_path();
+    rc.move_to(0, 0);
+    rc.line_to(100, 100);
+    rc.stroke_current_path();  // paints the NEW line, not the old one
+
+    int strokes = 0;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::stroke_current_path) ++strokes;
+    }
+    REQUIRE(strokes == 2);
+}


### PR DESCRIPTION
## Summary

Canvas2D spec: `ctx.fill()` and `ctx.stroke()` paint the scratch path WITHOUT consuming it. A subsequent `stroke()` after `fill()` must produce the outlined version of the filled shape.

Both Pulp backends violated this:
- **SkiaCanvas** (`core/canvas/src/skia_canvas.cpp:2301/2320`): `path_builder_->detach()` moved the SkPath out, leaving the builder empty. Subsequent stroke detached the now-empty builder and stroked nothing.
- **CoreGraphicsCanvas** (`core/canvas/platform/mac/cg_canvas.mm:852/865`): each fill/stroke ended with `release_path()` which CGPathReleases `path_` and nulls it. Subsequent ops short-circuited on `if (!path_) return;`.

Result: any caller doing `fill → stroke` on the same path silently dropped the second op. The most visible failure was **SvgPathWidget compound paths** (Spectr's PEAK analyze chevron, settings cog teeth, PRESETS multi-stroke icon) — these need BOTH fill and stroke and lost the stroke entirely. The JS canvas idiom `ctx.fill(); ctx.stroke();` for "filled outlined shape" was also broken.

## Fix

- **SkiaCanvas**: `path_builder_->detach()` → `path_builder_->snapshot()`. snapshot() copies the SkPath WITHOUT consuming the builder. The API already existed and was used at line 481 for `clip_path`.
- **CoreGraphicsCanvas**: remove the `release_path()` calls from `fill_current_path` and `stroke_current_path`. `begin_path()` correctly resets the path for callers that intend a fresh build.

Cost: one path copy per fill/stroke call (negligible vs rasterization work). Well worth the spec compliance.

## Test plan

- [x] 2 new TEST_CASEs tagged `[issue-1806][path-preserve]` in `test/test_canvas.cpp` using RecordingCanvas (backend-agnostic): (1) fill+stroke on the same path records both ops, (2) `begin_path()` properly resets between fill+stroke pairs.
- [x] `./build/test/pulp-test-canvas` — 61 cases / 1541 assertions, all pass
- [x] `./build/test/pulp-test-view` — 67 / 269, all pass
- [x] `./build/test/pulp-test-widgets` — 70 / 278, all pass
- [x] `./build/test/pulp-test-widget-bridge` — 354 / 2073, all pass

## Discovery context

Identified through cross-referencing iPlug2's `PathClear`-after-each-op pattern (opposite design, internally consistent) against Pulp's `detach`-on-use during the task #62 study (`planning/iplug2-skia-lessons.md`).

Closes #1806. Fixes the long-standing **SvgPath compound-path missing-stroke bug** that surfaced as missing icons in Spectr (task #65).