### PR TITLE
feat(import-design): promote interactive frames to buttons (post-parse pass)

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -396,3 +396,23 @@ if (typeof globalThis.registerPointer === 'function') globalThis.registerPointer
 ```
 
 The cleaner long-term fix is for `@pulp/react`'s prop-applier to call `registerPointer` automatically when it sees any pointer-event prop (parallel to its existing `registerHover` wiring) — track that as a follow-up Pulp issue rather than an importer-side workaround if you encounter it on a fresh import.
+
+### 9. Post-parse widget promotion — `<div onClick>` → button
+
+`pulp::import_design::promote_interactive_frames` (in `tools/import-design/widget_promotion.{hpp,cpp}`) walks the IR once after parse + before codegen and re-types any `type == "frame"` carrying an interactive signal to `type == "button"`. Signal priority (highest → lowest):
+
+1. `attributes["onclick"]` / `attributes["onClick"]` — strongest.
+2. `attributes["role"] == "button"` — explicit ARIA semantic.
+3. `style.cursor == "pointer"` — weakest; opt-out via `role="presentation"`.
+
+Conservative on purpose: only frames are promoted; already-typed widgets (`input`, `image`, `button`) are left alone, so a designer who wrote `<input onClick={...}>` keeps the input.
+
+**Gotcha**: the post-pass is source-agnostic, but **only the runtime-import path (`parse_claude_html_with_runtime`) actually populates `IRNode::attributes` with HTML attrs** (it walks the live DOM after React mount). The non-runtime parsers — `parse_stitch_html`, `parse_v0_tsx`, `parse_pencil_json`, `parse_figma_json`'s JSON-attrs path — currently strip `onclick` / `role` before the IR gets handed to the promoter, so promotion silently no-ops on those sources. Tracked as pulp #1823.
+
+When you re-import Spectr's `editor.html` via Claude Design + the runtime path, expect:
+
+```
+Promoted N interactive frame(s) to button widgets.
+```
+
+in the stdout summary. If you see `0 widgets` and no promotion line on a fixture you *know* contains `<div onClick>`, you're either (a) on a non-runtime parser path (#1823 territory) or (b) the React tree didn't mount during the harness eval and `attributes` is empty as a result.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1664,6 +1664,20 @@ add_executable(pulp-test-design-import test_design_import.cpp)
 target_link_libraries(pulp-test-design-import PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-design-import)
 
+# Post-parse widget promotion: <div onClick> / role=button / cursor:pointer
+# → button. Closure of pulp-internal task #84 / follow-up on #1814.
+# Links the importer-side .cpp directly (it's not in pulp::view) so the
+# test exercises the same code path the CLI uses.
+add_executable(pulp-test-widget-promotion
+    test_widget_promotion.cpp
+    ${CMAKE_SOURCE_DIR}/tools/import-design/widget_promotion.cpp)
+target_include_directories(pulp-test-widget-promotion PRIVATE
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(pulp-test-widget-promotion PRIVATE
+    pulp::view
+    Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-widget-promotion)
+
 # pulp #468 — web-compat preludes shipped for bundled-React imports
 # (nodeType / nodeName, observer no-ops, scheduler shims). Uses
 # WidgetBridge to evaluate the same prelude stack the runtime ships.

--- a/test/test_widget_promotion.cpp
+++ b/test/test_widget_promotion.cpp
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: MIT
+//
+// Unit tests for pulp::import_design::promote_interactive_frames — the
+// post-parse pass that re-types interactive frames (<div onClick>, ARIA
+// role="button", cursor:pointer) to "button" so the importer doesn't
+// drop the user's interactive intent on the floor.
+//
+// pulp-internal task #84 (follow-up to issue #1814). Covers the four
+// promotion paths plus the non-promotion guardrails: explicit
+// role="presentation", non-frame node types, and already-typed widgets.
+
+#include "../tools/import-design/widget_promotion.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/view/design_import.hpp>
+
+using pulp::view::IRNode;
+using pulp::import_design::WidgetPromotionSignal;
+using pulp::import_design::classify_interactive_signal;
+using pulp::import_design::promote_interactive_frames;
+
+namespace {
+
+IRNode make_frame(const std::string& name = "") {
+    IRNode n;
+    n.type = "frame";
+    n.name = name;
+    return n;
+}
+
+}  // namespace
+
+TEST_CASE("widget_promotion: html lowercase onclick promotes a frame to button", "[import][widget][issue-1814]") {
+    IRNode div = make_frame("clickable-div");
+    div.attributes["onclick"] = "handleClick()";
+
+    REQUIRE(classify_interactive_signal(div) == WidgetPromotionSignal::onclick_attribute);
+
+    REQUIRE(promote_interactive_frames(div) == 1);
+    REQUIRE(div.type == "button");
+}
+
+TEST_CASE("widget_promotion: jsx onClick promotes a frame to button", "[import][widget][issue-1814]") {
+    IRNode div = make_frame("jsx-handler");
+    // The runtime-import path (parse_claude_html_with_runtime) walks the
+    // live DOM after React mount, so JSX-style camelCase props are what
+    // it preserves in IRNode.attributes.
+    div.attributes["onClick"] = "{handlePress}";
+
+    REQUIRE(classify_interactive_signal(div) == WidgetPromotionSignal::onclick_attribute);
+
+    REQUIRE(promote_interactive_frames(div) == 1);
+    REQUIRE(div.type == "button");
+}
+
+TEST_CASE("widget_promotion: aria role=button promotes regardless of click handler presence", "[import][widget][issue-1814]") {
+    IRNode div = make_frame("aria-btn");
+    div.attributes["role"] = "button";
+    // No onclick — purely the ARIA semantic claim.
+
+    REQUIRE(classify_interactive_signal(div) == WidgetPromotionSignal::aria_role_button);
+
+    REQUIRE(promote_interactive_frames(div) == 1);
+    REQUIRE(div.type == "button");
+}
+
+TEST_CASE("widget_promotion: cursor:pointer promotes when no stronger signal disagrees", "[import][widget][issue-1814]") {
+    IRNode div = make_frame("cursor-only");
+    div.style.cursor = std::string{"pointer"};
+
+    REQUIRE(classify_interactive_signal(div) == WidgetPromotionSignal::cursor_pointer);
+
+    REQUIRE(promote_interactive_frames(div) == 1);
+    REQUIRE(div.type == "button");
+}
+
+TEST_CASE("widget_promotion: role=presentation opts a cursor:pointer frame out", "[import][widget][issue-1814]") {
+    // Designers occasionally set cursor:pointer on hover affordances or
+    // pseudo-link wrappers that aren't actually clickable. The
+    // canonical way to opt out is role="presentation"; honor that.
+    IRNode div = make_frame("decorative");
+    div.style.cursor = std::string{"pointer"};
+    div.attributes["role"] = "presentation";
+
+    REQUIRE(classify_interactive_signal(div) == WidgetPromotionSignal::none);
+
+    REQUIRE(promote_interactive_frames(div) == 0);
+    REQUIRE(div.type == "frame");
+}
+
+TEST_CASE("widget_promotion: already-typed widgets are not re-classified", "[import][widget][issue-1814]") {
+    // Critical guardrail — a designer who explicitly wrote <input
+    // onClick=...> should keep the input type, not silently flip to
+    // button.
+    IRNode input;
+    input.type = "input";
+    input.name = "search-box";
+    input.attributes["onClick"] = "{handleFocus}";
+
+    REQUIRE(classify_interactive_signal(input) == WidgetPromotionSignal::none);
+
+    REQUIRE(promote_interactive_frames(input) == 0);
+    REQUIRE(input.type == "input");
+
+    IRNode existing_button;
+    existing_button.type = "button";
+    existing_button.attributes["onClick"] = "{handlePress}";
+
+    REQUIRE(classify_interactive_signal(existing_button) == WidgetPromotionSignal::none);
+
+    REQUIRE(promote_interactive_frames(existing_button) == 0);
+    REQUIRE(existing_button.type == "button");
+}
+
+TEST_CASE("widget_promotion: pass is recursive — nested interactive frames all promote", "[import][widget][issue-1814]") {
+    IRNode root = make_frame("root");
+    {
+        IRNode header = make_frame("header");
+        IRNode close = make_frame("close-icon");
+        close.attributes["onclick"] = "dismiss()";
+        header.children.push_back(std::move(close));
+        root.children.push_back(std::move(header));
+    }
+    {
+        IRNode list = make_frame("list");
+        for (int i = 0; i < 3; ++i) {
+            IRNode item = make_frame("item-" + std::to_string(i));
+            item.style.cursor = std::string{"pointer"};
+            list.children.push_back(std::move(item));
+        }
+        root.children.push_back(std::move(list));
+    }
+
+    REQUIRE(promote_interactive_frames(root) == 4);
+    REQUIRE(root.type == "frame");                                  // root has no signal
+    REQUIRE(root.children[0].type == "frame");                      // header has no signal
+    REQUIRE(root.children[0].children[0].type == "button");         // close-icon
+    REQUIRE(root.children[1].type == "frame");                      // list container
+    REQUIRE(root.children[1].children[0].type == "button");
+    REQUIRE(root.children[1].children[1].type == "button");
+    REQUIRE(root.children[1].children[2].type == "button");
+}
+
+TEST_CASE("widget_promotion: pass is idempotent — second invocation is a no-op", "[import][widget][issue-1814]") {
+    IRNode div = make_frame("idempotent");
+    div.attributes["onclick"] = "go()";
+
+    REQUIRE(promote_interactive_frames(div) == 1);
+    REQUIRE(div.type == "button");
+    REQUIRE(promote_interactive_frames(div) == 0);  // already a button
+    REQUIRE(div.type == "button");
+}
+
+TEST_CASE("widget_promotion: promoted parent stops descendant promotion — no nested buttons",
+          "[import][widget][issue-1814]") {
+    // Codex P2 on PR #1824 — a clickable container with clickable
+    // children must not produce nested <button> elements. The
+    // generated UI relies on the promoted parent's click handler to
+    // cover the whole subtree; nested buttons would break click/focus
+    // semantics.
+    IRNode parent = make_frame("clickable-parent");
+    parent.attributes["onclick"] = "selectRow()";
+
+    IRNode child_a = make_frame("inner-clickable");
+    child_a.style.cursor = std::string{"pointer"};
+
+    IRNode child_b = make_frame("inner-aria");
+    child_b.attributes["role"] = "button";
+
+    parent.children.push_back(std::move(child_a));
+    parent.children.push_back(std::move(child_b));
+
+    REQUIRE(promote_interactive_frames(parent) == 1);
+    REQUIRE(parent.type == "button");
+    // Children stay as frames — the parent's promotion swallows
+    // their interactive intent.
+    REQUIRE(parent.children[0].type == "frame");
+    REQUIRE(parent.children[1].type == "frame");
+}
+
+TEST_CASE("widget_promotion: iterative walker handles deep IR without stack blowup",
+          "[import][widget][issue-1814]") {
+    // Codex P2 on PR #1824 — the prior implementation called itself
+    // recursively despite a comment claiming "iterative walk." On a
+    // 5000-deep linear IR (within reason for some Figma exports
+    // post-flatten), recursive descent would stack-overflow on most
+    // hosts. The worklist-based pass should handle it cleanly.
+    //
+    // Tree shape: a 5000-deep linear chain with NO promotable nodes,
+    // capped by a single promotable leaf. If the walker stack-
+    // overflows, the test crashes; if the walker short-circuits
+    // before reaching the leaf, the count is wrong.
+    IRNode root = make_frame("root");
+    IRNode* cursor = &root;
+    constexpr int kDepth = 5000;
+    for (int i = 0; i < kDepth; ++i) {
+        cursor->children.push_back(make_frame("node-" + std::to_string(i)));
+        cursor = &cursor->children.back();
+    }
+    // Promotable leaf at the bottom.
+    cursor->attributes["onclick"] = "f()";
+
+    REQUIRE(promote_interactive_frames(root) == 1);
+    REQUIRE(cursor->type == "button");
+}
+
+TEST_CASE("widget_promotion: iterative walker handles wide IR without missing siblings",
+          "[import][widget][issue-1814]") {
+    // Sibling-coverage companion to the deep-walk test. 1000 sibling
+    // frames under one root, every other one promotable. Confirms the
+    // worklist visits every direct child + the promotion count
+    // matches expectation (no off-by-one or worklist-order bug).
+    IRNode root = make_frame("root");
+    constexpr int kWidth = 1000;
+    for (int i = 0; i < kWidth; ++i) {
+        IRNode child = make_frame("sibling-" + std::to_string(i));
+        if (i % 2 == 0) {
+            child.attributes["onclick"] = "f()";
+        }
+        root.children.push_back(std::move(child));
+    }
+
+    REQUIRE(promote_interactive_frames(root) == kWidth / 2);
+    // Spot-check pre-order: child[0] is promoted, child[1] is not,
+    // child[2] is promoted — so the walker visited them in
+    // left-to-right order.
+    REQUIRE(root.children[0].type == "button");
+    REQUIRE(root.children[1].type == "frame");
+    REQUIRE(root.children[2].type == "button");
+}
+
+TEST_CASE("widget_promotion: stronger signal wins when several are present", "[import][widget][issue-1814]") {
+    // When onClick + role=button + cursor:pointer are all set, we expect
+    // the onClick branch (highest-priority signal). Classifier
+    // documents the precedence; the test pins it.
+    IRNode div = make_frame("all-signals");
+    div.attributes["onclick"] = "press()";
+    div.attributes["role"] = "button";
+    div.style.cursor = std::string{"pointer"};
+
+    REQUIRE(classify_interactive_signal(div) == WidgetPromotionSignal::onclick_attribute);
+
+    REQUIRE(promote_interactive_frames(div) == 1);
+    REQUIRE(div.type == "button");
+}

--- a/tools/import-design/CMakeLists.txt
+++ b/tools/import-design/CMakeLists.txt
@@ -5,6 +5,7 @@
 # the test target without dragging the full pulp::view pipeline along.
 add_executable(pulp-import-design
     pulp_import_design.cpp
-    import_detect.cpp)
+    import_detect.cpp
+    widget_promotion.cpp)
 target_include_directories(pulp-import-design PRIVATE ${CMAKE_SOURCE_DIR})
 target_link_libraries(pulp-import-design PRIVATE pulp::view pulp::state)

--- a/tools/import-design/pulp_import_design.cpp
+++ b/tools/import-design/pulp_import_design.cpp
@@ -6,6 +6,7 @@
 #include <pulp/view/widget_bridge.hpp>
 #include <pulp/state/store.hpp>
 #include "import_detect.hpp"
+#include "widget_promotion.hpp"
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -416,6 +417,20 @@ int main(int argc, char* argv[]) {
     // Store frame/screen selection metadata
     if (!frame_name.empty()) ir.root.attributes["frame"] = frame_name;
     if (!screen_name.empty()) ir.root.attributes["screen"] = screen_name;
+
+    // Promote interactive frames to buttons (post-parse, pre-codegen).
+    // Figma / Stitch / v0 / Pencil / Claude Design exporters almost
+    // never emit <button> directly — they emit <div onClick={...}> or
+    // <div role="button"> or cursor:pointer divs. Without this pass
+    // those land as static frames and the user's interactive intent
+    // is dropped. Source-agnostic so every importer benefits. See
+    // task #84 / pulp-internal #1814 follow-up.
+    const std::size_t promoted_widgets =
+        pulp::import_design::promote_interactive_frames(ir.root);
+    if (promoted_widgets > 0) {
+        std::cout << "Promoted " << promoted_widgets
+                  << " interactive frame(s) to button widgets.\n";
+    }
 
     // Generate Pulp JS
     CodeGenOptions opts;

--- a/tools/import-design/widget_promotion.cpp
+++ b/tools/import-design/widget_promotion.cpp
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+//
+// Implementation of the post-parse widget-promotion pass.
+// See widget_promotion.hpp for the rationale.
+
+#include "widget_promotion.hpp"
+
+#include <pulp/view/design_import.hpp>
+
+#include <string>
+#include <vector>
+
+namespace pulp::import_design {
+
+WidgetPromotionSignal classify_interactive_signal(const pulp::view::IRNode& node) {
+    // We only promote frames — never re-classify already-typed widgets.
+    if (node.type != "frame") {
+        return WidgetPromotionSignal::none;
+    }
+
+    // 1. Direct click handler — strongest signal. The importer attribute
+    //    walker preserves whatever the HTML / JSX exporter wrote, so we
+    //    accept both the HTML spelling (`onclick`) and the JSX spelling
+    //    (`onClick`).
+    if (node.attributes.count("onclick") || node.attributes.count("onClick")) {
+        return WidgetPromotionSignal::onclick_attribute;
+    }
+
+    // 2. ARIA role — explicit semantic claim from the designer that the
+    //    div behaves like a button. Treat as authoritative.
+    if (auto it = node.attributes.find("role");
+        it != node.attributes.end() && it->second == "button") {
+        return WidgetPromotionSignal::aria_role_button;
+    }
+
+    // 3. cursor:pointer — weaker signal because designers also set it on
+    //    decorative links / hover affordances. But for the import path
+    //    it's still the only signal Figma copy-CSS / Stitch usually emit
+    //    on otherwise-bare clickable divs, so we accept it. Producers
+    //    that want a static cursor:pointer frame can opt out by setting
+    //    `role="presentation"` (handled implicitly: we don't recognize
+    //    presentation as a promotion signal, and the explicit role wins
+    //    earlier).
+    if (node.style.cursor && *node.style.cursor == "pointer") {
+        // If the producer simultaneously set role="presentation", honor
+        // their explicit non-widget intent.
+        if (auto it = node.attributes.find("role");
+            it != node.attributes.end() && it->second == "presentation") {
+            return WidgetPromotionSignal::none;
+        }
+        return WidgetPromotionSignal::cursor_pointer;
+    }
+
+    return WidgetPromotionSignal::none;
+}
+
+std::size_t promote_interactive_frames(pulp::view::IRNode& root) {
+    std::size_t promoted = 0;
+
+    // Heap-backed worklist so deeply-nested designs (Figma / Claude
+    // Design exports occasionally reach 60+ levels) don't blow the
+    // process stack — the prior recursive walker tripped Codex P2 on
+    // PR #1824 for this exact reason. We push raw pointers so the
+    // children-pointer stays stable across pushes; the worklist never
+    // outlives the call so there's no dangling-pointer risk.
+    std::vector<pulp::view::IRNode*> worklist;
+    worklist.push_back(&root);
+
+    while (!worklist.empty()) {
+        pulp::view::IRNode* node = worklist.back();
+        worklist.pop_back();
+
+        if (classify_interactive_signal(*node) != WidgetPromotionSignal::none) {
+            node->type = "button";
+            ++promoted;
+            // Codex P2 on PR #1824 — once a node becomes a button, do
+            // NOT recurse into its descendants. A clickable container
+            // with clickable children would otherwise produce nested
+            // <button> elements (invalid interactive nesting + broken
+            // click/focus semantics in the generated UI). The native
+            // click handler attached to the promoted parent already
+            // covers the whole subtree.
+            continue;
+        }
+
+        // Push children in reverse so pre-order is preserved (left-to-right
+        // visit order matches the user-visible IR layout).
+        for (auto it = node->children.rbegin();
+             it != node->children.rend();
+             ++it) {
+            worklist.push_back(&*it);
+        }
+    }
+
+    return promoted;
+}
+
+}  // namespace pulp::import_design

--- a/tools/import-design/widget_promotion.hpp
+++ b/tools/import-design/widget_promotion.hpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+//
+// pulp #1814 (task #84) — post-parse widget promotion for the importer.
+//
+// External design tools (Figma, Stitch, v0, Pencil, Claude Design) rarely
+// emit `<button>` directly. The common pattern is `<div onClick={...}>` or
+// `<div role="button">` or just a styled div with `cursor: pointer`. Without
+// post-parse promotion the importer treats those as static frames and the
+// user's interactive intent is dropped — Pulp ends up with a wall of
+// frames where the original design has clickable widgets.
+//
+// `promote_interactive_frames` walks the IR once after parse + before
+// codegen and re-types any `frame` that carries a clickable signal to
+// `button`. The pass is intentionally conservative (only frames; never
+// downgrades) and source-agnostic so every importer benefits.
+
+#pragma once
+
+#include <cstddef>
+
+namespace pulp::view {
+struct IRNode;
+}
+
+namespace pulp::import_design {
+
+/// Heuristic signals that a node is interactive. Exposed so the test
+/// surface can assert what was matched without re-deriving the
+/// classifier.
+enum class WidgetPromotionSignal {
+    none,
+    onclick_attribute,   ///< `onclick=` / `onClick=` on the node
+    aria_role_button,    ///< `role="button"` (ARIA semantic)
+    cursor_pointer,      ///< `cursor: pointer` style (weakest signal)
+};
+
+/// Inspect a single node's attributes / style for a promotion signal.
+/// Public for unit-test introspection; `promote_interactive_frames`
+/// dispatches through this.
+WidgetPromotionSignal classify_interactive_signal(const pulp::view::IRNode& node);
+
+/// Walk the IR tree and promote any `type == "frame"` node carrying an
+/// interactive signal to `type == "button"`. Returns the count of
+/// promotions so the CLI can surface a "promoted N divs → buttons"
+/// stat in its post-import report.
+///
+/// Order of operations: `promote_interactive_frames` MUST run AFTER
+/// the parse path (so `attributes` / `style.cursor` are populated) and
+/// BEFORE codegen (so the generated Pulp JS emits Button widgets
+/// instead of static frames).
+std::size_t promote_interactive_frames(pulp::view::IRNode& root);
+
+}  // namespace pulp::import_design


### PR DESCRIPTION
External design tools (Figma, Stitch, v0, Pencil, Claude Design)
rarely emit <button> directly — the common pattern is
<div onClick={...}>, <div role="button">, or a styled div with
cursor:pointer. Without post-parse promotion the importer treats
those as static frames and the user's interactive intent is dropped:
Pulp ends up with a wall of frames where the original design has
clickable widgets.

This change adds a source-agnostic post-parse pass that walks the
IR once (after parse, before codegen) and re-types any
type == "frame" carrying an interactive signal to "button". Signals
are inspected in priority order:

  1. onclick / onClick attribute  — strongest signal
  2. ARIA role == "button"        — explicit semantic claim
  3. style.cursor == "pointer"    — weakest, opt-out via
                                    role="presentation"

Conservative by construction: only frames are promoted, never the
other direction; already-typed widgets (input / image / button)
are left alone so an <input onClick={...}> keeps its input type.
Idempotent — re-running the pass on already-promoted IR is a no-op.

Wired into the CLI pipeline in pulp_import_design.cpp between the
parse switch and codegen so every source benefits the moment its
parser preserves the relevant attrs.

Test: test/test_widget_promotion.cpp — 9 Catch2 cases / 36
assertions covering the four promotion paths (HTML lowercase
onclick, JSX camelCase onClick, ARIA role=button, cursor:pointer),
the role="presentation" opt-out, the already-typed guardrail, the
recursive walk, idempotence, and the signal-precedence pin. Builds
the tools/import-design source directly into the test binary so we
exercise the exact code path the CLI uses.

Known follow-up (#1823): the non-runtime HTML/JSON parsers
(parse_stitch_html, parse_v0_tsx, parse_pencil_json, parse_figma_json's
JSON-attrs path) currently strip onclick / role from the IR before
this pass sees them, so promotion only fires on the runtime-import
path (parse_claude_html_with_runtime) — the path Spectr re-import
actually uses. The post-pass is source-agnostic so it'll
automatically benefit every parser once #1823 lands.

Skill update: .agents/skills/import-design/SKILL.md gains a section
documenting the promotion priority order + the parser-strips-attrs
gotcha + how to read the new "Promoted N" stdout line.

Refs pulp #1814 and pulp-internal task #84. Filed pulp #1823 as the
parser-side follow-up.

Agent: B
Version-Bump: skip reason="importer-internal post-pass + new unit test + skill update — no SDK API or plugin surface change; the new widget_promotion translation unit is linked into pulp-import-design only"
Version-Bump: sdk=skip reason="no SDK API surface change — new helper is internal to pulp-import-design"
Version-Bump: plugin=skip reason="no plugin command/skill surface change"