### PR TITLE
test(canvas2d): pin 9-arg drawImage coverage for #1739

### DIFF
--- a/test/test_canvas_widget.cpp
+++ b/test/test_canvas_widget.cpp
@@ -2075,3 +2075,141 @@ TEST_CASE("CanvasWidget paint dispatches set_filter to the canvas",
     REQUIRE(saw_filter);
     REQUIRE(observed_string == "blur(5px) sepia(60%)");
 }
+
+// ── pulp #1739 codecov backfill — 9-arg drawImage paint-replay coverage ──
+//
+// PR #1739 wired the canvas2d/drawImage sprite-sheet form
+// (drawImage(img, sx,sy,sw,sh, dx,dy,dw,dh)) end-to-end through the JS
+// shim → WidgetBridge → CanvasWidget::paint() → Canvas::draw_image_*_rect.
+// The end-to-end test in test_widget_bridge.cpp [issue-1737] passes, but
+// codecov reported 0% patch coverage on the new lines because the bridge
+// → JS-shim → widget-paint dispatch chain was too indirect for per-line
+// attribution. These focused tests construct the CanvasDrawCmd directly
+// and call CanvasWidget::paint() against a RecordingCanvas — codecov
+// can attribute the `has_source_rect` branch in canvas_widget.cpp and
+// the `draw_image_from_file_rect` recording in recording_canvas.cpp
+// unambiguously to these test cases.
+
+// 9-arg form: `has_source_rect=true` routes through the `_rect` overload
+// so x2/y2/x3/y3 (sx,sy,sw,sh) ride alongside x/y/w/h (dx,dy,dw,dh) to
+// the canvas backend. Asserting on RecordingCanvas:
+//   - cmd.f[0..3] == dst rect
+//   - cmd.floats[0..3] == src rect
+// proves draw_image_from_file_rect was called (the dst-only path leaves
+// `floats` empty — see test below).
+TEST_CASE("CanvasWidget::paint routes draw_image through _rect overload when has_source_rect",
+          "[canvas_widget][issue-1739][canvas2d][coverage]") {
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 200, 100});
+
+    CanvasDrawCmd img;
+    img.type        = CanvasDrawCmd::Type::draw_image;
+    img.text        = "/sprites/walk.png";   // non-empty, non-data-URI path
+    // Destination rect (paint into 64x32 tile at 10,20):
+    img.x = 10; img.y = 20; img.w = 64; img.h = 32;
+    // Source rect (slice the (32,0)→(64,32) tile out of the sprite strip):
+    img.x2 = 32; img.y2 = 0; img.x3 = 32; img.y3 = 32;
+    img.has_source_rect = true;
+    cw.add_command(img);
+
+    RecordingCanvas rec;
+    cw.paint(rec);
+
+    // Find the recorded draw_image command. RecordingCanvas's
+    // draw_image_from_file_rect override stashes the src rect in
+    // `floats[0..3]` — the dst-only draw_image_from_file leaves it empty.
+    int drawIndex = -1;
+    int idx = 0;
+    for (const auto& cmd : rec.commands()) {
+        if (cmd.type == DrawCommand::Type::draw_image) {
+            drawIndex = idx;
+            REQUIRE(cmd.text == "/sprites/walk.png");
+            // dst rect in f[0..3].
+            REQUIRE(cmd.f[0] == Catch::Approx(10.0f));
+            REQUIRE(cmd.f[1] == Catch::Approx(20.0f));
+            REQUIRE(cmd.f[2] == Catch::Approx(64.0f));
+            REQUIRE(cmd.f[3] == Catch::Approx(32.0f));
+            // src rect in floats[0..3] — proves the _rect overload fired.
+            REQUIRE(cmd.floats.size() == 4);
+            REQUIRE(cmd.floats[0] == Catch::Approx(32.0f));
+            REQUIRE(cmd.floats[1] == Catch::Approx(0.0f));
+            REQUIRE(cmd.floats[2] == Catch::Approx(32.0f));
+            REQUIRE(cmd.floats[3] == Catch::Approx(32.0f));
+        }
+        ++idx;
+    }
+    REQUIRE(drawIndex >= 0);
+}
+
+// 5-arg form fallback: `has_source_rect=false` must route through the
+// dst-only draw_image_from_file path. RecordingCanvas leaves the
+// `floats` payload empty in that case, which is how the renderer (Skia
+// or CG) distinguishes the two forms downstream. This pins the else
+// branch of canvas_widget.cpp's has_source_rect check.
+TEST_CASE("CanvasWidget::paint routes draw_image through dst-only path when has_source_rect is false",
+          "[canvas_widget][issue-1739][canvas2d][coverage]") {
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 200, 100});
+
+    CanvasDrawCmd img;
+    img.type            = CanvasDrawCmd::Type::draw_image;
+    img.text            = "/icons/play.png";
+    img.x = 5; img.y = 5; img.w = 16; img.h = 16;
+    // x2/y2/x3/y3 stay at zero; flag stays false — dst-only path.
+    img.has_source_rect = false;
+    cw.add_command(img);
+
+    RecordingCanvas rec;
+    cw.paint(rec);
+
+    int drawIndex = -1;
+    int idx = 0;
+    for (const auto& cmd : rec.commands()) {
+        if (cmd.type == DrawCommand::Type::draw_image) {
+            drawIndex = idx;
+            REQUIRE(cmd.text == "/icons/play.png");
+            REQUIRE(cmd.f[0] == Catch::Approx(5.0f));
+            REQUIRE(cmd.f[1] == Catch::Approx(5.0f));
+            REQUIRE(cmd.f[2] == Catch::Approx(16.0f));
+            REQUIRE(cmd.f[3] == Catch::Approx(16.0f));
+            // dst-only path leaves `floats` untouched — RecordingCanvas's
+            // draw_image_from_file override doesn't populate it.
+            REQUIRE(cmd.floats.empty());
+        }
+        ++idx;
+    }
+    REQUIRE(drawIndex >= 0);
+}
+
+// Empty-path + has_source_rect=true: canvas_widget's draw_image case
+// guards the `_rect` call behind `!src.empty()`, so an empty path falls
+// through to the labeled placeholder fallback. This pins the empty-src
+// early-exit edge of the new branch.
+TEST_CASE("CanvasWidget::paint draws placeholder when image path is empty even with source rect",
+          "[canvas_widget][issue-1739][canvas2d][coverage]") {
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 200, 100});
+
+    CanvasDrawCmd img;
+    img.type            = CanvasDrawCmd::Type::draw_image;
+    img.text            = "";  // empty path — skip the file-decode branch
+    img.x = 10; img.y = 10; img.w = 32; img.h = 32;
+    img.x2 = 1; img.y2 = 2; img.x3 = 3; img.y3 = 4;
+    img.has_source_rect = true;
+    cw.add_command(img);
+
+    RecordingCanvas rec;
+    cw.paint(rec);
+
+    // No draw_image command should land because the empty-path branch
+    // doesn't call canvas.draw_image_from_file_rect — instead the
+    // placeholder fill_rect / fill_text path fires.
+    bool saw_draw_image = false;
+    bool saw_placeholder_fill = false;
+    for (const auto& cmd : rec.commands()) {
+        if (cmd.type == DrawCommand::Type::draw_image) saw_draw_image = true;
+        if (cmd.type == DrawCommand::Type::fill_rect) saw_placeholder_fill = true;
+    }
+    REQUIRE_FALSE(saw_draw_image);
+    REQUIRE(saw_placeholder_fill);
+}

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -2941,6 +2941,111 @@ TEST_CASE("WidgetBridge canvasDrawImage 9-arg form plumbs source rect end-to-end
     REQUIRE(drawIndex >= 0);
 }
 
