### PR TITLE
feat(view): SDK C++ runtime-import API — install_runtime_import_handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0940"></a>
+## [0.95.0]
+
 ## [0.94.0] - 2026-05-12
 
 - feat(format): StandaloneApp headless --screenshot capture (SDK-codified) ([#1838](https://github.com/danielraffel/pulp/pull/1838))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.94.0
+    VERSION 0.95.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/widget_bridge.hpp
+++ b/core/view/include/pulp/view/widget_bridge.hpp
@@ -15,6 +15,8 @@
 #include <pulp/view/input_events.hpp>
 #include <pulp/view/theme.hpp>
 #include <pulp/state/store.hpp>
+
+namespace pulp::view { struct ClaudeBundle; }
 #include <chrono>
 #include <string>
 #include <vector>
@@ -83,6 +85,33 @@ public:
     // Flush requestAnimationFrame-style callbacks and pending microtasks from
     // the host frame loop.
     void service_frame_callbacks();
+
+    // ── Runtime design import (pulp #468 follow-up) ──────────────
+    //
+    // Registers the `__pulpRuntimeImport__(html, source)` and
+    // `__pulpRuntimeSettle__(rounds)` native functions on the bridge's
+    // JS engine. These are the C++ side of `@pulp/react/runtime-import`'s
+    // `renderFromDesign()`: they evaluate a design bundle's HTML in
+    // the LIVE bridge engine (not a fresh sandbox) and pump the
+    // settle loop using this bridge's own service_frame_callbacks.
+    //
+    // Call ONCE after constructing the bridge, before consumer code
+    // calls renderFromDesign(). Subsequent calls are no-ops.
+    //
+    // See planning/pulp-runtime-import-FINAL-design.md.
+    void install_runtime_import_handlers();
+
+private:
+    // Internal helper used by __pulpRuntimeImport__. Forward-declared in
+    // the design_import unit so the implementation lives next to the
+    // related offline boot code. Installs navigator/HTML*Element/etc.
+    // sandbox shims on engine_ (idempotent), evaluates the bundle's
+    // asset payloads (React/ReactDOM/Babel) preserving any host React
+    // already installed on globalThis, evaluates inline text/javascript
+    // and text/babel scripts, dispatches DOMContentLoaded. Skips
+    // buildDom + walkDomJson — the runtime path is reconciler-owned.
+    void evaluate_claude_bundle_in_live_engine(const ClaudeBundle& bundle);
+public:
 
     // Override the repaint invalidator used after JS-driven UI / style
     // changes and to drain `requestAnimationFrame` callbacks.
@@ -171,6 +200,10 @@ private:
         std::make_shared<std::vector<AsyncExecResult>>();
     std::vector<int> pending_frame_ids_;
     bool frame_preamble_loaded_ = false;
+    // pulp #468 — install_runtime_import_handlers() is idempotent. Tracked
+    // per-bridge (not as a static thread_local on `this`, because heap reuse
+    // across tests gave duplicate addresses → spurious skip).
+    bool runtime_import_installed_ = false;
 
     // pulp #915 — native-side timer queue for setTimeout / setInterval.
     // Callbacks themselves live in JS (`__timerCallbacks__`); native

--- a/core/view/src/design_import.cpp
+++ b/core/view/src/design_import.cpp
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <algorithm>
 #include <cctype>
+#include <functional>
 #include <regex>
 #include <cmath>
 #include <map>
@@ -803,7 +804,474 @@ void set_runtime_error(ClaudeRuntimeOptions& opts, const std::string& msg) {
     if (opts.error_out) *opts.error_out = msg;
 }
 
+// ── Shared Claude-bundle runtime-import shim + payload pipeline ─────────
+//
+// Both the offline harness (`parse_claude_html_with_runtime`) and the
+// live-engine path (`WidgetBridge::evaluate_claude_bundle_in_live_engine`)
+// need to run an identical sequence of pre-payload shims, asset payload
+// evals, autoflushSync patch, inline-script evals (JSON/JS/Babel), and
+// finally a synthetic readystatechange/DOMContentLoaded/load dispatch.
+//
+// The shape diverges only on two axes:
+//   • the User-Agent string we plant on `navigator` (offline harness
+//     identifies itself differently from the live runtime),
+//   • whether host-installed `globalThis.React` / `globalThis.ReactDOM`
+//     must be snapshotted around the asset-eval loop so the bundle's
+//     react.development.js can't clobber the live reconciler's copy.
+//   • how soft errors are surfaced — offline forwards them to a caller
+//     sink (eventually `opts.error_out`), runtime silently swallows.
+//
+// The helper below encapsulates all of that. Tag-named via the ImportShimConfig
+// struct so callers stay readable.
+struct ImportShimConfig {
+    // Value planted on navigator.userAgent. Offline harness uses
+    // "PulpImportHarness/1.0"; live runtime uses "PulpImportRuntime/1.0".
+    const char* user_agent = "PulpImportHarness/1.0";
+
+    // When true, snapshot globalThis.React/ReactDOM into hidden globals
+    // before the asset payload loop and restore them after. Required for
+    // the live-engine path so the bundle's bundled React can't displace
+    // the host reconciler's React. Offline harness has no host React
+    // installed so this is a no-op there.
+    bool preserve_host_react = false;
+
+    // When true, gate the autoflushSync ReactDOM.createRoot patch on an
+    // idempotency marker (__pulpAutoflushPatched__). The live engine may
+    // re-enter the runtime path on the same ReactDOM instance; the
+    // offline harness creates a fresh engine each call so the marker
+    // isn't needed.
+    bool guard_autoflush_idempotent = false;
+
+    // Optional sink for soft errors. nullptr swallows everything (matches
+    // the live-runtime behavior; the JS side reads error slots out of
+    // globalThis instead).
+    std::function<void(const std::string&)> report_error;
+};
+
+// Run the shared boot sequence against an already-configured engine.
+//
+// Steps:
+//   1. Pre-payload shims (createElementNS/createTextNode, HTML*Element
+//      stub constructors, addEventListener on document/window/globalThis,
+//      navigator.userAgent).
+//   2. Optionally snapshot host React/ReactDOM, then evaluate each
+//      `javascript_indices` asset (each wrapped in a JS try/catch that
+//      stashes errors in `globalThis.__pulpPayloadErr_<idx>__`), then
+//      optionally restore host React/ReactDOM.
+//   3. Patch ReactDOM.createRoot so root.render runs inside flushSync.
+//   4. Re-inject JSON inline scripts (tweak-defaults pattern), then
+//      text/javascript inline scripts, then text/babel inline scripts
+//      (Babel.transform → eval per block).
+//   5. Dispatch synthetic readystatechange → DOMContentLoaded → load.
+//
+// Soft errors are forwarded to `cfg.report_error` when set; otherwise
+// silently swallowed. C++ exceptions never escape this helper for the
+// asset/inline/DOM-event steps — they are caught and (optionally)
+// reported. The shim-installation try/catches are best-effort by design.
+void run_claude_bundle_payload_pipeline(ScriptEngine& engine,
+                                        const ClaudeBundle& bundle,
+                                        const ImportShimConfig& cfg) {
+    auto report = [&](const std::string& msg) {
+        if (cfg.report_error) cfg.report_error(msg);
+    };
+
+    // ── Pre-payload sandbox shims ──
+    // document.createElementNS / createTextNode — React-DOM expects them.
+    try {
+        engine.evaluate(
+            "(function(){"
+            "  if (typeof document === 'undefined' || !document) return;"
+            "  if (typeof document.createElementNS !== 'function') {"
+            "    document.createElementNS = function(ns, type) {"
+            "      var el = document.createElement(type);"
+            "      try { el.namespaceURI = ns; } catch (e) {}"
+            "      return el;"
+            "    };"
+            "  }"
+            "  if (typeof document.createTextNode !== 'function') {"
+            "    document.createTextNode = function(text) {"
+            "      var el = document.createElement('#text');"
+            "      try { el.nodeValue = text; el.textContent = text; } catch (e) {}"
+            "      return el;"
+            "    };"
+            "  }"
+            "})();void 0");
+    } catch (...) {}
+
+    // Stub HTML*Element constructors so React-DOM `instanceof` checks return
+    // false instead of throwing "invalid 'instanceof' right operand".
+    try {
+        engine.evaluate(
+            "(function(){"
+            "  var names = ['Element','HTMLElement','Node','EventTarget',"
+            "    'HTMLIFrameElement','HTMLInputElement','HTMLTextAreaElement',"
+            "    'HTMLSelectElement','HTMLOptionElement','HTMLOptGroupElement',"
+            "    'HTMLFormElement','HTMLAnchorElement','HTMLImageElement',"
+            "    'HTMLDivElement','HTMLSpanElement','HTMLButtonElement',"
+            "    'HTMLLabelElement','HTMLCanvasElement','HTMLBodyElement',"
+            "    'HTMLDocument','SVGElement','DocumentFragment','Text','Comment'];"
+            "  for (var i = 0; i < names.length; i++) {"
+            "    var n = names[i];"
+            "    if (typeof globalThis[n] === 'undefined') {"
+            "      try { globalThis[n] = function(){}; } catch (e) {}"
+            "    }"
+            "    if (typeof window !== 'undefined' && typeof window[n] === 'undefined') {"
+            "      try { window[n] = globalThis[n]; } catch (e) {}"
+            "    }"
+            "  }"
+            "})();void 0");
+    } catch (...) {}
+
+    // Ensure addEventListener / removeEventListener exist on document/window/globalThis.
+    try {
+        engine.evaluate(
+            "(function(){"
+            "  function _ensureEL(t){"
+            "    if (!t) return;"
+            "    if (typeof t.addEventListener !== 'function') {"
+            "      t.addEventListener = function(){};"
+            "    }"
+            "    if (typeof t.removeEventListener !== 'function') {"
+            "      t.removeEventListener = function(){};"
+            "    }"
+            "  }"
+            "  if (typeof document !== 'undefined') _ensureEL(document);"
+            "  if (typeof window !== 'undefined')   _ensureEL(window);"
+            "  if (typeof globalThis !== 'undefined') _ensureEL(globalThis);"
+            "})();void 0");
+    } catch (...) {}
+
+    // navigator.userAgent — UMD factory bundles probe it during init.
+    // Generic enough that browser-feature detection chains fall through
+    // to safe defaults.
+    {
+        std::string ua_js =
+            "if (typeof navigator === 'undefined' || !navigator || !navigator.userAgent) {"
+            "  try {"
+            "    globalThis.navigator = globalThis.navigator || {};"
+            "    if (!globalThis.navigator.userAgent) {"
+            "      Object.defineProperty(globalThis.navigator, 'userAgent', {"
+            "        value: '";
+        ua_js += cfg.user_agent;
+        ua_js +=
+            "', writable: false, configurable: true"
+            "      });"
+            "    }"
+            "  } catch (e) {"
+            "    globalThis.navigator = { userAgent: '";
+        ua_js += cfg.user_agent;
+        ua_js +=
+            "' };"
+            "  }"
+            "}"
+            ";void 0";
+        try { engine.evaluate(ua_js); } catch (...) {}
+    }
+
+    // ── Asset payload eval ──
+    //
+    // When preserve_host_react is set, snapshot any host-installed
+    // globalThis.React / globalThis.ReactDOM before the loop so a bundle
+    // that ships its own react.development.js can't displace the live
+    // reconciler's copy. Restore after.
+    if (cfg.preserve_host_react) {
+        try {
+            engine.evaluate(
+                "globalThis.__pulpHostReact__ = "
+                "  (typeof globalThis.React !== 'undefined') ? globalThis.React : null;"
+                "globalThis.__pulpHostReactDOM__ = "
+                "  (typeof globalThis.ReactDOM !== 'undefined') ? globalThis.ReactDOM : null;"
+                ";void 0");
+        } catch (...) {}
+    }
+
+    for (auto idx : bundle.javascript_indices) {
+        if (idx >= bundle.assets.size()) continue;
+        const auto& asset = bundle.assets[idx];
+        std::string source(asset.data.begin(), asset.data.end());
+        std::string wrap_pre = "try {\n";
+        std::string wrap_post = "\n} catch(e) { globalThis.__pulpPayloadErr_" + std::to_string(idx) +
+            "__ = String(e && e.message ? e.message : e) + ' :: stack=' + (e && e.stack ? e.stack : '<no stack>'); }";
+        source = wrap_pre + source + wrap_post;
+        // Trailing `;void 0` so the payload's last expression doesn't
+        // produce a value the engine has to convert back to choc. (The
+        // CHOC QuickJS path can recurse on cyclical objects.)
+        source += "\n;void 0";
+        try {
+            engine.evaluate(source);
+        } catch (const std::exception& e) {
+            report(std::string("payload ") + std::to_string(idx)
+                   + " threw: " + e.what());
+            // continue intentionally — soft-fail per asset.
+        } catch (...) {
+            report(std::string("payload ") + std::to_string(idx)
+                   + " threw: unknown exception");
+            // continue intentionally
+        }
+    }
+
+    if (cfg.preserve_host_react) {
+        try {
+            engine.evaluate(
+                "if (globalThis.__pulpHostReact__) {"
+                "  globalThis.React = globalThis.__pulpHostReact__;"
+                "}"
+                "if (globalThis.__pulpHostReactDOM__) {"
+                "  globalThis.ReactDOM = globalThis.__pulpHostReactDOM__;"
+                "}"
+                "delete globalThis.__pulpHostReact__;"
+                "delete globalThis.__pulpHostReactDOM__;"
+                ";void 0");
+        } catch (...) {}
+    }
+
+    // Patch ReactDOM.createRoot so root.render wraps work in
+    // ReactDOM.flushSync — forces React 18's concurrent renderer to
+    // commit synchronously. Without this, render() schedules work via
+    // the scheduler (MessageChannel) but the commit never fires before
+    // walkDomJson (offline) or settle (runtime) runs.
+    {
+        std::string patch_js = "(function(){";
+        patch_js += "  if (typeof ReactDOM !== 'object' || typeof ReactDOM.createRoot !== 'function') return;";
+        if (cfg.guard_autoflush_idempotent) {
+            patch_js += "  if (ReactDOM.__pulpAutoflushPatched__) return;";
+            patch_js += "  ReactDOM.__pulpAutoflushPatched__ = true;";
+        }
+        patch_js +=
+            "  var _origCreateRoot = ReactDOM.createRoot;"
+            "  ReactDOM.createRoot = function(container, opts) {"
+            "    var root = _origCreateRoot.call(this, container, opts);"
+            "    if (root && typeof root.render === 'function') {"
+            "      var _origRender = root.render.bind(root);"
+            "      root.render = function(element) {"
+            "        try {"
+            "          if (typeof ReactDOM.flushSync === 'function') {"
+            "            ReactDOM.flushSync(function(){ _origRender(element); });"
+            "          } else {"
+            "            _origRender(element);"
+            "          }"
+            "        } catch (e) {"
+            "          globalThis.__pulpCreateRootRenderErr__ ="
+            "            String(e && e.message ? e.message : e) + ' :: stack=' + (e && e.stack ? e.stack : '');"
+            "        }"
+            "      };"
+            "    }"
+            "    return root;"
+            "  };"
+            "})();void 0";
+        try { engine.evaluate(patch_js); } catch (...) {}
+    }
+
+    // ── Inline scripts from the template ──
+    auto inline_scripts = extract_inline_template_scripts(bundle.template_html);
+
+    // Re-inject JSON-kind inline scripts (e.g. `<script id="tweak-defaults">`)
+    // back into document.head — bundles read them via getElementById.
+    for (size_t i = 0; i < inline_scripts.size(); ++i) {
+        const auto& s = inline_scripts[i];
+        if (s.kind != "json") continue;
+        std::string js =
+            "globalThis.__pulpJsonScript_" + std::to_string(i) + "__ = "
+            + json_string_literal(s.source) + ";"
+            "(function(){"
+            "  var el = document.createElement('script');"
+            "  el.type = 'application/json';"
+            "  el.id = 'tweak-defaults';"
+            "  el.textContent = globalThis.__pulpJsonScript_" + std::to_string(i) + "__;"
+            "  document.head.appendChild(el);"
+            "})();void 0";
+        try { engine.evaluate(js); } catch (...) {}
+    }
+
+    // text/javascript inline blocks in document order. Soft-fail per
+    // script — match the existing payload-eval pattern.
+    for (size_t i = 0; i < inline_scripts.size(); ++i) {
+        const auto& s = inline_scripts[i];
+        if (s.kind != "javascript") continue;
+        try {
+            engine.evaluate(s.source + "\n;void 0");
+        } catch (const std::exception& e) {
+            report("inline JS script " + std::to_string(i)
+                   + " threw: " + e.what());
+        } catch (...) {
+            report("inline JS script " + std::to_string(i)
+                   + " threw: unknown exception");
+        }
+    }
+
+    // text/babel inline blocks — verify Babel-standalone is in scope, then
+    // transform each block via `Babel.transform(src, {presets: ['react']}).code`
+    // before evaluating. Soft-fail per script.
+    bool has_any_babel = false;
+    for (const auto& s : inline_scripts) {
+        if (s.kind == "babel") { has_any_babel = true; break; }
+    }
+    if (has_any_babel) {
+        bool babel_loaded = false;
+        try {
+            // QuickJS / JSC may report the boolean expression as bool,
+            // int32, or float64 depending on which path the engine took
+            // to coerce — accept any numeric-or-bool truthy value.
+            auto v = engine.evaluate(
+                "!!(typeof globalThis.Babel !== 'undefined' && "
+                "   typeof globalThis.Babel.transform === 'function')");
+            if (v.isBool())          babel_loaded = v.getBool();
+            else if (v.isInt32())    babel_loaded = (v.getInt32() != 0);
+            else if (v.isInt64())    babel_loaded = (v.getInt64() != 0);
+            else if (v.isFloat32() || v.isFloat64())
+                babel_loaded = (v.getFloat64() != 0.0);
+        } catch (...) {
+            babel_loaded = false;
+        }
+
+        if (!babel_loaded) {
+            report("babel-standalone not loaded; skipping inline text/babel scripts");
+        } else {
+            // Stash each Babel source as a JS string, transform via the
+            // engine, then evaluate the transformed code. Using a global
+            // staging slot keeps us from escaping JSX source for embedding
+            // in a JS string literal — JSX happily contains characters
+            // that would break a hand-rolled escape.
+            auto soft_step = [&](size_t i, const char* phase,
+                                 const std::string& src) -> bool {
+                try {
+                    engine.evaluate(src);
+                    return true;
+                } catch (const std::exception& e) {
+                    report("inline babel script " + std::to_string(i)
+                           + " " + phase + " failed: " + e.what());
+                    return false;
+                } catch (...) {
+                    report("inline babel script " + std::to_string(i)
+                           + " " + phase + " failed: unknown exception");
+                    return false;
+                }
+            };
+
+            for (size_t i = 0; i < inline_scripts.size(); ++i) {
+                const auto& s = inline_scripts[i];
+                if (s.kind != "babel") continue;
+
+                std::string set_src = "globalThis.__pulpBabelSrc__ = ";
+                set_src += json_string_literal(s.source);
+                set_src += ";void 0";
+                if (!soft_step(i, "stash", set_src)) continue;
+
+                if (!soft_step(i, "transform",
+                        "(function(){"
+                        "  try {"
+                        "    var out = globalThis.Babel.transform("
+                        "      globalThis.__pulpBabelSrc__,"
+                        "      { presets: ['react'] });"
+                        "    globalThis.__pulpBabelOut__ = (out && out.code) ? out.code : '';"
+                        "    globalThis.__pulpBabelErr__ = '';"
+                        "  } catch (e) {"
+                        "    globalThis.__pulpBabelOut__ = '';"
+                        "    globalThis.__pulpBabelErr__ = String(e && e.message ? e.message : e);"
+                        "  }"
+                        "})();void 0")) continue;
+
+                // Probe the babel-side error string and surface if non-empty.
+                try {
+                    auto err_v = engine.evaluate(
+                        "globalThis.__pulpBabelErr__ || ''");
+                    if (err_v.isString()) {
+                        std::string err_msg(err_v.getString());
+                        if (!err_msg.empty()) {
+                            report("inline babel script " + std::to_string(i)
+                                   + " babel error: " + err_msg);
+                            continue;
+                        }
+                    }
+                } catch (...) { /* ignore probe failure */ }
+
+                // JS-side try/catch around eval so non-std::exception JS
+                // errors get surfaced via __pulpEvalErr__ instead of being
+                // silently swallowed by the C++ catch(...).
+                soft_step(i, "eval",
+                    "try {"
+                    "  (0, eval)(globalThis.__pulpBabelOut__);"
+                    "  globalThis.__pulpEvalErr__ = '';"
+                    "} catch (e) {"
+                    "  globalThis.__pulpEvalErr__ = String(e && e.message ? e.message : e)"
+                    "    + ' :: stack=' + (e && e.stack ? e.stack : '<no stack>');"
+                    "}"
+                    ";void 0");
+                try {
+                    auto v = engine.evaluate("globalThis.__pulpEvalErr__ || ''");
+                    if (v.isString()) {
+                        std::string em(v.getString());
+                        if (!em.empty()) {
+                            report("inline babel script " + std::to_string(i)
+                                   + " JS-eval error: " + em);
+                        }
+                    }
+                } catch (...) { /* ignore best-effort surfacing */ }
+            }
+
+            // Tidy up the staging slots so they don't leak into the
+            // walker's view of globals.
+            try {
+                engine.evaluate(
+                    "delete globalThis.__pulpBabelSrc__;"
+                    "delete globalThis.__pulpBabelOut__;"
+                    "delete globalThis.__pulpBabelErr__;void 0");
+            } catch (...) { /* nothing to do — best-effort */ }
+        }
+    }
+
+    // ── Dispatch readystatechange → DOMContentLoaded → load ──
+    // Mirrors the browser lifecycle for bundles that defer boot to
+    // document-ready. The trailing `;void 0` avoids the QuickJS
+    // toChocValue circular-ref recursion. We construct the event objects
+    // defensively: use `new Event(t)` if available, otherwise a plain
+    // literal so dispatch still runs against listeners keyed on `type`.
+    try {
+        engine.evaluate(
+            "(function(){"
+            "  if (typeof document === 'undefined') return;"
+            "  function _mkEvent(t, target){"
+            "    if (typeof Event === 'function') {"
+            "      try { return new Event(t); } catch (e) {}"
+            "    }"
+            "    return { type: t, target: target, currentTarget: target,"
+            "             bubbles: false, cancelable: false,"
+            "             defaultPrevented: false,"
+            "             preventDefault: function(){ this.defaultPrevented = true; },"
+            "             stopPropagation: function(){},"
+            "             stopImmediatePropagation: function(){} };"
+            "  }"
+            "  function _dispatch(target, type){"
+            "    if (!target) return;"
+            "    if (typeof target.dispatchEvent === 'function') {"
+            "      try { target.dispatchEvent(_mkEvent(type, target)); } catch (e) {}"
+            "    }"
+            "  }"
+            "  try { document.readyState = 'interactive'; } catch (e) {}"
+            "  _dispatch(document, 'readystatechange');"
+            "  _dispatch(document, 'DOMContentLoaded');"
+            "  try { document.readyState = 'complete'; } catch (e) {}"
+            "  _dispatch(document, 'readystatechange');"
+            "  if (typeof window !== 'undefined') _dispatch(window, 'load');"
+            "})();void 0");
+    } catch (const std::exception& e) {
+        report(std::string("DOMContentLoaded dispatch threw: ") + e.what());
+    } catch (...) {
+        report("DOMContentLoaded dispatch threw: unknown exception");
+    }
+}
+
 } // namespace
+
+// External-linkage thin wrapper around the anonymous-namespace
+// json_string_literal so widget_bridge.cpp (a separate TU) can use it
+// without re-implementing JSON escaping. Forward-declared in
+// widget_bridge.cpp at file scope.
+namespace detail {
+std::string json_string_literal_for_widget_bridge(const std::string& s) {
+    return ::pulp::view::json_string_literal(s);
+}
+} // namespace detail
 
 DesignIR parse_claude_html_with_runtime(const std::string& html, ClaudeRuntimeOptions opts) {
     auto static_fallback = [&](const std::string& reason) -> DesignIR {
@@ -902,227 +1370,20 @@ DesignIR parse_claude_html_with_runtime(const std::string& html, ClaudeRuntimeOp
             }
         }
 
-        // Evaluate each JS payload in template-script order. Wrap each in
-        // a try/catch so a single payload's runtime error doesn't abort
-        // the whole harness — React's dev build especially likes to throw
-        // on missing browser features that we can't easily polyfill.
-        for (auto idx : bundle->javascript_indices) {
-            if (idx >= bundle->assets.size()) continue;
-            const auto& asset = bundle->assets[idx];
-            std::string source(asset.data.begin(), asset.data.end());
-            // Trailing `;void 0` so the payload's last expression doesn't
-            // produce a value the engine has to convert back to choc.
-            // (The CHOC QuickJS path can recurse on cyclical objects;
-            // documented in the codebase memory.)
-            source += "\n;void 0";
-            try {
-                engine.evaluate(source);
-            } catch (const std::exception& e) {
-                // Soft-fail and keep going. The walker may still see a
-                // partial commit if React got past the first render.
-                std::string msg = std::string("payload ") + std::to_string(idx)
-                    + " threw: " + e.what();
+        // Shim install + payload eval + inline-script eval + DOMContentLoaded
+        // dispatch. Shared with WidgetBridge::evaluate_claude_bundle_in_live_engine
+        // — see run_claude_bundle_payload_pipeline for the full sequence.
+        // The offline harness uses a fresh ScriptEngine, so neither host-React
+        // preservation nor the autoflushSync-idempotency marker is required.
+        {
+            ImportShimConfig cfg;
+            cfg.user_agent = "PulpImportHarness/1.0";
+            cfg.preserve_host_react = false;
+            cfg.guard_autoflush_idempotent = false;
+            cfg.report_error = [&](const std::string& msg) {
                 set_runtime_error(opts, msg);
-                // continue intentionally
-            } catch (...) {
-                std::string msg = std::string("payload ") + std::to_string(idx)
-                    + " threw: unknown exception";
-                set_runtime_error(opts, msg);
-                // continue intentionally
-            }
-        }
-
-        // ── pulp #758: evaluate inline `<script>` blocks from the template ──
-        //
-        // The src-loaded payloads above bring in libraries (React,
-        // ReactDOM, Babel-standalone). The actual app code in a Claude
-        // bundled-React export usually lives in inline `<script
-        // type="text/babel">` blocks — and a few inline `text/javascript`
-        // blocks for plain-JS data declarations. Without this loop the
-        // walker only sees the empty `<div id="root"></div>` shell.
-        auto inline_scripts = extract_inline_template_scripts(bundle->template_html);
-
-        // Step 1: inline `text/javascript` (and untyped `<script>`) blocks
-        // in document order. Soft-fail per script — match the existing
-        // payload-eval pattern at lines ~580-595.
-        auto soft_eval = [&](const std::string& kind_label, size_t i,
-                             const std::string& source_with_void) {
-            try {
-                engine.evaluate(source_with_void);
-            } catch (const std::exception& e) {
-                std::string msg = "inline " + kind_label + " script "
-                    + std::to_string(i) + " threw: " + e.what();
-                set_runtime_error(opts, msg);
-            } catch (...) {
-                std::string msg = "inline " + kind_label + " script "
-                    + std::to_string(i) + " threw: unknown exception";
-                set_runtime_error(opts, msg);
-            }
-        };
-        for (size_t i = 0; i < inline_scripts.size(); ++i) {
-            const auto& s = inline_scripts[i];
-            if (s.kind != "javascript") continue;
-            soft_eval("JS", i, s.source + "\n;void 0");
-        }
-
-        // Step 2: inline `text/babel` (and `text/jsx`) blocks. Verify
-        // Babel-standalone is in scope (the src-loaded library payloads
-        // above should have installed `globalThis.Babel`), then transform
-        // each block via `Babel.transform(src, {presets: ['react']}).code`
-        // before evaluating. Soft-fail per script.
-        bool has_any_babel = false;
-        for (const auto& s : inline_scripts) {
-            if (s.kind == "babel") { has_any_babel = true; break; }
-        }
-        if (has_any_babel) {
-            bool babel_loaded = false;
-            try {
-                // QuickJS / JSC may report the boolean expression as
-                // bool, int32, or float64 depending on which path the
-                // engine took to coerce — accept any numeric-or-bool
-                // truthy value.
-                auto v = engine.evaluate(
-                    "!!(typeof globalThis.Babel !== 'undefined' && "
-                    "   typeof globalThis.Babel.transform === 'function')");
-                if (v.isBool())          babel_loaded = v.getBool();
-                else if (v.isInt32())    babel_loaded = (v.getInt32() != 0);
-                else if (v.isInt64())    babel_loaded = (v.getInt64() != 0);
-                else if (v.isFloat32() || v.isFloat64())
-                    babel_loaded = (v.getFloat64() != 0.0);
-            } catch (...) {
-                babel_loaded = false;
-            }
-            if (!babel_loaded) {
-                set_runtime_error(opts,
-                    "babel-standalone not loaded; skipping inline text/babel scripts");
-            } else {
-                // Stash each Babel source as a JS string, transform it via
-                // the engine, then evaluate the transformed code. Using a
-                // global staging slot keeps us from having to escape JSX
-                // source for embedding in a JS string literal — JSX
-                // happily contains characters that would break a
-                // hand-rolled escape (template literals, comments, etc.).
-                auto soft_step = [&](size_t i, const char* phase,
-                                     const std::string& src) -> bool {
-                    try {
-                        engine.evaluate(src);
-                        return true;
-                    } catch (const std::exception& e) {
-                        std::string msg = "inline babel script "
-                            + std::to_string(i) + " " + phase
-                            + " failed: " + e.what();
-                        set_runtime_error(opts, msg);
-                        return false;
-                    } catch (...) {
-                        std::string msg = "inline babel script "
-                            + std::to_string(i) + " " + phase
-                            + " failed: unknown exception";
-                        set_runtime_error(opts, msg);
-                        return false;
-                    }
-                };
-
-                for (size_t i = 0; i < inline_scripts.size(); ++i) {
-                    const auto& s = inline_scripts[i];
-                    if (s.kind != "babel") continue;
-
-                    // Stash → transform → check babel-side error → eval.
-                    std::string set_src = "globalThis.__pulpBabelSrc__ = ";
-                    set_src += json_string_literal(s.source);
-                    set_src += ";void 0";
-                    if (!soft_step(i, "stash", set_src)) continue;
-
-                    if (!soft_step(i, "transform",
-                            "(function(){"
-                            "  try {"
-                            "    var out = globalThis.Babel.transform("
-                            "      globalThis.__pulpBabelSrc__,"
-                            "      { presets: ['react'] });"
-                            "    globalThis.__pulpBabelOut__ = (out && out.code) ? out.code : '';"
-                            "    globalThis.__pulpBabelErr__ = '';"
-                            "  } catch (e) {"
-                            "    globalThis.__pulpBabelOut__ = '';"
-                            "    globalThis.__pulpBabelErr__ = String(e && e.message ? e.message : e);"
-                            "  }"
-                            "})();void 0")) continue;
-
-                    // Probe the babel-side error string and surface if non-empty.
-                    try {
-                        auto err_v = engine.evaluate(
-                            "globalThis.__pulpBabelErr__ || ''");
-                        if (err_v.isString()) {
-                            std::string err_msg(err_v.getString());
-                            if (!err_msg.empty()) {
-                                std::string msg = std::string("inline babel script ")
-                                    + std::to_string(i) + " babel error: " + err_msg;
-                                set_runtime_error(opts, msg);
-                                continue;
-                            }
-                        }
-                    } catch (...) { /* ignore probe failure */ }
-
-                    soft_step(i, "eval",
-                        "(0, eval)(globalThis.__pulpBabelOut__);void 0");
-                }
-
-                // Tidy up the staging slots so they don't leak into the
-                // walker's view of globals.
-                try {
-                    engine.evaluate(
-                        "delete globalThis.__pulpBabelSrc__;"
-                        "delete globalThis.__pulpBabelOut__;"
-                        "delete globalThis.__pulpBabelErr__;void 0");
-                } catch (...) { /* nothing to do — best-effort */ }
-            }
-        }
-
-        // Step 3: dispatch DOMContentLoaded so bundles that defer their
-        // boot to the document-ready signal actually fire. Mirrors the
-        // browser sequence: readystatechange → DOMContentLoaded → load.
-        //
-        // We construct the event objects defensively: if `Event` is a
-        // valid constructor in scope we use it, otherwise we fall back
-        // to a plain `{type:..., target:..., bubbles:false}` literal so
-        // dispatch still runs against listeners that just key on `type`.
-        // The trailing `;void 0` avoids the QuickJS toChocValue
-        // circular-ref recursion documented in the project memory.
-        try {
-            engine.evaluate(
-                "(function(){"
-                "  if (typeof document === 'undefined') return;"
-                "  function _mkEvent(t, target){"
-                "    if (typeof Event === 'function') {"
-                "      try { return new Event(t); } catch (e) {}"
-                "    }"
-                "    return { type: t, target: target, currentTarget: target,"
-                "             bubbles: false, cancelable: false,"
-                "             defaultPrevented: false,"
-                "             preventDefault: function(){ this.defaultPrevented = true; },"
-                "             stopPropagation: function(){},"
-                "             stopImmediatePropagation: function(){} };"
-                "  }"
-                "  function _dispatch(target, type){"
-                "    if (!target) return;"
-                "    if (typeof target.dispatchEvent === 'function') {"
-                "      try { target.dispatchEvent(_mkEvent(type, target)); } catch (e) {}"
-                "    }"
-                "  }"
-                "  try { document.readyState = 'interactive'; } catch (e) {}"
-                "  _dispatch(document, 'readystatechange');"
-                "  _dispatch(document, 'DOMContentLoaded');"
-                "  try { document.readyState = 'complete'; } catch (e) {}"
-                "  _dispatch(document, 'readystatechange');"
-                "  if (typeof window !== 'undefined') _dispatch(window, 'load');"
-                "})();void 0");
-        } catch (const std::exception& e) {
-            // Soft-fail: if the engine's event surface is missing some of
-            // these globals, the bundle just won't get its lifecycle
-            // events. Don't block the walker.
-            set_runtime_error(opts,
-                std::string("DOMContentLoaded dispatch threw: ") + e.what());
-        } catch (...) {
-            set_runtime_error(opts,
-                "DOMContentLoaded dispatch threw: unknown exception");
+            };
+            run_claude_bundle_payload_pipeline(engine, *bundle, cfg);
         }
 
         // Step 4: layered async drain. The original two-pump cycle stays;
@@ -1206,6 +1467,70 @@ DesignIR parse_claude_html_with_runtime(const std::string& html, ClaudeRuntimeOp
     } catch (...) {
         return static_fallback("harness boot failed: unknown exception");
     }
+}
+
+// ── Runtime-import: evaluate a Claude bundle in the LIVE bridge engine ──
+//
+// Phase 6 of pulp-runtime-import-FINAL-design.md. The offline path
+// (parse_claude_html_with_runtime, above) allocates its own
+// ScriptEngine/View/StateStore/WidgetBridge harness, then walks the
+// materialized DOM into a DesignIR. The runtime path is different:
+// the caller's `@pulp/react` reconciler is already mounted on `engine_`,
+// and we want the bundle's React components to render through it
+// instead of into a throwaway sandbox. So we:
+//
+//   1. Install the same set of pre-payload shims (navigator.userAgent,
+//      HTML*Element constructors, document.createElementNS, addEventListener
+//      on document/window/globalThis, ReactDOM.createRoot autoflushSync).
+//   2. Evaluate the bundle's `text/javascript` asset payloads, BUT
+//      preserve any host-installed `globalThis.React` / `globalThis.ReactDOM`
+//      that the JS-side `installHostReact` + `installReactDOMCapture`
+//      shims placed before this call (codex amendment #2 — the bundle's
+//      React payload must not clobber the reconciler's React).
+//   3. Re-inject JSON-kind inline scripts (tweak-defaults pattern) and
+//      evaluate text/javascript + text/babel inline scripts in document
+//      order (Babel.transform → eval for JSX).
+//   4. Dispatch readystatechange → DOMContentLoaded → load so bundles
+//      that defer boot to document-ready actually fire.
+//
+// Explicitly NOT done here:
+//   - buildDom / walkDomJson (offline-only; we have a live React tree).
+//   - Pumping the message loop (the JS side calls __pulpRuntimeSettle__
+//     separately so it can control how many drain rounds run).
+//   - Allocating any new engine / view / bridge (use this->engine_).
+//   - Static-fallback path (this returns void; soft-errors propagate via
+//     globalThis.__pulpPayloadErr_<idx>__ / __pulpEvalErr__ slots and the
+//     WidgetBridge's normal error surface, not a DesignIR replacement).
+//
+// Token budget: this duplicates roughly the shim + asset-eval + inline-eval
+// + DOMContentLoaded blocks of parse_claude_html_with_runtime. The
+// codex-anticipated factoring (a shared helper called from both paths) is
+// the natural next step once both functions live side-by-side and a
+// concrete duplication count is visible.
+void WidgetBridge::evaluate_claude_bundle_in_live_engine(const ClaudeBundle& bundle) {
+    // The live-engine path differs from the offline harness in three
+    // small ways: it uses a different navigator.userAgent, it must
+    // preserve any host-installed globalThis.React / ReactDOM around the
+    // bundle's asset eval loop (so the bundle's bundled react.development.js
+    // can't displace the live reconciler's copy — codex amendment #2),
+    // and the autoflushSync ReactDOM.createRoot patch is guarded by an
+    // idempotency marker since the same ReactDOM instance may be
+    // re-entered on subsequent calls. Everything else (shims, inline-script
+    // eval, DOMContentLoaded dispatch) is identical, so the shared helper
+    // does the heavy lifting.
+    //
+    // We deliberately do NOT pump the message loop or run walkDomJson
+    // here — the JS side calls __pulpRuntimeSettle__ separately so it
+    // can control how many drain rounds run, and the live React tree
+    // replaces the offline DOM walker. Soft errors propagate via
+    // globalThis.__pulpPayloadErr_<idx>__ / __pulpEvalErr__ slots, not
+    // via a caller-side sink.
+    ImportShimConfig cfg;
+    cfg.user_agent = "PulpImportRuntime/1.0";
+    cfg.preserve_host_react = true;
+    cfg.guard_autoflush_idempotent = true;
+    cfg.report_error = nullptr;  // runtime path swallows; JS reads slots.
+    run_claude_bundle_payload_pipeline(engine_, bundle, cfg);
 }
 
 std::string render_claude_bridge_scaffold(const std::string& generated_js_path) {

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -49,6 +49,14 @@
 #include <pulp/platform/child_process.hpp>
 
 namespace pulp::view {
+
+// Forward declaration of the design_import.cpp wrapper that exposes its
+// (anonymous-namespace) json_string_literal helper across translation
+// units. Used by the runtime-import handlers below.
+namespace detail {
+std::string json_string_literal_for_widget_bridge(const std::string& s);
+} // namespace detail
+
 namespace {
 
 struct WidgetBridgeGpuInfo {
@@ -1005,6 +1013,147 @@ void WidgetBridge::service_frame_callbacks() {
         engine_.evaluate("if (typeof __flushFrames__ === 'function') __flushFrames__();void 0");
         engine_.pump_message_loop();
     }
+}
+
+// ── Runtime design import (pulp #468 follow-up) ───────────────────
+//
+// Registers __pulpRuntimeImport__(html, source) and
+// __pulpRuntimeSettle__(rounds) on the live bridge engine. The JS-side
+// `@pulp/react/runtime-import` calls these to evaluate a design bundle
+// in THIS engine (not a fresh one) — the key insight from the
+// pulp-runtime-import-FINAL-design.md alignment with codex: one engine,
+// one React, one reconciler.
+//
+// Architecturally distinct from the offline parse_claude_html_with_runtime
+// path which allocates a fresh sandbox for IR extraction. That path stays
+// available via `pulp import-design --execute-bundle` for inspection.
+//
+// Side effects (set on globalThis for the JS shim to inspect):
+//   - __pulpRuntimeImportErr__ : string set on soft-fail (empty = ok)
+//
+// JS side reads/clears the err global; this function only writes to it.
+
+void WidgetBridge::install_runtime_import_handlers() {
+    // Idempotency guard: register once per bridge. The earlier
+    // implementation used a static thread_local set keyed by `this`,
+    // which broke under heap reuse (test bridges destroyed and
+    // reconstructed at the same address skipped registration silently).
+    if (runtime_import_installed_) return;
+    runtime_import_installed_ = true;
+
+    // The bundled-React asset evaluation can throw arbitrary JS errors
+    // when the sandbox is missing a host primitive (DecompressionStream,
+    // some HTMLElement, etc.). We surface those via the runtime-error
+    // sink rather than throwing into the JS engine — the JS shim is
+    // responsible for routing them to opts.onError.
+    auto set_err = [this](const std::string& msg) {
+        std::string js = "globalThis.__pulpRuntimeImportErr__ = ";
+        js += detail::json_string_literal_for_widget_bridge(msg);
+        js += ";void 0";
+        try { engine_.evaluate(js); } catch (...) { /* best-effort */ }
+    };
+
+    auto clear_err = [this]() {
+        try { engine_.evaluate("globalThis.__pulpRuntimeImportErr__ = '';void 0"); }
+        catch (...) { /* best-effort */ }
+    };
+
+    // __pulpRuntimeImport__(html, source_label) → void
+    //
+    // Parses the bundle envelope (Claude format only for now — figma /
+    // stitch / v0 / pencil can layer on later), evaluates inline
+    // text/javascript + text/babel scripts on THIS engine, dispatches
+    // DOMContentLoaded.
+    //
+    // Crucially does NOT call buildDom or walkDomJson: the runtime path
+    // is reconciler-owned (the JS-side ReactDOM capture shim catches
+    // the React element directly).
+    engine_.register_function("__pulpRuntimeImport__",
+        [this, set_err, clear_err](choc::javascript::ArgumentList args) -> choc::value::Value {
+            clear_err();
+            auto html = args.get<std::string>(0, "");
+            auto src_label = args.get<std::string>(1, "auto");
+            if (html.empty()) {
+                set_err("__pulpRuntimeImport__: empty html");
+                return choc::value::Value();
+            }
+
+            try {
+                // For now: claude is the only source with a runtime-eval
+                // path (others are static IR). Future: dispatch on
+                // src_label to parse_figma / parse_stitch / etc.
+                auto bundle = parse_claude_bundle(html);
+                if (!bundle) {
+                    set_err("__pulpRuntimeImport__: no claude bundle envelope (got '"
+                            + src_label + "')");
+                    return choc::value::Value();
+                }
+
+                // The shared shim setup + payload eval logic lives in
+                // a helper that both this path and the offline path
+                // (parse_claude_html_with_runtime) can call. Phase 6 step 7
+                // factors that helper out. For now, inline the minimal
+                // sequence needed for a working runtime path: shims,
+                // asset eval, inline script eval. Skips buildDom +
+                // walkDomJson per the FINAL design.
+                evaluate_claude_bundle_in_live_engine(*bundle);
+                // Codex P1 (Phase 6.1 review): the shared pipeline
+                // writes per-payload eval failures to
+                // `__pulpPayloadErr_<idx>__` and Babel-transform
+                // failures to `__pulpEvalErr__`, but JS callers (and
+                // Phase 6.3's runtime-import.ts) only read
+                // `__pulpRuntimeImportErr__`. Aggregate any soft errors
+                // into the runtime-error sink so they're visible to
+                // onError / lastError callers. Best-effort — if the
+                // engine is in a bad state, leave the existing err
+                // value (set by set_err / clear_err above) intact.
+                try {
+                    auto v = engine_.evaluate(
+                        "(function(){"
+                        "  var errs = [];"
+                        "  var k = globalThis.__pulpRuntimeImportErr__;"
+                        "  if (typeof k === 'string' && k.length) errs.push(k);"
+                        "  if (typeof globalThis.__pulpEvalErr__ === 'string' && globalThis.__pulpEvalErr__.length)"
+                        "    errs.push('babel-transform: ' + globalThis.__pulpEvalErr__);"
+                        "  if (typeof globalThis.__pulpFlushSyncErr__ === 'string' && globalThis.__pulpFlushSyncErr__.length)"
+                        "    errs.push('flushSync: ' + globalThis.__pulpFlushSyncErr__);"
+                        "  for (var key in globalThis) {"
+                        "    if (key.indexOf('__pulpPayloadErr_') === 0) {"
+                        "      var pe = globalThis[key];"
+                        "      if (typeof pe === 'string' && pe.length) errs.push('payload ' + key.slice(17, -2) + ': ' + pe);"
+                        "    }"
+                        "  }"
+                        "  return errs.join(' | ');"
+                        "})()");
+                    auto aggregated = v.getWithDefault<std::string>("");
+                    if (!aggregated.empty()) set_err(aggregated);
+                } catch (...) { /* leave existing err */ }
+            } catch (const std::exception& e) {
+                set_err(std::string("__pulpRuntimeImport__ threw: ") + e.what());
+            } catch (...) {
+                set_err("__pulpRuntimeImport__ threw: unknown exception");
+            }
+            return choc::value::Value();
+        });
+
+    // __pulpRuntimeSettle__(rounds) → void
+    //
+    // Pump the bridge's message loop + service_frame_callbacks the
+    // requested number of times. Used by the JS shim to drain
+    // useEffect callbacks, rAF queues, and timers after React commits.
+    engine_.register_function("__pulpRuntimeSettle__",
+        [this](choc::javascript::ArgumentList args) -> choc::value::Value {
+            int rounds = static_cast<int>(args.get<double>(0, 8.0));
+            if (rounds < 1) rounds = 1;
+            if (rounds > 64) rounds = 64;  // sanity cap
+            for (int i = 0; i < rounds; ++i) {
+                try {
+                    engine_.pump_message_loop();
+                    service_frame_callbacks();
+                } catch (...) { /* swallow — best-effort settle */ }
+            }
+            return choc::value::Value();
+        });
 }
 
 void WidgetBridge::register_api() {

--- a/packages/pulp-react/src/host-config.ts
+++ b/packages/pulp-react/src/host-config.ts
@@ -18,7 +18,7 @@ import type {
     PulpContainer,
     IntrinsicElementName,
 } from './types.js';
-import { applyAllProps, applyChangedProps } from './prop-applier.js';
+import { applyAllProps, applyChangedProps, normalizeHostProps } from './prop-applier.js';
 
 type Type = IntrinsicElementName;
 type Props = Record<string, unknown>;
@@ -190,12 +190,18 @@ export const PulpHostConfig: HostConfig<
         // to appendInitialChild / appendChild, which DO receive the parent.
         // (Codex + RepoPrompt review both flagged the original plan that
         // tried createX(id, parent) here as the wrong lifecycle point.)
-        const id = (props.id as string) ?? autoId(rootContainer);
+        // Flatten HTML/JSX-style `style` object + `className` string into
+        // the flat-prop shape applyAllProps/applyChangedProps expect.
+        // Native intrinsics already use flat props — normalizeHostProps
+        // is a no-op fast path for them. Runtime-import bundles
+        // (Claude/Stitch/Figma/v0/Pencil) reach prop-applier through here.
+        const normalizedProps = normalizeHostProps(type, props as Record<string, unknown>);
+        const id = (normalizedProps.id as string) ?? autoId(rootContainer);
         return {
             id,
             type,
             // parentId stays undefined until attached
-            props: { ...props },
+            props: { ...normalizedProps },
             childIds: [],
             onBridge: false,
             pendingChildren: [],
@@ -317,20 +323,24 @@ export const PulpHostConfig: HostConfig<
     },
 
     // ── Updates ────────────────────────────────────────────────────
-    prepareUpdate(_instance, _type, oldProps, newProps): UpdatePayload {
-        // Cheap shallow inequality check. Returning truthy schedules
-        // commitUpdate; falsy skips it. We do the actual diff inside
-        // commitUpdate via applyChangedProps for symmetry with mount.
-        return shallowDiff(oldProps, newProps);
+    prepareUpdate(_instance, type, oldProps, newProps): UpdatePayload {
+        // Flatten both sides before diffing so style/className changes
+        // surface as real prop deltas (and vice versa: a flat width:100
+        // → style:{width:100} swap collapses to a no-op).
+        const oldN = normalizeHostProps(type, oldProps as Record<string, unknown>);
+        const newN = normalizeHostProps(type, newProps as Record<string, unknown>);
+        return shallowDiff(oldN, newN);
     },
 
-    commitUpdate(instance, _updatePayload, _type, oldProps, newProps, _internalHandle) {
-        applyChangedProps(instance, oldProps, newProps);
-        instance.props = { ...newProps };
+    commitUpdate(instance, _updatePayload, type, oldProps, newProps, _internalHandle) {
+        const oldN = normalizeHostProps(type, oldProps as Record<string, unknown>);
+        const newN = normalizeHostProps(type, newProps as Record<string, unknown>);
+        applyChangedProps(instance, oldN, newN);
+        instance.props = { ...newN };
         // Re-apply text children if changed (Label/Button special-case).
         if (TEXT_BEARING.has(instance.type)) {
-            const oldText = asText(oldProps.children) ?? (oldProps.text as string | undefined);
-            const newText = asText(newProps.children) ?? (newProps.text as string | undefined);
+            const oldText = asText(oldN.children) ?? (oldN.text as string | undefined);
+            const newText = asText(newN.children) ?? (newN.text as string | undefined);
             if (oldText !== newText && newText !== undefined) {
                 if (typeof g.setText === 'function') call('setText', instance.id, newText);
             }

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -1571,6 +1571,86 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
     }
 }
 
+// ── normalizeHostProps (Phase 6 codex amendment #1) ─────────────────
+//
+// Imported React apps (Claude/Stitch/Figma/v0 bundles loaded via
+// @pulp/react/runtime-import) use HTML-style JSX:
+//   <div style={{ width: 100, color: 'red' }} className="card">
+// This flattens that to the shape applyAllProps/applyChangedProps
+// expect (flat `width: 100, color: 'red'` props).
+//
+// Merge precedence: className rules < inline style < explicit flat
+// props. Later overrides earlier.
+
+type ClassRulesProvider = (className: string) => Record<string, unknown> | null;
+
+let _classRulesProvider: ClassRulesProvider | null = null;
+
+/// Install a class-rules resolver. runtime-import wires this from the
+/// classnames.json that the source bundle ships. Pass null to clear.
+export function setClassRulesProvider(fn: ClassRulesProvider | null): void {
+    _classRulesProvider = fn;
+}
+
+/// Returns the active provider (test helper).
+export function getClassRulesProvider(): ClassRulesProvider | null {
+    return _classRulesProvider;
+}
+
+/// Flatten raw HTML/JSX props with `style` object + `className` string
+/// into the flat-prop shape prop-applier consumes. Idempotent on
+/// already-flat input.
+export function normalizeHostProps(
+    _type: string,
+    rawProps: Record<string, unknown>,
+): Record<string, unknown> {
+    const hasStyle = rawProps.style !== undefined && rawProps.style !== null
+        && typeof rawProps.style === 'object';
+    const hasClassName = typeof rawProps.className === 'string'
+        && (rawProps.className as string).length > 0;
+    if (!hasStyle && !hasClassName) return rawProps;
+
+    // Codex P2 (Phase 6.1 review) — `Object.create(null)` so the prop
+    // map is prototype-free. With a plain `{}`, a malformed CSS rule
+    // (or hostile class-rules JSON) carrying `__proto__` / `constructor`
+    // / `prototype` keys would poison Object.prototype on Object.assign.
+    // The applier later iterates `Object.keys(out)` which is safe on
+    // a null-proto object.
+    const out: Record<string, unknown> = Object.create(null);
+
+    // Filter dangerous keys when merging untrusted provider output. The
+    // inline `style` and flat-prop paths trust the JSX author (React
+    // already strips these at element-construction time), but the
+    // class-rules provider returns JSON parsed from a bundle asset —
+    // that's untrusted input.
+    const isSafeKey = (k: string): boolean =>
+        k !== '__proto__' && k !== 'constructor' && k !== 'prototype';
+
+    if (hasClassName && _classRulesProvider) {
+        const tokens = (rawProps.className as string)
+            .split(/\s+/).filter(t => t.length > 0);
+        for (const tok of tokens) {
+            const rules = _classRulesProvider(tok);
+            if (!rules) continue;
+            for (const k of Object.keys(rules)) {
+                if (isSafeKey(k)) out[k] = (rules as Record<string, unknown>)[k];
+            }
+        }
+    }
+
+    if (hasStyle) {
+        const style = rawProps.style as Record<string, unknown>;
+        for (const k of Object.keys(style)) out[k] = style[k];
+    }
+
+    for (const k of Object.keys(rawProps)) {
+        if (k === 'style' || k === 'className') continue;
+        out[k] = rawProps[k];
+    }
+
+    return out;
+}
+
 /// Apply ALL props for first-attach. Called from appendInitialChild /
 /// appendChild after the instance lands on the bridge.
 export function applyAllProps(instance: PulpInstance): void {

--- a/packages/pulp-react/test/normalize-host-props.test.ts
+++ b/packages/pulp-react/test/normalize-host-props.test.ts
@@ -1,0 +1,113 @@
+// Phase 6.1 — unit tests for the prop-applier's normalizeHostProps +
+// classRulesProvider surface. The full @pulp/react/runtime-import API
+// (installBindings, installHostReact, renderFromDesign, etc.) ships in
+// Phase 6.3; this file pins only the 6.1 contract.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    normalizeHostProps,
+    setClassRulesProvider,
+    getClassRulesProvider,
+} from '../src/prop-applier.js';
+
+afterEach(() => {
+    setClassRulesProvider(null);
+});
+
+describe('normalizeHostProps (Phase 6.1)', () => {
+    it('returns input unchanged when no style + no className (fast path)', () => {
+        const flat = { width: 100, color: 'red' };
+        expect(normalizeHostProps('div', flat)).toBe(flat);
+    });
+
+    it('flattens style object into top-level props', () => {
+        const out = normalizeHostProps('div', { style: { width: 100, color: 'red' } });
+        expect(out.width).toBe(100);
+        expect(out.color).toBe('red');
+        expect(out.style).toBeUndefined();
+    });
+
+    it('flat props override style props (flat > style precedence)', () => {
+        const out = normalizeHostProps('div', {
+            style: { width: 100 },
+            width: 200,
+        });
+        expect(out.width).toBe(200);
+    });
+
+    it('class-rules provider merges className tokens into style slot', () => {
+        setClassRulesProvider((cls) => {
+            if (cls === 'card') return { padding: 8, background: '#fff' };
+            if (cls === 'shadow') return { boxShadow: '0 2px 4px rgba(0,0,0,0.1)' };
+            return null;
+        });
+        const out = normalizeHostProps('div', { className: 'card shadow' });
+        expect(out.padding).toBe(8);
+        expect(out.background).toBe('#fff');
+        expect(out.boxShadow).toBe('0 2px 4px rgba(0,0,0,0.1)');
+    });
+
+    it('style overrides className rules (className < style precedence)', () => {
+        setClassRulesProvider((cls) => cls === 'card' ? { padding: 8 } : null);
+        const out = normalizeHostProps('div', {
+            className: 'card',
+            style: { padding: 16 },
+        });
+        expect(out.padding).toBe(16);
+    });
+
+    it('flat props override className rules (className < flat precedence)', () => {
+        setClassRulesProvider((cls) => cls === 'card' ? { padding: 8 } : null);
+        const out = normalizeHostProps('div', {
+            className: 'card',
+            padding: 24,
+        });
+        expect(out.padding).toBe(24);
+    });
+
+    it('no class-rules provider installed → className alone returns input (no flatten)', () => {
+        // With no provider, hasClassName is true but no rules merge.
+        // The function still strips className from output and copies
+        // flat props. Style absent + provider absent = empty out.
+        setClassRulesProvider(null);
+        const out = normalizeHostProps('div', { className: 'card', width: 100 });
+        expect(out.width).toBe(100);
+        expect(out.className).toBeUndefined();
+    });
+
+    // Codex P2 (Phase 6.1 review) — prototype-pollution guard.
+    it('class-rules provider returning __proto__ key does not poison Object.prototype', () => {
+        setClassRulesProvider(() => ({ __proto__: { polluted: 'yes' } } as Record<string, unknown>));
+        normalizeHostProps('div', { className: 'attacker' });
+        // Object.prototype must not have a new `polluted` field.
+        expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it('class-rules provider returning constructor / prototype keys are filtered', () => {
+        setClassRulesProvider(() => ({
+            constructor: 'evil',
+            prototype: 'evil',
+            __proto__: 'evil',
+            width: 100,
+        } as Record<string, unknown>));
+        const out = normalizeHostProps('div', { className: 'attacker' });
+        expect(out.width).toBe(100);
+        expect(out.constructor).not.toBe('evil');
+        expect(out.prototype).toBeUndefined();
+    });
+});
+
+describe('classRulesProvider (Phase 6.1)', () => {
+    it('setClassRulesProvider null clears the provider', () => {
+        setClassRulesProvider((cls) => ({ width: 100 }));
+        expect(getClassRulesProvider()).not.toBeNull();
+        setClassRulesProvider(null);
+        expect(getClassRulesProvider()).toBeNull();
+    });
+
+    it('getClassRulesProvider returns the installed fn', () => {
+        const fn = (cls: string) => ({ width: 100 });
+        setClassRulesProvider(fn);
+        expect(getClassRulesProvider()).toBe(fn);
+    });
+});

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -12331,3 +12331,83 @@ TEST_CASE("WidgetBridge setIsolation round-trips on View slot (no paint impact)"
     bridge.load_script("setIsolation('gain', 'auto')");
     REQUIRE(w->isolation() == "auto");
 }
+
+// ── Runtime design import (pulp #468 follow-up) ─────────────────────
+//
+// Contract for WidgetBridge::install_runtime_import_handlers() — the
+// C++ side of @pulp/react/runtime-import. These tests don't depend on
+// a real Claude bundle (parse_claude_bundle returns nullopt for
+// arbitrary HTML, which the handler correctly reports through
+// __pulpRuntimeImportErr__). The handler's job is to:
+//   1. Register __pulpRuntimeImport__(html, source) and
+//      __pulpRuntimeSettle__(rounds).
+//   2. Surface bundle-parse failures via __pulpRuntimeImportErr__
+//      rather than crashing the engine.
+//   3. Be idempotent on repeat install.
+
+TEST_CASE("WidgetBridge install_runtime_import_handlers registers native functions",
+          "[view][bridge][runtime-import]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.install_runtime_import_handlers();
+
+    // typeof __pulpRuntimeImport__ should be 'function' on the engine.
+    auto result = engine.evaluate(
+        "(typeof __pulpRuntimeImport__) + '|' + (typeof __pulpRuntimeSettle__)");
+    REQUIRE(result.getWithDefault<std::string>("") == "function|function");
+}
+
+TEST_CASE("WidgetBridge __pulpRuntimeImport__ surfaces parse failure as soft error",
+          "[view][bridge][runtime-import]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.install_runtime_import_handlers();
+
+    // Non-Claude HTML — parse_claude_bundle() returns nullopt; the
+    // handler must capture that as a string error on __pulpRuntimeImportErr__,
+    // not throw.
+    engine.evaluate(
+        "globalThis.__pulpRuntimeImportErr__ = null;"
+        "try { __pulpRuntimeImport__('<html><body>plain</body></html>', 'plain'); }"
+        "catch (e) { globalThis.__pulpRuntimeImportErr__ = 'threw:' + String(e); }");
+    const auto err_str = engine.evaluate(
+        "String(globalThis.__pulpRuntimeImportErr__ || '')")
+        .getWithDefault<std::string>("");
+    // Must contain the bundle envelope marker — and must NOT be a 'threw:' string.
+    REQUIRE(err_str.find("threw:") == std::string::npos);
+    REQUIRE(err_str.find("claude bundle") != std::string::npos);
+}
+
+TEST_CASE("WidgetBridge __pulpRuntimeSettle__ pumps without crashing",
+          "[view][bridge][runtime-import]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.install_runtime_import_handlers();
+
+    // 8 rounds is the default settleRounds; should be a no-op when nothing
+    // is pending. Clamping at [1, 64] is enforced inside the handler.
+    auto result = engine.evaluate(
+        "__pulpRuntimeSettle__(8); __pulpRuntimeSettle__(0); __pulpRuntimeSettle__(999); 'ok'");
+    REQUIRE(result.getWithDefault<std::string>("") == "ok");
+}
+
+TEST_CASE("WidgetBridge install_runtime_import_handlers is idempotent",
+          "[view][bridge][runtime-import]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // Calling twice must not throw and must leave the registrations intact.
+    bridge.install_runtime_import_handlers();
+    bridge.install_runtime_import_handlers();
+
+    auto result = engine.evaluate("typeof __pulpRuntimeImport__");
+    REQUIRE(result.getWithDefault<std::string>("") == "function");
+}


### PR DESCRIPTION
The C++ binding that lets a running app load a Claude/Stitch/Figma/v0/
Pencil design HTML at runtime and render it through the live engine.
Previously, design import was a one-shot build-time pipeline (`pulp
import-design`); now WidgetBridge can host designs at runtime via two
new JS natives.

C++ side (core/view/src/widget_bridge.cpp + design_import.cpp):
- `WidgetBridge::install_runtime_import_handlers()` registers two
  engine natives: `__pulpRuntimeImport__(html, source)` and
  `__pulpRuntimeSettle__(rounds)`. Both feed into the same boot
  sequence as the offline path (shims → asset payloads →
  autoflushSync patch → JSON+JS+Babel inline scripts →
  DOMContentLoaded) but evaluate on the live bridge engine instead
  of a sandbox.
- Idempotency tracked via `runtime_import_installed_` member rather
  than a static thread_local on `this`, after heap-reuse across
  Catch2 test cases produced spurious skips.
- `design_import.cpp` factored: `run_claude_bundle_payload_pipeline()`
  in the anonymous namespace is the single source of truth for the
  boot sequence; both `parse_claude_html_with_runtime` (offline) and
  `evaluate_claude_bundle_in_live_engine` (runtime) call it through
  an `ImportShimConfig` variance struct. ~241 LOC removed inline,
  ~50 LOC pipeline call replaces them.

JS host-config (packages/pulp-react/src/):
- `prop-applier.ts`: `normalizeHostProps()` flattens HTML/JSX style
  objects and className tokens onto flat props with `className <
  style < flat` precedence. `setClassRulesProvider()` lets the
  runtime-import path wire a classnames.json provider per source.
  No-op fast path for already-flat intrinsics.
- `host-config.ts`: `createInstance` + `prepareUpdate` +
  `commitUpdate` run inputs through `normalizeHostProps` so
  Yoga/Canvas2D see real deltas regardless of which surface authored
  the JSX.

Codex (`/codex review` on the slice) flagged 3 findings; all addressed:
- P1 (widget_bridge.cpp): runtime path writes soft errors to
  `__pulpPayloadErr_<idx>__` / `__pulpEvalErr__` / `__pulpFlushSyncErr__`
  globals, but JS callers only read `__pulpRuntimeImportErr__`.
  `__pulpRuntimeImport__` now aggregates per-payload + Babel + flushSync
  errors into `__pulpRuntimeImportErr__` after the pipeline returns.
- P2 (prop-applier.ts): the merged-prop output object was a plain `{}`,
  poisonable via `__proto__`/`constructor`/`prototype` keys in
  malformed class-rules JSON. Now uses `Object.create(null)` plus a
  filtered key-merge in the class-rules loop.
- note (idempotency test): two-bridge heap-reuse coverage marked as
  TODO for the 6.3 slice that adds the full JS contract test.

The remaining two Codex P1s on `runtime-import.ts` apply to the Phase
6.3 slice (the JS-side `renderFromDesign` + `lastError`/`onError`
surfaces) — they'll be addressed there. `runtime-import.test.ts`
removed from this slice; it imports from `runtime-import-impl.js`
which only exists in 6.3.

Tests:
- test/test_widget_bridge.cpp: 4 Catch2 cases under [runtime-import]
  covering native registration, soft-error reporting on non-Claude
  HTML, settle pumping, and idempotency. 2099 assertions total in
  362 cases, all passing.
- packages/pulp-react/test/normalize-host-props.test.ts: 11 vitest
  cases covering merge precedence + prototype-pollution defense +
  class-rules provider lifecycle. 417 total vitest cases, all passing.
- Pre-existing test_design_import / claude-runtime / claude-bundle
  suites still pass (329 + 11 + 45 assertions), proving the
  extract-method refactor preserved behavior.

Spec reference: planning/pulp-runtime-import-FINAL-design.md steps 1-9.
Unblocks Spectr import-validation loop: standalone can compile against
origin/main because `install_runtime_import_handlers` now exists.

Version-Bump: skip reason="pure additive SDK API surface; no public ABI change to existing methods. Phase 6.3 will bring the matching JS-side API + a coordinated minor bump"
Skill-Update: skip skill=view-bridge reason="runtime-import handlers are a new optional opt-in API; the view-bridge skill teaches lifecycle/multi-view/ABI traps and remains accurate. Phase 6.3 documentation lands with the JS slice."
Skill-Update: skip skill=import-design reason="design_import.cpp gains a new internal helper run_claude_bundle_payload_pipeline + emit_jsx codegen target; the skill teaches IR shape + offline pipeline gotchas which both remain accurate. Phase 6.3 lands the consumer-facing JS docs."
Compat-Update: skip surface=react reason="C++ binding + host-config flattening; runtime import API is a new opt-in path, not a compat-catalog change"
Compat-Update: skip surface=rn reason="C++ binding + host-config flattening; no RN compat surface change"
Compat-Update: skip surface=yoga reason="C++ binding + host-config flattening; no Yoga compat surface change"
Compat-Update: skip surface=css reason="C++ binding + host-config flattening; no CSS compat surface change"
Compat-Update: skip surface=html reason="C++ binding + host-config flattening; no HTML compat surface change"
Compat-Update: skip surface=canvas2d reason="C++ binding + host-config flattening; no canvas2d compat surface change"