### PR TITLE
fix(mcp): wrap pulp-mcp in launcher so .mcp.json resolves regardless of cwd

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "pulp": {
-      "command": "./build/tools/mcp/pulp-mcp",
+      "command": "${CLAUDE_PLUGIN_ROOT}/tools/mcp/pulp-mcp-launcher",
       "env": {}
     }
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,6 +75,16 @@ if(UNIX)
     set_tests_properties(retry-git-clone PROPERTIES TIMEOUT 30)
 endif()
 
+# Launcher unit test (pulp #1821) — verifies tools/mcp/pulp-mcp-launcher
+# resolves the source-tree build, falls back to $PATH, and emits a
+# readable diagnostic when neither is present. Hermetic (stages a
+# tempdir layout), no real binary required.
+if(UNIX)
+    add_test(NAME pulp-mcp-launcher
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_pulp_mcp_launcher.sh)
+    set_tests_properties(pulp-mcp-launcher PROPERTIES TIMEOUT 15)
+endif()
+
 # Android end-to-end smoke (issue #337). Runs the tools/scripts/android_smoke.sh
 # against a locally attached emulator or device. Skipped by default because
 # the smoke requires an already-booted AVD/device and an arm64-v8a APK —

--- a/test/test_pulp_mcp_launcher.sh
+++ b/test/test_pulp_mcp_launcher.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# Unit test for tools/mcp/pulp-mcp-launcher. Verifies the fix in pulp #1821:
+# the launcher (referenced from .mcp.json so Claude Code can resolve the
+# pulp-mcp binary regardless of cwd) finds the source-tree build, falls
+# back to $PATH, and emits a useful diagnostic when neither is available.
+#
+# Run directly:
+#   bash test/test_pulp_mcp_launcher.sh
+#
+# Exits 0 on pass, non-zero on fail.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LAUNCHER_SRC="$SCRIPT_DIR/tools/mcp/pulp-mcp-launcher"
+
+if [ ! -x "$LAUNCHER_SRC" ]; then
+    echo "FAIL: launcher not executable at $LAUNCHER_SRC" >&2
+    exit 1
+fi
+
+TMPDIR_T="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_T"' EXIT
+
+# Each case stages the launcher into a fresh fake-repo layout so the
+# launcher's BASH_SOURCE-based resolution can be exercised without
+# touching the real repo's build/ dir.
+stage_fake_repo() {
+    local repo="$1"
+    mkdir -p "$repo/tools/mcp"
+    cp "$LAUNCHER_SRC" "$repo/tools/mcp/pulp-mcp-launcher"
+    chmod +x "$repo/tools/mcp/pulp-mcp-launcher"
+}
+
+pass() { echo "PASS: $*"; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Case 1: no source-tree binary, nothing on PATH → diagnostic + exit 127.
+# ---------------------------------------------------------------------------
+case1="$TMPDIR_T/case1"
+stage_fake_repo "$case1"
+
+set +e
+output=$(PATH=/usr/bin:/bin "$case1/tools/mcp/pulp-mcp-launcher" 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" -ne 127 ]; then
+    fail "case1: expected exit 127 when no binary found, got $rc (output: $output)"
+fi
+if ! grep -q "cannot locate pulp-mcp binary" <<<"$output"; then
+    fail "case1: diagnostic missing 'cannot locate pulp-mcp binary' (output: $output)"
+fi
+if ! grep -q "$case1/build/tools/mcp/pulp-mcp" <<<"$output"; then
+    fail "case1: diagnostic should reference resolved candidate path (output: $output)"
+fi
+pass "case1: no-binary error path emits readable diagnostic + exits 127"
+
+# ---------------------------------------------------------------------------
+# Case 2: source-tree binary present → launcher exec's it (stub echoes a
+# canary; PATH is scrubbed so a real pulp-mcp install can't interfere).
+# ---------------------------------------------------------------------------
+case2="$TMPDIR_T/case2"
+stage_fake_repo "$case2"
+mkdir -p "$case2/build/tools/mcp"
+cat > "$case2/build/tools/mcp/pulp-mcp" <<'STUB'
+#!/usr/bin/env bash
+echo "PULP_MCP_LAUNCHER_TEST_CANARY"
+exit 0
+STUB
+chmod +x "$case2/build/tools/mcp/pulp-mcp"
+
+set +e
+output=$(PATH=/usr/bin:/bin "$case2/tools/mcp/pulp-mcp-launcher" 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" -ne 0 ]; then
+    fail "case2: expected exit 0 when stub binary runs cleanly, got $rc (output: $output)"
+fi
+if [ "$output" != "PULP_MCP_LAUNCHER_TEST_CANARY" ]; then
+    fail "case2: expected stub canary, got: $output"
+fi
+pass "case2: source-tree build is exec'd when present"
+
+# ---------------------------------------------------------------------------
+# Case 3: source-tree binary absent but pulp-mcp on $PATH → PATH stub runs.
+# ---------------------------------------------------------------------------
+case3="$TMPDIR_T/case3"
+stage_fake_repo "$case3"
+
+pathdir="$TMPDIR_T/case3-path"
+mkdir -p "$pathdir"
+cat > "$pathdir/pulp-mcp" <<'STUB'
+#!/usr/bin/env bash
+echo "PULP_MCP_PATH_FALLBACK_CANARY"
+exit 0
+STUB
+chmod +x "$pathdir/pulp-mcp"
+
+set +e
+output=$(PATH="$pathdir:/usr/bin:/bin" "$case3/tools/mcp/pulp-mcp-launcher" 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" -ne 0 ]; then
+    fail "case3: expected exit 0 when PATH fallback runs cleanly, got $rc (output: $output)"
+fi
+if [ "$output" != "PULP_MCP_PATH_FALLBACK_CANARY" ]; then
+    fail "case3: expected PATH-fallback canary, got: $output"
+fi
+pass "case3: \$PATH fallback runs when source-tree build is absent"
+
+# ---------------------------------------------------------------------------
+# Case 4: argv is forwarded — launcher must exec, not interpret args.
+# ---------------------------------------------------------------------------
+case4="$TMPDIR_T/case4"
+stage_fake_repo "$case4"
+mkdir -p "$case4/build/tools/mcp"
+cat > "$case4/build/tools/mcp/pulp-mcp" <<'STUB'
+#!/usr/bin/env bash
+echo "ARGS:$*"
+exit 0
+STUB
+chmod +x "$case4/build/tools/mcp/pulp-mcp"
+
+set +e
+output=$(PATH=/usr/bin:/bin "$case4/tools/mcp/pulp-mcp-launcher" --foo bar baz 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" -ne 0 ]; then
+    fail "case4: expected exit 0, got $rc (output: $output)"
+fi
+if [ "$output" != "ARGS:--foo bar baz" ]; then
+    fail "case4: launcher did not forward argv as-is (output: $output)"
+fi
+pass "case4: argv forwarded verbatim"
+
+echo "OK — all 4 cases passed."

--- a/tools/mcp/pulp-mcp-launcher
+++ b/tools/mcp/pulp-mcp-launcher
@@ -1,0 +1,40 @@
+#!/bin/bash
+# pulp-mcp launcher — invoked from .mcp.json so Claude Code can find the
+# pulp-mcp binary regardless of the cwd it spawns the MCP server with.
+#
+# Resolution order:
+#   1. ${CLAUDE_PLUGIN_ROOT-derived}/build/tools/mcp/pulp-mcp  (source-tree build)
+#   2. pulp-mcp on $PATH                                       (installed binary)
+#
+# If neither is found, the launcher emits a readable diagnostic on stderr
+# and exits 127 so Claude Code surfaces the failure rather than treating
+# it as silent. See pulp #1821.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+CANDIDATE_SOURCE_BUILD="$REPO_ROOT/build/tools/mcp/pulp-mcp"
+if [ -x "$CANDIDATE_SOURCE_BUILD" ]; then
+  exec "$CANDIDATE_SOURCE_BUILD" "$@"
+fi
+
+if command -v pulp-mcp >/dev/null 2>&1; then
+  exec pulp-mcp "$@"
+fi
+
+cat >&2 <<EOF
+pulp-mcp-launcher: cannot locate pulp-mcp binary.
+
+Looked in:
+  1. $CANDIDATE_SOURCE_BUILD  (source-tree build)
+  2. \$PATH (no executable named 'pulp-mcp' found)
+
+Fix one of:
+  - Build it: 'cmake --build build --target pulp-mcp' from $REPO_ROOT
+  - Install it on \$PATH so 'pulp-mcp' resolves globally
+
+See https://github.com/danielraffel/pulp/issues/1821 for context.
+EOF
+exit 127


### PR DESCRIPTION
## Summary

`.mcp.json` previously used a bare relative path (`./build/tools/mcp/pulp-mcp`) for the pulp MCP server command. Claude Code did not consistently invoke it because the cwd it spawned the server with was not guaranteed to be the plugin's root, so the relative path did not resolve and the MCP silently failed to load.

- New executable `tools/mcp/pulp-mcp-launcher` — resolves its own directory via `BASH_SOURCE` then exec's the binary it finds in (1) the source-tree build, (2) `$PATH`, or (3) exits 127 with a readable stderr diagnostic.
- `.mcp.json` switched to `${CLAUDE_PLUGIN_ROOT}/tools/mcp/pulp-mcp-launcher` — same path-substitution pulp's `hooks/hooks.json` already uses.

Closes #1821.

## Test plan

- [x] `bash test/test_pulp_mcp_launcher.sh` — 4 cases (no-binary error, source-tree happy path, `$PATH` fallback, argv forwarding). All pass locally.
- [x] CMake wires it as CTest `pulp-mcp-launcher` (UNIX-gated, 15s timeout).
- [ ] Post-merge + plugin reinstall: restart Claude Code, confirm pulp MCP tools surface in `ToolSearch`.
- [ ] Negative path: rename binary aside, confirm launcher diagnostic surfaces in Claude Code's MCP error log (not silent failure).

## Out of scope

Shipping a precompiled pulp-mcp binary in plugin release artifacts (so marketplace-cache users without a local build still get a working MCP). Worth filing once this lands.