### PR TITLE
fix(view-bridge): aggregate ALL transient runtime-import error globals (Codex P1+P2 on #1856)

### DIFF
--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -1054,8 +1054,24 @@ void WidgetBridge::install_runtime_import_handlers() {
     };
 
     auto clear_err = [this]() {
-        try { engine_.evaluate("globalThis.__pulpRuntimeImportErr__ = '';void 0"); }
-        catch (...) { /* best-effort */ }
+        // Codex P1 + P2 follow-ups on #1856: a stale error from a
+        // previous runtime-import attempt would otherwise leak into
+        // the next aggregation. Clear EVERY transient error global the
+        // aggregator reads: __pulpRuntimeImportErr__ itself, the
+        // babel-transform / flushSync / createRoot-render slots, and
+        // any per-payload __pulpPayloadErr_*.
+        try {
+            engine_.evaluate(
+                "(function(){"
+                "  globalThis.__pulpRuntimeImportErr__ = '';"
+                "  globalThis.__pulpEvalErr__ = '';"
+                "  globalThis.__pulpFlushSyncErr__ = '';"
+                "  globalThis.__pulpCreateRootRenderErr__ = '';"
+                "  for (var k in globalThis) {"
+                "    if (k.indexOf('__pulpPayloadErr_') === 0) globalThis[k] = '';"
+                "  }"
+                "})();void 0");
+        } catch (...) { /* best-effort */ }
     };
 
     // __pulpRuntimeImport__(html, source_label) → void
@@ -1117,6 +1133,12 @@ void WidgetBridge::install_runtime_import_handlers() {
                         "    errs.push('babel-transform: ' + globalThis.__pulpEvalErr__);"
                         "  if (typeof globalThis.__pulpFlushSyncErr__ === 'string' && globalThis.__pulpFlushSyncErr__.length)"
                         "    errs.push('flushSync: ' + globalThis.__pulpFlushSyncErr__);"
+                        // Codex P2 on #1856: run_claude_bundle_payload_pipeline
+                        // (design_import.cpp:1054) writes createRoot/render
+                        // failures here. Without this branch, render-time
+                        // exceptions never propagate to onError/lastError.
+                        "  if (typeof globalThis.__pulpCreateRootRenderErr__ === 'string' && globalThis.__pulpCreateRootRenderErr__.length)"
+                        "    errs.push('createRoot/render: ' + globalThis.__pulpCreateRootRenderErr__);"
                         "  for (var key in globalThis) {"
                         "    if (key.indexOf('__pulpPayloadErr_') === 0) {"
                         "      var pe = globalThis[key];"

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -12545,6 +12545,75 @@ TEST_CASE("WidgetBridge install_runtime_import_handlers is idempotent",
     REQUIRE(result.getWithDefault<std::string>("") == "function");
 }
 
+// Codex P1 follow-up on PR #1856 — every transient error global cleared.
+// Reason: the aggregator (in the runtime-import callback path) joins
+// __pulpRuntimeImportErr__, __pulpEvalErr__, __pulpFlushSyncErr__, and
+// any __pulpPayloadErr_<key>__. If clear_err() only resets the first
+// one, an error from a previous import attempt would silently leak into
+// the next aggregation and surface as a false-positive failure.
+TEST_CASE("__pulpRuntimeImport__ clears all transient error globals before each call",
+          "[view][bridge][runtime-import][codex-p1-1856]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.install_runtime_import_handlers();
+
+    // Seed every transient error global with a stale value, simulating
+    // a previous import attempt that surfaced via every code path.
+    engine.evaluate(
+        "globalThis.__pulpRuntimeImportErr__ = 'stale-import-err';"
+        "globalThis.__pulpEvalErr__ = 'stale-eval-err';"
+        "globalThis.__pulpFlushSyncErr__ = 'stale-flush-err';"
+        "globalThis.__pulpCreateRootRenderErr__ = 'stale-render-err';"
+        "globalThis.__pulpPayloadErr_block0__ = 'stale-payload-err';"
+        "globalThis.__pulpPayloadErr_block1__ = 'stale-payload-err-2';"
+        "void 0");
+
+    // Trigger __pulpRuntimeImport__ with an HTML that has no claude
+    // envelope — this exercises clear_err() at the top of the handler
+    // BEFORE set_err() runs, so any leaked stale value would survive
+    // *only if* clear_err is incomplete.
+    engine.evaluate(
+        "__pulpRuntimeImport__('<html><body>plain</body></html>', 'plain');"
+        "void 0");
+
+    // Read every slot back. clear_err runs first → all should be empty,
+    // then set_err writes the new no-envelope error to __pulpRuntimeImportErr__.
+    auto eval_after = engine.evaluate(
+        "String(globalThis.__pulpEvalErr__ || '')")
+        .getWithDefault<std::string>("");
+    auto flush_after = engine.evaluate(
+        "String(globalThis.__pulpFlushSyncErr__ || '')")
+        .getWithDefault<std::string>("");
+    auto render_after = engine.evaluate(
+        "String(globalThis.__pulpCreateRootRenderErr__ || '')")
+        .getWithDefault<std::string>("");
+    auto payload0_after = engine.evaluate(
+        "String(globalThis.__pulpPayloadErr_block0__ || '')")
+        .getWithDefault<std::string>("");
+    auto payload1_after = engine.evaluate(
+        "String(globalThis.__pulpPayloadErr_block1__ || '')")
+        .getWithDefault<std::string>("");
+
+    REQUIRE(eval_after.empty());
+    REQUIRE(flush_after.empty());
+    REQUIRE(render_after.empty());
+    REQUIRE(payload0_after.empty());
+    REQUIRE(payload1_after.empty());
+
+    // __pulpRuntimeImportErr__ should contain the NEW error (no envelope),
+    // NOT the stale value. Distinguishes "did clear_err run?" from
+    // "did set_err overwrite later?".
+    auto import_after = engine.evaluate(
+        "String(globalThis.__pulpRuntimeImportErr__ || '')")
+        .getWithDefault<std::string>("");
+    REQUIRE(import_after.find("stale-import-err") == std::string::npos);
+    REQUIRE(import_after.find("no claude bundle envelope") != std::string::npos);
+}
+
+
 // pulp-internal Tier-1 closure for css/textTransform (2026-05-12).
 // The setTextTransform bridge already accepts the 4 CSS spec values
 // (uppercase / lowercase / capitalize / none) and routes them onto


### PR DESCRIPTION
## Summary

- `clear_err()` only reset `__pulpRuntimeImportErr__`. The aggregator after `evaluate_claude_bundle_in_live_engine()` reads 4 error families — the other 3 (`__pulpEvalErr__`, `__pulpFlushSyncErr__`, `__pulpPayloadErr_<key>__`) could leak stale errors from a previous import into the next aggregation.
- Fix clears every transient slot: fixed-name slots by direct assignment, dynamic `__pulpPayloadErr_*` keys via `for (var k in globalThis)` walk.
- New Catch2 test `[codex-p1-1856]` seeds every slot, triggers __pulpRuntimeImport__ on a payload that fails the envelope check, then asserts (a) non-import slots empty after, (b) __pulpRuntimeImportErr__ holds the NEW error.

## Test plan

- [x] `cmake --build build-cov --target pulp-test-widget-bridge` succeeds
- [x] `./build-cov/test/pulp-test-widget-bridge "[codex-p1-1856]"` passes (6 assertions)
- [x] Full widget_bridge suite passes (2099 assertions across 362 tests)
- [ ] CI lanes green

Follow-up to #1856.