+// pulp #1739 codecov backfill — focused unit test for the bridge-side
+// 9-arg drawImage plumbing. The end-to-end test above (#1737) exercises
+// the same path through the JS shim, but codecov's per-line attribution
+// reported 0% on widget_bridge.cpp lines 7045-7051 (the `args.numArgs
+// >= 10` branch that sets has_source_rect + stashes sx,sy,sw,sh in
+// x2,y2,x3,y3). This test invokes canvasDrawImage directly via JS to
+// pin the bridge plumbing to a tight Catch2 fixture so codecov measures
+// it. Asserts target the CanvasDrawCmd state right at the
+// JS-→-bridge boundary (read back via CanvasWidget::commands()).
+TEST_CASE("WidgetBridge canvasDrawImage 10-arg call sets has_source_rect on the recorded cmd",
+          "[view][bridge][canvas][issue-1739][canvas2d][coverage]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // Drive canvasDrawImage directly with the 10-arg shape so the
+    // `args.numArgs >= 10` branch in widget_bridge.cpp fires. Using the
+    // raw bridge function (not the JS shim) keeps the call site tightly
+    // bound to the lines under test for codecov line-attribution.
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'bridge-9arg-canvas';
+        c.width = 256; c.height = 64;
+        document.body.appendChild(c);
+        // 10 args: canvasId, src, dx, dy, dw, dh, sx, sy, sw, sh.
+        // Bridge stashes sx,sy,sw,sh in x2,y2,x3,y3 and flags
+        // has_source_rect=true. Use c._id — the bridge looks up the
+        // CanvasWidget by its internal id, not the DOM `id` attribute.
+        canvasDrawImage(c._id, '/atlas/strip.png',
+                        100, 50, 64, 32,
+                        128, 16, 32, 16);
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "bridge-9arg-canvas");
+    REQUIRE(canvas != nullptr);
+    REQUIRE(canvas->command_count() == 1);
+
+    // CanvasWidget::commands() exposes the recorded cmd queue (read-only).
+    // We assert directly on the CanvasDrawCmd to pin the bridge's
+    // x2/y2/x3/y3 + has_source_rect writes — no paint-replay layer in
+    // between for codecov to lose track of.
+    const auto& cmds = canvas->commands();
+    REQUIRE(cmds.size() == 1);
+    const auto& cmd = cmds.front();
+    REQUIRE(cmd.type == CanvasDrawCmd::Type::draw_image);
+    REQUIRE(cmd.text == "/atlas/strip.png");
+    // dst rect (args[2..5])
+    REQUIRE_THAT(cmd.x, WithinAbs(100.0f, 1e-5f));
+    REQUIRE_THAT(cmd.y, WithinAbs(50.0f, 1e-5f));
+    REQUIRE_THAT(cmd.w, WithinAbs(64.0f, 1e-5f));
+    REQUIRE_THAT(cmd.h, WithinAbs(32.0f, 1e-5f));
+    // src rect (args[6..9]) — proves the args.numArgs >= 10 branch fired.
+    REQUIRE(cmd.has_source_rect == true);
+    REQUIRE_THAT(cmd.x2, WithinAbs(128.0f, 1e-5f));
+    REQUIRE_THAT(cmd.y2, WithinAbs(16.0f, 1e-5f));
+    REQUIRE_THAT(cmd.x3, WithinAbs(32.0f, 1e-5f));
+    REQUIRE_THAT(cmd.y3, WithinAbs(16.0f, 1e-5f));
+}
+
+// 6-arg form (canvas-only-dst): the bridge's `args.numArgs >= 10`
+// branch must NOT fire, so has_source_rect stays false. Pins the
+// else-branch of the bridge plumbing.
+TEST_CASE("WidgetBridge canvasDrawImage 6-arg call leaves has_source_rect=false",
+          "[view][bridge][canvas][issue-1739][canvas2d][coverage]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'bridge-6arg-canvas';
+        c.width = 64; c.height = 64;
+        document.body.appendChild(c);
+        // 6 args — dst-only form. has_source_rect must stay false.
+        canvasDrawImage(c._id, '/icons/save.png',
+                        4, 4, 32, 32);
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "bridge-6arg-canvas");
+    REQUIRE(canvas != nullptr);
+    REQUIRE(canvas->command_count() == 1);
+
+    const auto& cmd = canvas->commands().front();
+    REQUIRE(cmd.type == CanvasDrawCmd::Type::draw_image);
+    REQUIRE(cmd.text == "/icons/save.png");
+    REQUIRE_THAT(cmd.x, WithinAbs(4.0f, 1e-5f));
+    REQUIRE_THAT(cmd.y, WithinAbs(4.0f, 1e-5f));
+    REQUIRE_THAT(cmd.w, WithinAbs(32.0f, 1e-5f));
+    REQUIRE_THAT(cmd.h, WithinAbs(32.0f, 1e-5f));
+    // Source-rect branch did NOT fire.
+    REQUIRE(cmd.has_source_rect == false);
+    REQUIRE_THAT(cmd.x2, WithinAbs(0.0f, 1e-5f));
+    REQUIRE_THAT(cmd.y2, WithinAbs(0.0f, 1e-5f));
+    REQUIRE_THAT(cmd.x3, WithinAbs(0.0f, 1e-5f));
+    REQUIRE_THAT(cmd.y3, WithinAbs(0.0f, 1e-5f));
+}
+
 TEST_CASE("WidgetBridge canvasPutImageData records pixel buffer for paint replay",
           "[view][bridge][canvas][issue-916]") {
     ScriptEngine engine;


### PR DESCRIPTION
## Summary

Closes the codecov patch-coverage gap on the merged PR #1739
(`feat(canvas2d): wire drawImage 9-arg sprite-sheet source-rect form`).
Codecov reported **0% patch coverage** on the 39 newly-added lines
despite the existing end-to-end test in `test_widget_bridge.cpp`
([issue-1737]) passing — the bridge → JS-shim → widget-paint dispatch
chain is too indirect for per-line attribution.

A note already exists in `test_canvas.cpp` documenting this gap and
adding `RecordingCanvas`-direct tests for the `recording_canvas.cpp`
lines. This PR closes the remaining surface:

- `core/view/src/canvas_widget.cpp` (8 missing lines — the `has_source_rect` branch in the `draw_image` case)
- `core/view/src/widget_bridge.cpp` (7 missing lines — the `args.numArgs >= 10` branch in the `canvasDrawImage` callback)

## What this PR does

**`test/test_canvas_widget.cpp`** — 3 focused unit tests:

1. `CanvasWidget::paint` with `has_source_rect=true` routes through
   `Canvas::draw_image_from_file_rect` — asserts src rect lands in
   `RecordingCanvas`'s `floats[0..3]`.
2. `CanvasWidget::paint` with `has_source_rect=false` routes through
   the dst-only `Canvas::draw_image_from_file` — asserts `floats` empty.
3. Empty path + `has_source_rect=true` falls through to the placeholder
   `fill_rect` path — asserts no `draw_image` command lands.

**`test/test_widget_bridge.cpp`** — 2 focused bridge tests:

4. `canvasDrawImage` invoked with exactly 10 args via JS — asserts the
   recorded `CanvasDrawCmd` has `has_source_rect=true` and
   `x2/y2/x3/y3 = sx,sy,sw,sh`.
5. `canvasDrawImage` invoked with 6 args (5-arg form) — asserts
   `has_source_rect=false` and `x2/y2/x3/y3 = 0`.

All five tests use the `[issue-1739][canvas2d][coverage]` tag triplet.
No Apple-only / Skia-only / GPU code paths — runs on Linux-Clang too.

## Test plan

- [x] `cmake --build build --target pulp-test-canvas-widget pulp-test-widget-bridge`
- [x] `./build/test/pulp-test-canvas-widget '[issue-1739]'` → 3 cases, 20 assertions pass
- [x] `./build/test/pulp-test-widget-bridge '[issue-1739]'` → 2 cases, 27 assertions pass
- [x] Full `pulp-test-canvas-widget` suite — 43 cases, 154 assertions, all pass
- [x] Full `pulp-test-widget-bridge` suite — 368 cases, 2144 assertions, all pass
- [x] Full `pulp-test-canvas` suite — 61 cases, 1541 assertions, all pass (no regressions)
- [ ] CI codecov reports patch coverage > 0% on `canvas_widget.cpp` and `widget_bridge.cpp` lines from #1739

Refs: pulp #1739