### PR TITLE
feat(view): add Element.prototype.contains — DOM Node.contains contract

### DIFF
--- a/core/view/js/web-compat-element.js
+++ b/core/view/js/web-compat-element.js
@@ -805,6 +805,33 @@ Element.prototype.getRootNode = function() {
     return this;
 };
 
+// Standard DOM `Node.contains(other)` — returns true if `other` is this
+// element OR a descendant. Walks `_parentElement` upward from `other`
+// until we hit `this`, the root, or a cycle. Required for click-outside
+// detection (the `ref.current.contains(e.target)` pattern in React
+// portals / ContextMenus). Pre-#1859 audit of Spectr's working bundle
+// found this missing from the modular Element shim, would have thrown
+// `TypeError: ref.current.contains is not a function` on
+// ContextMenu dismiss after #1859 lands the DOM-shim path.
+//
+// Treats non-Element arguments (text nodes, null, etc.) as `false` —
+// the contract is loose because most consumers feed e.target which is
+// always an Element in our event system.
+Element.prototype.contains = function(other) {
+    if (other == null) return false;
+    if (other === this) return true;
+    // Guard against pathological cycles even though _parentElement
+    // walks should be acyclic in practice.
+    var seen = 0;
+    var node = other._parentElement;
+    while (node) {
+        if (node === this) return true;
+        if (++seen > 4096) return false;
+        node = node._parentElement;
+    }
+    return false;
+};
+
 // ── Events ───────────────────────────────────────────────────────────────────
 
 Element.prototype.addEventListener = function(type, fn, opts) {

--- a/test/test_web_compat_react_shims.cpp
+++ b/test/test_web_compat_react_shims.cpp
@@ -197,6 +197,48 @@ TEST_CASE("insertBefore(fragment) flattens fragment children in order",
 
 // ── DOM-ops idempotency (#745) ──────────────────────────────────────────
 //
+// pulp pre-#1859 audit: Spectr's ContextMenu uses
+// `ref.current.contains(e.target)` for click-outside dismiss. The
+// modular web-compat-element.js was missing `Element.prototype.contains`
+// — would have thrown `TypeError` post-#1859 when the DOM-shim path
+// is the active one for ref.current. Pin the standard `Node.contains`
+// contract here so future regressions surface in CI, not in Spectr.
+
+TEST_CASE("Element.contains walks _parentElement chain — DOM Node.contains contract",
+          "[view][web-compat][element-contains]") {
+    auto result = run_in_bridge(R"(
+        var grand = document.createElement('div');
+        var parent = document.createElement('div');
+        var child = document.createElement('span');
+        var sibling = document.createElement('span');
+        var detached = document.createElement('span');
+        grand.appendChild(parent);
+        parent.appendChild(child);
+        grand.appendChild(sibling);
+        return [
+            // self
+            'self=' + grand.contains(grand),
+            // direct child
+            'directChild=' + grand.contains(parent),
+            // grandchild
+            'grandchild=' + grand.contains(child),
+            // sibling
+            'sibling=' + grand.contains(sibling),
+            // detached node — not in tree
+            'detached=' + grand.contains(detached),
+            // null/undefined are false
+            'nullArg=' + grand.contains(null),
+            'undefinedArg=' + grand.contains(undefined),
+            // ancestor doesn't contain its own ancestor
+            'childContainsGrand=' + child.contains(grand)
+        ].join('|');
+    )");
+    REQUIRE(result ==
+            "self=true|directChild=true|grandchild=true|sibling=true|"
+            "detached=false|nullArg=false|undefinedArg=false|"
+            "childContainsGrand=false");
+}
+
 // pulp #745 consolidated the inline `kDomOpsInit` C-string in
 // widget_bridge.cpp with the standalone web-compat-dom-ops.js prelude.
 // The JS file now carries an idempotency guard so re-eval'ing the


### PR DESCRIPTION
## Summary

Pre-#1859 audit of Spectr's working OLD bundle (`dist/editor.js`) found that the modular `web-compat-element.js` is missing `Element.prototype.contains`. The legacy consolidated `web-compat.js` had it; the modular load path `widget_bridge.cpp` uses does not. Post-#1859 (when `getPublicInstance` returns the Element-shim `_dom`), Spectr's ContextMenu component calls `ref.current.contains(e.target)` to detect click-outside-to-dismiss and would have thrown `TypeError: ref.current.contains is not a function`.

Visible symptom: right-click opens the menu; clicking outside throws, menu doesn't dismiss, throw cascades through React's event handler boundary.

Implements standard DOM `Node.contains` semantics by walking `other._parentElement` upward from the argument to either `this`, null (top of tree), or 4096-step cycle guard. Returns true if other is this element or any descendant of it.

## Test plan

- [x] `[element-contains]` Catch2 test: 3-level tree (grand → parent → child) + sibling + detached node, asserts 8-case contract:
  - self.contains(self) === true
  - direct child / grandchild / sibling-of-parent / detached
  - null / undefined arguments → false
  - reverse direction (descendant.contains(ancestor)) → false
- [ ] CI lanes green

Discovered by sub-agent audit of OLD bundle's `.current.*` accesses, comparing against current Element shim. Prevents a known post-#1859 regression rather than waiting for it to surface in Spectr.