### PR TITLE
test(view/css): pin display:contents arch-deferred no-op (closes coverage-gap rn/display + yoga/display)

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -4242,9 +4242,10 @@
         "contents"
       ],
       "tests": [
+        "test/test_widget_bridge.cpp [display-contents]",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "@pulp/react users opt out via the boolean `visible` prop. No 'contents' equivalent. pulp #1434 (Triage #12): the prop-applier now accepts display: flex / none, mirroring the yoga side wired in #1422. \"contents\" remains unsupported (Yoga has no equivalent).",
+      "notes": "@pulp/react users opt out via the boolean `visible` prop. No 'contents' equivalent. pulp #1434 (Triage #12): the prop-applier now accepts display: flex / none, mirroring the yoga side wired in #1422. \"contents\" remains unsupported (Yoga has no equivalent). ARCH-DEFERRED: display: contents requires parallel block/inline-flow layout that CLAUDE.md's flex+grid-only policy (Yoga 3.0 ceiling) explicitly rules out — the dispatcher silently no-ops; pinned by test/test_widget_bridge.cpp [display-contents].",
       "issue": ""
     },
     "rn/elevation": {
@@ -6381,9 +6382,10 @@
         "contents"
       ],
       "tests": [
+        "test/test_widget_bridge.cpp [display-contents]",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1420: claim flex+none as supported. CSS translator at web-compat-style-decl.js:86-118 routes display:none to setVisible(false) and display:flex to setVisible(true)+setFlex(direction). 'flex' is implicit in pulp's layout model; 'none' uses View visibility. Yoga has YGDisplay {flex, none, contents}; pulp doesn't model 'contents'.",
+      "notes": "pulp #1420: claim flex+none as supported. CSS translator at web-compat-style-decl.js:86-118 routes display:none to setVisible(false) and display:flex to setVisible(true)+setFlex(direction). 'flex' is implicit in pulp's layout model; 'none' uses View visibility. Yoga has YGDisplay {flex, none, contents}; pulp doesn't model 'contents'. ARCH-DEFERRED: display: contents requires parallel block/inline-flow layout that CLAUDE.md's flex+grid-only policy (Yoga 3.0 ceiling) explicitly rules out — the dispatcher silently no-ops; pinned by test/test_widget_bridge.cpp [display-contents].",
       "issue": "https://github.com/danielraffel/pulp/issues/1420"
     },
     "yoga/overflow": {

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -4545,6 +4545,53 @@ TEST_CASE("CSSStyleDeclaration display routes none/flex/block/inline-block/inlin
     REQUIRE_FALSE(p_none->visible());
 }
 
+// pulp-internal #105 / rn-display + yoga-display coverage-gap closures —
+// `display: contents` is intentionally NOT implemented in Pulp's display
+// dispatcher. Per CLAUDE.md's flex+grid-only layout policy (Yoga is the
+// engine; CSS block-flow / inline-flow / table-flow are out of scope by
+// design), `display: contents` — which renders an element's children as
+// if they were children of the element's parent — cannot be modeled
+// without a parallel layout engine. Closing the coverage-gap rows means
+// pinning the safe no-op: an unrecognized display value must not crash
+// the dispatch path, must not silently mutate visible() / flex(), and
+// must let consumers fall back to whatever the previous display state
+// was.
+TEST_CASE("CSSStyleDeclaration display: contents is a safe arch-deferred no-op",
+          "[view][bridge][css][issue-1420][display-contents]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // Start the panel with display: flex so we have a known baseline:
+    // visible=true, direction=row. Then write display: contents and
+    // assert nothing moves.
+    bridge.load_script(R"((function(){
+        createPanel('p_contents', '');
+        var el = { _id: 'p_contents', _nativeCreated: true };
+        var sd = new CSSStyleDeclaration(el);
+        sd._applyProperty('display', 'flex');
+        sd._applyProperty('display', 'contents');
+    })();)");
+
+    auto* p_contents = dynamic_cast<Panel*>(bridge.widget("p_contents"));
+    REQUIRE(p_contents != nullptr);
+
+    // Two invariants:
+    //  1. The bridge did not crash and the widget exists.
+    //  2. `display: contents` did NOT touch visibility — the prior
+    //     `display: flex` state survives. (If a future change adds a
+    //     `contents` branch that calls setVisible(false), this assert
+    //     fails first.)
+    REQUIRE(p_contents->visible());
+
+    // And the flex direction set by the prior `display: flex` is also
+    // intact — `display: contents` is a no-op on the flex direction
+    // because the dispatcher doesn't have a `contents` branch.
+    REQUIRE(p_contents->flex().direction == FlexDirection::row);
+}
+
 // ── pulp #1416 — SvgRectWidget + SvgLineWidget JS bridge integration ─────────
 //
 // Mirrors the #965 SvgPath bridge tests. Closes Spectr [G] preset


### PR DESCRIPTION
## Summary

Closes the `rn/display` and `yoga/display` coverage-gap one-pagers (`planning/coverage-gaps/`) under Agent A's Phase-7 Tier-1 plan. Both rows listed only `display: contents` as the remaining unsupported value. Per CLAUDE.md's flex+grid-only layout policy (Yoga 3.0 ceiling), `display: contents` cannot be implemented without a parallel block/inline-flow layout engine — it's an architectural ceiling, not a closeable gap.

## What changed

- **Regression test** `test/test_widget_bridge.cpp [display-contents]` — 1 case / 3 assertions pinning the safe no-op:
  1. Bridge does not crash when `display: contents` is applied.
  2. A prior `display: flex` state survives — `contents` doesn't silently flip visibility.
  3. The flex direction set by the prior `display: flex` is intact — `contents` is a no-op on the flex side.
- **compat.json** `yoga/display` + `rn/display` — `notes` extended to mark `contents` ARCH-DEFERRED with the CLAUDE.md rationale; `tests` array gains the new test reference. `unsupportedValues=["contents"]` retained (the listing is still accurate).
- **planning submodule** (commit `9aecf4f`): closure sections appended to `coverage-gaps/{rn-display,yoga-display}.md` + `_INDEX.md` Kind column flipped to `✅ closed in #TBD (arch-deferred contents)`.

## Test plan

- [x] `pulp-test-widget-bridge [display-contents]` — 1 case / 3 assertions all pass locally.
- [x] Existing `[issue-1420]` display test still green (unaffected by this change).
- [ ] Post-merge: I'll backfill `#TBD` → actual PR number in the planning submodule.

## Per Agent A's closure protocol

- One-pagers: `## Closure` section appended above the auto-gen footer ✓
- compat.json: `notes` + `tests` updated ✓
- `_INDEX.md`: Kind column → `✅ closed in #TBD` ✓ (will backfill PR number post-merge)
- One-pagers + `_HARVESTER.md` + `_TEMPLATE.md` preserved ✓