### PR TITLE
docs(compat): document CG canvas-backend gap on canvas2d/filter (Codex P? on #1724)

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -8036,7 +8036,7 @@
         "test/test_canvas.cpp [skia][filter-chain][drop-shadow]",
         "test/test_canvas2d_shim.cpp [issue-1520]"
       ],
-      "notes": "pulp #1520 — JS shim + bridge + Skia parser/chain. Parser is local to skia_canvas.cpp; #1503's CSS filter on View elements is a parallel parser to be unified in a follow-up. arch-no-svg-filter-refs — url(#filter-id) SVG filter references are not supported — Pulp doesn't have an SVG filter graph. The 9 filter functions (blur/brightness/contrast/grayscale/hue-rotate/invert/opacity/saturate/sepia) plus drop-shadow are all wired.",
+      "notes": "pulp #1520 — JS shim + bridge + Skia parser/chain. Parser is local to skia_canvas.cpp; #1503's CSS filter on View elements is a parallel parser to be unified in a follow-up. arch-no-svg-filter-refs — url(#filter-id) SVG filter references are not supported — Pulp doesn't have an SVG filter graph. The 9 filter functions (blur/brightness/contrast/grayscale/hue-rotate/invert/opacity/saturate/sepia) plus drop-shadow are all wired on the Skia (GPU) backend. CG canvas backend (the CPU fallback used when no GPU context is available — `core/canvas/platform/mac/cg_canvas.mm` inherits the base `Canvas::set_filter` no-op) silently drops ALL filter functions; promoting CG to honor the chain requires CGImage filter wiring + a CG color-matrix equivalent (follow-up, tracked alongside the parallel `css/filter` CG-degradation note). For now, ctx.filter is honest-supported only when a Skia context is active; the Skia tests cited above prove that path.",
       "issue": "1520"
     },
     "canvas2d/shadowColor": {


### PR DESCRIPTION
The canvas2d/filter compat entry was implicitly claiming end-to-end
"supported" status but the CG canvas backend (`core/canvas/platform/
mac/cg_canvas.mm`, the CPU fallback used when no GPU context is
available) inherits `Canvas::set_filter`'s base no-op and silently
drops every filter function. Only the Skia backend implements the
chain via `parse_filter_chain` / `SkPaint::setImageFilter`.

This commit makes the notes honest about the asymmetry rather than
hiding it behind generic "supported" prose. Mirrors the existing
`css/filter` note that already documents CG degradation to "blur-only
collapse". No code change, no behavior change — pure honesty edit.

Codex P? finding on #1724: "Keep canvas2d/filter partial until CG
backend applies filters." compat.json doesn't have a "partial" status
in its schema (only `supported` / `wontfix`); the schema-aligned
expression is in `notes` + `unsupportedValues`.

Version-Bump: skip reason="compat.json documentation edit only — no SDK/CLI/plugin surface change"
Skill-Update: skip skill=view-bridge reason="compat.json notes edit, no view-bridge code or skill scope touched"
Compat-Update: skip surface=react reason="canvas2d-only notes edit, no react surface change"
Compat-Update: skip surface=rn reason="canvas2d-only notes edit, no rn surface change"
Compat-Update: skip surface=yoga reason="canvas2d-only notes edit, no yoga surface change"
Compat-Update: skip surface=css reason="canvas2d-only notes edit, no css surface change"
Compat-Update: skip surface=html reason="canvas2d-only notes edit, no html surface change"