### PR TITLE
test(import-validation): use POSIX [[:space:]] in #81 regression guard (Codex P2 followup)

### DIFF
--- a/test/test_spectr_roundtrip_window_only_capture.sh
+++ b/test/test_spectr_roundtrip_window_only_capture.sh
@@ -43,7 +43,13 @@ pass "syntax: bash -n clean"
 #    no `screencapture -x "$OUT"` followed by EOL with no further flags
 #    — the only acceptable fullscreen invocation is gated by an env
 #    var AND uses `-o`.
-if grep -E '^\s*screencapture -x "\$OUT"\s*$' "$HARNESS" >/dev/null; then
+#
+# Use POSIX `[[:space:]]`, not GNU `\s`. BSD/macOS grep does not honor
+# `\s` as whitespace, so the regex would silently miss an indented
+# `screencapture -x "$OUT"` line and the regression check would
+# *pass* even when the harness had reintroduced the bug. See Codex P2
+# on PR #1849.
+if grep -E '^[[:space:]]*screencapture -x "\$OUT"[[:space:]]*$' "$HARNESS" >/dev/null; then
     fail "found bare unconditional fullscreen screencapture (re-introduces task #81 regression)"
 fi
 pass "no unconditional fullscreen fallback"


### PR DESCRIPTION
## Summary

Follow-up to pulp #1849. The regression test added in #1849 used `\s` in its grep -E regex to anchor whitespace — but `\s` is a GNU extension that BSD / macOS grep does **not** honor as whitespace. On macOS CI, an indented `screencapture -x \"\$OUT\"` reintroduced into the harness would slip past the check entirely and the test would still report PASS.

Codex P2 on PR #1849.

## Fix

One-line regex change: `\s` → `[[:space:]]` (POSIX character class, honored by both GNU and BSD grep) at both anchor sites.

## Test plan

- [x] Positive: existing harness on `main` — test still passes 4/4 (no behavior regression).
- [x] Negative: injected `    screencapture -x \"\$OUT\"` at end of `tools/import-validation/spectr-roundtrip.sh` and re-ran — test now correctly FAILS with `found bare unconditional fullscreen screencapture (re-introduces task #81 regression)`. Pre-fix the regex would not have matched the indented line on BSD grep.