### PR TITLE
feat(cmake): Debug-SDK perf-killer guard in PulpConfig.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -808,6 +808,25 @@ endforeach()
 file(WRITE "${CMAKE_BINARY_DIR}/version.txt" "${PROJECT_VERSION}\n")
 install(FILES "${CMAKE_BINARY_DIR}/version.txt" DESTINATION ".")
 
+# SDK build-type marker (pulp-internal task #35).
+#
+# Records the CMAKE_BUILD_TYPE the SDK was built with so PulpConfig.cmake
+# can refuse — or at least loudly warn — when a downstream plugin tries
+# to consume a Debug-built Pulp SDK. Debug-built Skia + audio framework
+# blow real-time deadlines on every reasonable host, so consumers who
+# stumble into this on a local checkout deserve a clear "this SDK
+# install is unusable for plugin work" message instead of a silently
+# unusable plugin that drops audio.
+#
+# Multi-config generators (Visual Studio, Xcode) don't have a single
+# CMAKE_BUILD_TYPE at configure time; the install step picks one via
+# `cmake --install --config <Type>`. In that case CMAKE_BUILD_TYPE is
+# empty here and the guard in PulpConfig.cmake.in falls back to
+# "unknown" — which it interprets as "trust the user, do not warn".
+file(WRITE "${CMAKE_BINARY_DIR}/sdk_build_type.txt"
+     "${CMAKE_BUILD_TYPE}\n")
+install(FILES "${CMAKE_BINARY_DIR}/sdk_build_type.txt" DESTINATION ".")
+
 # CMake config files for find_package(Pulp)
 install(EXPORT PulpTargets
     FILE PulpTargets.cmake

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,6 +97,36 @@ if(UNIX)
     set_tests_properties(pulp-mcp-launcher PROPERTIES TIMEOUT 15)
 endif()
 
+# Debug-SDK perf-killer guard smoke (pulp-internal task #35).
+# Hermetic — runs the guard against a tempdir-fabricated SDK install,
+# exercises the three branches (Debug-no-override → FATAL_ERROR,
+# Debug-with-override → WARNING+proceed, Release → silent). Runs under
+# `cmake -P` so it works on every platform without building the Pulp
+# tree.
+foreach(_pulp_debug_sdk_scenario
+        "debug-no-override:fail"
+        "debug-with-override:warn"
+        "debug-lowercase:fail"
+        "debug-mixed-case:fail"
+        "release:silent")
+    string(REPLACE ":" ";" _scenario_pair "${_pulp_debug_sdk_scenario}")
+    list(GET _scenario_pair 0 _scenario_name)
+    list(GET _scenario_pair 1 _scenario_outcome)
+    add_test(NAME cmake-debug-sdk-guard-${_scenario_name}
+        COMMAND ${CMAKE_COMMAND}
+            -DPULP_SRC_DIR=${CMAKE_SOURCE_DIR}
+            -DFIXTURE_DIR=${CMAKE_CURRENT_BINARY_DIR}/debug-sdk-guard-${_scenario_name}
+            -DSCENARIO=${_scenario_name}
+            -DEXPECTED_OUTCOME=${_scenario_outcome}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/test_debug_sdk_guard.cmake)
+    set_tests_properties(cmake-debug-sdk-guard-${_scenario_name}
+        PROPERTIES TIMEOUT 30)
+endforeach()
+unset(_pulp_debug_sdk_scenario)
+unset(_scenario_pair)
+unset(_scenario_name)
+unset(_scenario_outcome)
+
 # Android end-to-end smoke (issue #337). Runs the tools/scripts/android_smoke.sh
 # against a locally attached emulator or device. Skipped by default because
 # the smoke requires an already-booted AVD/device and an arm64-v8a APK —

--- a/test/cmake/test_debug_sdk_guard.cmake
+++ b/test/cmake/test_debug_sdk_guard.cmake
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: MIT
+#
+# pulp-internal task #35 — CMake smoke for the Debug-SDK perf-killer guard
+# in PulpConfig.cmake.
+#
+# Runs three scenarios against a tempdir-fabricated SDK install:
+#
+#   1. sdk_build_type.txt == "Debug", PULP_ALLOW_DEBUG_SDK unset.
+#      Expect: FATAL_ERROR from PulpConfig.cmake.
+#   2. sdk_build_type.txt == "Debug", PULP_ALLOW_DEBUG_SDK=ON.
+#      Expect: WARNING, configure succeeds.
+#   3. sdk_build_type.txt == "Release". Expect: silent, configure succeeds.
+#
+# The fixture SDK only contains the files the guard reads
+# (sdk_build_type.txt + a minimal PulpConfig.cmake that includes the same
+# guard block); we do NOT need a full SDK install to validate the
+# guard's branch logic. This keeps the test cheap and CI-portable.
+
+cmake_minimum_required(VERSION 3.20)
+
+# Args plumbed via `cmake -P`:
+#   PULP_SRC_DIR        — repo root (so we can pull the cmake-in file).
+#   FIXTURE_DIR         — tempdir to stage the fake SDK under.
+#   SCENARIO            — "debug-no-override" | "debug-with-override" | "release"
+#   EXPECTED_OUTCOME    — "fail" | "warn" | "silent"
+
+if(NOT PULP_SRC_DIR OR NOT FIXTURE_DIR OR NOT SCENARIO OR NOT EXPECTED_OUTCOME)
+    message(FATAL_ERROR
+        "test_debug_sdk_guard.cmake requires:\n"
+        "  -DPULP_SRC_DIR=...   -DFIXTURE_DIR=...   -DSCENARIO=...   -DEXPECTED_OUTCOME=...")
+endif()
+
+set(_template "${PULP_SRC_DIR}/tools/cmake/PulpConfig.cmake.in")
+if(NOT EXISTS "${_template}")
+    message(FATAL_ERROR "PulpConfig.cmake.in not found at ${_template}")
+endif()
+
+# Fabricate a minimal SDK layout under FIXTURE_DIR/sdk-install/.
+set(_sdk_dir "${FIXTURE_DIR}/sdk-install")
+file(MAKE_DIRECTORY "${_sdk_dir}/lib/cmake/Pulp")
+file(WRITE "${_sdk_dir}/version.txt" "0.0.0-fixture\n")
+if(SCENARIO STREQUAL "debug-no-override" OR SCENARIO STREQUAL "debug-with-override")
+    file(WRITE "${_sdk_dir}/sdk_build_type.txt" "Debug\n")
+elseif(SCENARIO STREQUAL "debug-lowercase")
+    # Codex P1 — CMake accepts CMAKE_BUILD_TYPE case-insensitively
+    # (so `-DCMAKE_BUILD_TYPE=debug` is a real Debug build), and the
+    # marker preserves the user's spelling. Pin that the guard
+    # normalizes to lowercase before comparing — otherwise it
+    # silently bypasses on a real Debug install.
+    file(WRITE "${_sdk_dir}/sdk_build_type.txt" "debug\n")
+elseif(SCENARIO STREQUAL "debug-mixed-case")
+    # Same gotcha, with the camelCase spelling CMake also accepts.
+    file(WRITE "${_sdk_dir}/sdk_build_type.txt" "DeBuG\n")
+elseif(SCENARIO STREQUAL "release")
+    file(WRITE "${_sdk_dir}/sdk_build_type.txt" "Release\n")
+else()
+    message(FATAL_ERROR "Unknown scenario: ${SCENARIO}")
+endif()
+
+# Extract just the guard block from the real PulpConfig.cmake.in so we
+# don't accidentally execute parts of the template that depend on
+# @PACKAGE_INIT@ or other configure-time substitutions.
+file(READ "${_template}" _template_content)
+string(REGEX MATCH
+       "# Debug-SDK perf-killer guard.*unset\\(_pulp_sdk_build_type_marker\\)"
+       _guard_block "${_template_content}")
+if(NOT _guard_block)
+    message(FATAL_ERROR
+        "Could not locate the Debug-SDK guard block in ${_template}. "
+        "Did the comment header change?")
+endif()
+
+# Wrap the guard with the variables it depends on (PULP_SDK_DIR + the
+# user's PULP_ALLOW_DEBUG_SDK opt-in).
+set(_guard_cmake "${FIXTURE_DIR}/run_guard.cmake")
+file(WRITE "${_guard_cmake}"
+"set(PULP_SDK_DIR \"${_sdk_dir}\")\n"
+"${_guard_block}\n"
+"message(STATUS \"guard completed without FATAL_ERROR\")\n")
+
+# Invoke that snippet via `cmake -P`, capturing stdout/stderr.
+set(_allow_arg "")
+if(SCENARIO STREQUAL "debug-with-override")
+    set(_allow_arg "-DPULP_ALLOW_DEBUG_SDK=ON")
+endif()
+
+execute_process(
+    COMMAND "${CMAKE_COMMAND}" ${_allow_arg} -P "${_guard_cmake}"
+    OUTPUT_VARIABLE _guard_stdout
+    ERROR_VARIABLE  _guard_stderr
+    RESULT_VARIABLE _guard_result)
+
+set(_combined "${_guard_stdout}\n${_guard_stderr}")
+
+if(EXPECTED_OUTCOME STREQUAL "fail")
+    if(_guard_result EQUAL 0)
+        message(FATAL_ERROR
+            "Expected guard to FATAL_ERROR but it exited 0.\n"
+            "stdout: ${_guard_stdout}\nstderr: ${_guard_stderr}")
+    endif()
+    if(NOT _combined MATCHES "was built with[ \t\r\n]+CMAKE_BUILD_TYPE=Debug")
+        message(FATAL_ERROR
+            "Guard failed (exit ${_guard_result}) but the message did "
+            "not mention the Debug build type.\n"
+            "stdout: ${_guard_stdout}\nstderr: ${_guard_stderr}")
+    endif()
+    message(STATUS "OK: scenario '${SCENARIO}' produced the expected FATAL_ERROR.")
+elseif(EXPECTED_OUTCOME STREQUAL "warn")
+    if(NOT _guard_result EQUAL 0)
+        message(FATAL_ERROR
+            "Expected guard to WARN-but-proceed but it exited ${_guard_result}.\n"
+            "stdout: ${_guard_stdout}\nstderr: ${_guard_stderr}")
+    endif()
+    if(NOT _combined MATCHES "CMake Warning" AND NOT _combined MATCHES "PULP_ALLOW_DEBUG_SDK=ON")
+        message(FATAL_ERROR
+            "Expected the override path to log a warning, but no warning "
+            "marker found.\nstdout: ${_guard_stdout}\nstderr: ${_guard_stderr}")
+    endif()
+    message(STATUS "OK: scenario '${SCENARIO}' warned and proceeded.")
+elseif(EXPECTED_OUTCOME STREQUAL "silent")
+    if(NOT _guard_result EQUAL 0)
+        message(FATAL_ERROR
+            "Expected guard to be silent (exit 0) for Release SDK but exited ${_guard_result}.\n"
+            "stdout: ${_guard_stdout}\nstderr: ${_guard_stderr}")
+    endif()
+    # Match the guard's specific phrasing rather than the literal token
+    # "FATAL_ERROR" (which appears as plain text in the success-path
+    # status message printed at the bottom of run_guard.cmake).
+    if(_combined MATCHES "was built with[ \t\r\n]+CMAKE_BUILD_TYPE=Debug"
+       OR _combined MATCHES "CMake Warning")
+        message(FATAL_ERROR
+            "Expected guard to stay silent on Release SDK but it emitted "
+            "an error/warning.\nstdout: ${_guard_stdout}\nstderr: ${_guard_stderr}")
+    endif()
+    message(STATUS "OK: scenario '${SCENARIO}' silent on Release SDK.")
+else()
+    message(FATAL_ERROR "Unknown EXPECTED_OUTCOME: ${EXPECTED_OUTCOME}")
+endif()

--- a/tools/cmake/PulpConfig.cmake.in
+++ b/tools/cmake/PulpConfig.cmake.in
@@ -60,6 +60,72 @@ foreach(_pulp_cfg Debug MinSizeRel RelWithDebInfo)
 endforeach()
 unset(_pulp_cfg)
 
+# Debug-SDK perf-killer guard (pulp-internal task #35).
+#
+# A Pulp SDK that was itself BUILT with CMAKE_BUILD_TYPE=Debug ships
+# debug-mode Skia, debug-mode audio framework, and debug-mode JS
+# engine. Consuming it from a downstream plugin produces real-time
+# audio code so slow that buffer underruns happen on every reasonable
+# host — a UX failure mode that's hard to attribute to "the SDK
+# install is wrong" because the link succeeds and the plugin appears
+# to work, just very poorly.
+#
+# The CMakeLists.txt that produced this SDK install writes the
+# CMAKE_BUILD_TYPE it was configured with to `${PULP_SDK_DIR}/sdk_build_type.txt`.
+# If we can read that file and it contains "Debug", refuse the
+# find_package — with an escape hatch (`PULP_ALLOW_DEBUG_SDK=ON`) for
+# the rare developer who *does* want a Debug SDK (e.g. debugging
+# Skia internals from a host that doesn't care about real-time).
+#
+# Empty marker file (older SDK installs that predate the marker) and
+# multi-config generators (which install per-config without recording
+# a single canonical build-type) fall through silently — we cannot
+# tell, so we don't warn.
+set(_pulp_sdk_build_type_marker "${PULP_SDK_DIR}/sdk_build_type.txt")
+if(EXISTS "${_pulp_sdk_build_type_marker}")
+    file(READ "${_pulp_sdk_build_type_marker}" _pulp_sdk_build_type)
+    string(STRIP "${_pulp_sdk_build_type}" _pulp_sdk_build_type)
+    # CMake accepts CMAKE_BUILD_TYPE case-insensitively and preserves
+    # the user's spelling on disk, so `-DCMAKE_BUILD_TYPE=debug` /
+    # `DeBuG` are valid Debug builds whose marker won't STREQUAL
+    # "Debug". Normalize to lowercase before comparing — otherwise
+    # the guard silently no-ops on a real Debug install (Codex P1 on
+    # PR #1828).
+    string(TOLOWER "${_pulp_sdk_build_type}" _pulp_sdk_build_type_lc)
+    if(_pulp_sdk_build_type_lc STREQUAL "debug")
+        if(PULP_ALLOW_DEBUG_SDK)
+            message(WARNING
+                "Pulp SDK at '${PULP_SDK_DIR}' was built with "
+                "CMAKE_BUILD_TYPE=Debug. PULP_ALLOW_DEBUG_SDK=ON — proceeding, but expect "
+                "buffer underruns + slow paint on the resulting plugin. "
+                "See task #35 / pulp-internal #36 for the path-forward "
+                "plan to make a Debug SDK usable for data collection.")
+        else()
+            message(FATAL_ERROR
+                "Pulp SDK at '${PULP_SDK_DIR}' was built with "
+                "CMAKE_BUILD_TYPE=Debug. This SDK ships debug-mode "
+                "Skia / audio framework / JS engine — plugins linked "
+                "against it are NOT usable for real-time audio work "
+                "(buffer underruns, audible glitches, multi-second "
+                "paint hitches).\n"
+                "\n"
+                "Fix: rebuild the Pulp SDK with "
+                "CMAKE_BUILD_TYPE=Release and reinstall:\n"
+                "    cmake -S <pulp-src> -B build -DCMAKE_BUILD_TYPE=Release\n"
+                "    cmake --build build --target install\n"
+                "\n"
+                "Or, if you genuinely want a Debug SDK (e.g. debugging "
+                "Skia internals on a host that doesn't care about "
+                "real-time), re-configure your consumer with "
+                "-DPULP_ALLOW_DEBUG_SDK=ON to acknowledge the perf "
+                "implications and proceed anyway.")
+        endif()
+    endif()
+    unset(_pulp_sdk_build_type)
+    unset(_pulp_sdk_build_type_lc)
+endif()
+unset(_pulp_sdk_build_type_marker)
+
 set(_pulp_webgpu_runtime
     "${PULP_SDK_LIBRARY_DIR}/${PULP_SDK_SHARED_LIBRARY_PREFIX}wgpu_native${PULP_SDK_SHARED_LIBRARY_SUFFIX}")
 set(_pulp_webgpu_include_dir "${PULP_SDK_DIR}/external/webgpu/include")


### PR DESCRIPTION
## Summary

A Pulp SDK that was built with `CMAKE_BUILD_TYPE=Debug` ships debug-mode Skia, debug-mode audio framework, and debug-mode JS engine. Consuming it from a downstream plugin produces real-time audio so slow that buffer underruns happen on every reasonable host — a UX failure mode that's hard to attribute to "the SDK install is wrong" because the link succeeds and the plugin appears to work.

This PR wires a structural guard that refuses (or, with an opt-in, warns) when `find_package(Pulp)` resolves to a Debug-built SDK.

## What changed

- `CMakeLists.txt` — install step writes `${install-prefix}/sdk_build_type.txt` with the SDK's `CMAKE_BUILD_TYPE`.
- `tools/cmake/PulpConfig.cmake.in` — new guard reads the marker. `Debug` → `FATAL_ERROR` with remediation text; `PULP_ALLOW_DEBUG_SDK=ON` demotes to `CMake Warning` + proceed; missing marker (older SDK installs) or multi-config generators fall through silently.

## Test plan

- [x] `ctest -R "cmake-debug-sdk-guard"` — all 3 scenarios pass:
  - `debug-no-override` → expects `FATAL_ERROR` with the documented text.
  - `debug-with-override` → expects `CMake Warning` + exit 0.
  - `release` → expects silent + exit 0.
- Hermetic test extracts the live guard block from `PulpConfig.cmake.in` and runs it against a tempdir-fabricated SDK install, so future edits to the guard are auto-tracked.
- [ ] Post-merge: download a Release SDK release artifact, drop a `sdk_build_type.txt` with `Debug` into it, run `cmake -DCMAKE_PREFIX_PATH=...` from an example plugin and verify the `FATAL_ERROR` surfaces with the documented text.

This is the structural half of the Debug-SDK story. Pulp-internal #36 will document the plan to make a Debug SDK *actually usable* (for data-collection scenarios where real-time deadlines don't matter).

Closes pulp-internal task #35.