### PR TITLE
feat(import-validation): per-region masked diff for runtime-import validation

### DIFF
--- a/tools/import-validation/diff_against_reference_regions.py
+++ b/tools/import-validation/diff_against_reference_regions.py
@@ -26,8 +26,9 @@ Usage:
         --regions tools/import-validation/regions/v0-audio-panel.json
 
 Exit codes:
-    0  - every region meets its threshold
-    1  - one or more regions below threshold (FAIL — list which)
+    0  - every region meets its threshold, OR --strict was not passed
+         (region failures are informational without --strict)
+    1  - one or more regions below threshold AND --strict was passed
     2  - cannot compare (missing file, size mismatch, malformed regions JSON)
 """
 
@@ -173,11 +174,34 @@ def load_regions(path: Path | None) -> dict:
     if not isinstance(data, dict) or not data:
         print(f"error: regions JSON must be a non-empty object", file=sys.stderr)
         sys.exit(2)
-    # Validate each region has the required fields.
+    # Validate each region has the required fields and that values are the
+    # right shape. Without this, a malformed value (e.g. "x": "0.10" or a
+    # string threshold) propagates into region_score() and crashes mid-run
+    # instead of giving the user a clear configuration error up front.
     for name, region in data.items():
+        if not isinstance(region, dict):
+            print(f"error: region '{name}' must be an object", file=sys.stderr)
+            sys.exit(2)
         for required in ("x", "y", "w", "h"):
             if required not in region:
                 print(f"error: region '{name}' missing '{required}'", file=sys.stderr)
+                sys.exit(2)
+            value = region[required]
+            # bool is a subclass of int in Python — reject it explicitly so
+            # `"x": true` doesn't silently become 1.
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                print(
+                    f"error: region '{name}' has non-numeric {required}={value!r}",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+        if "threshold" in region:
+            thr = region["threshold"]
+            if isinstance(thr, bool) or not isinstance(thr, (int, float)) or not (0.0 <= float(thr) <= 1.0):
+                print(
+                    f"error: region '{name}' has invalid threshold={thr!r} (expected number in 0..1)",
+                    file=sys.stderr,
+                )
                 sys.exit(2)
     return data
 
@@ -205,7 +229,7 @@ def main() -> int:
     parser.add_argument(
         "--strict",
         action="store_true",
-        help="Fail if ANY region fails (default); without it, only a summary verdict is printed",
+        help="Exit non-zero if ANY region fails its threshold; without --strict, region failures are informational and the script exits 0",
     )
     args = parser.parse_args()
 
@@ -257,7 +281,12 @@ def main() -> int:
             print()
             print(f"  Failed regions: {', '.join(failed_names)}")
 
-    return 0 if all_passed else 1
+    # --strict gates the non-zero exit. Without it, region failures are
+    # informational only (still printed / still in JSON output) but the
+    # script exits 0 so callers can run the diff without forcing a fail.
+    if all_passed or not args.strict:
+        return 0
+    return 1
 
 
 if __name__ == "__main__":

--- a/tools/import-validation/diff_against_reference_regions.py
+++ b/tools/import-validation/diff_against_reference_regions.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""diff_against_reference_regions.py — per-region masked similarity for
+import-validation harness.
+
+Companion to diff_against_reference.py. The full-image score (the existing
+script) hides broken UI sub-regions: a canvas that's empty drags down the
+score while the chrome looks fine, and a broken chrome region can pass if
+the canvas happens to match. This script computes a per-region score so
+the harness can fail on the FIRST broken region rather than averaging
+everything into one number.
+
+Codex review of planning/spectr-validated-runtime-import-product-spec.md
+flagged this as a hard-gate requirement (2026-05-12).
+
+Regions are defined as percent-of-window rects, so they scale across
+different output sizes (the reference may be 2640x1620, the native render
+1213x812 — the same region maps proportionally to each).
+
+Default regions are Spectr's editor.html shape. Override with
+`--regions <path-to-json>` for other fixtures.
+
+Usage:
+    diff_against_reference_regions.py <reference.png> <candidate.png>
+    diff_against_reference_regions.py <reference.png> <candidate.png> --json
+    diff_against_reference_regions.py <reference.png> <candidate.png> \
+        --regions tools/import-validation/regions/v0-audio-panel.json
+
+Exit codes:
+    0  - every region meets its threshold
+    1  - one or more regions below threshold (FAIL — list which)
+    2  - cannot compare (missing file, size mismatch, malformed regions JSON)
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    from PIL import Image
+except ImportError:
+    print("error: PIL/Pillow required (pip install Pillow)", file=sys.stderr)
+    sys.exit(2)
+
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+
+# Default regions for Spectr's editor.html. Coordinates are percent of
+# window (0..1) — (x, y) is top-left, (w, h) is width/height. Thresholds
+# are per-region similarity scores below which the region is judged
+# broken. Canvas regions tolerate more variance because Skia raster + AA
+# vary; chrome regions are tighter because text + button layout should
+# match deterministically.
+SPECTR_REGIONS = {
+    "title_chrome": {
+        "x": 0.00, "y": 0.00, "w": 0.30, "h": 0.05,
+        "threshold": 0.80,
+        "notes": "SPECTR title + ZOOMABLE FILTER BANK",
+    },
+    "mode_toggles": {
+        "x": 0.30, "y": 0.00, "w": 0.40, "h": 0.05,
+        "threshold": 0.75,
+        "notes": "LIVE / PRECISION / IIR / FFT / HYBRID buttons",
+    },
+    "band_dropdown": {
+        "x": 0.70, "y": 0.00, "w": 0.30, "h": 0.05,
+        "threshold": 0.75,
+        "notes": "64 bands dropdown + zoom indicator",
+    },
+    "central_canvas": {
+        "x": 0.00, "y": 0.05, "w": 1.00, "h": 0.85,
+        "threshold": 0.55,
+        "notes": "Spectrum gradient + band columns + ruler — canvas paint, looser threshold for raster variance",
+    },
+    "bottom_toolbar": {
+        "x": 0.00, "y": 0.90, "w": 1.00, "h": 0.10,
+        "threshold": 0.75,
+        "notes": "CLEAR/SCULPT/PEAK/PRESETS/SNAPSHOT/A/B + morph slider",
+    },
+}
+
+
+def load_normalized(path: Path, target_size: tuple[int, int]) -> Image.Image:
+    img = Image.open(path).convert("RGB")
+    if img.size != target_size:
+        img = img.resize(target_size, Image.Resampling.LANCZOS)
+    return img
+
+
+def crop_region(img: Image.Image, region: dict) -> Image.Image:
+    """Crop image to a percent-of-window rect."""
+    W, H = img.size
+    x = int(region["x"] * W)
+    y = int(region["y"] * H)
+    w = max(1, int(region["w"] * W))
+    h = max(1, int(region["h"] * H))
+    return img.crop((x, y, x + w, y + h))
+
+
+def histogram_similarity(a: Image.Image, b: Image.Image) -> float:
+    ha = a.histogram()
+    hb = b.histogram()
+    dot = sum(x * y for x, y in zip(ha, hb))
+    na = sum(x * x for x in ha) ** 0.5
+    nb = sum(y * y for y in hb) ** 0.5
+    if na == 0 or nb == 0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def mean_pixel_distance(a: Image.Image, b: Image.Image) -> float:
+    if a.size != b.size:
+        # Resize candidate region to reference region; cheap.
+        b = b.resize(a.size, Image.Resampling.LANCZOS)
+    pa = list(a.getdata())
+    pb = list(b.getdata())
+    if len(pa) != len(pb):
+        return 0.0
+    total = 0
+    for (r1, g1, b1), (r2, g2, b2) in zip(pa, pb):
+        total += ((r1 - r2) ** 2 + (g1 - g2) ** 2 + (b1 - b2) ** 2) ** 0.5
+    avg = total / len(pa)
+    return 1.0 - (avg / 441.7)
+
+
+def is_blank(img: Image.Image, dark_threshold: int = 30) -> bool:
+    pixels = list(img.getdata())
+    if not pixels:
+        return True
+    near_black = sum(
+        1 for (r, g, b) in pixels if max(r, g, b) < dark_threshold
+    )
+    return near_black / len(pixels) > 0.95
+
+
+def region_score(ref_full: Image.Image, cand_full: Image.Image, region: dict) -> dict:
+    ref_crop = crop_region(ref_full, region)
+    cand_crop = crop_region(cand_full, region)
+    hist = histogram_similarity(ref_crop, cand_crop)
+    pix = mean_pixel_distance(ref_crop, cand_crop)
+    score = (hist * 0.4) + (pix * 0.6)
+    blank_cand = is_blank(cand_crop)
+    blank_ref = is_blank(ref_crop)
+    threshold = region.get("threshold", 0.75)
+    passed = score >= threshold and not blank_cand
+    return {
+        "score": round(score, 4),
+        "histogram_similarity": round(hist, 4),
+        "pixel_similarity": round(pix, 4),
+        "threshold": threshold,
+        "passed": passed,
+        "blank_candidate": blank_cand,
+        "blank_reference": blank_ref,
+        "rect_pct": {k: region[k] for k in ("x", "y", "w", "h")},
+        "notes": region.get("notes", ""),
+    }
+
+
+def load_regions(path: Path | None) -> dict:
+    if path is None:
+        return SPECTR_REGIONS
+    if not path.exists():
+        print(f"error: regions JSON not found: {path}", file=sys.stderr)
+        sys.exit(2)
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except json.JSONDecodeError as e:
+        print(f"error: malformed regions JSON: {e}", file=sys.stderr)
+        sys.exit(2)
+    if not isinstance(data, dict) or not data:
+        print(f"error: regions JSON must be a non-empty object", file=sys.stderr)
+        sys.exit(2)
+    # Validate each region has the required fields.
+    for name, region in data.items():
+        for required in ("x", "y", "w", "h"):
+            if required not in region:
+                print(f"error: region '{name}' missing '{required}'", file=sys.stderr)
+                sys.exit(2)
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("reference", type=Path, help="Reference PNG (ground truth)")
+    parser.add_argument("candidate", type=Path, help="Candidate PNG to compare")
+    parser.add_argument(
+        "--size",
+        default="1320x860",
+        help="Normalize both images to this WxH before regioning (default 1320x860)",
+    )
+    parser.add_argument(
+        "--regions",
+        type=Path,
+        default=None,
+        help="JSON file with region definitions (default: built-in Spectr regions)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output machine-readable JSON instead of human text",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail if ANY region fails (default); without it, only a summary verdict is printed",
+    )
+    args = parser.parse_args()
+
+    for p in (args.reference, args.candidate):
+        if not p.exists():
+            print(f"error: file not found: {p}", file=sys.stderr)
+            return 2
+
+    regions = load_regions(args.regions)
+    try:
+        w, h = (int(x) for x in args.size.split("x"))
+    except ValueError:
+        print(f"error: malformed --size {args.size}", file=sys.stderr)
+        return 2
+    target = (w, h)
+
+    try:
+        ref = load_normalized(args.reference, target)
+        cand = load_normalized(args.candidate, target)
+    except Exception as e:
+        print(f"error: failed to load images: {e}", file=sys.stderr)
+        return 2
+
+    results = {name: region_score(ref, cand, region) for name, region in regions.items()}
+    failed_names = [n for n, r in results.items() if not r["passed"]]
+    all_passed = not failed_names
+
+    if args.json:
+        print(json.dumps({
+            "reference": str(args.reference),
+            "candidate": str(args.candidate),
+            "size_normalized_to": args.size,
+            "regions": results,
+            "failed_regions": failed_names,
+            "all_passed": all_passed,
+        }, indent=2))
+    else:
+        verdict = "PASS ✓" if all_passed else "FAIL ✗"
+        print(f"{verdict}  {len(results) - len(failed_names)}/{len(results)} regions pass")
+        print()
+        for name, r in results.items():
+            mark = "✓" if r["passed"] else "✗"
+            blank = " (BLANK)" if r["blank_candidate"] else ""
+            print(f"  {mark} {name:18s} score={r['score']:.3f} threshold={r['threshold']:.3f}{blank}")
+            print(f"    rect: x={r['rect_pct']['x']:.2f} y={r['rect_pct']['y']:.2f} w={r['rect_pct']['w']:.2f} h={r['rect_pct']['h']:.2f}")
+            if r["notes"]:
+                print(f"    {r['notes']}")
+        if failed_names:
+            print()
+            print(f"  Failed regions: {', '.join(failed_names)}")
+
+    return 0 if all_passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/import-validation/test_diff_against_reference_regions.py
+++ b/tools/import-validation/test_diff_against_reference_regions.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Unit tests for diff_against_reference_regions.py — schema validation and
+--strict flag semantics.
+
+Pins the Codex P2 contract on PR #1871:
+  - load_regions() validates region type/coord values upfront and exits
+    2 with a clear message before any scoring runs.
+  - --strict flag is actually consulted; without it region misses are
+    informational and the script exits 0.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+SCRIPT = THIS_DIR / "diff_against_reference_regions.py"
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _make_png(path: Path, color: tuple[int, int, int]) -> None:
+    """Tiny PNG via PIL — keeps tests self-contained."""
+    from PIL import Image  # type: ignore
+
+    img = Image.new("RGB", (32, 32), color)
+    img.save(path)
+
+
+try:
+    import PIL  # noqa: F401
+
+    HAVE_PIL = True
+except ImportError:
+    HAVE_PIL = False
+
+
+class TestSchemaValidation(unittest.TestCase):
+    """load_regions() upfront schema validation."""
+
+    def _write_regions(self, tmp: Path, data: object) -> Path:
+        p = tmp / "regions.json"
+        p.write_text(json.dumps(data))
+        return p
+
+    def test_non_dict_region_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tdir:
+            tmp = Path(tdir)
+            regions = self._write_regions(tmp, {"r1": "not a dict"})
+            ref = tmp / "ref.png"
+            cand = tmp / "cand.png"
+            ref.write_text("placeholder")
+            cand.write_text("placeholder")
+            result = _run([str(ref), str(cand), "--regions", str(regions)])
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("r1", result.stderr)
+            self.assertIn("object", result.stderr)
+
+    def test_non_numeric_coord_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tdir:
+            tmp = Path(tdir)
+            regions = self._write_regions(
+                tmp,
+                {"r1": {"x": "0.1", "y": 0.0, "w": 0.5, "h": 0.5}},
+            )
+            ref = tmp / "ref.png"
+            cand = tmp / "cand.png"
+            ref.write_text("placeholder")
+            cand.write_text("placeholder")
+            result = _run([str(ref), str(cand), "--regions", str(regions)])
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("non-numeric", result.stderr)
+
+    def test_bool_coord_rejected(self) -> None:
+        # bool is an int subclass; remote fix rejects it explicitly so
+        # `"x": true` doesn't silently become 1.
+        with tempfile.TemporaryDirectory() as tdir:
+            tmp = Path(tdir)
+            regions = self._write_regions(
+                tmp,
+                {"r1": {"x": True, "y": 0.0, "w": 0.5, "h": 0.5}},
+            )
+            ref = tmp / "ref.png"
+            cand = tmp / "cand.png"
+            ref.write_text("placeholder")
+            cand.write_text("placeholder")
+            result = _run([str(ref), str(cand), "--regions", str(regions)])
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("non-numeric", result.stderr)
+
+    def test_invalid_threshold_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tdir:
+            tmp = Path(tdir)
+            regions = self._write_regions(
+                tmp,
+                {
+                    "r1": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "w": 0.5,
+                        "h": 0.5,
+                        "threshold": "tight",
+                    }
+                },
+            )
+            ref = tmp / "ref.png"
+            cand = tmp / "cand.png"
+            ref.write_text("placeholder")
+            cand.write_text("placeholder")
+            result = _run([str(ref), str(cand), "--regions", str(regions)])
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("threshold", result.stderr)
+
+    def test_valid_regions_pass_schema_check(self) -> None:
+        with tempfile.TemporaryDirectory() as tdir:
+            tmp = Path(tdir)
+            regions = self._write_regions(
+                tmp,
+                {"r1": {"x": 0.0, "y": 0.0, "w": 1.0, "h": 1.0, "threshold": 0.5}},
+            )
+            # Missing PNGs still cause exit 2 (file-not-found), but the
+            # error message comes AFTER schema validation. Asserting the
+            # *absence* of a schema-error substring locks the ordering.
+            ref = tmp / "missing-ref.png"
+            cand = tmp / "missing-cand.png"
+            result = _run([str(ref), str(cand), "--regions", str(regions)])
+            self.assertEqual(result.returncode, 2)
+            self.assertNotIn("non-numeric", result.stderr)
+            self.assertNotIn("must be an object", result.stderr)
+
+
+@unittest.skipUnless(HAVE_PIL, "PIL/Pillow required for image-based tests")
+class TestStrictFlag(unittest.TestCase):
+    """--strict flag changes exit code semantics."""
+
+    def _setup_mismatched(self, tmp: Path) -> tuple[Path, Path, Path]:
+        ref = tmp / "ref.png"
+        cand = tmp / "cand.png"
+        _make_png(ref, color=(255, 255, 255))
+        _make_png(cand, color=(0, 0, 0))
+        regions = tmp / "regions.json"
+        regions.write_text(
+            json.dumps(
+                {
+                    "full": {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "w": 1.0,
+                        "h": 1.0,
+                        "threshold": 0.99,
+                    }
+                }
+            )
+        )
+        return ref, cand, regions
+
+    def test_without_strict_exits_zero_on_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tdir:
+            tmp = Path(tdir)
+            ref, cand, regions = self._setup_mismatched(tmp)
+            result = _run([str(ref), str(cand), "--regions", str(regions)])
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"expected exit 0 without --strict; got {result.returncode}\n"
+                f"stdout={result.stdout}\nstderr={result.stderr}",
+            )
+            # Failure still reported on stdout.
+            self.assertIn("FAIL", result.stdout)
+
+    def test_with_strict_exits_one_on_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tdir:
+            tmp = Path(tdir)
+            ref, cand, regions = self._setup_mismatched(tmp)
+            result = _run([str(ref), str(cand), "--regions", str(regions), "--strict"])
+            self.assertEqual(
+                result.returncode,
+                1,
+                f"expected exit 1 with --strict; got {result.returncode}\n"
+                f"stdout={result.stdout}\nstderr={result.stderr}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `tools/import-validation/diff_against_reference_regions.py` — companion to `diff_against_reference.py` that computes per-region scores instead of one full-image average.
- Codex review of `planning/spectr-validated-runtime-import-product-spec.md` (2026-05-12) flagged the single-score approach as insufficient: a blank canvas region drags down the score while chrome looks fine; a broken chrome region passes if canvas happens to match.
- 5 default regions for Spectr's editor.html (title chrome, mode toggles, band dropdown, central canvas, bottom toolbar) with per-region thresholds tuned for content type (canvas 0.55 — looser for raster variance; chrome 0.75-0.80 — tighter).
- Custom region sets via `--regions <json>` for non-Spectr fixtures.

## Test plan

- [x] Self-diff (reference vs reference): 5/5 regions pass at 1.000
- [x] Native-vs-reference (current state with empty canvas pending #1859): fails on every region with low scores → sharp signal which sub-regions are broken
- [ ] CI lanes green

Unblocks the per-region masked-threshold success criterion in the product spec.