### PR TITLE
feat(format): StandaloneApp headless --screenshot capture (SDK-codified)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0930"></a>
+## [0.94.0]
+
 ## [0.93.0] - 2026-05-11
 
 - fix(view): mac mouseDown/keyDown stale pointers — PAC crash on react unmount ([#1819](https://github.com/danielraffel/pulp/pull/1819))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.93.0
+    VERSION 0.94.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/detail/screenshot_capture.hpp
+++ b/core/format/include/pulp/format/detail/screenshot_capture.hpp
@@ -1,0 +1,62 @@
+// pulp #468 — headless screenshot capture helper for StandaloneApp.
+//
+// Factored out of standalone.cpp so the capture state machine (frame
+// counter + one-shot guard + capture/write/close composition) is
+// unit-testable without a real WindowHost. The runtime wiring composes
+// this with the existing idle callback (inspector + scripted_ui + settings
+// poll) inside StandaloneApp::run_with_editor.
+//
+// Lifecycle (called once per idle tick):
+//   frames 0 .. delay-1  → increment counter, return.
+//   frame delay          → invoke capture_fn(), write bytes to path,
+//                          invoke close_fn(), set the one-shot guard.
+//   frame delay+1 ..     → guarded no-op.
+//
+// All side effects (PNG bytes, file writes, window close) are injected
+// as std::function so tests can substitute deterministic stand-ins.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace pulp::format::detail {
+
+struct ScreenshotCapture {
+    int delay = 30;
+    std::string path;
+    std::function<std::vector<uint8_t>()> capture_fn;
+    std::function<void()> close_fn;
+    std::function<void(const std::string&)> on_error;
+
+    // Heap-allocated state — the capture is wrapped in a std::function and
+    // copied into the WindowHost's idle callback, so two layers of copies
+    // must observe the same counter.
+    std::shared_ptr<int> frame = std::make_shared<int>(0);
+    std::shared_ptr<bool> captured = std::make_shared<bool>(false);
+
+    void operator()() {
+        if (*captured) return;
+        ++(*frame);
+        if (*frame < delay) return;
+        *captured = true;
+        auto bytes = capture_fn ? capture_fn() : std::vector<uint8_t>{};
+        if (bytes.empty()) {
+            if (on_error) on_error("capture_png returned empty bytes");
+        } else if (path.empty()) {
+            if (on_error) on_error("screenshot path is empty");
+        } else {
+            std::ofstream out(path, std::ios::binary);
+            out.write(reinterpret_cast<const char*>(bytes.data()),
+                      static_cast<std::streamsize>(bytes.size()));
+            if (!out && on_error) on_error("failed to write screenshot");
+        }
+        if (close_fn) close_fn();
+    }
+};
+
+}  // namespace pulp::format::detail

--- a/core/format/include/pulp/format/standalone.hpp
+++ b/core/format/include/pulp/format/standalone.hpp
@@ -24,6 +24,16 @@ struct StandaloneConfig {
     // When false, run_with_editor() hosts the editor directly and omits the
     // built-in Settings tab.
     bool show_settings_tab = true;
+    // When non-empty, run_with_editor() installs a one-shot idle callback
+    // that captures the first painted frame via WindowHost::capture_png()
+    // and writes to this path, then closes the window. Codified in the SDK
+    // (not per-app) so every pulp::format::StandaloneApp consumer gets
+    // headless screenshot capture for free. Set via set_config() or by
+    // parsing `--screenshot=PATH` from argv in main().
+    std::string screenshot_path;
+    // Frames to wait before capture. Default 30 (~0.5s @60fps) gives the
+    // first React-driven layout + effects pass time to settle.
+    int screenshot_frame_delay = 30;
 };
 
 class StandaloneApp {

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -1,4 +1,5 @@
 #include <pulp/format/standalone.hpp>
+#include <pulp/format/detail/screenshot_capture.hpp>
 #include <pulp/format/detail/standalone_editor_chrome.hpp>
 #include <pulp/format/editor_ui.hpp>
 #include <pulp/format/settings_panel.hpp>
@@ -273,9 +274,14 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     // Wire inspector into the idle callback to push overlay paint each frame.
     // The inspector uses View::overlay_queue() for rendering and intercepts
     // key events through the root view's on_global_click callback for Cmd+I.
+    //
+    // pulp #468 — extract the pre-screenshot idle work into a std::function
+    // so the headless screenshot block (further below) can compose with it
+    // instead of clobbering via a second set_idle_callback.
+    std::function<void()> pre_screenshot_idle;
 #if !defined(__ANDROID__) && defined(PULP_HAS_INSPECT)
     if (scripted_ui_ptr) {
-        window->set_idle_callback([scripted_ui_ptr, settings_ptr, inspector_ptr, inspector_host] {
+        pre_screenshot_idle = [scripted_ui_ptr, settings_ptr, inspector_ptr, inspector_host] {
             if (scripted_ui_ptr) scripted_ui_ptr->poll();
             if (settings_ptr) settings_ptr->poll();
             if (inspector_ptr->is_active()) {
@@ -286,9 +292,10 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
                     inspector_host
                 });
             }
-        });
+        };
+        window->set_idle_callback(pre_screenshot_idle);
     } else {
-        window->set_idle_callback([settings_ptr, inspector_ptr, inspector_host] {
+        pre_screenshot_idle = [settings_ptr, inspector_ptr, inspector_host] {
             if (settings_ptr) settings_ptr->poll();
             if (inspector_ptr->is_active()) {
                 view::View::overlay_queue().push_back({
@@ -298,7 +305,8 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
                     inspector_host
                 });
             }
-        });
+        };
+        window->set_idle_callback(pre_screenshot_idle);
     }
 
     // Enable inspector by default when PULP_INSPECTOR env var is set
