### PR TITLE
fix(import-validation): no full-screen capture fallback — preserves window-only diff against REFERENCE

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,6 +97,18 @@ if(UNIX)
     set_tests_properties(pulp-mcp-launcher PROPERTIES TIMEOUT 15)
 endif()
 
+# Window-only capture invariants (pulp-internal task #81) —
+# spectr-roundtrip.sh must not silently fall back to full-screen
+# screencapture, because terminal / desktop background then poisons
+# the histogram diff against the REFERENCE render. Static-content
+# regression pins the structural fix.
+if(UNIX)
+    add_test(NAME spectr-roundtrip-window-only-capture
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_spectr_roundtrip_window_only_capture.sh)
+    set_tests_properties(spectr-roundtrip-window-only-capture
+        PROPERTIES TIMEOUT 10)
+endif()
+
 # Debug-SDK perf-killer guard smoke (pulp-internal task #35).
 # Hermetic — runs the guard against a tempdir-fabricated SDK install,
 # exercises the three branches (Debug-no-override → FATAL_ERROR,

--- a/test/test_spectr_roundtrip_window_only_capture.sh
+++ b/test/test_spectr_roundtrip_window_only_capture.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Regression test for pulp-internal task #81 — `tools/import-validation/
+# spectr-roundtrip.sh` must NOT silently fall back to a full-screen
+# screencapture when the per-window capture fails, because the desktop /
+# terminal background then bleeds into the histogram diff against the
+# REFERENCE render and the similarity score reflects wallpaper instead
+# of plugin UI.
+#
+# This test pins:
+#   1. The script parses cleanly under `bash -n` (no syntax regressions).
+#   2. The legacy unconditional fullscreen fallback line is GONE.
+#   3. The opt-in env var `PULP_HARNESS_ALLOW_FULLSCREEN` is documented
+#      and used to gate the fullscreen path.
+#   4. Every retained `screencapture` invocation uses `-o` (drop shadow),
+#      so even the explicit opt-in fullscreen path doesn't grow back
+#      the same drop-shadow-noise problem.
+#
+# Hermetic: reads only the script source; no real screencapture, no
+# launch of Spectr, no Pillow / Python deps. Exits 0 on pass.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HARNESS="$SCRIPT_DIR/tools/import-validation/spectr-roundtrip.sh"
+
+if [ ! -f "$HARNESS" ]; then
+    echo "FAIL: $HARNESS not found" >&2
+    exit 1
+fi
+
+pass() { echo "PASS: $*"; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# 1. Syntax — bash -n.
+if ! bash -n "$HARNESS"; then
+    fail "spectr-roundtrip.sh has bash syntax errors"
+fi
+pass "syntax: bash -n clean"
+
+# 2. The pre-#81 fallback `screencapture -x "$OUT"` (no -l, no -o, no
+#    -W) must NOT appear as an unconditional invocation. Specifically,
+#    no `screencapture -x "$OUT"` followed by EOL with no further flags
+#    — the only acceptable fullscreen invocation is gated by an env
+#    var AND uses `-o`.
+if grep -E '^\s*screencapture -x "\$OUT"\s*$' "$HARNESS" >/dev/null; then
+    fail "found bare unconditional fullscreen screencapture (re-introduces task #81 regression)"
+fi
+pass "no unconditional fullscreen fallback"
+
+# 3. Opt-in env var present.
+if ! grep -q "PULP_HARNESS_ALLOW_FULLSCREEN" "$HARNESS"; then
+    fail "PULP_HARNESS_ALLOW_FULLSCREEN opt-out gate not documented in the harness"
+fi
+pass "PULP_HARNESS_ALLOW_FULLSCREEN gate present"
+
+# 4. Every retained screencapture *invocation* uses -o (drop shadow).
+# We match lines that BEGIN with whitespace then `screencapture` —
+# real invocations live at the start of a line (modulo indentation).
+# Error/log strings that mention "screencapture" inside `red "..."`
+# or `echo "..."` are excluded by the leading-anchor.
+bad=$(grep -nE '^[[:space:]]*screencapture\b' "$HARNESS" | grep -v -- '-o' || true)
+if [ -n "$bad" ]; then
+    echo "FAIL: screencapture invocation without -o (drop shadow) — these lines:" >&2
+    echo "$bad" >&2
+    exit 1
+fi
+pass "every screencapture invocation uses -o (drop shadow)"
+
+echo "OK — all 4 assertions passed."

--- a/tools/import-validation/spectr-roundtrip.sh
+++ b/tools/import-validation/spectr-roundtrip.sh
@@ -134,22 +134,59 @@ if [[ $SKIP_CAPTURE -eq 0 ]]; then
     end tell
 EOF
   sleep 1
-  # Try window-specific capture; fall back to full screen
-  WID=$(osascript 2>/dev/null <<EOF || echo ""
-    tell application "System Events"
-      tell first process whose unix id is $PID
-        if (count of windows) > 0 then
-          return id of window 1
-        end if
+  # Window-specific capture only. A full-screen fallback was tempting but
+  # poisons the histogram diff against the REFERENCE render (terminal /
+  # desktop background bleeds into the global color distribution and the
+  # similarity score ends up reflecting the wallpaper, not the plugin
+  # UI). See task #81. Retry the window-id query a few times — Cocoa
+  # windows can take a moment to appear in System Events after launch.
+  WID=""
+  for attempt in 1 2 3 4 5; do
+    WID=$(osascript 2>/dev/null <<EOF || echo ""
+      tell application "System Events"
+        tell first process whose unix id is $PID
+          if (count of windows) > 0 then
+            return id of window 1
+          end if
+        end tell
       end tell
-    end tell
 EOF
 )
-  if [[ -n "$WID" && "$WID" =~ ^[0-9]+$ ]]; then
-    screencapture -x -l"$WID" -o "$OUT" 2>&1 || screencapture -x "$OUT"
+    if [[ -n "$WID" && "$WID" =~ ^[0-9]+$ ]]; then break; fi
+    sleep 0.5
+  done
+
+  if [[ -z "$WID" || ! "$WID" =~ ^[0-9]+$ ]]; then
+    red "ERROR: could not query Spectr window id after 5 attempts."
+    red "  pid=$PID — process may have crashed during launch, or System"
+    red "  Events accessibility permission is missing for Terminal."
+    red "  (Full-screen capture intentionally skipped — it would poison"
+    red "  the histogram diff with desktop/terminal background colors."
+    red "  Set PULP_HARNESS_ALLOW_FULLSCREEN=1 to opt back into the"
+    red "  legacy fallback if you really want a fullscreen capture.)"
+    if [[ -n "${PULP_HARNESS_ALLOW_FULLSCREEN:-}" ]]; then
+      yel "  PULP_HARNESS_ALLOW_FULLSCREEN=1 set — falling back to full-screen capture (-o to drop shadow)"
+      screencapture -x -o "$OUT"
+    else
+      kill $PID 2>/dev/null
+      exit 2
+    fi
   else
-    yel "  (could not query window id; full-screen capture)"
-    screencapture -x "$OUT"
+    # -o drops the drop-shadow border (which would otherwise pick up
+    # whatever's behind the window — terminal, desktop, etc. — and
+    # contribute the same kind of background noise to the diff).
+    if ! screencapture -x -l"$WID" -o "$OUT"; then
+      red "ERROR: screencapture -l$WID failed."
+      red "  (Falling back to full-screen capture would poison the diff;"
+      red "  set PULP_HARNESS_ALLOW_FULLSCREEN=1 if that's what you want.)"
+      if [[ -n "${PULP_HARNESS_ALLOW_FULLSCREEN:-}" ]]; then
+        yel "  PULP_HARNESS_ALLOW_FULLSCREEN=1 set — falling back"
+        screencapture -x -o "$OUT"
+      else
+        kill $PID 2>/dev/null
+        exit 2
+      fi
+    fi
   fi
   [[ -f "$OUT" ]] || { red "ERROR: screenshot was not written to $OUT"; kill $PID 2>/dev/null; exit 2; }
   green "  captured to $OUT ($(stat -f %z "$OUT") bytes)"


### PR DESCRIPTION
## Summary

Closes pulp-internal task #81 (Agent A unblocked it via PR #1847 / `tools/import-validation/` directory landing on `main`).

`tools/import-validation/spectr-roundtrip.sh` previously fell back to an unconditional full-screen `screencapture -x` when the per-window osascript query couldn't extract a window id. That fallback silently poisons the histogram diff against the canonical `REFERENCE-spectr-editor-html.png` — the candidate ends up dominated by desktop wallpaper + terminal background, so the similarity score reflects whatever is behind the Spectr window instead of the plugin UI itself.

## What changed

- Retry the `id of window 1` query up to 5× with 0.5s spacing (Cocoa windows can lag the launch).
- When retries still don't yield a window id, fail hard with an actionable error pointing at the two likely causes (process crashed during launch / Terminal lacks Accessibility permission).
- Explicit opt-in env var `PULP_HARNESS_ALLOW_FULLSCREEN=1` for the rare case where the caller deliberately wants the fullscreen path. That path now also uses `-o` (drop shadow).
- Both retained `screencapture` invocations use `-o` — the drop-shadow border itself picks up desktop / terminal pixels through its alpha edge.

## Test plan

- [x] `bash test/test_spectr_roundtrip_window_only_capture.sh` — 4 static-content + syntax assertions pass (bash -n clean, no unconditional fullscreen fallback, env-var gate present, every `screencapture` invocation uses `-o`).
- [x] CTest wires it as `spectr-roundtrip-window-only-capture` (UNIX-gated, 10s timeout).
- [ ] Post-merge: run `tools/import-validation/spectr-roundtrip.sh` against the live Spectr build; verify the captured PNG no longer contains terminal pixels around the Spectr window border.