### PR TITLE
fix(import-validation): length-gate substring fallback in label-coverage check (Codex P1 on #1847)

### DIFF
--- a/tools/import-validation/check_label_coverage.sh
+++ b/tools/import-validation/check_label_coverage.sh
@@ -52,7 +52,14 @@ while IFS= read -r expected; do
   ref_total=$((ref_total + 1))
   if grep -Fxq "$expected" "$captured"; then
     hit=$((hit + 1))
-  elif grep -Fq "$expected" "$captured"; then
+  elif [[ ${#expected} -ge 4 ]] && grep -Fq "$expected" "$captured"; then
+    # Codex P1 follow-up on PR #1847: limit the substring fallback to
+    # labels of >= 4 characters. Short labels like "A" / "B" / "?" /
+    # "⋯" would otherwise match as substrings inside unrelated longer
+    # labels ("▸ A", "BANDS", etc), inflating coverage and letting
+    # missing controls slip past the 70% gate. Exact-match path
+    # (grep -Fxq above) still works for every length — short labels
+    # are detected, just not via substring promotion.
     fuzzy=$((fuzzy + 1))
     hit=$((hit + 1))
   else


### PR DESCRIPTION
## Summary

- The fuzzy substring fallback in `check_label_coverage.sh` could inflate coverage by matching short reference labels (`A`, `B`, `?`, `⋯`) inside unrelated longer captured labels — Codex P1 on #1847.
- Limit substring fallback to labels of length >= 4. Exact match (`grep -Fxq`) still works for every length, so short labels are still detected by their exact form, just not via substring promotion.

## Test plan

- [x] Synthetic case: ref={B, BAND}, captured={BAND, BANDS, A B}. Pre-fix: hit=2 (B inflated via BAND). Post-fix: hit=1, B correctly flagged missing.
- [ ] CI lanes green

Follow-up to #1847.