### PR TITLE
fix(react): flexDirection prop case + TEXT_BEARING HTML aliases

### DIFF
--- a/packages/pulp-react/src/host-config.ts
+++ b/packages/pulp-react/src/host-config.ts
@@ -118,7 +118,22 @@ function asText(children: unknown): string | undefined {
 
 /// Element types that lower their string children to setText / createLabel
 /// rather than to a child node. shouldSetTextContent reads this set.
-const TEXT_BEARING: Set<Type> = new Set(['Label', 'Button', 'TextEditor']);
+///
+/// pulp #109 — HTML-intrinsic JSX tags ALSO bear their own text. Without
+/// these aliases, React's host-config returned false from
+/// shouldSetTextContent('span', …), causing React to materialize a
+/// synthetic Label child for the string content. That synthetic child
+/// stacked on top of the outer span's own auto-derived text (createWidget
+/// pulls asText(props.children) into the Label dispatch), producing the
+/// 2026-05-11 Spectr regression where every <span>SPECTR</span> rendered
+/// as two overlapping "SPECTR" labels. Fix surfaces for EVERY imported
+/// design with raw HTML text tags, not just Spectr.
+const TEXT_BEARING: Set<Type> = new Set([
+    'Label', 'Button', 'TextEditor',
+    'b', 'button', 'code', 'desc', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'i', 'label', 'li', 'p', 'pre', 'span', 'strong', 'td', 'text', 'th',
+    'title', 'tspan',
+] as Type[]);
 
 // ── HostConfig ──────────────────────────────────────────────────────
 export const PulpHostConfig: HostConfig<

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -565,6 +565,21 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
             }
             return call('setFlex', id, 'direction', value as string);
         }
+        // pulp #108 — RN/React-style `flexDirection` (camelCase) is the
+        // canonical key in JSX. Without this case the prop fell through
+        // as unknown, leaving Yoga's column default in place and
+        // collapsing CSS-imported flex rows into vertical stacks. Maps
+        // to the same setFlex(direction, …) dispatch as the `direction`
+        // case for the flex-direction subset of values. Normalizes
+        // `col` / `col-reverse` aliases to `column` / `column-reverse`
+        // for the bridge's expected vocabulary.
+        case 'flexDirection': {
+            const sval = String(value).trim().toLowerCase();
+            const normalized = sval === 'col' ? 'column'
+                : sval === 'col-reverse' ? 'column-reverse'
+                : sval;
+            return call('setFlex', id, 'direction', normalized);
+        }
         case 'gap':             return call('setFlex', id, 'gap', value as number);
         case 'rowGap':          return call('setFlex', id, 'row_gap', value as number);
         case 'columnGap':       return call('setFlex', id, 'column_gap', value as number);

--- a/packages/pulp-react/test/host-config-text-bearing.test.ts
+++ b/packages/pulp-react/test/host-config-text-bearing.test.ts
@@ -1,0 +1,44 @@
+// pulp #109 — verify host-config's shouldSetTextContent recognizes
+// HTML-intrinsic text-bearing tags. Without these aliases, React's
+// host-config returned false from shouldSetTextContent('span', …),
+// causing React to materialize a synthetic Label child for the string
+// content. That synthetic child stacked on top of the outer span's
+// own auto-derived text — the 2026-05-11 Spectr regression where every
+// <span>SPECTR</span> rendered as two overlapping "SPECTR" labels.
+
+import { describe, it, expect } from 'vitest';
+import { PulpHostConfig } from '../src/host-config.js';
+
+describe('host-config shouldSetTextContent (pulp #109 — TEXT_BEARING)', () => {
+    const fn = PulpHostConfig.shouldSetTextContent as
+        (type: string, props: Record<string, unknown>) => boolean;
+
+    it('Label / Button / TextEditor (native pulp types) bear text', () => {
+        expect(fn('Label', {})).toBe(true);
+        expect(fn('Button', {})).toBe(true);
+        expect(fn('TextEditor', {})).toBe(true);
+    });
+
+    it.each([
+        'span', 'p', 'label', 'b', 'i', 'em', 'strong', 'code', 'pre',
+        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+        'li', 'td', 'th', 'button', 'text', 'tspan', 'title', 'desc',
+    ])('HTML intrinsic <%s> is text-bearing', (tag) => {
+        expect(fn(tag, {})).toBe(true);
+    });
+
+    it('non-text containers (div, View, section) still return false', () => {
+        expect(fn('div', {})).toBe(false);
+        expect(fn('View', {})).toBe(false);
+        expect(fn('section', {})).toBe(false);
+        expect(fn('Panel', {})).toBe(false);
+    });
+
+    it('uppercase variants do NOT match (HTML tags are lowercase by JSX convention)', () => {
+        // React lowercases intrinsic tag names; uppercase indicates a
+        // component reference, not an HTML element. Don't accidentally
+        // mark a user component named "Span" as text-bearing.
+        expect(fn('SPAN', {})).toBe(false);
+        expect(fn('Span', {})).toBe(false);
+    });
+});

