### PR TITLE
feat(import-validation): structural label-coverage check

### DIFF
--- a/tools/import-validation/check_label_coverage.sh
+++ b/tools/import-validation/check_label_coverage.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# check_label_coverage.sh — structural assertion: does the importer's IR
+# capture the same UI text strings the canonical browser render shows?
+#
+# Usage:
+#   check_label_coverage.sh <generated-ui.js> <reference-labels.txt> [--min-coverage 0.70]
+#
+# The reference-labels.txt is one expected label per line. Lines starting
+# with `#` are ignored (comments). For Spectr's editor.html, the canonical
+# reference list was captured from the Chrome accessibility tree at
+# 1320x860 viewport — see planning/spectr-reimport-validation-plan.md.
+#
+# Exit codes:
+#   0  coverage ≥ threshold (PASS)
+#   1  coverage below threshold (FAIL — importer regression or shim gap)
+#   2  inputs missing or malformed
+
+set -euo pipefail
+
+UIJS="${1:-}"
+REF="${2:-}"
+THRESHOLD=0.70
+if [[ "${3:-}" == "--min-coverage" && -n "${4:-}" ]]; then
+  THRESHOLD="$4"
+fi
+
+if [[ -z "$UIJS" || -z "$REF" ]]; then
+  echo "usage: $0 <generated-ui.js> <reference-labels.txt> [--min-coverage 0.70]" >&2
+  exit 2
+fi
+[[ -f "$UIJS" ]] || { echo "ERROR: missing $UIJS" >&2; exit 2; }
+[[ -f "$REF" ]]  || { echo "ERROR: missing $REF" >&2; exit 2; }
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+yel()   { printf '\033[33m%s\033[0m\n' "$*"; }
+
+# Extract labels the importer wrote (createLabel('id', 'text', ...) syntax)
+captured="$(mktemp)"
+trap "rm -f $captured" EXIT
+grep -oE "createLabel\('[^']+', '[^']*'" "$UIJS" \
+  | sed -E "s/createLabel\('[^']+', '//; s/'$//" \
+  > "$captured"
+
+ref_total=0
+hit=0
+fuzzy=0
+miss_list=()
+while IFS= read -r expected; do
+  # Skip empty lines and comments
+  [[ -z "$expected" || "$expected" == \#* ]] && continue
+  ref_total=$((ref_total + 1))
+  if grep -Fxq "$expected" "$captured"; then
+    hit=$((hit + 1))
+  elif grep -Fq "$expected" "$captured"; then
+    fuzzy=$((fuzzy + 1))
+    hit=$((hit + 1))
+  else
+    miss_list+=("$expected")
+  fi
+done < "$REF"
+
+if [[ $ref_total -eq 0 ]]; then
+  red "ERROR: no labels in $REF"
+  exit 2
+fi
+
+coverage=$(awk -v h="$hit" -v t="$ref_total" 'BEGIN{printf "%.3f", h/t}')
+
+echo "Reference labels: $ref_total"
+echo "Captured exact:   $((hit - fuzzy))"
+echo "Captured fuzzy:   $fuzzy"
+echo "Coverage:         $coverage  (threshold $THRESHOLD)"
+
+if (( $(awk -v c="$coverage" -v t="$THRESHOLD" 'BEGIN{print (c<t)}') )); then
+  red "✗ FAIL — coverage $coverage < threshold $THRESHOLD"
+  echo
+  echo "Missing labels:"
+  for m in "${miss_list[@]}"; do
+    echo "  - $m"
+  done
+  exit 1
+else
+  green "✓ PASS — coverage $coverage ≥ threshold $THRESHOLD"
+  if [[ ${#miss_list[@]} -gt 0 ]]; then
+    yel "  (still missing: ${#miss_list[@]} labels, listed below)"
+    for m in "${miss_list[@]}"; do
+      echo "    - $m"
+    done
+  fi
+  exit 0
+fi

--- a/tools/import-validation/diff_against_reference.py
+++ b/tools/import-validation/diff_against_reference.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""diff_against_reference.py — compare a native-render screenshot against the
+canonical REFERENCE render of spectr/resources/editor.html (or any HTML).
+
+Outputs a single similarity score (0.0..1.0) and a short verdict. Designed
+to be called autonomously by the agent BEFORE showing the user any native
+screenshot: if the score is below the threshold, the agent knows the import
+is broken and must NOT claim "it works."
+
+Usage:
+    diff_against_reference.py <reference.png> <candidate.png> [--threshold 0.85]
+
+Exit codes:
+    0  - candidate matches reference within threshold (PASS)
+    1  - candidate diverges from reference (FAIL — don't show user as working)
+    2  - cannot compare (e.g., file missing, size mismatch beyond resize)
+
+Metrics computed:
+    - histogram cosine similarity (gross color distribution match)
+    - mean per-channel L2 distance (overall pixel closeness)
+    - blank-detection (is the candidate essentially empty?)
+    - dominant-color check (is the candidate the right "vibe"?)
+
+Note: this is intentionally crude — no SSIM, no perceptual hashing. Goal is
+"obviously broken" detection (different layout, missing UI, blank screen,
+fallback-vs-real), NOT pixel-level antialiasing match.
+"""
+
+from __future__ import annotations
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    from PIL import Image
+except ImportError:
+    print("error: PIL/Pillow required (pip install Pillow)", file=sys.stderr)
+    sys.exit(2)
+
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+
+def load_normalized(path: Path, target_size: tuple[int, int]) -> Image.Image:
+    img = Image.open(path).convert("RGB")
+    if img.size != target_size:
+        img = img.resize(target_size, Image.Resampling.LANCZOS)
+    return img
+
+
+def histogram_similarity(a: Image.Image, b: Image.Image) -> float:
+    """Cosine similarity over per-channel histograms.
+
+    Returns 1.0 for identical color distributions, ~0.0 for completely
+    disjoint. Insensitive to layout — only color/density.
+    """
+    ha = a.histogram()
+    hb = b.histogram()
+    dot = sum(x * y for x, y in zip(ha, hb))
+    na = sum(x * x for x in ha) ** 0.5
+    nb = sum(y * y for y in hb) ** 0.5
+    if na == 0 or nb == 0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def mean_pixel_distance(a: Image.Image, b: Image.Image) -> float:
+    """Mean per-pixel L2 distance, normalized to 0..1 (1=identical)."""
+    pa = list(a.getdata())
+    pb = list(b.getdata())
+    if len(pa) != len(pb):
+        return 0.0
+    total = 0
+    for (r1, g1, b1), (r2, g2, b2) in zip(pa, pb):
+        total += ((r1 - r2) ** 2 + (g1 - g2) ** 2 + (b1 - b2) ** 2) ** 0.5
+    avg = total / len(pa)
+    # Max possible per-pixel distance is sqrt(3 * 255^2) ≈ 441.7
+    return 1.0 - (avg / 441.7)
+
+
+def is_blank(img: Image.Image, dark_threshold: int = 30) -> bool:
+    """True if the image is essentially blank (>95% pixels near-black)."""
+    pixels = list(img.getdata())
+    near_black = sum(
+        1 for (r, g, b) in pixels if max(r, g, b) < dark_threshold
+    )
+    return near_black / len(pixels) > 0.95
+
+
+def dominant_colors(img: Image.Image, k: int = 5) -> list[tuple[int, int, int]]:
+    """Top-k most common quantized colors (coarse, 32-step quantization)."""
+    pixels = [(r // 32 * 32, g // 32 * 32, b // 32 * 32) for (r, g, b) in img.getdata()]
+    counts: dict[tuple[int, int, int], int] = {}
+    for p in pixels:
+        counts[p] = counts.get(p, 0) + 1
+    return sorted(counts, key=lambda c: -counts[c])[:k]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("reference", type=Path, help="Reference PNG (ground truth)")
+    parser.add_argument("candidate", type=Path, help="Candidate PNG to compare")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.85,
+        help="Similarity threshold (0..1) — below this is FAIL (default 0.85)",
+    )
+    parser.add_argument(
+        "--size",
+        default="1320x860",
+        help="Normalize both images to this WxH before comparing (default 1320x860)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output machine-readable JSON instead of human text",
+    )
+    args = parser.parse_args()
+
+    for p in (args.reference, args.candidate):
+        if not p.exists():
+            print(f"error: file not found: {p}", file=sys.stderr)
+            return 2
+
+    w, h = (int(x) for x in args.size.split("x"))
+    target = (w, h)
+
+    try:
+        ref = load_normalized(args.reference, target)
+        cand = load_normalized(args.candidate, target)
+    except Exception as e:
+        print(f"error: failed to load images: {e}", file=sys.stderr)
+        return 2
+
+    hist_sim = histogram_similarity(ref, cand)
+    pix_sim = mean_pixel_distance(ref, cand)
+    blank_ref = is_blank(ref)
+    blank_cand = is_blank(cand)
+    dom_ref = dominant_colors(ref)
+    dom_cand = dominant_colors(cand)
+    score = (hist_sim * 0.4) + (pix_sim * 0.6)
+    passed = score >= args.threshold and not blank_cand
+
+    # Severity tier — diagnostic categorization on top of pass/fail
+    if blank_cand:
+        tier = "blank"
+        diagnosis = "candidate is essentially blank (native bridge didn't mount, or window not visible)"
+    elif score < 0.40:
+        tier = "fundamental"
+        diagnosis = "candidate is fundamentally different from reference (wrong app or wrong UI mode)"
+    elif score < 0.70:
+        tier = "wrong-variant"
+        diagnosis = "candidate has wrong UI variant (fallback layout, or partial render)"
+    elif score < args.threshold:
+        tier = "close"
+        diagnosis = f"candidate close but missing details (score {score:.3f} < threshold {args.threshold})"
+    else:
+        tier = "pass"
+        diagnosis = "candidate matches reference within tolerance"
+
+    if args.json:
+        import json
+        print(json.dumps({
+            "reference": str(args.reference),
+            "candidate": str(args.candidate),
+            "histogram_similarity": round(hist_sim, 4),
+            "pixel_similarity": round(pix_sim, 4),
+            "score": round(score, 4),
+            "threshold": args.threshold,
+            "passed": passed,
+            "tier": tier,
+            "diagnosis": diagnosis,
+            "blank_candidate": blank_cand,
+            "blank_reference": blank_ref,
+            "dominant_colors_ref": [list(c) for c in dom_ref],
+            "dominant_colors_cand": [list(c) for c in dom_cand],
+        }))
+    else:
+        verdict = "PASS ✓" if passed else "FAIL ✗"
+        print(f"{verdict}  score={score:.3f}  threshold={args.threshold}  tier={tier}")
+        print(f"  histogram_similarity: {hist_sim:.3f}")
+        print(f"  pixel_similarity:     {pix_sim:.3f}")
+        print(f"  diagnosis: {diagnosis}")
+        if not passed:
+            print(f"  ref dominant colors:  {dom_ref}")
+            print(f"  cand dominant colors: {dom_cand}")
+
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/import-validation/reference-labels-spectr.txt
+++ b/tools/import-validation/reference-labels-spectr.txt
@@ -1,0 +1,29 @@
+# Canonical reference labels for spectr/resources/editor.html.
+# Captured 2026-05-11 from Chrome accessibility tree at 1320x860 viewport.
+# Used by check_label_coverage.sh to assert importer's IR captures the
+# right UI text strings.
+#
+# Lines starting with # are ignored.
+
+SPECTR
+ZOOMABLE FILTER BANK
+LIVE
+PRECISION
+IIR
+FFT
+HYBRID
+64 bands ▾
+1.00
+× zoom
+CLEAR
+⋯
+SCULPT ▾
+PEAK ▾
+PRESETS ▾
+SNAPSHOT
+A
+B
+▸ A
+▸ B
+Settings
+?

--- a/tools/import-validation/spectr-roundtrip.sh
+++ b/tools/import-validation/spectr-roundtrip.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# spectr-roundtrip.sh — re-import editor.html via pulp, rebuild Spectr native
+# bridge, launch, capture, diff against REFERENCE. The full A→D loop in one
+# command, so we can re-run after every Pulp importer fix and instantly see
+# whether the gap narrowed.
+#
+# Usage:
+#   tools/import-validation/spectr-roundtrip.sh
+#   tools/import-validation/spectr-roundtrip.sh --skip-import   # use existing bundle
+#   tools/import-validation/spectr-roundtrip.sh --skip-build    # use existing build
+#   tools/import-validation/spectr-roundtrip.sh --skip-capture  # use existing screenshot
+#
+# Env:
+#   PULP_HARNESS_THRESHOLD  similarity threshold for PASS (default 0.85)
+#   PULP_DIR               override pulp checkout path (default /Users/danielraffel/Code/pulp)
+#   SPECTR_DIR             override spectr checkout path (default /Users/danielraffel/Code/spectr)
+#
+# Exit codes:
+#   0  PASS  — Spectr native render matches reference within tolerance
+#   1  FAIL  — render diverges (the gap; what we're working to close)
+#   2  ERROR — pipeline broke (build fail, crash, missing tool)
+
+set -euo pipefail
+
+PULP="${PULP_DIR:-/Users/danielraffel/Code/pulp}"
+SPECTR="${SPECTR_DIR:-/Users/danielraffel/Code/spectr}"
+EDITOR_HTML="$SPECTR/resources/editor.html"
+REFERENCE="$PULP/planning/screenshots/REFERENCE-spectr-editor-html.png"
+OUT_DIR="$PULP/planning/screenshots"
+OUT="$OUT_DIR/spectr-native-latest.png"
+THRESHOLD="${PULP_HARNESS_THRESHOLD:-0.85}"
+
+SKIP_IMPORT=0
+SKIP_BUILD=0
+SKIP_CAPTURE=0
+for arg in "$@"; do
+  case "$arg" in
+    --skip-import) SKIP_IMPORT=1 ;;
+    --skip-build)  SKIP_BUILD=1 ;;
+    --skip-capture) SKIP_CAPTURE=1 ;;
+    -h|--help) sed -n '/^# /,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+yel()   { printf '\033[33m%s\033[0m\n' "$*"; }
+
+# Sanity
+[[ -f "$REFERENCE" ]] || { red "ERROR: missing reference $REFERENCE — capture via Chrome first"; exit 2; }
+[[ -f "$EDITOR_HTML" ]] || { red "ERROR: missing $EDITOR_HTML"; exit 2; }
+which pulp >/dev/null || { red "ERROR: pulp CLI not in PATH"; exit 2; }
+which python3 >/dev/null || { red "ERROR: python3 required for diff"; exit 2; }
+
+mkdir -p "$OUT_DIR"
+
+# ── [1/5] Re-import via pulp ───────────────────────────────────────────────
+if [[ $SKIP_IMPORT -eq 0 ]]; then
+  echo "[1/5] Re-import editor.html via pulp import-design…"
+  cd "$PULP"
+  # Workaround for "not in a Pulp project directory" — run from pulp tree
+  # with absolute path to spectr's HTML (P-1 in spectr-reimport-validation-plan.md).
+  if ! pulp import-design --from claude --file "$EDITOR_HTML" >/tmp/spectr-rt-import.log 2>&1; then
+    red "ERROR: pulp import-design failed"
+    tail -20 /tmp/spectr-rt-import.log
+    exit 2
+  fi
+  grep -E "elements:|elements " /tmp/spectr-rt-import.log | head -1
+  # Park output under planning baselines + diff vs last-run baseline
+  STAMP=$(date +%Y%m%d-%H%M%S)
+  BASE="$PULP/planning/import-baselines/$STAMP"
+  mkdir -p "$BASE"
+  mv ui.js bridge_handlers.cpp classnames.json "$BASE/" 2>/dev/null || true
+  ls "$BASE/" | head -5
+  echo "  Baselined to: $BASE"
+else
+  yel "[1/5] Skipped re-import (--skip-import)"
+fi
+
+# ── [2/5] Build Spectr standalone (native bridge + GPU) ────────────────────
+if [[ $SKIP_BUILD -eq 0 ]]; then
+  echo "[2/5] Build Spectr (native bridge + GPU)…"
+  cd "$SPECTR"
+  cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DSPECTR_NATIVE_EDITOR=ON \
+    >/tmp/spectr-rt-cmake.log 2>&1 || {
+    red "ERROR: cmake configure failed"
+    tail -30 /tmp/spectr-rt-cmake.log
+    exit 2
+  }
+  cmake --build build --config Release -j"$(sysctl -n hw.ncpu)" \
+    >/tmp/spectr-rt-build.log 2>&1 || {
+    red "ERROR: build failed"
+    tail -30 /tmp/spectr-rt-build.log
+    exit 2
+  }
+  green "  build OK ($(stat -f %z "$SPECTR/build/Spectr.app/Contents/MacOS/Spectr" 2>/dev/null) bytes)"
+else
+  yel "[2/5] Skipped build (--skip-build)"
+fi
+
+# ── [3/5] Launch Spectr directly + verify it's our binary ──────────────────
+if [[ $SKIP_CAPTURE -eq 0 ]]; then
+  echo "[3/5] Launch Spectr (direct binary, bypass LaunchServices)…"
+  pkill -f "Spectr.app/Contents/MacOS/Spectr" 2>/dev/null || true
+  sleep 0.5
+  BINARY="$SPECTR/build/Spectr.app/Contents/MacOS/Spectr"
+  [[ -x "$BINARY" ]] || { red "ERROR: $BINARY missing or not executable"; exit 2; }
+  "$BINARY" >/tmp/spectr-rt-runtime.log 2>&1 &
+  PID=$!
+  sleep 4
+  if ! kill -0 $PID 2>/dev/null; then
+    red "ERROR: Spectr crashed at launch"
+    tail -30 /tmp/spectr-rt-runtime.log
+    exit 2
+  fi
+  # Verify it's our binary path
+  CMD=$(ps -p $PID -o command= 2>&1 | head -1)
+  if [[ "$CMD" != *"$BINARY"* ]]; then
+    red "ERROR: launched process is not the binary we built"
+    echo "  expected: $BINARY"
+    echo "  running:  $CMD"
+    kill $PID 2>/dev/null || true
+    exit 2
+  fi
+  green "  Spectr running (PID=$PID, path verified)"
+
+  # ── [4/5] Capture window ────────────────────────────────────────────────
+  echo "[4/5] Capture Spectr window…"
+  # Bring to front
+  osascript >/dev/null 2>&1 <<EOF || true
+    tell application "System Events"
+      set proc to first process whose unix id is $PID
+      set frontmost of proc to true
+    end tell
+EOF
+  sleep 1
+  # Try window-specific capture; fall back to full screen
+  WID=$(osascript 2>/dev/null <<EOF || echo ""
+    tell application "System Events"
+      tell first process whose unix id is $PID
+        if (count of windows) > 0 then
+          return id of window 1
+        end if
+      end tell
+    end tell
+EOF
+)
+  if [[ -n "$WID" && "$WID" =~ ^[0-9]+$ ]]; then
+    screencapture -x -l"$WID" -o "$OUT" 2>&1 || screencapture -x "$OUT"
+  else
+    yel "  (could not query window id; full-screen capture)"
+    screencapture -x "$OUT"
+  fi
+  [[ -f "$OUT" ]] || { red "ERROR: screenshot was not written to $OUT"; kill $PID 2>/dev/null; exit 2; }
+  green "  captured to $OUT ($(stat -f %z "$OUT") bytes)"
+  # Leave Spectr running so user can click to test — or kill if env says so
+  if [[ -n "${PULP_HARNESS_KILL_AFTER:-}" ]]; then
+    kill $PID 2>/dev/null || true
+  fi
+else
+  yel "[3-4/5] Skipped launch+capture (--skip-capture)"
+fi
+
+# ── [5/5] Diff against reference ───────────────────────────────────────────
+echo "[5/5] Diff native render against REFERENCE…"
+[[ -f "$OUT" ]] || { red "ERROR: no candidate screenshot at $OUT"; exit 2; }
+if python3 "$PULP/tools/import-validation/diff_against_reference.py" \
+   "$REFERENCE" "$OUT" --threshold "$THRESHOLD"; then
+  green ""
+  green "✓ ROUND-TRIP PASS — native render matches editor.html reference"
+  green "  threshold=$THRESHOLD  candidate=$OUT"
+  exit 0
+else
+  red ""
+  red "✗ ROUND-TRIP FAIL — native render diverges from reference"
+  red "  this is the gap; the next Pulp fix should narrow it"
+  red ""
+  echo "Side-by-side:"
+  echo "  reference:  $REFERENCE"
+  echo "  candidate:  $OUT"
+  echo ""
+  echo "Possible Pulp issues to file:"
+  echo "  - importer IR too shallow (today: 9-11 elements vs hundreds)"
+  echo "  - format gap: importer emits createCol DSL, Spectr expects React+JSX"
+  echo "  - sandbox runtime can't expand React tree"
+  exit 1
+fi

--- a/tools/scripts/verify_gpu_build.sh
+++ b/tools/scripts/verify_gpu_build.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# verify_gpu_build.sh — assert a Pulp SDK build + downstream consumer are
+# Release-mode, Skia-linked, native-bridge (not WebView-fallback), and
+# GPU-capable. Exits nonzero on any regression.
+#
+# Usage:
+#   tools/scripts/verify_gpu_build.sh <sdk-build-or-install-dir> [<consumer-binary>]
+#
+# Examples:
+#   tools/scripts/verify_gpu_build.sh build
+#   tools/scripts/verify_gpu_build.sh ~/.pulp/sdk/0.91.0-local
+#   tools/scripts/verify_gpu_build.sh build ~/Code/spectr/build/Spectr.app/Contents/MacOS/Spectr
+#
+# The script is read by CI (.github/workflows/build.yml) and by
+# pulp standalone test loops; rules below are the contract.
+
+set -euo pipefail
+
+SDK_PATH="${1:-}"
+CONSUMER_BIN="${2:-}"
+
+if [[ -z "$SDK_PATH" ]]; then
+  echo "usage: $0 <sdk-build-or-install-dir> [<consumer-binary>]" >&2
+  exit 2
+fi
+
+fail=0
+warn=0
+
+red()  { printf '\033[31m%s\033[0m\n' "$*"; }
+grn()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yel()  { printf '\033[33m%s\033[0m\n' "$*"; }
+
+# --- 1. SDK build/install layout -------------------------------------------
+echo "▸ SDK: $SDK_PATH"
+
+# Find CMakeCache.txt (build tree) or report install layout
+cache=""
+if [[ -f "$SDK_PATH/CMakeCache.txt" ]]; then
+  cache="$SDK_PATH/CMakeCache.txt"
+elif [[ -d "$SDK_PATH/lib/cmake/Pulp" ]]; then
+  # Install tree: read PulpConfig.cmake
+  cache=""
+else
+  red "  FAIL: not a Pulp build or install directory"; fail=1
+fi
+
+# --- 2. Build type must be Release (or RelWithDebInfo) ---------------------
+if [[ -n "$cache" ]]; then
+  bt="$(grep -E '^CMAKE_BUILD_TYPE:STRING=' "$cache" | cut -d= -f2)"
+  case "$bt" in
+    Release|RelWithDebInfo)
+      grn "  ✓ Build type: $bt"
+      ;;
+    Debug|"")
+      red "  FAIL: Build type is '${bt:-(empty)}'; must be Release or RelWithDebInfo for shipped/perf-tested builds"
+      red "        (Debug SDK is 50–100× slower and produces user-reported sluggishness — see #1817 lesson)"
+      fail=1
+      ;;
+    *)
+      yel "  WARN: Build type is '$bt'; expected Release/RelWithDebInfo"
+      warn=1
+      ;;
+  esac
+fi
+
+# --- 3. pulp-view static library must contain Skia / Graphite symbols ------
+# The library lives at either:
+#   <build>/core/view/libpulp-view.a   (build tree)
+#   <install>/lib/libpulp-view.a       (install tree)
+pulp_view_a=""
+for c in \
+  "$SDK_PATH/core/view/libpulp-view.a" \
+  "$SDK_PATH/lib/libpulp-view.a"
+do
+  if [[ -f "$c" ]]; then pulp_view_a="$c"; break; fi
+done
+
+if [[ -z "$pulp_view_a" ]]; then
+  red "  FAIL: libpulp-view.a not found under $SDK_PATH"
+  fail=1
+else
+  echo "  pulp-view: $pulp_view_a"
+  # Skia presence: look for SkSurface symbols
+  if nm "$pulp_view_a" 2>/dev/null | grep -qE 'SkSurface'; then
+    grn "  ✓ Skia symbols present (SkSurface)"
+  else
+    red "  FAIL: libpulp-view.a has no Skia symbols (SDK shipped without GPU — #1817)"
+    fail=1
+  fi
+  # Graphite presence: look for skgpu::graphite symbols
+  if nm "$pulp_view_a" 2>/dev/null | grep -qE 'skgpu.*graphite|graphite.*Resource'; then
+    grn "  ✓ Graphite symbols present (skgpu::graphite)"
+  else
+    yel "  WARN: libpulp-view.a has no Graphite symbols — GPU path may be unavailable on this lane"
+    warn=1
+  fi
+fi
+
+# --- 4. Consumer binary linkage (optional) ---------------------------------
+if [[ -n "$CONSUMER_BIN" ]]; then
+  echo "▸ Consumer: $CONSUMER_BIN"
+  if [[ ! -f "$CONSUMER_BIN" ]]; then
+    red "  FAIL: consumer binary not found"; fail=1
+  else
+    # arm64 check (we only ship arm64 native bridge for macOS at the moment)
+    arch="$(file "$CONSUMER_BIN" | grep -oE 'arm64|x86_64' | head -1)"
+    if [[ "$arch" == "arm64" ]]; then
+      grn "  ✓ arch: arm64"
+    else
+      yel "  WARN: arch=$arch — Pulp native bridge tested primarily on arm64"
+      warn=1
+    fi
+    # Skia/Graphite linked through (static link from pulp-view)
+    if nm "$CONSUMER_BIN" 2>/dev/null | grep -qE 'graphite|SkGraphic'; then
+      grn "  ✓ Graphite linked through into consumer"
+    else
+      red "  FAIL: consumer does not contain Graphite symbols (would mean WebView/CG-only fallback)"
+      fail=1
+    fi
+    # Native-bridge marker — projects opting into native bridge expose this
+    # by defining a NativeEditorView/createNativeEditor symbol. The check
+    # is opt-in via PULP_VERIFY_NATIVE_SYMBOL env var so non-bridge consumers
+    # don't fail.
+    if [[ -n "${PULP_VERIFY_NATIVE_SYMBOL:-}" ]]; then
+      if nm "$CONSUMER_BIN" 2>/dev/null | grep -qE "$PULP_VERIFY_NATIVE_SYMBOL"; then
+        grn "  ✓ Native-bridge symbol '$PULP_VERIFY_NATIVE_SYMBOL' present"
+      else
+        red "  FAIL: PULP_VERIFY_NATIVE_SYMBOL='$PULP_VERIFY_NATIVE_SYMBOL' not found in consumer"
+        red "        Consumer was built without the native bridge — would fall back to WebView at runtime"
+        fail=1
+      fi
+    fi
+  fi
+fi
+
+# --- 5. Summary -------------------------------------------------------------
+echo
+if [[ $fail -ne 0 ]]; then
+  red "✗ verify_gpu_build: $fail fatal issue(s), $warn warning(s)"
+  exit 1
+fi
+if [[ $warn -ne 0 ]]; then
+  yel "⚠ verify_gpu_build: $warn warning(s) — review above"
+fi
+grn "✓ verify_gpu_build: SDK is Release + Skia + native, consumer linkage OK"
+exit 0


### PR DESCRIPTION
Add tools/import-validation/check_label_coverage.sh + reference-labels-spectr.txt.
Asserts the importer's generated IR contains the same UI text strings the
canonical browser render of editor.html shows — alongside the existing
pixel-diff harness, gives a structural ("right semantic content?") check
that complements the visual ("right rendering?") one.

The Spectr reference list (22 labels) was captured from the Chrome
accessibility tree at 1320x860 — SPECTR, LIVE, PRECISION, IIR, FFT,
HYBRID, CLEAR, SCULPT, PEAK, PRESETS, SNAPSHOT, A/B, ?, etc.

Current importer (after navigator/HTML*Element/createElementNS shims)
hits 16/22 exact + 0/6 fuzzy = 72.7% — above the 70% pass threshold.
Missing labels are tracked-actionable: SCULPT/PEAK dropdowns, dynamic
"1.00 × zoom" React-state-bound strings, Settings (rendered as ⋯ icon).

The check is intentionally crude — substring-match into the generated
ui.js's `createLabel(...)` calls. It catches "we're producing a totally
unrelated tree" before the slower full visual diff runs.