@@ -313,6 +321,37 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     window->show();
 
     detail::log_standalone_window_open(w, h, use_gpu, bridge->uses_script_ui(), chrome);
+
+    // ── Headless one-shot screenshot (SDK-codified, pulp #468 follow-up) ──
+    //
+    // When `config_.screenshot_path` is non-empty (set via set_config or
+    // parsed from `--screenshot=PATH` argv in the consumer's main), wait
+    // `screenshot_frame_delay` frames, then capture the window via
+    // `WindowHost::capture_png()` and exit. This is the SDK-level shape
+    // so every consumer (Spectr, examples, future plugins) gets headless
+    // visual-regression capture without bespoke per-app code.
+    if (!config_.screenshot_path.empty()) {
+        auto* host = window.get();
+        detail::ScreenshotCapture cap;
+        cap.delay = config_.screenshot_frame_delay > 0
+            ? config_.screenshot_frame_delay : 30;
+        cap.path = config_.screenshot_path;
+        cap.capture_fn = [host] { return host->capture_png(); };
+        cap.close_fn   = [host] { host->request_close(); };
+        cap.on_error   = [out_path = config_.screenshot_path](const std::string& msg) {
+            runtime::log_error("Standalone: screenshot {} ({})", msg, out_path);
+        };
+        // Compose with the pre-screenshot idle callback (inspector +
+        // scripted_ui poll + settings poll). The wrap calls the prior
+        // callback every frame, then on frame N captures + closes.
+        auto prior = pre_screenshot_idle;  // may be empty (Android path)
+        host->set_idle_callback([prior, cap = std::move(cap)]() mutable {
+            if (prior) prior();
+            cap();
+        });
+        runtime::log_info("Standalone: screenshot mode armed — will capture to {} after {} frames",
+                          config_.screenshot_path, cap.delay);
+    }
 
     // Blocks until the window is closed. The close callback above has
     // already fired bridge->close() (before stop() reset processor_),

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -973,6 +973,11 @@ add_executable(pulp-test-standalone-editor-chrome test_standalone_editor_chrome.
 target_link_libraries(pulp-test-standalone-editor-chrome PRIVATE pulp::standalone Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-standalone-editor-chrome)
 
+# Headless screenshot capture state machine (pulp #468)
+add_executable(pulp-test-screenshot-capture test_screenshot_capture.cpp)
+target_link_libraries(pulp-test-screenshot-capture PRIVATE pulp::standalone Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-screenshot-capture)
+
 # STFT and audio visualization signal tests
 add_executable(pulp-test-stft test_stft.cpp)
 target_link_libraries(pulp-test-stft PRIVATE pulp::signal Catch2::Catch2WithMain)

--- a/test/test_screenshot_capture.cpp
+++ b/test/test_screenshot_capture.cpp
@@ -1,0 +1,137 @@
+// pulp #468 — unit test for headless screenshot capture state machine.
+//
+// Verifies the delay → capture → write → close lifecycle without a real
+// WindowHost. The runtime composes this with the inspector / scripted_ui
+// / settings idle callback chain inside StandaloneApp::run_with_editor;
+// here we exercise only the capture helper in isolation.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/format/detail/screenshot_capture.hpp>
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+using pulp::format::detail::ScreenshotCapture;
+
+namespace {
+
+struct CaptureHarness {
+    int capture_calls = 0;
+    int close_calls = 0;
+    std::vector<std::string> errors;
+    std::vector<uint8_t> bytes_to_return = {0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
+
+    ScreenshotCapture make(const std::string& path, int delay) {
+        ScreenshotCapture cap;
+        cap.delay = delay;
+        cap.path = path;
+        cap.capture_fn = [this] { ++capture_calls; return bytes_to_return; };
+        cap.close_fn   = [this] { ++close_calls; };
+        cap.on_error   = [this](const std::string& msg) { errors.push_back(msg); };
+        return cap;
+    }
+};
+
+std::string tmp_screenshot_path(const char* suffix) {
+    auto dir = std::filesystem::temp_directory_path();
+    return (dir / (std::string("pulp_test_screenshot_") + suffix + ".png")).string();
+}
+
+std::vector<uint8_t> read_file_bytes(const std::string& path) {
+    std::ifstream in(path, std::ios::binary | std::ios::ate);
+    if (!in) return {};
+    auto size = static_cast<std::size_t>(in.tellg());
+    in.seekg(0);
+    std::vector<uint8_t> out(size);
+    in.read(reinterpret_cast<char*>(out.data()), static_cast<std::streamsize>(size));
+    return out;
+}
+
+}  // namespace
+
+TEST_CASE("ScreenshotCapture waits delay frames before capturing", "[issue-468][screenshot]") {
+    CaptureHarness h;
+    auto path = tmp_screenshot_path("delay");
+    std::filesystem::remove(path);
+    auto cap = h.make(path, 5);
+
+    // Frames 1..4: no capture, no close, file does not yet exist.
+    for (int i = 0; i < 4; ++i) {
+        cap();
+        REQUIRE(h.capture_calls == 0);
+        REQUIRE(h.close_calls == 0);
+        REQUIRE_FALSE(std::filesystem::exists(path));
+    }
+
+    // Frame 5: capture, write, close fire exactly once.
+    cap();
+    REQUIRE(h.capture_calls == 1);
+    REQUIRE(h.close_calls == 1);
+    REQUIRE(std::filesystem::exists(path));
+    REQUIRE(read_file_bytes(path) == h.bytes_to_return);
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("ScreenshotCapture is one-shot — extra ticks no-op", "[issue-468][screenshot]") {
+    CaptureHarness h;
+    auto path = tmp_screenshot_path("oneshot");
+    std::filesystem::remove(path);
+    auto cap = h.make(path, 2);
+
+    for (int i = 0; i < 10; ++i) cap();
+
+    REQUIRE(h.capture_calls == 1);
+    REQUIRE(h.close_calls == 1);
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("ScreenshotCapture reports error on empty capture bytes", "[issue-468][screenshot]") {
+    CaptureHarness h;
+    h.bytes_to_return.clear();
+    auto path = tmp_screenshot_path("empty");
+    std::filesystem::remove(path);
+    auto cap = h.make(path, 1);
+
+    cap();
+    REQUIRE(h.capture_calls == 1);
+    REQUIRE(h.errors.size() == 1);
+    REQUIRE(h.errors[0].find("empty") != std::string::npos);
+    // close_fn always fires even on error so the app exits deterministically.
+    REQUIRE(h.close_calls == 1);
+    // No file written when bytes are empty.
+    REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
+TEST_CASE("ScreenshotCapture survives copies — shared state advances together",
+          "[issue-468][screenshot]") {
+    // The runtime wraps the capture into a std::function and copies it
+    // into WindowHost's idle callback. With value-typed state, the copy
+    // would have its OWN frame counter and never trigger. Shared-state
+    // pointers ensure both copies advance the same counter.
+    CaptureHarness h;
+    auto path = tmp_screenshot_path("copy");
+    std::filesystem::remove(path);
+    auto cap = h.make(path, 3);
+
+    std::function<void()> wrapped = cap;  // copy
+    wrapped();  // frame 1
+    wrapped();  // frame 2
+    REQUIRE(h.capture_calls == 0);
+    cap();      // frame 3 via the original — same shared state
+    REQUIRE(h.capture_calls == 1);
+    REQUIRE(h.close_calls == 1);
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("ScreenshotCapture default delay (30) honored when caller leaves field unset",
+          "[issue-468][screenshot]") {
+    // The runtime defaults to 30 frames; verify the helper's own default
+    // matches (so an unset config doesn't fire on the first tick).
+    ScreenshotCapture cap;
+    REQUIRE(cap.delay == 30);
+}


### PR DESCRIPTION
## Summary

Adds `StandaloneConfig::screenshot_path` + `screenshot_frame_delay`. When set, `run_with_editor()` installs a one-shot idle callback that captures the window via `WindowHost::capture_png()` and exits cleanly. Codified at the SDK level so every `pulp::format::StandaloneApp` consumer (Spectr, examples, future plugins) gets headless visual-regression capture by parsing `--screenshot=PATH` from argv.

The capture state machine is factored into `pulp::format::detail::ScreenshotCapture` (header-only, side effects injected as `std::function`) so the lifecycle is unit-testable without a real `WindowHost`.

## What changed

- `core/format/include/pulp/format/standalone.hpp` — two new fields on `StandaloneConfig`
- `core/format/include/pulp/format/detail/screenshot_capture.hpp` — new helper struct with injected `capture_fn` / `close_fn` / `on_error`
- `core/format/src/standalone.cpp` — `run_with_editor()` composes the helper with the existing inspector/scripted_ui/settings idle callback chain
- `test/test_screenshot_capture.cpp` — 5 Catch2 cases / 27 assertions: delay-frames-before-capture, one-shot, empty-bytes error, shared-state-across-copies, default delay

## Validation

- 412 vitest tests in pulp-react still pass
- New test target \`pulp-test-screenshot-capture\` passes all 5 cases
- \`pulp-test-standalone-editor-chrome\` (existing, exercises the same code path) still passes 19 cases / 105 assertions
- End-to-end: Spectr standalone built against this SDK + \`--screenshot=/tmp/out.png --screenshot-frame-delay=180\` produces a 302KB PNG in 14s and self-exits

## Why now

This is the load-bearing primitive for the import-design → render → diff validation loop:
\`\`\`
pulp import-design --emit ...
build app SPECTR_RUNTIME_IMPORT=ON
app --screenshot=/tmp/render.png --screenshot-frame-delay=180
diff_against_reference.py /tmp/render.png REFERENCE.png
\`\`\`