### PR TITLE
fix(view): mac mouseDown/keyDown stale pointers — PAC crash on react unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0920"></a>
+## [0.93.0]
+
 ## [0.92.0] - 2026-05-11
 
 - feat(view): rn/borderCurve squircle + css/rn isolation flip (RN to 100% PASS) ([#1816](https://github.com/danielraffel/pulp/pull/1816))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.92.0
+    VERSION 0.93.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/ui_components.hpp
+++ b/core/view/include/pulp/view/ui_components.hpp
@@ -32,6 +32,16 @@ public:
         set_access_role(AccessRole::slider);
     }
 
+    // pulp #1818 — clear the static `active_popup_` slot if this dying
+    // ComboBox holds it. Without this, an unmounted React dropdown leaves
+    // a dangling pointer that the platform window host dereferences on
+    // the next mouseDown (PAC failure on the vtable load — exact crash
+    // signature in the issue). Pattern matches `~View()` for `active_overlay_`
+    // and `focused_input_`.
+    ~ComboBox() override {
+        if (active_popup_ == this) active_popup_ = nullptr;
+    }
+
     void set_items(std::vector<std::string> items) { items_ = std::move(items); }
     const std::vector<std::string>& items() const { return items_; }
 

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -374,6 +374,21 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             }
             auto pt = [self localPoint:event];
 
+            // pulp #1818 — the Obj-C `_focusedView` ivar is a parallel
+            // pointer to `pulp::view::View::focused_input_`. The static is
+            // auto-cleared by ~View() (pulp #1708) when the focused widget
+            // is destroyed (e.g., a React unmount of a clicked widget),
+            // but nothing clears the ivar. The next mouseDown then
+            // dereferences `_focusedView->on_focus_changed(false)` on
+            // freed memory and PAC-faults on the vtable load — this is
+            // the exact crash in pulp #1818 ("-[PulpView mouseDown:] + 664",
+            // KERN_INVALID_ADDRESS, x9 = corrupt high bits). Re-sync from
+            // the auto-clearing static at the top of every mouseDown so
+            // the ivar can never be dangling for any deref below.
+            if (_focusedView && _focusedView != pulp::view::View::focused_input_) {
+                _focusedView = pulp::view::View::focused_input_;
+            }
+
         // Inspector intercept — consume clicks when inspector is active
         {
             auto mods = modifiersFromNSFlags(event.modifierFlags);
@@ -713,6 +728,17 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
         try {
             auto key = keyCodeFromNS(event.keyCode);
             auto mods = modifiersFromNSFlags(event.modifierFlags);
+
+            // pulp #1818 — re-sync the Obj-C `_focusedView` ivar from the
+            // auto-clearing `View::focused_input_` static. Same rationale
+            // as mouseDown: if the focused View was unmounted between the
+            // last input event and this one (~View clears the static),
+            // the ivar still dangles and any deref below (Tab nav at
+            // L749/751 or the final dispatch at L808) would PAC-fault on
+            // freed memory.
+            if (_focusedView && _focusedView != pulp::view::View::focused_input_) {
+                _focusedView = pulp::view::View::focused_input_;
+            }
 
         // Inspector intercept — check before all other key handling
         {

--- a/test/test_combo_dropdown.cpp
+++ b/test/test_combo_dropdown.cpp
@@ -201,3 +201,55 @@ TEST_CASE("ComboBox: opening a second dropdown closes the first [issue-overlay]"
 
     ComboBox::close_active_popup();
 }
+
+// pulp #1818 — when a ComboBox is destroyed while its dropdown is open,
+// `~ComboBox` MUST clear the static `active_popup_` slot. Otherwise the
+// platform window host dereferences a dangling pointer on the next
+// mouseDown (PAC failure on the vtable load — exact crash signature in
+// the issue report). Reproducer: open dropdown (sets active_popup_),
+// drop the ComboBox, assert the slot is nullptr.
+TEST_CASE("ComboBox: dtor clears active_popup_ when destroyed while open [issue-1818]",
+          "[combo][regression][issue-1818]") {
+    ComboBox::close_active_popup();
+    REQUIRE(ComboBox::active_popup_ == nullptr);
+
+    {
+        ComboBox combo;
+        combo.set_items({"one", "two", "three"});
+        combo.set_bounds({0, 0, 100, 28});
+
+        MouseEvent click;
+        click.position = {50.0f, 14.0f};
+        click.is_down = true;
+        combo.on_mouse_event(click);
+
+        REQUIRE(combo.is_open());
+        REQUIRE(ComboBox::active_popup_ == &combo);
+    }
+    // Destructor ran — the static must NOT still hold a freed pointer,
+    // because any subsequent `notify_global_click` / window-host
+    // `active_popup_` deref would crash.
+    REQUIRE(ComboBox::active_popup_ == nullptr);
+
+    // notify_global_click is the hot path called from -[PulpView mouseDown:].
+    // Must be safe to call after the dropdown owner has been freed.
+    ComboBox::notify_global_click(nullptr);
+    REQUIRE(ComboBox::active_popup_ == nullptr);
+}
+
+// pulp #1818 — same shape for `View::active_overlay_`. This regression
+// guard mirrors the pulp #1148 fix already present in `~View()` but
+// asserts it explicitly so a future refactor that drops the clear is
+// caught immediately rather than at the next user click.
+TEST_CASE("View: dtor clears active_overlay_ when destroyed while claimed [issue-1818]",
+          "[view][regression][issue-1818]") {
+    REQUIRE(pulp::view::View::active_overlay_ == nullptr);
+
+    {
+        pulp::view::View v;
+        v.claim_overlay();
+        REQUIRE(pulp::view::View::active_overlay_ == &v);
+    }
+    REQUIRE(pulp::view::View::active_overlay_ == nullptr);
+}
+


### PR DESCRIPTION
## Summary

Fixes the EXC_BAD_ACCESS at `-[PulpView mouseDown:] + 664` seen on first click into a React-tree-managed widget after #1817 enabled GPU rendering. Two dangling-pointer bugs in the macOS window-host event path, both triggered when React unmounts the clicked widget between mouseDown and the next input event:

1. `ComboBox::active_popup_` static was never cleared on ComboBox destruction — same shape as the pulp #1148 fix for `View::active_overlay_`. Added `~ComboBox()` that clears the static if `this` is the popup owner.
2. `PulpView`'s Obj-C `_focusedView` ivar is a parallel pointer to `pulp::view::View::focused_input_` (the auto-clearing static from #1708). The static gets cleared in `~View()` on unmount, but the ivar continued to point at freed memory. mouseDown/keyDown then deref'd it for `on_focus_changed(false)` / `on_key_event` / Tab-nav, crashing on the vtable load (matches `ldr x9, [x9, #0x70]` at +664 in the user's disassembly).

Resync the ivar against `View::focused_input_` at the top of `mouseDown:` and `keyDown:` — cheap, narrow, fail-closed.

Closes #1818

## Test plan

- [x] New tests `test/test_combo_dropdown.cpp` — `[issue-1818]` cases for ComboBox destruction clearing `active_popup_`, and stale-popup-after-unmount survival.
- [x] Manually verified: Spectr standalone built against the patched SDK, clicked into the spectrum repeatedly — no crash (was reproducing 100% on first click before this fix).
- [x] Screenshot: `planning/screenshots/spectr-v0.91.0-combined-fix.png` shows post-fix GPU-rendered spectrum with bands.