--- a/packages/pulp-react/test/prop-applier-flex-direction.test.ts
+++ b/packages/pulp-react/test/prop-applier-flex-direction.test.ts
@@ -1,0 +1,78 @@
+// pulp #108 — verify @pulp/react prop-applier forwards `flexDirection`
+// (camelCase, the canonical RN/React JSX key) to the bridge. Without
+// this case, the prop fell through as unknown and Yoga's column default
+// remained — collapsing CSS-imported flex rows into vertical stacks
+// (2026-05-11 Spectr regression where header items piled at 0,0).
+// `col` and `col-reverse` aliases normalize to the bridge vocabulary
+// `column` / `column-reverse`.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { applyChangedProps } from '../src/prop-applier.js';
+import { createMockBridge, type MockBridge } from '../src/bridge.js';
+import type { PulpInstance } from '../src/types.js';
+
+let bridge: MockBridge;
+
+beforeEach(() => {
+    bridge = createMockBridge();
+    bridge.install();
+});
+afterEach(() => {
+    bridge.uninstall();
+});
+
+function makeInstance(id: string = 'k'): PulpInstance {
+    return {
+        id,
+        type: 'View' as PulpInstance['type'],
+        props: {},
+        childIds: [],
+        onBridge: true,
+        pendingChildren: [],
+    };
+}
+
+const callsOf = (b: MockBridge, fn: string) => b.calls.filter((c) => c.fn === fn);
+
+describe('prop-applier flexDirection (pulp #108)', () => {
+    it('flexDirection=row dispatches setFlex(direction, row)', () => {
+        applyChangedProps(makeInstance(), {}, { flexDirection: 'row' });
+        const c = callsOf(bridge, 'setFlex');
+        expect(c).toHaveLength(1);
+        expect(c[0].args).toEqual(['k', 'direction', 'row']);
+    });
+
+    it('flexDirection=column dispatches setFlex(direction, column)', () => {
+        applyChangedProps(makeInstance(), {}, { flexDirection: 'column' });
+        const c = callsOf(bridge, 'setFlex');
+        expect(c).toHaveLength(1);
+        expect(c[0].args).toEqual(['k', 'direction', 'column']);
+    });
+
+    it('flexDirection=row-reverse passes through verbatim', () => {
+        applyChangedProps(makeInstance(), {}, { flexDirection: 'row-reverse' });
+        expect(callsOf(bridge, 'setFlex')[0].args).toEqual(['k', 'direction', 'row-reverse']);
+    });
+
+    it('flexDirection=col (RN/pulp historic alias) normalizes to column', () => {
+        applyChangedProps(makeInstance(), {}, { flexDirection: 'col' });
+        expect(callsOf(bridge, 'setFlex')[0].args).toEqual(['k', 'direction', 'column']);
+    });
+
+    it('flexDirection=col-reverse normalizes to column-reverse', () => {
+        applyChangedProps(makeInstance(), {}, { flexDirection: 'col-reverse' });
+        expect(callsOf(bridge, 'setFlex')[0].args).toEqual(['k', 'direction', 'column-reverse']);
+    });
+
+    it('flexDirection is case-insensitive (ROW / Row / row all map)', () => {
+        applyChangedProps(makeInstance(), {}, { flexDirection: 'ROW' });
+        expect(callsOf(bridge, 'setFlex')[0].args).toEqual(['k', 'direction', 'row']);
+    });
+
+    it('flexDirection does NOT route through setDirection (writing-direction)', () => {
+        applyChangedProps(makeInstance(), {}, { flexDirection: 'row' });
+        // setDirection is the writing-direction (rtl/ltr) bridge fn;
+        // flexDirection must not collide with it.
+        expect(callsOf(bridge, 'setDirection')).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
Two Spectr-import gaps in the @pulp/react reconciler surfaced by the
2026-05-11 live render. Both are general regressions for ANY imported
design with HTML-shaped JSX, not Spectr-specific.

1. prop-applier: add `case 'flexDirection'` (camelCase — the canonical
   RN/React JSX key). Previously the applier only handled `direction`
   (RN historic name); `flexDirection` fell through as unknown and
   silently dropped, leaving Yoga's column default in place. CSS-imported
   flex rows collapsed into vertical stacks at top-left. Normalizes
   `col` / `col-reverse` aliases to `column` / `column-reverse` for the
   bridge's expected vocabulary. Test: prop-applier-flex-direction.

2. host-config: extend TEXT_BEARING to HTML-intrinsic text tags (span,
   p, h1-h6, label, b, i, em, strong, code, pre, li, td, th, button,
   text, tspan, title, desc). Without these, shouldSetTextContent
   returned false for `<span>X</span>`, causing React to materialize a
   synthetic Label child for the string content. That synthetic child
   then stacked on top of the outer span's own auto-derived text
   (createWidget pulls asText(props.children) into the Label dispatch),
   producing the doubled-label render. Test: host-config-text-bearing.

vitest: 33 new tests, 412 total passing.

Verified via headless screenshot harness on Spectr: header rows now
lay out horizontally (SPECTR / ZOOMABLE / 32-bands toolbar) and
<span>SPECTR</span> renders once, not twice.