### PR TITLE
fix(host): cache dlerror() before std::format call (ASan SEGV on macOS ARM64)

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -64,6 +64,38 @@ case `pulp scan --no-load` exists for. When adding new entry-point
 calls, wrap them too — the goal is "one bad bundle never crashes a
 scan."
 
+### dlerror() must be cached (ASan-only SEGV — pulp #1862 / #1873)
+
+**Never** call `dlerror()` more than once per failure log line. POSIX
+clears dlerror's internal buffer after every call, so a ternary like:
+
+```cpp
+// WRONG — second dlerror() returns nullptr
+runtime::log_warn("dlopen failed: {}",
+                  dlerror() ? dlerror() : "unknown");
+```
+
+calls dlerror() twice and the SECOND call returns `nullptr`.
+`std::format`'s `string_view(char const*)` ctor then runs
+`strlen(nullptr)` and ASan flags a SEGV in `libsystem_platform`'s
+`_platform_strlen`. **The bug is invisible on non-ASan builds** —
+release builds happen to survive the near-null strlen because the
+zero page is read-protected one access deep. Caught on PR #1862's
+macOS ARM64 ASan lane 2026-05-12; fixed in PR #1873.
+
+Correct idiom:
+
+```cpp
+const char* err = dlerror();
+runtime::log_warn("dlopen failed: {}", err ? err : "unknown");
+```
+
+The other format backends (`plugin_slot_vst3.cpp`, `plugin_slot_lv2.cpp`,
+`plugin_slot_clap.cpp`, `core/runtime/src/dynamic_library.cpp`) all
+already cache via a local — the only offender was the defensive #812
+fallback path at `scanner_clap.cpp:90`. When adding a new format
+backend that calls `dlopen`, mirror the cache-into-local pattern.
+
 ## Testing against a real plug-in
 
 Integration tests gate on a compile-time path macro:

--- a/core/host/src/scanner_clap.cpp
+++ b/core/host/src/scanner_clap.cpp
@@ -87,8 +87,16 @@ std::vector<PluginInfo> scan_clap_bundle_descriptors(const std::string& path) {
         // doesn't ship a deliberately-broken CLAP fixture. The user-
         // visible surface is exercised by `pulp scan --no-load`
         // (test_cli_shellout.cpp [issue-812]).
+        //
+        // ASan caught (PR #1862 macOS ARM64 lane, 2026-05-12): cache
+        // `dlerror()` in a local before the format call. POSIX
+        // dlerror() clears its internal state after every call, so a
+        // ternary `dlerror() ? dlerror() : "..."` calls it twice and
+        // the SECOND call returns nullptr. std::format's
+        // string_view(nullptr) ctor then runs strlen on null → SEGV.
+        const char* err = dlerror();
         runtime::log_warn("CLAP scan: dlopen failed for '{}': {}",
-                          binary, dlerror() ? dlerror() : "unknown");
+                          binary, err ? err : "unknown");
         results.push_back(make_filename_fallback(path));
         return results;
     } // LCOV_EXCL_STOP

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -93,6 +93,84 @@ TEST_CASE("PluginScanner scan runs without crash", "[host][scanner]") {
     REQUIRE(plugins.size() >= 0);
 }
 
