### PR TITLE
fix(cli): version-pin SDK tarball filename — kills pulp install stale-cache

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -875,3 +875,58 @@ Gotchas:
 - **MSVC transitive-include hygiene.** `migration_runtime.cpp`
   explicitly `#include <cstddef>`, `<sstream>`, `<string>`, `<vector>`,
   `<tuple>`. Don't rely on libc++ giving you those transitively.
+
+## SDK cache filenames — version pin (pulp #1814)
+
+`pulp install` (and the underlying `pulp cache fetch skia`) used to write
+the downloaded SDK tarball to `~/.pulp/cache/pulp-sdk-<platform>.tar.gz` —
+unversioned. The cache-hit path checked only `fs::exists()`, so a stale
+tarball from a prior release would silently shadow a fresh download and
+the CLI would "install" yesterday's SDK without warning. The fix pins the
+SDK version into the filename:
+
+```
+~/.pulp/cache/pulp-sdk-v0.92.0-darwin-arm64.tar.gz
+```
+
+Plumbing:
+
+- `tools/cli/sdk_cache_paths.{hpp,cpp}` — two helpers,
+  `sdk_tarball_filename` and `legacy_unversioned_sdk_tarball_filename`.
+  Standalone TU (no `cli_common` deps) so the unit test
+  `test/test_cli_sdk_tarball_filename.cpp` can link them without dragging
+  in pulp::runtime / pulp::platform. Same pattern as `version_diag` and
+  `fetchcontent_cache`.
+- `tools/cli/cmd_misc.cpp` `cmd_cache` `fetch skia` branch — calls
+  `pulp::cli::sdk_tarball_filename(PULP_SDK_VERSION, platform)` for the
+  local cache filename. GitHub release assets are still uploaded with the
+  unversioned filename (the version lives in the URL path segment), so
+  the remote URL uses `legacy_unversioned_sdk_tarball_filename` only as
+  a *filename component of the URL*, not as a local cache key.
+- Best-effort legacy cleanup — if `~/.pulp/cache/pulp-sdk-<platform>.tar.gz`
+  exists from a pre-#1814 install, the fetch path removes it before
+  resolving the versioned filename, so stale tarballs don't sit in
+  `~/.pulp/cache/` forever. `std::error_code` is used to skip silently
+  on permission / mount errors.
+- User-facing output — both "fresh download" and "cache hit" paths now
+  print the SDK version explicitly: `SDK v0.92.0 (includes Skia) already
+  cached at …` / `Downloading SDK v0.92.0 (Skia binaries for …)`.
+
+Gotchas:
+
+- **Don't compare the local filename against the URL filename.** They're
+  intentionally different — local pins the version (so cache lookup
+  misses on stale tarballs), URL doesn't (because that's the GitHub
+  release-asset shape). The version-pin contract is between cache lookup
+  and cache write, not against the remote.
+- **`pulp install` is the user-facing alias.** It calls
+  `cmd_cache({"fetch", "skia"})` internally — fixing `cache fetch` fixes
+  `install` automatically.
+- **`pulp sdk install` is *not* the same path.** That's the Rust CLI's
+  fall-through to `pulp-cpp sdk install` (see `pulp-rs/src/cmd/sdk.rs`);
+  the C++ `cmd_sdk` is a different code path with its own per-version
+  `~/.pulp/sdk/<version>/` layout. #1814 fix lives only in `cmd_cache`.
+- **If you bump `PULP_SDK_VERSION`, you do NOT need to manually
+  invalidate `~/.pulp/cache`.** The new version means the filename
+  misses on the old cache and the user gets a fresh download
+  automatically.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -296,6 +296,21 @@ target_link_libraries(pulp-test-cli-fetchcontent-cache PRIVATE
     Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-cli-fetchcontent-cache)
 
+# pulp #1814 — version-pinned SDK tarball filename helper.
+# sdk_cache_paths.cpp is deliberately free of cli_common link deps so
+# the tests link it standalone (same pattern as fetchcontent_cache /
+# version_diag).
+add_executable(pulp-test-cli-sdk-tarball-filename
+    test_cli_sdk_tarball_filename.cpp
+    ${CMAKE_SOURCE_DIR}/tools/cli/sdk_cache_paths.cpp
+)
+target_include_directories(pulp-test-cli-sdk-tarball-filename PRIVATE
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/tools/cli)
+target_link_libraries(pulp-test-cli-sdk-tarball-filename PRIVATE
+    Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-cli-sdk-tarball-filename)
+
 # CLI package commands (#643): local-only tests for target/search/list/
 # update/suggest/audit/add/remove behavior against staged project files
 # and registry fixtures. Stays off remote fetch / archive extraction /

