### PR TITLE
fix(css): resolve calc/min/max/clamp everywhere via resolveCSSLength + 2 Codex closeouts (replaces stale #1576)

### DIFF
--- a/core/view/js/css-parser.js
+++ b/core/view/js/css-parser.js
@@ -549,18 +549,167 @@ function resolveLength(parsed, ctx) {
     }
 }
 
-// Resolve a CSS length string to px in one call
+// Resolve a CSS length string into the same {value, unit} shape that
+// parseCSSLength returns, but with calc() / min() / max() / clamp()
+// support. pulp #1553 — drop-in replacement for parseCSSLength so call
+// sites in web-compat-style-decl.js gain calc-family expression support
+// without each per-property branch having to special-case the function
+// syntax.
+//
+// Return shape (matches parseCSSLength):
+//   { value: <number>, unit: "px" | "%" | "auto" | "em" | "rem" | ... }
+//   or null if the input is empty / unparseable / malformed.
+//
+// Per-input behaviour:
+//   - calc-family with all-percent operands  →  { value, unit: "%" }
+//     so the bridge routes through the percent path (Codex P2 on #1576).
+//   - calc-family otherwise                   →  { value: <px>, unit: "px" }
+//     (evaluateCalc resolves mixed-unit operands inline against ctx).
+//   - non-calc-family                         →  parseCSSLength passthrough.
+//   - malformed calc-family (empty parens,
+//     unbalanced parens, no operands)          →  null
+//     (Codex P1 on #1576 — was infinite-recursing through evaluateCalc).
 function resolveCSSLength(str, ctx) {
-    if (!str) return 0;
-    str = String(str).trim();
-    // Check for calc/min/max/clamp first
-    if (str.indexOf("calc(") === 0 || str.indexOf("min(") === 0 ||
-        str.indexOf("max(") === 0 || str.indexOf("clamp(") === 0) {
-        return evaluateCalc(str, ctx);
+    if (str === undefined || str === null || str === "") return null;
+    var s = String(str).trim();
+    var isCalcFamily =
+        s.indexOf("calc(")  === 0 ||
+        s.indexOf("min(")   === 0 ||
+        s.indexOf("max(")   === 0 ||
+        s.indexOf("clamp(") === 0;
+
+    if (isCalcFamily) {
+        // P1 guard: reject malformed calc-family inputs before delegating
+        // to evaluateCalc. `min()` / `max()` / `clamp()` with empty parens
+        // would otherwise infinite-recurse through evaluateCalc's nested-
+        // function regex (line ~598: /(calc|min|max|clamp)\([^)]*\)/g
+        // matches zero-char inner content).
+        var inner = _calcFamilyInner(s);
+        if (inner === null) return null;
+
+        // Unit-preservation fast path: if every operand of the calc-
+        // family expression is a bare `<num><unit>` token sharing a
+        // single unit, preserve that unit so the bridge can route
+        // through the right layout path (% layout, em font-size, vh
+        // viewport-relative, etc.). Mixed-unit or arithmetic expressions
+        // (e.g. `calc(50% + 10px)`) fall through to evaluateCalc, which
+        // resolves them to px against ctx — Pulp has no deferred-
+        // resolution layer, so cross-unit arithmetic resolves at the JS
+        // boundary. Closes Codex P2 on #1576 (% preservation) and the
+        // follow-up P1 on #1862 (vh/vw/em/rem preservation).
+        var single = _calcFamilySingleUnit(s);
+        if (single !== null) return single;
+
+        var px = evaluateCalc(s, ctx);
+        return { value: px, unit: "px" };
     }
-    var parsed = parseCSSLength(str);
-    if (!parsed) return 0;
-    return resolveLength(parsed, ctx);
+    return parseCSSLength(s);
+}
+
+// Resolve a CSS length string to a raw px number. Convenience wrapper
+// for callers that only want the numeric value. Returns 0 on null /
+// non-px (auto, %) inputs — callers that need the unit information
+// should use `resolveCSSLength` directly.
+function resolveCSSLengthPx(str, ctx) {
+    var r = resolveCSSLength(str, ctx);
+    if (!r) return 0;
+    return resolveLength(r, ctx);
+}
+
+// Internal: returns the trimmed contents inside a calc-family's outer
+// parens, or null if the input is malformed (no opening paren, no
+// matching closing paren, or empty operands). Codex P1 guard.
+function _calcFamilyInner(s) {
+    var open = s.indexOf("(");
+    if (open < 0 || s.charAt(s.length - 1) !== ")") return null;
+    var inner = s.slice(open + 1, -1).trim();
+    return inner.length > 0 ? inner : null;
+}
+
+// Internal: if every operand of a calc-family expression is a bare
+// `<num><unit>` token (no operators, all the same unit), return the
+// resolved `{value, unit}` so the caller can preserve that unit
+// through to the bridge instead of losing it in px-resolution.
+//
+// Closes BOTH Codex P-tier findings on PR #1576 and its follow-up
+// P1 on PR #1862:
+//   - PR #1576 P2: `calc(50%)` → {value: 50, unit: '%'} so the
+//     bridge routes through the percent layout path.
+//   - PR #1862 P1: `calc(10vh)` / `min(1em, 2em)` etc. — unit
+//     preservation extended to every unit parseCSSLength
+//     recognises (px, em, rem, %, vw, vh, vmin, vmax). Units
+//     outside that set (ch, pt, in, cm, etc.) fall through to
+//     px resolution rather than introducing helper-only support
+//     that would diverge from `parseCSSLength` (Codex P2 review).
+//
+// Expressions with operators (`calc(50% + 10px)`) or mixed units
+// (`min(10vh, 20px)`) return null so they fall through to
+// evaluateCalc's px resolution — Pulp has no deferred-resolution
+// layer, so a mixed-unit arithmetic gets resolved at the JS layer
+// using the supplied ctx. Documented in [issue-1576][fallback-behaviour].
+//
+// Examples:
+//   calc(50%)               → {value: 50, unit: '%'}
+//   calc(10vh)              → {value: 10, unit: 'vh'}
+//   min(10%, 20%)           → {value: 10, unit: '%'}
+//   min(1em, 2em)           → {value: 1, unit: 'em'}
+//   max(10vw, 20vw)         → {value: 20, unit: 'vw'}
+//   clamp(10%, 50%, 90%)    → {value: 50, unit: '%'}
+//   calc(50% + 10px)        → null  (operator → px fallthrough)
+//   min(10vh, 20px)         → null  (mixed unit → px fallthrough)
+//   calc(50)                → null  (no unit → px fallthrough)
+//   calc(3ch)               → null  (unit outside parseCSSLength
+//                                    set → px fallthrough)
+//   calc(.px) / calc(1.2.3em) → null  (malformed number)
+function _calcFamilySingleUnit(s) {
+    var prefix =
+        s.indexOf("calc(")  === 0 ? "calc"  :
+        s.indexOf("min(")   === 0 ? "min"   :
+        s.indexOf("max(")   === 0 ? "max"   :
+        s.indexOf("clamp(") === 0 ? "clamp" : null;
+    if (prefix === null) return null;
+
+    var inner = s.slice(prefix.length + 1, -1).trim();
+    // Match: optional sign + valid number + required unit. The unit
+    // set is intentionally kept aligned with `parseCSSLength` so a
+    // bare `3em` and `calc(3em)` resolve the same way (no
+    // helper-only units). Number pattern is strict — accepts
+    // `12`, `1.5`, `.5`, `-2`, `-.25` but rejects `.`, `1.2.3`, `..`
+    // (Codex P2 review on PR #1862).
+    var bareRe = /^(-?(?:\d+(?:\.\d+)?|\.\d+))(px|em|rem|%|vw|vh|vmin|vmax)$/;
+
+    function parseOperand(tok) {
+        var m = tok.match(bareRe);
+        if (!m) return null;
+        return { value: parseFloat(m[1]), unit: m[2] };
+    }
+
+    if (prefix === "calc") {
+        return parseOperand(inner);  // single bare unit or null
+    }
+
+    // min / max / clamp — every operand must parse, and they must all
+    // share the SAME unit.
+    var args = _splitCalcArgs(inner);
+    if (args.length === 0) return null;
+    var sharedUnit = null;
+    var vals = [];
+    for (var i = 0; i < args.length; i++) {
+        var op = parseOperand(args[i].trim());
+        if (!op) return null;
+        if (sharedUnit === null) sharedUnit = op.unit;
+        else if (sharedUnit !== op.unit) return null;
+        vals.push(op.value);
+    }
+    var result = null;
+    if (prefix === "min")   result = Math.min.apply(null, vals);
+    if (prefix === "max")   result = Math.max.apply(null, vals);
+    if (prefix === "clamp") {
+        if (vals.length < 3) return null;
+        result = Math.min(Math.max(vals[1], vals[0]), vals[2]);
+    }
+    if (result === null) return null;
+    return { value: result, unit: sharedUnit };
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -604,8 +753,14 @@ function evaluateCalc(expr, ctx) {
     }
 
     // Evaluate arithmetic expression: supports +, -, *, /
-    // First resolve nested function calls
-    expr = expr.replace(/(calc|min|max|clamp)\([^)]*\)/g, function(match) {
+    // First resolve nested function calls. Codex P1 defense-in-depth on
+    // PR #1576: require AT LEAST ONE char inside the inner function
+    // parens. `[^)]*` (zero-or-more) would otherwise match `min()` and
+    // re-enter evaluateCalc with the same empty token, causing
+    // RangeError: maximum call stack size exceeded. `[^)]+` (one-or-
+    // more) means malformed calls fall through to the tokenizer below
+    // where they cleanly evaluate to 0 instead of crashing the engine.
+    expr = expr.replace(/(calc|min|max|clamp)\([^)]+\)/g, function(match) {
         return String(evaluateCalc(match, ctx));
     });
 

--- a/core/view/js/web-compat-style-decl.js
+++ b/core/view/js/web-compat-style-decl.js
@@ -147,7 +147,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             setFlex(id, "flex_shrink", parseFloat(resolved) || 0);
             break;
         case "flexBasis":
-            var fb = parseCSSLength(resolved);
+            var fb = resolveCSSLength(resolved);
             if (fb) setFlex(id, "flex_basis", fb.value);
             break;
         case "flex": {
@@ -180,7 +180,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
                 if (basisTok === "auto") {
                     setFlex(id, "flex_basis", "auto");
                 } else {
-                    var b = parseCSSLength(parts[2]);
+                    var b = resolveCSSLength(parts[2]);
                     if (b) setFlex(id, "flex_basis", b.unit === "%" ? (b.value + "%") : b.value);
                 }
             }
@@ -211,8 +211,8 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             // shared slot so the new shorthand value actually wins.
             var gapToks = String(resolved).trim().split(/\s+/);
             if (gapToks.length >= 2) {
-                var grRow = parseCSSLength(gapToks[0]);
-                var grCol = parseCSSLength(gapToks[1]);
+                var grRow = resolveCSSLength(gapToks[0]);
+                var grCol = resolveCSSLength(gapToks[1]);
                 if (grRow) setFlex(id, "row_gap",
                     grRow.unit === "%" ? (grRow.value + "%") : grRow.value);
                 if (grCol) setFlex(id, "column_gap",
@@ -223,7 +223,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
                 // The earlier ordering cleared row_gap/column_gap
                 // unconditionally, which silently nuked prior 2-token
                 // state when the new value was malformed.
-                var g = parseCSSLength(resolved);
+                var g = resolveCSSLength(resolved);
                 if (g) {
                     // Reset per-axis (-1 = "consult shared gap") so
                     // the new single-token value isn't shadowed by a
@@ -241,7 +241,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             // stores the percent value on the FlexStyle.row_gap slot
             // (best-effort: Yoga has no row-gap percent API yet, so the
             // value is treated as px until the Yoga update lands).
-            var rg = parseCSSLength(resolved);
+            var rg = resolveCSSLength(resolved);
             if (rg) setFlex(id, "row_gap",
                 rg.unit === "%" ? (rg.value + "%") : rg.value);
             break;
@@ -249,7 +249,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         case "columnGap": {
             // pulp Wave 2 css.2 — forward `'NN%'` verbatim (same caveat
             // as rowGap above).
-            var cg = parseCSSLength(resolved);
+            var cg = resolveCSSLength(resolved);
             if (cg) setFlex(id, "column_gap",
                 cg.unit === "%" ? (cg.value + "%") : cg.value);
             break;
@@ -267,7 +267,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             // verbatim so the bridge can route to YGNodeStyleSetWidthAuto
             // ("hug contents"). Mirrors the percent path.
             if (resolved === "auto") { setFlex(id, "width", "auto"); break; }
-            var w = parseCSSLength(resolved);
+            var w = resolveCSSLength(resolved);
             if (!w) break;
             if (w.unit === "auto") setFlex(id, "width", "auto");
             else if (w.unit === "%") setFlex(id, "width", w.value + "%");
@@ -276,53 +276,40 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         }
         case "height": {
             if (resolved === "auto") { setFlex(id, "height", "auto"); break; }
-            var h = parseCSSLength(resolved);
+            var h = resolveCSSLength(resolved);
             if (!h) break;
             if (h.unit === "auto") setFlex(id, "height", "auto");
             else if (h.unit === "%") setFlex(id, "height", h.value + "%");
             else setFlex(id, "height", h.value);
             break;
         }
+        // pulp #1576 — these four min/max length properties previously
+        // had a dual-path: a `/^(calc|min|max|clamp)\(/` guard that
+        // routed calc-family values into resolveCSSLength's number-
+        // return shape, and a parseCSSLength branch for the px/%/auto
+        // case. After #1576 restored resolveCSSLength to the unified
+        // {value, unit} shape (drop-in replacement for parseCSSLength),
+        // both paths collapse into a single resolveCSSLength call.
         case "minWidth": {
-            // pulp Wave 2 css.2 — accept `calc()` / `min()` / `max()` /
-            // `clamp()` via the existing resolveCSSLength helper. Numeric
-            // px and % paths route through the legacy parseCSSLength
-            // dispatch (which the bridge then forwards to Yoga).
-            if (/^(calc|min|max|clamp)\(/.test(String(resolved).trim())) {
-                setFlex(id, "min_width", resolveCSSLength(resolved, null));
-                break;
-            }
-            var mw = parseCSSLength(resolved);
+            var mw = resolveCSSLength(resolved);
             if (mw) setFlex(id, "min_width",
                 mw.unit === "%" ? (mw.value + "%") : mw.value);
             break;
         }
         case "minHeight": {
-            if (/^(calc|min|max|clamp)\(/.test(String(resolved).trim())) {
-                setFlex(id, "min_height", resolveCSSLength(resolved, null));
-                break;
-            }
-            var mh = parseCSSLength(resolved);
+            var mh = resolveCSSLength(resolved);
             if (mh) setFlex(id, "min_height",
                 mh.unit === "%" ? (mh.value + "%") : mh.value);
             break;
         }
         case "maxWidth": {
-            if (/^(calc|min|max|clamp)\(/.test(String(resolved).trim())) {
-                setFlex(id, "max_width", resolveCSSLength(resolved, null));
-                break;
-            }
-            var xw = parseCSSLength(resolved);
+            var xw = resolveCSSLength(resolved);
             if (xw) setFlex(id, "max_width",
                 xw.unit === "%" ? (xw.value + "%") : xw.value);
             break;
         }
         case "maxHeight": {
-            if (/^(calc|min|max|clamp)\(/.test(String(resolved).trim())) {
-                setFlex(id, "max_height", resolveCSSLength(resolved, null));
-                break;
-            }
-            var xh = parseCSSLength(resolved);
+            var xh = resolveCSSLength(resolved);
             if (xh) setFlex(id, "max_height",
                 xh.unit === "%" ? (xh.value + "%") : xh.value);
             break;
@@ -336,7 +323,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         // marginRight: auto`) — Yoga supports it on margin only.
         case "marginTop": {
             if (resolved === "auto") { setFlex(id, "margin_top", "auto"); break; }
-            var mt = parseCSSLength(resolved);
+            var mt = resolveCSSLength(resolved);
             if (!mt) break;
             if (mt.unit === "%") setFlex(id, "margin_top", mt.value + "%");
             else setFlex(id, "margin_top", mt.value);
@@ -344,7 +331,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         }
         case "marginRight": {
             if (resolved === "auto") { setFlex(id, "margin_right", "auto"); break; }
-            var mr = parseCSSLength(resolved);
+            var mr = resolveCSSLength(resolved);
             if (!mr) break;
             if (mr.unit === "%") setFlex(id, "margin_right", mr.value + "%");
             else setFlex(id, "margin_right", mr.value);
@@ -352,7 +339,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         }
         case "marginBottom": {
             if (resolved === "auto") { setFlex(id, "margin_bottom", "auto"); break; }
-            var mb = parseCSSLength(resolved);
+            var mb = resolveCSSLength(resolved);
             if (!mb) break;
             if (mb.unit === "%") setFlex(id, "margin_bottom", mb.value + "%");
             else setFlex(id, "margin_bottom", mb.value);
@@ -360,7 +347,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         }
         case "marginLeft": {
             if (resolved === "auto") { setFlex(id, "margin_left", "auto"); break; }
-            var ml = parseCSSLength(resolved);
+            var ml = resolveCSSLength(resolved);
             if (!ml) break;
             if (ml.unit === "%") setFlex(id, "margin_left", ml.value + "%");
             else setFlex(id, "margin_left", ml.value);
@@ -387,7 +374,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
                 if (tok === "auto") {
                     setFlex(id, mNames[mi], "auto");
                 } else {
-                    var mp = parseCSSLength(tok);
+                    var mp = resolveCSSLength(tok);
                     if (!mp) continue;
                     setFlex(id, mNames[mi],
                         mp.unit === "%" ? (mp.value + "%") : mp.value);
@@ -414,7 +401,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
                 setFlex(id, "margin_right", "auto");
                 break;
             }
-            var mhv = parseCSSLength(resolved);
+            var mhv = resolveCSSLength(resolved);
             if (!mhv) break;
             var mhArg = mhv.unit === "%" ? mhv.value + "%" : mhv.value;
             setFlex(id, "margin_left",  mhArg);
@@ -427,7 +414,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
                 setFlex(id, "margin_bottom", "auto");
                 break;
             }
-            var mvv = parseCSSLength(resolved);
+            var mvv = resolveCSSLength(resolved);
             if (!mvv) break;
             var mvArg = mvv.unit === "%" ? mvv.value + "%" : mvv.value;
             setFlex(id, "margin_top",    mvArg);
@@ -441,28 +428,28 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         // `auto` (only margin does), so the keyword is silently dropped
         // here.
         case "paddingTop": {
-            var pt = parseCSSLength(resolved);
+            var pt = resolveCSSLength(resolved);
             if (!pt) break;
             if (pt.unit === "%") setFlex(id, "padding_top", pt.value + "%");
             else setFlex(id, "padding_top", pt.value);
             break;
         }
         case "paddingRight": {
-            var pr = parseCSSLength(resolved);
+            var pr = resolveCSSLength(resolved);
             if (!pr) break;
             if (pr.unit === "%") setFlex(id, "padding_right", pr.value + "%");
             else setFlex(id, "padding_right", pr.value);
             break;
         }
         case "paddingBottom": {
-            var pb = parseCSSLength(resolved);
+            var pb = resolveCSSLength(resolved);
             if (!pb) break;
             if (pb.unit === "%") setFlex(id, "padding_bottom", pb.value + "%");
             else setFlex(id, "padding_bottom", pb.value);
             break;
         }
         case "paddingLeft": {
-            var pl = parseCSSLength(resolved);
+            var pl = resolveCSSLength(resolved);
             if (!pl) break;
             if (pl.unit === "%") setFlex(id, "padding_left", pl.value + "%");
             else setFlex(id, "padding_left", pl.value);
@@ -481,7 +468,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             for (var pi = 0; pi < 4; pi++) {
                 var ptok = String(pEdges[pi]).trim().toLowerCase();
                 if (ptok === "auto") continue; // Yoga padding has no auto
-                var pp = parseCSSLength(ptok);
+                var pp = resolveCSSLength(ptok);
                 if (!pp) continue;
                 setFlex(id, pNames[pi],
                     pp.unit === "%" ? (pp.value + "%") : pp.value);
@@ -498,7 +485,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             // `style={{ paddingHorizontal: '5%' }}` route correctly.
             // Yoga's padding does NOT support 'auto', so the keyword is
             // a no-op (unlike the marginHorizontal alias).
-            var phv = parseCSSLength(resolved);
+            var phv = resolveCSSLength(resolved);
             if (!phv) break;
             var phArg = phv.unit === "%" ? phv.value + "%" : phv.value;
             setFlex(id, "padding_left",  phArg);
@@ -506,7 +493,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             break;
         }
         case "paddingVertical": {
-            var pvv = parseCSSLength(resolved);
+            var pvv = resolveCSSLength(resolved);
             if (!pvv) break;
             var pvArg = pvv.unit === "%" ? pvv.value + "%" : pvv.value;
             setFlex(id, "padding_top",    pvArg);
@@ -552,7 +539,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
                 setFontSize(id, inherited * 1.2);
                 break;
             }
-            var fs = parseCSSLength(resolved);
+            var fs = resolveCSSLength(resolved);
             if (!fs) break;
             if (fs.unit === "em" || fs.unit === "rem") {
                 setFontSize(id, fs.value * inherited);
@@ -611,7 +598,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
                 setLetterSpacing(id, 0);
                 break;
             }
-            var ls = parseCSSLength(resolved);
+            var ls = resolveCSSLength(resolved);
             if (!ls) break;
             if (ls.unit === "em" || ls.unit === "rem") {
                 setLetterSpacing(id, ls.value * 14);
@@ -643,7 +630,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
                 setLineHeight(id, parseFloat(lhResolved) * 14);
                 break;
             }
-            var lh = parseCSSLength(resolved);
+            var lh = resolveCSSLength(resolved);
             if (!lh) break;
             if (lh.unit === "em" || lh.unit === "rem") {
                 setLineHeight(id, lh.value * 14);
@@ -706,7 +693,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             // have the box size here. The catalog flips %/elliptical to
             // `partial` honest. Users wanting a circle should use a
             // numeric radius >= half their min(width, height).
-            var br = parseCSSLength(resolved);
+            var br = resolveCSSLength(resolved);
             if (br) setBorderRadius(id, br.value);
             break;
         }
@@ -741,7 +728,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             if (bwResolved === "thin")   { setBorderWidth(id, 1); break; }
             if (bwResolved === "medium") { setBorderWidth(id, 2); break; }
             if (bwResolved === "thick")  { setBorderWidth(id, 4); break; }
-            var bw = parseCSSLength(resolved);
+            var bw = resolveCSSLength(resolved);
             if (bw) setBorderWidth(id, bw.value);
             break;
         }
@@ -947,7 +934,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
                 if (v === "center") return 0.5;
                 if (v === "left" || v === "top") return 0;
                 if (v === "right" || v === "bottom") return 1;
-                var l = parseCSSLength(v);
+                var l = resolveCSSLength(v);
                 if (l && l.unit === "%") return l.value / 100;
                 return 0.5;
             }
@@ -1021,7 +1008,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         // resolveLength in css-parser.js). Numeric px and `%` paths
         // are unchanged.
         case "top": {
-            var tv = parseCSSLength(resolved); if (!tv) break;
+            var tv = resolveCSSLength(resolved); if (!tv) break;
             if (tv.unit === "%") setTop(id, tv.value + "%");
             else if (tv.unit === "em" || tv.unit === "rem") setTop(id, tv.value * 14);
             else if (tv.unit === "vh") setTop(id, tv.value / 100 * 600);
@@ -1030,7 +1017,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             break;
         }
         case "right": {
-            var rv = parseCSSLength(resolved); if (!rv) break;
+            var rv = resolveCSSLength(resolved); if (!rv) break;
             if (rv.unit === "%") setRight(id, rv.value + "%");
             else if (rv.unit === "em" || rv.unit === "rem") setRight(id, rv.value * 14);
             else if (rv.unit === "vh") setRight(id, rv.value / 100 * 600);
@@ -1039,7 +1026,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             break;
         }
         case "bottom": {
-            var bv = parseCSSLength(resolved); if (!bv) break;
+            var bv = resolveCSSLength(resolved); if (!bv) break;
             if (bv.unit === "%") setBottom(id, bv.value + "%");
             else if (bv.unit === "em" || bv.unit === "rem") setBottom(id, bv.value * 14);
             else if (bv.unit === "vh") setBottom(id, bv.value / 100 * 600);
@@ -1048,7 +1035,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             break;
         }
         case "left": {
-            var lv = parseCSSLength(resolved); if (!lv) break;
+            var lv = resolveCSSLength(resolved); if (!lv) break;
             if (lv.unit === "%") setLeft(id, lv.value + "%");
             else if (lv.unit === "em" || lv.unit === "rem") setLeft(id, lv.value * 14);
             else if (lv.unit === "vh") setLeft(id, lv.value / 100 * 600);
@@ -1405,7 +1392,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             break;
         }
         case "outlineWidth": {
-            var ow = parseCSSLength(resolved);
+            var ow = resolveCSSLength(resolved);
             if (ow) {
                 if (typeof setOutlineWidth === "function") setOutlineWidth(id, ow.value);
                 else if (typeof setOutline === "function") setOutline(id, ow.value, "");
@@ -1424,7 +1411,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         // bridge setters. Outline doesn't take Yoga layout space, so the
         // CSS path mirrors borderStyle keyword set verbatim.
         case "outlineOffset": {
-            var oo = parseCSSLength(resolved);
+            var oo = resolveCSSLength(resolved);
             if (oo && typeof setOutlineOffset === "function") setOutlineOffset(id, oo.value);
             break;
         }
@@ -1534,22 +1521,22 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         // applyBorderSide in widget_bridge.cpp). Calling setBorderSide
         // with a placeholder 0/"" for the unset slot would clobber it.
         case "borderTopWidth": {
-            var bwT = parseCSSLength(resolved);
+            var bwT = resolveCSSLength(resolved);
             if (bwT && typeof setBorderTopWidth === "function") setBorderTopWidth(id, bwT.value);
             break;
         }
         case "borderRightWidth": {
-            var bwR = parseCSSLength(resolved);
+            var bwR = resolveCSSLength(resolved);
             if (bwR && typeof setBorderRightWidth === "function") setBorderRightWidth(id, bwR.value);
             break;
         }
         case "borderBottomWidth": {
-            var bwB = parseCSSLength(resolved);
+            var bwB = resolveCSSLength(resolved);
             if (bwB && typeof setBorderBottomWidth === "function") setBorderBottomWidth(id, bwB.value);
             break;
         }
         case "borderLeftWidth": {
-            var bwL = parseCSSLength(resolved);
+            var bwL = resolveCSSLength(resolved);
             if (bwL && typeof setBorderLeftWidth === "function") setBorderLeftWidth(id, bwL.value);
             break;
         }
@@ -1578,7 +1565,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         case "borderTopLeftRadius": case "borderTopRightRadius":
         case "borderBottomLeftRadius": case "borderBottomRightRadius": {
             var corner = key.replace("border", "").replace("Radius", "");
-            var cr = parseCSSLength(resolved);
+            var cr = resolveCSSLength(resolved);
             if (cr && typeof setCornerRadius === "function")
                 setCornerRadius(id, corner, cr.value);
             break;
@@ -1705,7 +1692,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         case "marginInlineStart": {
             // LTR fast path — inline-start ≡ left.
             if (resolved === "auto") { setFlex(id, "margin_left", "auto"); break; }
-            var mis = parseCSSLength(resolved);
+            var mis = resolveCSSLength(resolved);
             if (!mis) break;
             setFlex(id, "margin_left", mis.unit === "%" ? mis.value + "%" : mis.value);
             break;
@@ -1713,7 +1700,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         case "marginInlineEnd": {
             // LTR fast path — inline-end ≡ right.
             if (resolved === "auto") { setFlex(id, "margin_right", "auto"); break; }
-            var mie = parseCSSLength(resolved);
+            var mie = resolveCSSLength(resolved);
             if (!mie) break;
             setFlex(id, "margin_right", mie.unit === "%" ? mie.value + "%" : mie.value);
             break;
@@ -1726,7 +1713,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         case "marginBlockStart": {
             // horizontal-tb fast path — block-start ≡ top.
             if (resolved === "auto") { setFlex(id, "margin_top", "auto"); break; }
-            var mbs = parseCSSLength(resolved);
+            var mbs = resolveCSSLength(resolved);
             if (!mbs) break;
             setFlex(id, "margin_top", mbs.unit === "%" ? mbs.value + "%" : mbs.value);
             break;
@@ -1734,7 +1721,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         case "marginBlockEnd": {
             // horizontal-tb fast path — block-end ≡ bottom.
             if (resolved === "auto") { setFlex(id, "margin_bottom", "auto"); break; }
-            var mbe = parseCSSLength(resolved);
+            var mbe = resolveCSSLength(resolved);
             if (!mbe) break;
             setFlex(id, "margin_bottom", mbe.unit === "%" ? mbe.value + "%" : mbe.value);
             break;
@@ -1747,14 +1734,14 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         case "paddingInlineStart": {
             // LTR fast path — inline-start ≡ left. Yoga's padding doesn't
             // support `auto` (only margin does); keyword silently dropped.
-            var pis = parseCSSLength(resolved);
+            var pis = resolveCSSLength(resolved);
             if (!pis) break;
             setFlex(id, "padding_left", pis.unit === "%" ? pis.value + "%" : pis.value);
             break;
         }
         case "paddingInlineEnd": {
             // LTR fast path — inline-end ≡ right.
-            var pie = parseCSSLength(resolved);
+            var pie = resolveCSSLength(resolved);
             if (!pie) break;
             setFlex(id, "padding_right", pie.unit === "%" ? pie.value + "%" : pie.value);
             break;
@@ -1766,24 +1753,24 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         }
         case "paddingBlockStart": {
             // horizontal-tb fast path — block-start ≡ top.
-            var pbs = parseCSSLength(resolved);
+            var pbs = resolveCSSLength(resolved);
             if (!pbs) break;
             setFlex(id, "padding_top", pbs.unit === "%" ? pbs.value + "%" : pbs.value);
             break;
         }
         case "paddingBlockEnd": {
             // horizontal-tb fast path — block-end ≡ bottom.
-            var pbe = parseCSSLength(resolved);
+            var pbe = resolveCSSLength(resolved);
             if (!pbe) break;
             setFlex(id, "padding_bottom", pbe.unit === "%" ? pbe.value + "%" : pbe.value);
             break;
         }
         case "inset": {
             var ins = expandShorthand(resolved);
-            var tv2 = parseCSSLength(String(ins[0])); if (tv2) setTop(id, tv2.value);
-            var rv2 = parseCSSLength(String(ins[1])); if (rv2) setRight(id, rv2.value);
-            var bv2 = parseCSSLength(String(ins[2])); if (bv2) setBottom(id, bv2.value);
-            var lv2 = parseCSSLength(String(ins[3])); if (lv2) setLeft(id, lv2.value);
+            var tv2 = resolveCSSLength(String(ins[0])); if (tv2) setTop(id, tv2.value);
+            var rv2 = resolveCSSLength(String(ins[1])); if (rv2) setRight(id, rv2.value);
+            var bv2 = resolveCSSLength(String(ins[2])); if (bv2) setBottom(id, bv2.value);
+            var lv2 = resolveCSSLength(String(ins[3])); if (lv2) setLeft(id, lv2.value);
             break;
         }
 
@@ -1810,7 +1797,7 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         // text-indent — first-line indent. Storage-only; SkParagraph
         // setTextIndent integration is the follow-up.
         case "textIndent": {
-            var ti = parseCSSLength(resolved);
+            var ti = resolveCSSLength(resolved);
             if (ti && typeof setTextIndent === "function") setTextIndent(id, ti.value);
             break;
         }
@@ -2002,7 +1989,7 @@ CSSStyleDeclaration.prototype.setProperty = function(name, value) {
         // non-active slot up front, then write the new value.
         if (typeof setStringToken === 'function') setStringToken(tokenName, "");
         if (typeof setMotionToken === 'function') setMotionToken(tokenName, 0);
-        var parsed = parseCSSLength(value);
+        var parsed = resolveCSSLength(value);
         if (parsed) {
             setMotionToken(tokenName, parsed.value);
         } else {

--- a/docs/reference/compat/css.md
+++ b/docs/reference/compat/css.md
@@ -34,6 +34,43 @@ specifics are out of scope.
 
 ## Recently changed
 
+- **2026-05-12 (pulp #1576 replacement — `resolveCSSLength` everywhere + 2 Codex closeouts)** —
+  `core/view/js/web-compat-style-decl.js` swept: 58 `parseCSSLength(...)`
+  call sites swapped to `resolveCSSLength(...)`. The new helper is a
+  drop-in `{value, unit}`-shape replacement that also handles
+  `calc()` / `min()` / `max()` / `clamp()` expression inputs. Two
+  Codex-flagged correctness issues from the stale pulp #1576
+  addressed in the same PR:
+  * **P1** — `calc()` / `min()` / `max()` / `clamp()` with empty
+    parens previously infinite-recursed through `evaluateCalc`'s
+    nested-function regex (RangeError on user/theme strings). Fixed
+    at two layers: `resolveCSSLength` guards malformed inputs via
+    a `_calcFamilyInner` helper before delegating, and `evaluateCalc`'s
+    inner regex tightened from `\([^)]*\)` to `\([^)]+\)`.
+  * **P2** — calc-family expressions whose operands all share a
+    single unit now preserve that unit so the bridge routes through
+    the correct layout path:
+    - `calc(50%)` / `min(10%, 20%)` → `{value, unit: '%'}` —
+      percent layout path (was mis-applying `calc(50%)` as absolute px).
+    - `calc(10vh)` / `min(1em, 2em)` / `calc(2rem)` / `calc(25vw)` /
+      `calc(40vmin)` / `calc(40vmax)` / `calc(12px)` — original unit
+      preserved (Codex P1 on PR #1862 follow-up; bridge call sites
+      like `top/right/bottom/left` and `fontSize` need unit info for
+      property-specific conversion). The unit set is the same one
+      `parseCSSLength` already supports — units outside that set
+      (`ch`, `pt`, `in`, etc.) fall through to px resolution rather
+      than diverging from the existing bare-length parser.
+    - Mixed-unit (`calc(50% + 10px)` / `min(10vh, 20px)`) and
+      operator-bearing expressions still resolve to px via
+      `evaluateCalc` (documented; Pulp has no deferred-resolution
+      layer).
+    Detection via `_calcFamilySingleUnit`.
+  * The four `minWidth` / `minHeight` / `maxWidth` / `maxHeight`
+    dispatchers consolidate — their previous dual-path (calc-family
+    detection guard + parseCSSLength fallback) collapses into a
+    single `resolveCSSLength` call now that the unified shape handles
+    both branches.
+
 - **2026-05-12 (Tier 1 PR-B — alignItems CSS-spec alias, justifyContent honest reclassification per Codex P1)** —
   widget_bridge.cpp `setFlex` dispatcher gains exactly ONE new
   alias plus an honest documentation pass on the rest:

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -13402,3 +13402,65 @@ TEST_CASE("WidgetBridge pumps microtasks after JS dispatch so drag-state commits
     REQUIRE(engine.evaluate("move_count").getWithDefault<int>(0) == 1);
     REQUIRE(engine.evaluate("move_saw_drag_active").getWithDefault<bool>(false));
 }
+
+// pulp #1576 — bridge-level pin for min/max width/height with %, auto,
+// and calc-family inputs. The dispatcher at web-compat-style-decl.js
+// cases minWidth / minHeight / maxWidth / maxHeight previously had a
+// dual-path (calc-family detection guard + parseCSSLength fallback);
+// #1576 collapsed both into a single resolveCSSLength call. These
+// tests pin the unified shape end-to-end through the bridge so a
+// regression that re-introduces the dual-path (or drops % preservation
+// for calc-family inputs) fails first.
+TEST_CASE("minWidth / minHeight / maxWidth / maxHeight route % and calc-family through unified resolveCSSLength",
+          "[view][bridge][css][issue-1576]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        // Plain % path — unified resolveCSSLength must preserve unit='%'.
+        createPanel('mw-pct', '');
+        var sd1 = new CSSStyleDeclaration({ _id: 'mw-pct', _nativeCreated: true });
+        sd1._applyProperty('minWidth', '25%');
+
+        createPanel('mh-pct', '');
+        var sd2 = new CSSStyleDeclaration({ _id: 'mh-pct', _nativeCreated: true });
+        sd2._applyProperty('minHeight', '33%');
+
+        // calc-family % path — Codex P2: calc(50%) must reach the
+        // bridge as a percent, not absolute px.
+        createPanel('xw-calc-pct', '');
+        var sd3 = new CSSStyleDeclaration({ _id: 'xw-calc-pct', _nativeCreated: true });
+        sd3._applyProperty('maxWidth', 'min(50%, 75%)');
+
+        // calc-family px path — calc(100px + 50px) must resolve to 150px.
+        createPanel('xh-calc-px', '');
+        var sd4 = new CSSStyleDeclaration({ _id: 'xh-calc-px', _nativeCreated: true });
+        sd4._applyProperty('maxHeight', 'calc(100px + 50px)');
+    )");
+
+    auto* mw_pct      = dynamic_cast<Panel*>(bridge.widget("mw-pct"));
+    auto* mh_pct      = dynamic_cast<Panel*>(bridge.widget("mh-pct"));
+    auto* xw_calc_pct = dynamic_cast<Panel*>(bridge.widget("xw-calc-pct"));
+    auto* xh_calc_px  = dynamic_cast<Panel*>(bridge.widget("xh-calc-px"));
+    REQUIRE(mw_pct      != nullptr);
+    REQUIRE(mh_pct      != nullptr);
+    REQUIRE(xw_calc_pct != nullptr);
+    REQUIRE(xh_calc_px  != nullptr);
+
+    // % survives: dim_<dim>.unit is the percent sentinel.
+    REQUIRE(mw_pct->flex().dim_min_width.unit  == DimensionUnit::percent);
+    REQUIRE_THAT(mw_pct->flex().dim_min_width.value, WithinAbs(25.0f, 0.001f));
+    REQUIRE(mh_pct->flex().dim_min_height.unit == DimensionUnit::percent);
+    REQUIRE_THAT(mh_pct->flex().dim_min_height.value, WithinAbs(33.0f, 0.001f));
+
+    // calc-family % survives — Codex P2 pin (min(50%, 75%) = 50%).
+    REQUIRE(xw_calc_pct->flex().dim_max_width.unit  == DimensionUnit::percent);
+    REQUIRE_THAT(xw_calc_pct->flex().dim_max_width.value, WithinAbs(50.0f, 0.001f));
+
+    // calc-family px resolves to 150.
+    REQUIRE(xh_calc_px->flex().dim_max_height.unit == DimensionUnit::px);
+    REQUIRE_THAT(xh_calc_px->flex().dim_max_height.value, WithinAbs(150.0f, 0.001f));
+}

--- a/test/web-compat/test_web_compat_prelude.cpp
+++ b/test/web-compat/test_web_compat_prelude.cpp
@@ -1537,3 +1537,339 @@ TEST_CASE("WebCompat: :root pseudo does not match detached elements",
     REQUIRE(std::string(body_width.getWithDefault<std::string_view>(""))
             == "99px");
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// resolveCSSLength — pulp #1576 (the 56-site swap PR)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// `resolveCSSLength` is the unified entry point that combines
+// `parseCSSLength`'s {value, unit} shape with `evaluateCalc`'s
+// calc()/min()/max()/clamp() expression support. These tests pin:
+//
+//   - The shape is {value, unit} matching parseCSSLength (so the
+//     56 web-compat-style-decl.js call sites swap 1:1).
+//   - calc-family operands that are all-percent preserve unit='%'
+//     so the bridge routes through the percent path (Codex P2 on
+//     PR #1576 — was misapplying calc(50%) as absolute px).
+//   - Malformed calc-family inputs (`calc()`, `min()`, `max()`,
+//     `clamp()` with empty parens) return null instead of crashing
+//     the engine via infinite recursion in evaluateCalc (Codex P1
+//     on PR #1576).
+//   - Defense-in-depth: the inner nested-function regex in
+//     evaluateCalc also requires non-empty operands so a malformed
+//     value reaching evaluateCalc directly doesn't blow the stack.
+
+TEST_CASE("resolveCSSLength: returns parseCSSLength-compatible {value, unit} shape",
+          "[webcompat][css-parser][issue-1576]") {
+    TestEnvironment env;
+
+    auto eval_unit = [&](const std::string& expr) {
+        return std::string(env.engine
+            .evaluate("(function(){var r=" + expr + ";return r?r.unit:'(null)';})()")
+            .getWithDefault<std::string_view>(""));
+    };
+    auto eval_value = [&](const std::string& expr) {
+        return env.engine
+            .evaluate("(function(){var r=" + expr + ";return r?r.value:NaN;})()")
+            .getWithDefault<double>(-9999.0);
+    };
+
+    // Basic px / % / auto — passthrough to parseCSSLength.
+    REQUIRE(eval_unit("resolveCSSLength('100px')") == "px");
+    REQUIRE(eval_value("resolveCSSLength('100px')") == 100.0);
+    REQUIRE(eval_unit("resolveCSSLength('50%')") == "%");
+    REQUIRE(eval_value("resolveCSSLength('50%')") == 50.0);
+    REQUIRE(eval_unit("resolveCSSLength('auto')") == "auto");
+
+    // calc-family — all-px arithmetic resolves to {value: <px>, unit: 'px'}.
+    REQUIRE(eval_unit("resolveCSSLength('calc(100px + 50px)')") == "px");
+    REQUIRE(eval_value("resolveCSSLength('calc(100px + 50px)')") == 150.0);
+}
+
+TEST_CASE("resolveCSSLength: P2 — calc-family with all-percent operands preserves unit='%'",
+          "[webcompat][css-parser][issue-1576]") {
+    TestEnvironment env;
+
+    auto eval_pair = [&](const std::string& expr) {
+        auto u = std::string(env.engine
+            .evaluate("(function(){var r=" + expr + ";return r?r.unit:'(null)';})()")
+            .getWithDefault<std::string_view>(""));
+        auto v = env.engine
+            .evaluate("(function(){var r=" + expr + ";return r?r.value:NaN;})()")
+            .getWithDefault<double>(-9999.0);
+        return std::pair<std::string, double>{u, v};
+    };
+
+    // calc(50%)               → {value: 50, unit: '%'}
+    auto a = eval_pair("resolveCSSLength('calc(50%)')");
+    REQUIRE(a.first == "%");
+    REQUIRE(a.second == 50.0);
+
+    // min(10%, 20%)           → {value: 10, unit: '%'}
+    auto b = eval_pair("resolveCSSLength('min(10%, 20%)')");
+    REQUIRE(b.first == "%");
+    REQUIRE(b.second == 10.0);
+
+    // max(10%, 20%)           → {value: 20, unit: '%'}
+    auto c = eval_pair("resolveCSSLength('max(10%, 20%)')");
+    REQUIRE(c.first == "%");
+    REQUIRE(c.second == 20.0);
+
+    // clamp(10%, 50%, 90%)    → {value: 50, unit: '%'} (preferred within bounds)
+    auto d = eval_pair("resolveCSSLength('clamp(10%, 50%, 90%)')");
+    REQUIRE(d.first == "%");
+    REQUIRE(d.second == 50.0);
+
+    // clamp(10%, 5%, 90%)     → {value: 10, unit: '%'} (preferred below lo, clamped)
+    auto e = eval_pair("resolveCSSLength('clamp(10%, 5%, 90%)')");
+    REQUIRE(e.first == "%");
+    REQUIRE(e.second == 10.0);
+
+    // Mixed-unit calc → falls through to px (no all-percent shortcut).
+    // We don't assert the exact px value (depends on ctx) — just the unit.
+    auto f = eval_pair("resolveCSSLength('calc(50% + 10px)', {parentWidth: 200})");
+    REQUIRE(f.first == "px");
+}
+
+TEST_CASE("resolveCSSLength: P1 — malformed calc-family returns null, never crashes",
+          "[webcompat][css-parser][issue-1576]") {
+    TestEnvironment env;
+
+    auto returns_null = [&](const std::string& input) {
+        return env.engine
+            .evaluate("(function(){var r=resolveCSSLength('" + input + "');return r===null;})()")
+            .getWithDefault<bool>(false);
+    };
+
+    // Empty parens — pre-fix these reached evaluateCalc and tripped the
+    // nested-function regex into infinite recursion (RangeError: maximum
+    // call stack size exceeded). Post-fix they return null cleanly.
+    REQUIRE(returns_null("min()"));
+    REQUIRE(returns_null("max()"));
+    REQUIRE(returns_null("clamp()"));
+    REQUIRE(returns_null("calc()"));
+
+    // Whitespace-only operands — same shape, same fix.
+    REQUIRE(returns_null("min(   )"));
+    REQUIRE(returns_null("calc(  )"));
+
+    // Defense-in-depth: a malformed nested function inside a valid
+    // outer should not crash either. evaluateCalc's inner-function
+    // regex now requires non-empty content, so the malformed `min()`
+    // falls through to the tokenizer rather than re-entering.
+    auto nested = env.engine.evaluate(
+        "(function(){"
+        "  try { var r = resolveCSSLength('calc(min() + 10px)'); return 'ok:' + (r?r.value:'null'); }"
+        "  catch (e) { return 'threw:' + String(e); }"
+        "})()");
+    auto nestedStr = std::string(nested.getWithDefault<std::string_view>(""));
+    // Should NOT contain 'threw:' — i.e. no RangeError leaked out.
+    REQUIRE(nestedStr.find("threw:") == std::string::npos);
+}
+
+TEST_CASE("resolveCSSLength: non-calc invalid inputs return null (parseCSSLength compat)",
+          "[webcompat][css-parser][issue-1576]") {
+    TestEnvironment env;
+    auto returns_null = [&](const std::string& input) {
+        return env.engine
+            .evaluate("(function(){var r=resolveCSSLength('" + input + "');return r===null;})()")
+            .getWithDefault<bool>(false);
+    };
+
+    REQUIRE(returns_null(""));
+    REQUIRE(returns_null("not-a-length"));
+    REQUIRE(returns_null("calc(abc"));  // unbalanced paren — malformed
+}
+
+TEST_CASE("resolveCSSLength: signed percentages + whitespace operands preserve unit='%'",
+          "[webcompat][css-parser][issue-1576]") {
+    // Codex pre-push tweak — the all-percent shortcut must work for
+    // negative percentages and operand strings that have leading or
+    // trailing whitespace inside the parens. `_splitCalcArgs` already
+    // trims; `bareRe` already accepts `-?` — these tests pin both.
+    TestEnvironment env;
+    auto eval_pair = [&](const std::string& expr) {
+        auto u = std::string(env.engine
+            .evaluate("(function(){var r=" + expr + ";return r?r.unit:'(null)';})()")
+            .getWithDefault<std::string_view>(""));
+        auto v = env.engine
+            .evaluate("(function(){var r=" + expr + ";return r?r.value:NaN;})()")
+            .getWithDefault<double>(-9999.0);
+        return std::pair<std::string, double>{u, v};
+    };
+
+    auto a = eval_pair("resolveCSSLength('min(-10%, 0%)')");
+    REQUIRE(a.first == "%");
+    REQUIRE(a.second == -10.0);
+
+    auto b = eval_pair("resolveCSSLength('clamp(-10%, 5%, 90%)')");
+    REQUIRE(b.first == "%");
+    REQUIRE(b.second == 5.0);
+
+    auto c = eval_pair("resolveCSSLength('calc(  -25%  )')");
+    REQUIRE(c.first == "%");
+    REQUIRE(c.second == -25.0);
+
+    // Whitespace around comma-separated operands.
+    auto d = eval_pair("resolveCSSLength('min(  10%  ,  20%  )')");
+    REQUIRE(d.first == "%");
+    REQUIRE(d.second == 10.0);
+}
+
+TEST_CASE("resolveCSSLength: mixed-unit calc fallthrough documented (resolves to px, not deferred)",
+          "[webcompat][css-parser][issue-1576][fallback-behaviour]") {
+    // Codex pre-push tweak: rather than silently mis-route mixed-unit
+    // calc-family expressions, pin the documented fallback. Pulp has
+    // no deferred-resolution layer (no separate layout pass for CSS
+    // calc), so mixed-unit expressions resolve to px at the JS layer
+    // using the supplied ctx. Consumers who need percent-aware
+    // layout-time calc need a different mechanism; this test pins
+    // the "fall through to px" choice so a future change can't
+    // silently flip it.
+    TestEnvironment env;
+    auto eval_pair = [&](const std::string& expr) {
+        auto u = std::string(env.engine
+            .evaluate("(function(){var r=" + expr + ";return r?r.unit:'(null)';})()")
+            .getWithDefault<std::string_view>(""));
+        auto v = env.engine
+            .evaluate("(function(){var r=" + expr + ";return r?r.value:NaN;})()")
+            .getWithDefault<double>(-9999.0);
+        return std::pair<std::string, double>{u, v};
+    };
+
+    // 50% of 200 = 100; 100 + 10 = 110px.
+    auto mixed = eval_pair("resolveCSSLength('calc(50% + 10px)', {parentWidth: 200, parentSize: 200})");
+    REQUIRE(mixed.first == "px");
+    REQUIRE(mixed.second == 110.0);
+
+    // calc(100% - 10%) is all-percent BUT with an operator. The
+    // current `_calcFamilySingleUnit` only matches "single bare
+    // operand per arg" (no operators), so operator-bearing inputs
+    // fall through to px resolution. Pinned so a future change can
+    // choose to expand the shortcut into a richer all-percent
+    // evaluator that returns {value: 90, unit: '%'}.
+    auto opPct = eval_pair("resolveCSSLength('calc(100% - 10%)', {parentWidth: 200, parentSize: 200})");
+    REQUIRE(opPct.first == "px");
+}
+
+TEST_CASE("resolveCSSLength: calc-family preserves vh/vw/em/rem/vmin/vmax/ch when all operands share one unit",
+          "[webcompat][css-parser][issue-1576][issue-1862]") {
+    // Codex P1 on PR #1862: the percent-only fast path was discarding
+    // unit info for `calc(10vh)` / `min(1em, 2em)` etc., routing them
+    // as plain px through the bridge. Bridge callers like
+    //   top/right/bottom/left, fontSize, padding, margin
+    // need the original unit to do property-specific conversion. Pin
+    // every unit parseCSSLength understands.
+    TestEnvironment env;
+    auto eval_pair = [&](const std::string& expr) {
+        auto u = std::string(env.engine
+            .evaluate("(function(){var r=" + expr + ";return r?r.unit:'(null)';})()")
+            .getWithDefault<std::string_view>(""));
+        auto v = env.engine
+            .evaluate("(function(){var r=" + expr + ";return r?r.value:NaN;})()")
+            .getWithDefault<double>(-9999.0);
+        return std::pair<std::string, double>{u, v};
+    };
+
+    // calc(<bare><unit>) — every unit round-trips as { value, unit }.
+    auto vh1 = eval_pair("resolveCSSLength('calc(10vh)')");
+    REQUIRE(vh1.first  == "vh");
+    REQUIRE(vh1.second == 10.0);
+
+    auto vw1 = eval_pair("resolveCSSLength('calc(25vw)')");
+    REQUIRE(vw1.first  == "vw");
+    REQUIRE(vw1.second == 25.0);
+
+    auto em1 = eval_pair("resolveCSSLength('calc(1.5em)')");
+    REQUIRE(em1.first  == "em");
+    REQUIRE(em1.second == 1.5);
+
+    auto rem1 = eval_pair("resolveCSSLength('calc(2rem)')");
+    REQUIRE(rem1.first  == "rem");
+    REQUIRE(rem1.second == 2.0);
+
+    auto vmin1 = eval_pair("resolveCSSLength('calc(40vmin)')");
+    REQUIRE(vmin1.first  == "vmin");
+    REQUIRE(vmin1.second == 40.0);
+
+    auto vmax1 = eval_pair("resolveCSSLength('calc(40vmax)')");
+    REQUIRE(vmax1.first  == "vmax");
+    REQUIRE(vmax1.second == 40.0);
+
+    auto px1 = eval_pair("resolveCSSLength('calc(12px)')");
+    REQUIRE(px1.first  == "px");
+    REQUIRE(px1.second == 12.0);
+
+    // min / max / clamp with all operands of the same unit.
+    auto minVh = eval_pair("resolveCSSLength('min(10vh, 20vh)')");
+    REQUIRE(minVh.first  == "vh");
+    REQUIRE(minVh.second == 10.0);
+
+    auto maxEm = eval_pair("resolveCSSLength('max(1em, 2em, 3em)')");
+    REQUIRE(maxEm.first  == "em");
+    REQUIRE(maxEm.second == 3.0);
+
+    auto clampRem = eval_pair("resolveCSSLength('clamp(1rem, 2rem, 4rem)')");
+    REQUIRE(clampRem.first  == "rem");
+    REQUIRE(clampRem.second == 2.0);
+
+    // Mixed units in a min/max/clamp must fall through to px, never
+    // silently coerce. Pinned: a fix that flips this to anything other
+    // than `px` MUST think through deferred resolution.
+    auto mixed = eval_pair("resolveCSSLength('min(10vh, 20px)', {viewportHeight: 100})");
+    REQUIRE(mixed.first == "px");
+
+    // calc(10) — bare number, no unit — must fall through to px
+    // resolution (parseCSSLength would normally treat as px anyway,
+    // but evaluateCalc returns 10).
+    auto bare = eval_pair("resolveCSSLength('calc(10)', {parentSize: 100})");
+    REQUIRE(bare.first == "px");
+    REQUIRE(bare.second == 10.0);
+
+    // `ch` is a CSS unit but NOT one parseCSSLength supports — the
+    // helper intentionally rejects it so the helper-supported unit
+    // set stays aligned with the bare-length parser. Falls through
+    // to evaluateCalc → px (Codex P2 review).
+    auto chFall = eval_pair("resolveCSSLength('calc(3ch)')");
+    REQUIRE(chFall.first == "px");
+}
+
+TEST_CASE("resolveCSSLength: malformed calc-family operands fall through to px",
+          "[webcompat][css-parser][issue-1862]") {
+    // Codex P2 review: the bare-operand regex must not accept
+    // malformed numbers like `.`, `..`, `1.2.3`. Pin the fallthrough
+    // behavior so a future regression can't silently route a NaN as
+    // `{value: NaN, unit: '<unit>'}`.
+    TestEnvironment env;
+    auto eval_pair = [&](const std::string& expr) {
+        auto u = std::string(env.engine
+            .evaluate("(function(){var r=" + expr + ";return r?r.unit:'(null)';})()")
+            .getWithDefault<std::string_view>(""));
+        auto v = env.engine
+            .evaluate("(function(){var r=" + expr + ";return r?r.value:NaN;})()")
+            .getWithDefault<double>(-9999.0);
+        return std::pair<std::string, double>{u, v};
+    };
+
+    // Bare `.` before unit — invalid, no leading-digit-or-dot-digit form.
+    auto dotPx = eval_pair("resolveCSSLength('calc(.px)')");
+    REQUIRE(dotPx.first == "px");  // evaluateCalc fallthrough
+
+    // Multiple decimal points — invalid.
+    auto multiDot = eval_pair("resolveCSSLength('calc(1.2.3em)')");
+    REQUIRE(multiDot.first == "px");  // evaluateCalc fallthrough
+
+    // One bogus operand in a min() — entire expression falls through.
+    auto bogus = eval_pair("resolveCSSLength('min(10vh, bogus)')");
+    REQUIRE(bogus.first == "px");  // evaluateCalc fallthrough
+
+    // Verify legal edge-case numbers DO pin to the helper:
+    // leading-dot decimals are valid.
+    auto leadingDot = eval_pair("resolveCSSLength('calc(.5em)')");
+    REQUIRE(leadingDot.first  == "em");
+    REQUIRE(leadingDot.second == 0.5);
+
+    auto negLeadingDot = eval_pair("resolveCSSLength('calc(-.25rem)')");
+    REQUIRE(negLeadingDot.first  == "rem");
+    REQUIRE(negLeadingDot.second == -0.25);
+}


### PR DESCRIPTION
## Summary

Replacement for the stale pulp #1576 (closed). 5 days old, 3 merge commits dropping ~338 lines from SKILL.md files, 5+ failing CI checks. Per Agent A's coordination plan in `planning/AGENT-STATUS.md`, this is the fresh rebuild on current main.

## What changed

1. **`resolveCSSLength` shape restoration** — returns `{value, unit}` (matching parseCSSLength) instead of a raw number. Current main had drifted from the original `dfd33597a` shape; this restores it.

2. **Codex P1 closeout**: `calc()` / `min()` / `max()` / `clamp()` with empty parens previously infinite-recursed through `evaluateCalc` (RangeError). Fixed at two layers — guard in resolveCSSLength + tightened inner regex in evaluateCalc.

3. **Codex P2 closeout**: calc-family with all-percent operands now preserves `unit: '%'` so `calc(50%)` / `min(10%, 20%)` / `clamp(10%, 50%, 90%)` route through the percent path instead of mis-applying as absolute px.

4. **58-site sweep** in `core/view/js/web-compat-style-decl.js`: `parseCSSLength(...)` → `resolveCSSLength(...)`. The 4 min/max width/height dispatchers consolidate (dual-path → unified path).

## Test plan

- [x] `pulp-test-web-compat-prelude [issue-1576]` — 6 cases / 39 assertions covering shape compat, P2 percent preservation, P1 null returns, signed/whitespace percents, mixed-unit fallback docs.
- [x] `pulp-test-widget-bridge [issue-1576]` — 1 case / 12 assertions pinning bridge-level dim_min_width / dim_max_height unit + value end-to-end for plain %, calc-family %, and calc-family px inputs.
- [x] Full pulp-test-widget-bridge: 2117 assertions / 366 cases — green
- [x] Full pulp-test-web-compat-prelude: 249 / 115 — green
- [x] Full pulp-test-web-compat-events: 188 / 100 — green
- [x] Full pulp-test-web-compat-parser: 345 / 157 — green

## Codex consult log

Pre-push consultation (high effort). Verdict: do not open until 4 tightenings adopted:

- ✅ Signed-percent + whitespace-operand test coverage added
- ✅ Mixed-unit fallback behavior pinned by explicit test (vs silenced with console.warn)
- ✅ Bridge-level assertion for `%` AND calc-family on the 4 min/max width/height props
- ✅ Malformed-end-to-end null contract verified at both layers

Closes stale #1576 (already closed).