+// Regression test for the scanner_clap.cpp `dlerror()` double-call SEGV
+// caught by ASan on PR #1862's macOS ARM64 lane (2026-05-12). The
+// defensive #812 fallback path in `scan_clap_bundle_descriptors` logs
+// the dlerror() string when dlopen fails, but the original code called
+// `dlerror()` TWICE in a `cond ? dlerror() : "..."` ternary. POSIX
+// dlerror() clears its internal buffer after each call, so the second
+// invocation returns nullptr — which `std::format`'s
+// `string_view(char const*)` ctor then passes to `strlen(nullptr)`,
+// crashing under ASan with a SEGV on libsystem_platform's
+// _platform_strlen.
+//
+// Pin: scan a malformed `.clap` bundle and assert (a) it doesn't crash
+// and (b) the filename-fallback path produces a single PluginInfo so
+// users see SOMETHING in the catalog instead of a silent drop.
+TEST_CASE("scan_clap_bundle_descriptors survives malformed bundle (dlopen-fail path)",
+          "[host][scanner][issue-1862][coverage]") {
+    namespace fs = std::filesystem;
+    auto tmp = fs::temp_directory_path() / "pulp_clap_dlopen_fail_test.clap";
+    std::error_code ec;
+    fs::remove_all(tmp, ec);
+
+    // A `.clap` bundle whose binary is a plain text file rather than a
+    // valid dylib. macOS dlopen / Linux dlopen will both fail; the
+    // dlerror() will be non-empty on the first call and (originally)
+    // null on the second. Our fix caches the first call in a local.
+    //
+    // Bundle layout matches what `resolve_clap_binary` expects on each
+    // platform; on macOS, that's `<bundle>.clap/Contents/MacOS/<name>`.
+    // On Linux / Windows the resolver looks for a flat binary path —
+    // either way, `dlopen()` will fail on garbage contents.
+#if defined(__APPLE__)
+    auto inner = tmp / "Contents" / "MacOS";
+    fs::create_directories(inner, ec);
+    REQUIRE(!ec);
+    std::ofstream(inner / "pulp_clap_dlopen_fail_test")
+        << "not a real dylib — should fail dlopen()\n";
+#else
+    fs::create_directories(tmp, ec);
+    REQUIRE(!ec);
+    std::ofstream(tmp / "pulp_clap_dlopen_fail_test.so")
+        << "not a real shared object\n";
+#endif
+
+    // Drive through PluginScanner::scan() with hermetic extra_paths so
+    // the malformed bundle is discovered through the normal scan path
+    // and we exercise the dlopen-fail branch deterministically without
+    // requiring a system CLAP folder. `only_extra_paths = true` keeps
+    // the test from walking the dev's installed CLAP collection (per
+    // Codex 2026-04-21 review on #545).
+    PluginScanner scanner;
+    ScanOptions opts;
+    opts.scan_vst3 = false;
+    opts.scan_au = false;
+    opts.scan_lv2 = false;
+    opts.scan_clap = true;
+    opts.only_extra_paths = true;
+    opts.extra_paths = { tmp.parent_path().string() };
+    auto results = scanner.scan(opts);
+
+    // The fix returns a filename-fallback entry instead of crashing.
+    // Find the entry for our specific test bundle (other CLAP bundles
+    // may exist in tmp on shared CI runners).
+    bool found = false;
+    for (const auto& info : results) {
+        if (info.path == tmp.string()) {
+            REQUIRE(info.format == PluginFormat::CLAP);
+            // make_filename_fallback derives a non-empty name from
+            // the bundle stem.
+            REQUIRE(!info.name.empty());
+            found = true;
+            break;
+        }
+    }
+    REQUIRE(found);
+
+    fs::remove_all(tmp, ec);
+}
+
 // Issue #491 P2: scan_lv2_bundle must set unique_id to the plugin URI
 // parsed from manifest.ttl, not the filesystem stem. This keeps
 // graph_serializer rehydration stable across sessions even when two


### PR DESCRIPTION
## Summary

Fix the ASan SEGV in `scan_clap_bundle_descriptors` that agent A flagged on PR #1862's macOS ARM64 lane (and that likely blocks every Agent B PR's ASan lane this session).

**Root cause**: `scanner_clap.cpp:90-91` calls `dlerror()` twice in a ternary. POSIX clears dlerror's internal buffer after the first call, so the second returns `nullptr` → `std::format`'s `string_view(char const*)` ctor runs `strlen(nullptr)` → SEGV.

**Fix**: cache `dlerror()` in a local before the format call. One-line idiom, matches the next `runtime::log_warn` call which already only invokes dlerror once.

**Test**: new `[issue-1862][coverage]` regression in `test/test_host.cpp` builds a malformed `.clap` bundle, drives `PluginScanner::scan()` with `only_extra_paths=true`, asserts no crash + correct filename-fallback. Verified the test catches the bug — without the fix, SIGSEGV reproduces deterministically.

## Test plan

- [x] `pulp-test-host "[issue-1862]"` → 1 case / 4 assertions green (with fix)
- [x] `pulp-test-host "[issue-1862]"` → SIGSEGV (without fix, verified by reverting only `scanner_clap.cpp` to origin/main)
- [x] `pulp-test-host "[host][scanner]"` → 8 cases / 25 assertions green (no regression in adjacent suite)

This is a pre-existing bug (commit `687425bc2` from 2026-04-22, 3 weeks before #1862). Not in any agent's hot-files lock. Should unblock the ASan lane on all 5 open Agent B PRs.

Refs: pulp #1862, pulp #812