--- a/test/test_cli_sdk_tarball_filename.cpp
+++ b/test/test_cli_sdk_tarball_filename.cpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+//
+// pulp #1814 — unit tests for the version-pinned SDK tarball filename
+// helper. Pins the back-compat contract on the legacy unversioned
+// filename so `pulp cache fetch skia` can clean it up best-effort
+// without ambiguity, and asserts the new versioned shape so a future
+// edit can't accidentally drop the version pin and reintroduce the
+// stale-cache bug.
+
+#include "../tools/cli/sdk_cache_paths.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+
+using pulp::cli::sdk_tarball_filename;
+using pulp::cli::legacy_unversioned_sdk_tarball_filename;
+
+TEST_CASE("sdk_tarball_filename: encodes the SDK version + platform",
+          "[cli][cache][issue-1814]") {
+    REQUIRE(sdk_tarball_filename("0.92.0", "darwin-arm64") ==
+            "pulp-sdk-v0.92.0-darwin-arm64.tar.gz");
+    REQUIRE(sdk_tarball_filename("1.0.0", "linux-x64") ==
+            "pulp-sdk-v1.0.0-linux-x64.tar.gz");
+    REQUIRE(sdk_tarball_filename("0.78.3", "windows-arm64") ==
+            "pulp-sdk-v0.78.3-windows-arm64.tar.gz");
+}
+
+TEST_CASE("sdk_tarball_filename: different versions produce different filenames "
+          "so cache lookup misses on stale tarballs",
+          "[cli][cache][issue-1814]") {
+    // The pulp #1814 bug was that v0.85 and v0.92 shared the same
+    // cache key. The structural fix here is to make the cache key
+    // include the version so a v0.92 install cannot find a v0.85
+    // tarball even by accident.
+    const std::string v_old = sdk_tarball_filename("0.85.0", "darwin-arm64");
+    const std::string v_new = sdk_tarball_filename("0.92.0", "darwin-arm64");
+    REQUIRE_FALSE(v_old == v_new);
+}
+
+TEST_CASE("legacy_unversioned_sdk_tarball_filename: matches the pre-#1814 shape",
+          "[cli][cache][issue-1814]") {
+    // The legacy name is the public contract between the pre-#1814 CLI
+    // and the post-#1814 cleanup path; locking it in unit tests keeps
+    // a future rename from breaking the cleanup of stale tarballs.
+    REQUIRE(legacy_unversioned_sdk_tarball_filename("darwin-arm64") ==
+            "pulp-sdk-darwin-arm64.tar.gz");
+    REQUIRE(legacy_unversioned_sdk_tarball_filename("linux-x64") ==
+            "pulp-sdk-linux-x64.tar.gz");
+    REQUIRE(legacy_unversioned_sdk_tarball_filename("windows-x64") ==
+            "pulp-sdk-windows-x64.tar.gz");
+}
+
+TEST_CASE("sdk_tarball_filename and legacy form disagree on every supported "
+          "platform — guarantees the cleanup pass deletes legacy files only",
+          "[cli][cache][issue-1814]") {
+    // If the legacy file ever happens to equal a versioned file, the
+    // cleanup pass would delete a fresh cache hit. Guard against
+    // accidental shape convergence.
+    for (const auto& platform : {"darwin-arm64", "darwin-x64",
+                                  "linux-arm64", "linux-x64",
+                                  "windows-arm64", "windows-x64"}) {
+        const std::string legacy = legacy_unversioned_sdk_tarball_filename(platform);
+        const std::string versioned = sdk_tarball_filename("0.92.0", platform);
+        REQUIRE_FALSE(legacy == versioned);
+    }
+}

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -69,6 +69,7 @@ add_executable(pulp-cli
     version_diag.cpp
     projects_registry.cpp
     fetchcontent_cache.cpp
+    sdk_cache_paths.cpp
     cmd_projects.cpp
     project_bump.cpp
     cmd_project.cpp

--- a/tools/cli/cli_common.cpp
+++ b/tools/cli/cli_common.cpp
@@ -601,6 +601,10 @@ fs::path local_sdk_cache_path(const std::string& version) {
     return pulp_home() / "sdk-local" / detect_platform() / version;
 }
 
+// pulp #1814 — sdk_tarball_filename / legacy_unversioned_sdk_tarball_filename
+// live in tools/cli/sdk_cache_paths.cpp so the matching unit test can
+// compile + link them standalone.
+
 std::string detect_platform() {
 #ifdef __APPLE__
     #if defined(__aarch64__) || defined(__arm64__)

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -110,6 +110,10 @@ fs::path pulp_home();
 fs::path sdk_cache_path(const std::string& version);
 fs::path local_sdk_cache_path(const std::string& version);
 std::string detect_platform();
+
+// pulp #1814 — sdk_tarball_filename + legacy_unversioned_sdk_tarball_filename
+// live in tools/cli/sdk_cache_paths.hpp so the matching unit test can
+// link them without the cli_common dep chain.
 fs::path ensure_sdk(const std::string& version);
 fs::path ensure_checkout_sdk(const fs::path& repo_root, const std::string& version);
 int ensure_checkout_dependencies(const fs::path& repo_root);

--- a/tools/cli/cmd_misc.cpp
+++ b/tools/cli/cmd_misc.cpp
@@ -4,6 +4,7 @@
 // Slice 2 (#547) so the update-check surface can grow independently.
 
 #include "cli_common.hpp"
+#include "sdk_cache_paths.hpp"
 
 #include <fstream>
 #include <iostream>
@@ -313,20 +314,48 @@ int cmd_cache(const std::vector<std::string>& args) {
         }
 
         auto platform = detect_platform();
-        std::string sdk_tarball_name = "pulp-sdk-" + platform + ".tar.gz";
+        const std::string version = PULP_SDK_VERSION;
+
+        // Versioned cache filename — `pulp-sdk-v<version>-<platform>.tar.gz`.
+        // The version pin in the filename is the structural fix for pulp
+        // #1814: a stale tarball from a prior release cannot silently
+        // shadow a fresh download because the filename lookup misses.
+        std::string sdk_tarball_name = pulp::cli::sdk_tarball_filename(version, platform);
         auto sdk_cache = cache_dir / sdk_tarball_name;
 
+        // Best-effort cleanup of the pre-#1814 unversioned tarball so it
+        // doesn't sit in ~/.pulp/cache/ forever eating ~20 MB. Skipped
+        // silently on any error — this is purely housekeeping.
+        {
+            auto legacy_cache = cache_dir / pulp::cli::legacy_unversioned_sdk_tarball_filename(platform);
+            if (fs::exists(legacy_cache)) {
+                std::error_code ec;
+                fs::remove(legacy_cache, ec);
+                if (!ec) {
+                    std::cout << "Removed legacy unversioned cache: "
+                              << legacy_cache.string() << "\n";
+                }
+            }
+        }
+
         if (fs::exists(sdk_cache)) {
-            std::cout << "SDK (includes Skia) already cached at " << sdk_cache.string() << "\n";
+            std::cout << "SDK v" << version << " (includes Skia) already cached at "
+                      << sdk_cache.string() << "\n";
             return 0;
         }
 
         fs::create_directories(cache_dir);
+        // GitHub release assets are uploaded with the unversioned filename;
+        // the version lives in the path segment. Local filename is
+        // versioned so consumers can tell from `ls ~/.pulp/cache/` which
+        // SDK is actually downloaded.
+        std::string remote_filename = pulp::cli::legacy_unversioned_sdk_tarball_filename(platform);
         std::string url = "https://github.com/" + std::string(PULP_GITHUB_REPO)
-                        + "/releases/download/v" + std::string(PULP_SDK_VERSION)
-                        + "/" + sdk_tarball_name;
+                        + "/releases/download/v" + version
+                        + "/" + remote_filename;
 
-        std::cout << "Downloading Skia binaries for " << platform << "...\n";
+        std::cout << "Downloading SDK v" << version << " (Skia binaries for "
+                  << platform << ")...\n";
 
         std::string download_cmd;
 #ifdef _WIN32
@@ -345,7 +374,7 @@ int cmd_cache(const std::vector<std::string>& args) {
             return 1;
         }
 
-        print_ok("Skia binaries cached at " + sdk_cache.string());
+        print_ok("SDK v" + version + " cached at " + sdk_cache.string());
         return 0;
     }
 

--- a/tools/cli/sdk_cache_paths.cpp
+++ b/tools/cli/sdk_cache_paths.cpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+//
+// pulp #1814 — version-pinned SDK tarball filename helpers used by
+// `pulp install` / `pulp cache fetch skia`.
+//
+// Pulled out of cli_common.cpp into its own translation unit so the
+// matching unit-test target can compile + link these two functions
+// standalone (mirrors the version_diag / fetchcontent_cache pattern
+// elsewhere in tools/cli/).
+
+#include "sdk_cache_paths.hpp"
+
+#include <string>
+
+namespace pulp::cli {
+
+std::string sdk_tarball_filename(const std::string& version,
+                                  const std::string& platform) {
+    // Pinning the version into the filename is the structural fix for
+    // pulp #1814 — a cached v0.85 tarball cannot shadow a v0.92
+    // download because the lookup misses on the filename, not on a
+    // version field that has to be checked separately. Format:
+    //   pulp-sdk-v0.92.0-darwin-arm64.tar.gz
+    return "pulp-sdk-v" + version + "-" + platform + ".tar.gz";
+}
+
+std::string legacy_unversioned_sdk_tarball_filename(const std::string& platform) {
+    // The pre-#1814 filename. Used only for best-effort cleanup of
+    // stale tarballs from older CLI installs and for back-compat
+    // unit tests; never produced by the post-#1814 code path.
+    return "pulp-sdk-" + platform + ".tar.gz";
+}
+
+}  // namespace pulp::cli

--- a/tools/cli/sdk_cache_paths.hpp
+++ b/tools/cli/sdk_cache_paths.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+//
+// pulp #1814 — version-pinned SDK tarball filename helpers used by
+// `pulp install` / `pulp cache fetch skia`.
+//
+// Lives in a standalone header (free of pulp::runtime / pulp::platform
+// deps) so the unit test can compile this surface without dragging the
+// whole CLI link-graph in (mirrors the version_diag / fetchcontent_cache
+// pattern in tools/cli/).
+
+#pragma once
+
+#include <string>
+
+namespace pulp::cli {
+
+/// Versioned SDK tarball filename for the `~/.pulp/cache/` download cache.
+/// Returns `pulp-sdk-v<version>-<platform>.tar.gz`.
+///
+/// Pinning the version into the filename is the structural fix for the
+/// stale-cache bug: a cached tarball from a prior release cannot
+/// silently shadow a fresh download because the filename lookup misses,
+/// not a version field that has to be checked separately. See
+/// https://github.com/danielraffel/pulp/issues/1814.
+std::string sdk_tarball_filename(const std::string& version,
+                                  const std::string& platform);
+
+/// Pre-#1814 unversioned filename. Used only for best-effort cleanup of
+/// stale tarballs from older CLI installs and for back-compat unit
+/// tests; never produced by the post-#1814 code path.
+std::string legacy_unversioned_sdk_tarball_filename(const std::string& platform);
+
+}  // namespace pulp::cli


### PR DESCRIPTION
## Summary

Closes #1814. `pulp install` (and the underlying `pulp cache fetch skia`) used to write the downloaded SDK tarball to `~/.pulp/cache/pulp-sdk-<platform>.tar.gz` — unversioned. The cache-hit path checked only `fs::exists()`, so a stale tarball from a prior release silently shadowed every subsequent install.

Fix pins the SDK version into the filename:

```
~/.pulp/cache/pulp-sdk-v0.92.0-darwin-arm64.tar.gz
```

A cached v0.85 tarball cannot shadow a v0.92 download because the filename lookup misses on the version — no version field check needed, the structural shape does the work.

## What changed

- New `tools/cli/sdk_cache_paths.{hpp,cpp}` — two helpers (`sdk_tarball_filename`, `legacy_unversioned_sdk_tarball_filename`). Standalone TU so the test links them without the cli_common dep chain.
- `cmd_misc.cpp` `cmd_cache` `fetch skia` branch — uses the versioned local filename, keeps the unversioned remote filename (GitHub release-asset shape), adds best-effort cleanup of pre-#1814 stale tarballs.
- Both "fresh download" and "cache hit" paths now print the SDK version explicitly so users can see exactly which build they're getting.

## Test plan

- [x] Unit: `bash -c "ctest --test-dir build --output-on-failure -R pulp-test-cli-sdk-tarball-filename"` — 4 cases / 13 assertions covering version+platform encoding, miss-on-stale, legacy shape, and version-vs-legacy non-collision across all 6 supported platforms.
- [x] End-to-end smoke (PULP_HOME=tempdir): fresh download lands at `pulp-sdk-v0.92.0-darwin-arm64.tar.gz`, second call reports cache hit with version, pre-staged legacy `pulp-sdk-darwin-arm64.tar.gz` is removed on the next fetch.
- [ ] Post-merge: `pulp install` on a clean ~/.pulp/cache produces a versioned filename, second run reports the cache hit with the version, leftover unversioned tarballs get cleaned up.