### PR TITLE
test(view/css): close css/__selector_class as INTENTIONAL design (Tier 4)

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -1,18 +1,18 @@
 {
   "compat-schema-version": "0.3",
-  "_comment": "Compat matrix per #1027. This file is the spec-driven inventory of every prop / style / API surface Pulp's React + DOM-lite consumers might use, mapped to its current implementation status. Status values: supported | partial | missing | wontfix. The 'mapsTo' field names the bridge / Yoga / Skia path the prop lowers to. The 'tests' field records validation references; legacy free-form test paths may coexist with typed routes such as semantic:<fixture-id>, visual:<fixture-id>, dom:<fixture-id>, behavior:<fixture-id>, unit:<test-id>, or cannot-validate:<tracking-id>. The audit was generated 2026-04-30 by walking three reference specs (Yoga via React Native Layout Props, React Native View / Text / Transform Style Props, and the most-used MDN CSS reference) and cross-referencing against four implementation surfaces: packages/pulp-react/src/prop-applier.ts (the @pulp/react switch), core/view/js/web-compat-style-decl.js (the DOM-lite CSS adapter), core/view/src/widget_bridge.cpp (the C++ bridge — 251 register_function entries), and core/view/include/pulp/view/{view,geometry}.hpp (the Flex / View widget surface).",
+  "_comment": "Compat matrix per #1027. This file is the spec-driven inventory of every prop / style / API surface Pulp's React + DOM-lite consumers might use, mapped to its current implementation status. Status values: supported | partial | missing | wontfix. The 'mapsTo' field names the bridge / Yoga / Skia path the prop lowers to. The 'tests' field records validation references; legacy free-form test paths may coexist with typed routes such as semantic:<fixture-id>, visual:<fixture-id>, dom:<fixture-id>, behavior:<fixture-id>, unit:<test-id>, or cannot-validate:<tracking-id>. The audit was generated 2026-04-30 by walking three reference specs (Yoga via React Native Layout Props, React Native View / Text / Transform Style Props, and the most-used MDN CSS reference) and cross-referencing against four implementation surfaces: packages/pulp-react/src/prop-applier.ts (the @pulp/react switch), core/view/js/web-compat-style-decl.js (the DOM-lite CSS adapter), core/view/src/widget_bridge.cpp (the C++ bridge \u2014 251 register_function entries), and core/view/include/pulp/view/{view,geometry}.hpp (the Flex / View widget surface).",
   "_audit": {
     "_evidence_grace_until": "2026-05-22",
     "generated": "2026-05-04",
     "main_sha": "a5f4f5ac",
     "spec_sources": {
-      "yoga": "https://www.yogalayout.dev/docs/styling — list cross-checked against https://reactnative.dev/docs/layout-props which mirrors the upstream Yoga API",
+      "yoga": "https://www.yogalayout.dev/docs/styling \u2014 list cross-checked against https://reactnative.dev/docs/layout-props which mirrors the upstream Yoga API",
       "rn_view": "https://reactnative.dev/docs/view-style-props",
       "rn_text": "https://reactnative.dev/docs/text-style-props",
       "rn_transform": "https://reactnative.dev/docs/transforms",
       "rn_layout": "https://reactnative.dev/docs/layout-props",
-      "css": "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties — top ~150 commonly-used properties across layout, box-model, typography, color, transforms, flex/grid, opacity. Print, paged-media, and CSS-fonts loading specifics are out of scope.",
-      "canvas2d": "https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D — HTML Living Standard CanvasRenderingContext2D",
+      "css": "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties \u2014 top ~150 commonly-used properties across layout, box-model, typography, color, transforms, flex/grid, opacity. Print, paged-media, and CSS-fonts loading specifics are out of scope.",
+      "canvas2d": "https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D \u2014 HTML Living Standard CanvasRenderingContext2D",
       "html_element": "https://developer.mozilla.org/en-US/docs/Web/API/Element + HTMLElement attribute coverage, ARIA attributes, dataset, classList, the DocumentFragment shim"
     },
     "implementation_surfaces": [
@@ -31,15 +31,15 @@
     ],
     "_notes_on_consumer_surfaces": "The same prop can have different status across consumer surfaces. 'css/*' tracks what core/view/js/web-compat-style-decl.js (the DOM-lite el.style adapter) routes; 'rn/*' tracks what packages/pulp-react/src/prop-applier.ts (the React renderer for @pulp/react JSX intrinsics) routes; 'yoga/*' tracks the underlying Yoga-shaped layout surface in core/view/include/pulp/view/geometry.hpp::FlexStyle; 'canvas2d/*' tracks the Canvas2D shim in web-compat-canvas.js paired with the canvas* family in widget_bridge.cpp + the Skia/CG backends in core/canvas/; 'html/*' tracks the DOM-lite Element / HTMLElement surface in web-compat-element.js + web-compat-document.js. Where a prop is supported by one consumer but not another, both are noted explicitly in 'notes'.",
     "_changelog": {
-      "2026-04-30": "Initial population — 361 entries across css/, rn/, yoga/. react/, html/, canvas2d/ stubbed. PR #1166.",
+      "2026-04-30": "Initial population \u2014 361 entries across css/, rn/, yoga/. react/, html/, canvas2d/ stubbed. PR #1166.",
       "2026-05-04": "Refresh after PRs #1167, #1169, #1173, #1174, #1291, #1297, #1344, #1345, #1347, #1348, #1353. Populated canvas2d/ (~60 entries) and html/ (~30 entries). Added rn/d, rn/viewBox, rn/fill, rn/stroke, rn/strokeWidth, rn/overlay (SvgPath + overlay-routing). Updated css/border, css/borderRadius, css/borderColor, css/fontFamily status to reflect per-attribute setter routing. Added css/_hover_pseudo for :hover stylesheet support.",
       "2026-05-05": "pulp #1434 batch 4: React Native shorthand aliases marginHorizontal / marginVertical / paddingHorizontal / paddingVertical now fan out at the JS-side translators (web-compat-style-decl.js + prop-applier.ts) to the existing per-edge bridge setters. Reclassified rn/* + yoga/* entries from missing -> supported and added new css/* entries (4 new keys; css count 195 -> 199).",
-      "2026-05-06": "pulp #1545: yoga catalog work. Promoted yoga/flexBasis from partial -> supported after re-verifying YGNodeStyleSetFlexBasisPercent fires for 'NN%' strings end-to-end through the bridge (test [issue-1545] in test_widget_bridge.cpp). The 'content' keyword stays in unsupportedValues (Yoga itself does not expose it). yoga/boxSizing was also added as a placeholder entry but kept at status `missing` — the FlexStyle::box_sizing field + YGNodeStyleSetBoxSizing dispatch is a forward dependency on pulp #1516 (PR #1538) and will flip to `supported` once #1538 merges (yoga count stays at 53 + 1 placeholder = 54 total entries).",
-      "2026-05-06_1551": "pulp #1551 (Phase A3 Bundle 3 inside pulp #1434 umbrella): pure catalog add of 13 already-implemented css/* meta entries — `__StyleSheet`, `__matchMedia`, `__pseudo_active` / `__pseudo_disabled` / `__pseudo_focus` / `__pseudo_hover`, `__selector_child` / `__selector_class` / `__selector_descendant` / `__selector_id` / `__selector_tag`, `__setProperty_var`, `__var`. Documents existing wiring in `core/view/js/web-compat-document.js`, `web-compat-style-decl.js`, `css-parser.js` and `web-compat.js`. No code changes; +13 instant supported entries. css count 199 -> 212.",
+      "2026-05-06": "pulp #1545: yoga catalog work. Promoted yoga/flexBasis from partial -> supported after re-verifying YGNodeStyleSetFlexBasisPercent fires for 'NN%' strings end-to-end through the bridge (test [issue-1545] in test_widget_bridge.cpp). The 'content' keyword stays in unsupportedValues (Yoga itself does not expose it). yoga/boxSizing was also added as a placeholder entry but kept at status `missing` \u2014 the FlexStyle::box_sizing field + YGNodeStyleSetBoxSizing dispatch is a forward dependency on pulp #1516 (PR #1538) and will flip to `supported` once #1538 merges (yoga count stays at 53 + 1 placeholder = 54 total entries).",
+      "2026-05-06_1551": "pulp #1551 (Phase A3 Bundle 3 inside pulp #1434 umbrella): pure catalog add of 13 already-implemented css/* meta entries \u2014 `__StyleSheet`, `__matchMedia`, `__pseudo_active` / `__pseudo_disabled` / `__pseudo_focus` / `__pseudo_hover`, `__selector_child` / `__selector_class` / `__selector_descendant` / `__selector_id` / `__selector_tag`, `__setProperty_var`, `__var`. Documents existing wiring in `core/view/js/web-compat-document.js`, `web-compat-style-decl.js`, `css-parser.js` and `web-compat.js`. No code changes; +13 instant supported entries. css count 199 -> 212.",
       "2026-05-06_1544": "pulp #1544: Added yoga/flex and yoga/flexFlow catalog entries documenting the unsupported CSS shorthand surface on the Yoga side (yoga count 53 -> 55). PR #1563.",
       "2026-05-07": "pulp #1434 A4 Bundles 2-7: css NOT-IMPL closure. 30 entries flipped missing -> partial / noop / wontfix across animations tail (animationPlayState), logical-edge fan-out (margin/padding Block/Inline Start/End -- 7 entries), overflow per-axis + 3D (overflowX, overflowY, overflowWrap, perspective, perspectiveOrigin), text rendering tail (textIndent, verticalAlign, wordBreak, writingMode, scroll* -- 8), isolation + clipPath + mask + direction + mixBlendMode (6), and resize + fontVariant (2). New bridge fns: setTextIndent, setVerticalAlign, setWordBreak, setFontVariant. Extended setAnimation with the \"play_state\" control token. Synthetic __pseudo_classes_note flipped wontfix. Catalog css count holds at 212; missing -> 0.",
       "2026-05-07_B2": "Phase B.2 visual accounting: bumped compat-schema-version to 0.3 so tests can carry typed validation routes; backfilled semantic Yoga fixture refs for the checked-in layout goldens without changing support status counts.",
-      "2026-05-07_W3css3": "pulp #1434 Wave 3 css.3 + Codex P1 audit follow-through on #1508. css/animationPlayState flipped partial → supported by adding View::tick_animations(dt) which honors the `paused` keyword (no-op when paused, advance-each-CssAnimation otherwise) — the playback driver pause/resume gap the previous A4 Bundle 2 entry had explicitly deferred. Prop-applier `animationPlayState` case added (was missing; only the JS shim path existed). Verified the two Codex P1 fixes from #1508 hold in the final form: (1) setAnimation(id, \"name\"|\"duration\"|... , value) control-token ABI is implemented in the bridge alongside the positional ABI so the JS shim's per-longhand calls land on the staged_animation slot rather than missing the keyframes registry, (2) animationDuration in prop-applier.ts dispatches to setAnimation/duration, not setTransitionDuration. css count holds at 212."
+      "2026-05-07_W3css3": "pulp #1434 Wave 3 css.3 + Codex P1 audit follow-through on #1508. css/animationPlayState flipped partial \u2192 supported by adding View::tick_animations(dt) which honors the `paused` keyword (no-op when paused, advance-each-CssAnimation otherwise) \u2014 the playback driver pause/resume gap the previous A4 Bundle 2 entry had explicitly deferred. Prop-applier `animationPlayState` case added (was missing; only the JS shim path existed). Verified the two Codex P1 fixes from #1508 hold in the final form: (1) setAnimation(id, \"name\"|\"duration\"|... , value) control-token ABI is implemented in the bridge alongside the positional ABI so the JS shim's per-longhand calls land on the staged_animation slot rather than missing the keyframes registry, (2) animationDuration in prop-applier.ts dispatches to setAnimation/duration, not setTransitionDuration. css count holds at 212."
     },
     "counts": {
       "css": 217,
@@ -51,7 +51,7 @@
       "imports": 5
     },
     "changelog": {
-      "2026-05-07_W4css": "pulp Wave 4 css extensive — DIVERGE sweep. Drove the css surface from 128 PASS / 49 DIVERGE (60.4%) to 177 PASS / 0 DIVERGE (83.5%) in a single pass — the 35 non-PASS remainder is fully architectural (10 noop intentional stubs + 25 wontfix). Per-entry reclassifications follow the Wave 1 backgroundAttachment precedent: paint-time / architectural value-coverage caveats moved out of unsupportedValues into notes; status flipped partial -> supported when value-coverage is complete; partial-deferred-* used when a real subsystem (image loader, HarfBuzz, paint pipeline) is the gating block. Border family (5) arch-solid-only-pen; border-radius (2) arch-skia-rrect-single-radius; background family (5) arch-deferred-image-loader / arch-skia-no-conic-gradient / arch-single-bg; mask family (2) arch-paint-deferred; layout-length (2) arch-yoga-no-intrinsic-sizing + arch-no-calc-eval + single-level-cascade for em/rem; outline family (4) arch-numeric-only + arch-no-cascade-color + arch-paint-px-only; overflow (3) arch-scroll-via-scrollview + arch-axis-tied-overflow; display (1) arch-flex-only; enum cleanups (8) cursor / pointerEvents / textDecoration / userSelect / visibility / whiteSpace / fontStyle label trimming + arch caveats. Drift count: 7 -> 0 on css. css count holds at 212."
+      "2026-05-07_W4css": "pulp Wave 4 css extensive \u2014 DIVERGE sweep. Drove the css surface from 128 PASS / 49 DIVERGE (60.4%) to 177 PASS / 0 DIVERGE (83.5%) in a single pass \u2014 the 35 non-PASS remainder is fully architectural (10 noop intentional stubs + 25 wontfix). Per-entry reclassifications follow the Wave 1 backgroundAttachment precedent: paint-time / architectural value-coverage caveats moved out of unsupportedValues into notes; status flipped partial -> supported when value-coverage is complete; partial-deferred-* used when a real subsystem (image loader, HarfBuzz, paint pipeline) is the gating block. Border family (5) arch-solid-only-pen; border-radius (2) arch-skia-rrect-single-radius; background family (5) arch-deferred-image-loader / arch-skia-no-conic-gradient / arch-single-bg; mask family (2) arch-paint-deferred; layout-length (2) arch-yoga-no-intrinsic-sizing + arch-no-calc-eval + single-level-cascade for em/rem; outline family (4) arch-numeric-only + arch-no-cascade-color + arch-paint-px-only; overflow (3) arch-scroll-via-scrollview + arch-axis-tied-overflow; display (1) arch-flex-only; enum cleanups (8) cursor / pointerEvents / textDecoration / userSelect / visibility / whiteSpace / fontStyle label trimming + arch caveats. Drift count: 7 -> 0 on css. css count holds at 212."
     }
   },
   "css": {
@@ -68,12 +68,12 @@
         "@media / @keyframes / @supports / @import at-rules",
         ":focus-within / :focus-visible / :checked / :nth-child / :not(...)",
         "attribute selectors in rule keys (`[data-role='x']`)",
-        "rule reordering (StyleSheets layer in attach order — no specificity-based sort)"
+        "rule reordering (StyleSheets layer in attach order \u2014 no specificity-based sort)"
       ],
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add — already implemented (StyleSheet has been available since the DOM-lite shim landed and was extended for `:hover` support in pulp #1149 / #1345). The same engine drives both JS-API consumers (`new StyleSheet(...)`) and HTML-input consumers (parsed `<style>` tags via `_parseCssText`).",
+      "notes": "pulp #1551 catalog add \u2014 already implemented (StyleSheet has been available since the DOM-lite shim landed and was extended for `:hover` support in pulp #1149 / #1345). The same engine drives both JS-API consumers (`new StyleSheet(...)`) and HTML-input consumers (parsed `<style>` tags via `_parseCssText`).",
       "issue": "1551"
     },
     "css/__hover_pseudo": {
@@ -99,7 +99,7 @@
     },
     "css/__matchMedia": {
       "status": "supported",
-      "mapsTo": "core/view/js/css-parser.js `_matchMediaQuery` (lines 593-617) evaluates a media-query string against the current root size obtained from `getRootSize()`. Stylesheets and matched-media @rules consume this directly. The `window.matchMedia(query)` wrapper that returns a MediaQueryList shim lives in core/view/js/web-compat.js (lines 2101-2114) but that file is NOT loaded by the WidgetBridge prelude chain — the wrapper is reachable only when web-compat.js is loaded explicitly.",
+      "mapsTo": "core/view/js/css-parser.js `_matchMediaQuery` (lines 593-617) evaluates a media-query string against the current root size obtained from `getRootSize()`. Stylesheets and matched-media @rules consume this directly. The `window.matchMedia(query)` wrapper that returns a MediaQueryList shim lives in core/view/js/web-compat.js (lines 2101-2114) but that file is NOT loaded by the WidgetBridge prelude chain \u2014 the wrapper is reachable only when web-compat.js is loaded explicitly.",
       "supportedValues": [
         "(min-width: <px>)",
         "(max-width: <px>)",
@@ -111,7 +111,7 @@
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add — already implemented. Existing `WebCompat: matchMedia min-width` and `WebCompat: matchMedia orientation landscape` cases in test_web_compat_prelude.cpp exercise the parser; pulp #1551 adds an end-to-end case that walks through `window.matchMedia()` and asserts the returned MediaQueryList shape. Wave 4 css extensive — drift cleanup — value-coverage is complete (the parser handles the documented query forms; live re-evaluation on resize + extended @media features are paint/runtime-deferred follow-ups documented in mapsTo). Reclassified as runtime-side gap rather than value-coverage gap.",
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Existing `WebCompat: matchMedia min-width` and `WebCompat: matchMedia orientation landscape` cases in test_web_compat_prelude.cpp exercise the parser; pulp #1551 adds an end-to-end case that walks through `window.matchMedia()` and asserts the returned MediaQueryList shape. Wave 4 css extensive \u2014 drift cleanup \u2014 value-coverage is complete (the parser handles the documented query forms; live re-evaluation on resize + extended @media features are paint/runtime-deferred follow-ups documented in mapsTo). Reclassified as runtime-side gap rather than value-coverage gap.",
       "issue": "1551"
     },
     "css/__pseudo_active": {
@@ -123,13 +123,13 @@
         "ordinary CSS properties inside the `:active` rule body (anything the inline-setter trap routes)"
       ],
       "unsupportedValues": [
-        "`:active` combined with descendant / child combinators in the `<style>` text parser — TRACKED in pulp #1323 (text-parser parser-extension); not a per-row gap",
-        "keyboard activation of `:active` (synthesized only on mousedown/mouseup; no Enter/Space key handling) — INTENTIONAL (matches HTML default: `:active` is the pointer-pressed state; keyboard activation is a separate accessibility concern that consumers handle via keydown listeners)"
+        "`:active` combined with descendant / child combinators in the `<style>` text parser \u2014 TRACKED in pulp #1323 (text-parser parser-extension); not a per-row gap",
+        "keyboard activation of `:active` (synthesized only on mousedown/mouseup; no Enter/Space key handling) \u2014 INTENTIONAL (matches HTML default: `:active` is the pointer-pressed state; keyboard activation is a separate accessibility concern that consumers handle via keydown listeners)"
       ],
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add — already implemented. Wiring is parallel to `:hover` but uses mousedown/mouseup edges instead of mouseenter/mouseleave. Closure: :active mousedown/mouseup wiring pinned by test/web-compat/test_web_compat_prelude.cpp [issue-1551] (existing test). Combinator gap is tracked in #1323; keyboard activation is INTENTIONAL design (matches HTML default; consumers handle key activation via keydown listeners).",
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Wiring is parallel to `:hover` but uses mousedown/mouseup edges instead of mouseenter/mouseleave. Closure: :active mousedown/mouseup wiring pinned by test/web-compat/test_web_compat_prelude.cpp [issue-1551] (existing test). Combinator gap is tracked in #1323; keyboard activation is INTENTIONAL design (matches HTML default; consumers handle key activation via keydown listeners).",
       "issue": "1551"
     },
     "css/__pseudo_classes_note": {
@@ -149,7 +149,7 @@
         "etc."
       ],
       "tests": [],
-      "notes": "Pulp routes hover/click/etc. through bridge event registrations (registerHover, registerClick) rather than through CSS pseudo-classes. JSX consumers wire interactivity via on* event props, not via CSS. Superseded by the per-pseudo-class catalog entries (`css/__pseudo_hover`, `css/__pseudo_focus`, `css/__pseudo_active`, `css/__pseudo_disabled`) added in pulp #1551. pulp #1434 A4 Bundle 6 closure: status flipped missing → wontfix (architectural — the per-pseudo entries are the canonical claim).",
+      "notes": "Pulp routes hover/click/etc. through bridge event registrations (registerHover, registerClick) rather than through CSS pseudo-classes. JSX consumers wire interactivity via on* event props, not via CSS. Superseded by the per-pseudo-class catalog entries (`css/__pseudo_hover`, `css/__pseudo_focus`, `css/__pseudo_active`, `css/__pseudo_disabled`) added in pulp #1551. pulp #1434 A4 Bundle 6 closure: status flipped missing \u2192 wontfix (architectural \u2014 the per-pseudo entries are the canonical claim).",
       "issue": ""
     },
     "css/__pseudo_disabled": {
@@ -160,13 +160,13 @@
         "rules apply on attach / appendChild when `el.disabled === true`"
       ],
       "unsupportedValues": [
-        "live re-application when `disabled` is toggled at runtime — INTENTIONAL: Pulp's :disabled is an apply-time styling helper, not a live pseudo-class engine; StyleSheet._applyTo runs at attach / appendChild time only. Consumers should treat :disabled styling as one-way (set disabled before mount, or re-attach to re-apply).",
-        "snapshot-restore symmetry on re-enable — INTENTIONAL (same rationale): the disabled branch does not capture pre-disabled values; one-way styling avoids the storage / replay overhead a live pseudo-class engine would need."
+        "live re-application when `disabled` is toggled at runtime \u2014 INTENTIONAL: Pulp's :disabled is an apply-time styling helper, not a live pseudo-class engine; StyleSheet._applyTo runs at attach / appendChild time only. Consumers should treat :disabled styling as one-way (set disabled before mount, or re-attach to re-apply).",
+        "snapshot-restore symmetry on re-enable \u2014 INTENTIONAL (same rationale): the disabled branch does not capture pre-disabled values; one-way styling avoids the storage / replay overhead a live pseudo-class engine would need."
       ],
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add — already implemented. The pseudo branch is wired distinctly from `:hover` / `:focus` / `:active` because `:disabled` is not interaction-driven — it gates on element state. Closure: :disabled apply-time semantics pinned by [issue-1551] :disabled test; live re-apply + snapshot-restore are INTENTIONAL one-way design choices, not bounded edges of a live engine. Documented so consumers expecting browser-style live pseudo behaviour know to opt into re-mount instead.",
+      "notes": "pulp #1551 catalog add \u2014 already implemented. The pseudo branch is wired distinctly from `:hover` / `:focus` / `:active` because `:disabled` is not interaction-driven \u2014 it gates on element state. Closure: :disabled apply-time semantics pinned by [issue-1551] :disabled test; live re-apply + snapshot-restore are INTENTIONAL one-way design choices, not bounded edges of a live engine. Documented so consumers expecting browser-style live pseudo behaviour know to opt into re-mount instead.",
       "issue": "1551"
     },
     "css/__pseudo_focus": {
@@ -178,14 +178,14 @@
         "ordinary CSS properties inside the `:focus` rule body"
       ],
       "unsupportedValues": [
-        "`:focus-within` (focus inside any descendant) — TRACKED in a separate :focus-engine extension (real CSS feature; implementable when a consumer files for it)",
-        "`:focus-visible` (keyboard-only focus) — TRACKED in the same :focus-engine extension (real CSS feature; needs distinction between keyboard and mouse focus)",
-        "rule selectors that combine `:focus` with combinators in the `<style>` text parser — TRACKED in pulp #1323"
+        "`:focus-within` (focus inside any descendant) \u2014 TRACKED in a separate :focus-engine extension (real CSS feature; implementable when a consumer files for it)",
+        "`:focus-visible` (keyboard-only focus) \u2014 TRACKED in the same :focus-engine extension (real CSS feature; needs distinction between keyboard and mouse focus)",
+        "rule selectors that combine `:focus` with combinators in the `<style>` text parser \u2014 TRACKED in pulp #1323"
       ],
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add — already implemented. Wiring is parallel to `:hover` / `:active` and routes through the same `addEventListener` channel so it coexists with JSX `onFocus` / `onBlur` handlers. Closure: :focus focus/blur wiring pinned by test/web-compat/test_web_compat_prelude.cpp [issue-1551] (existing test). :focus-within and :focus-visible are real CSS features tracked in a follow-up :focus-engine extension; combinator gap is tracked in #1323. None are closeable on this row alone.",
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Wiring is parallel to `:hover` / `:active` and routes through the same `addEventListener` channel so it coexists with JSX `onFocus` / `onBlur` handlers. Closure: :focus focus/blur wiring pinned by test/web-compat/test_web_compat_prelude.cpp [issue-1551] (existing test). :focus-within and :focus-visible are real CSS features tracked in a follow-up :focus-engine extension; combinator gap is tracked in #1323. None are closeable on this row alone.",
       "issue": "1551"
     },
     "css/__pseudo_hover": {
@@ -198,31 +198,31 @@
         "ordinary CSS properties inside the `:hover` rule body"
       ],
       "unsupportedValues": [
-        "`:hover` combinators in the `<style>` text parser (e.g. `.a:hover .b`) — TRACKED in pulp #1323 (text-parser parser-extension follow-up); not a gap to close on this row",
-        "synthesized hover from touch / pen input — INTENTIONAL: Pulp does NOT synthesize mouse hover from touch (touch != mouseenter); consumers wanting touch-driven highlight behaviour should use a touch-specific class toggle or :active"
+        "`:hover` combinators in the `<style>` text parser (e.g. `.a:hover .b`) \u2014 TRACKED in pulp #1323 (text-parser parser-extension follow-up); not a gap to close on this row",
+        "synthesized hover from touch / pen input \u2014 INTENTIONAL: Pulp does NOT synthesize mouse hover from touch (touch != mouseenter); consumers wanting touch-driven highlight behaviour should use a touch-specific class toggle or :active"
       ],
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]",
         "test/web-compat/test_css_hover_translation.cpp"
       ],
-      "notes": "pulp #1551 catalog add — already implemented. Companion to the original `css/__hover_pseudo` entry, with full multi-rule + idempotency + native-arming details captured. Hover rules originate either from the JS-API (`new StyleSheet({...})`) or from `<style>` text parsed via `_parseCssText`. Closure: :hover supported core pinned by [issue-1551] :hover test; combinator gap is tracked in #1323; touch-synth omission is intentional design (matches RN; documented for consumer expectations).",
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Companion to the original `css/__hover_pseudo` entry, with full multi-rule + idempotency + native-arming details captured. Hover rules originate either from the JS-API (`new StyleSheet({...})`) or from `<style>` text parsed via `_parseCssText`. Closure: :hover supported core pinned by [issue-1551] :hover test; combinator gap is tracked in #1323; touch-synth omission is intentional design (matches RN; documented for consumer expectations).",
       "issue": "1551"
     },
     "css/__selector_child": {
       "status": "supported",
-      "mapsTo": "core/view/js/web-compat-document.js _parseSelector (lines 296-335): splits on ` > ` and recurses with `direct=true`. _matchesSelector (lines 337-367): when `parsed.direct` is set, the element's immediate `_parentElement` must match the parent selector — descendant ancestors do NOT count.",
+      "mapsTo": "core/view/js/web-compat-document.js _parseSelector (lines 296-335): splits on ` > ` and recurses with `direct=true`. _matchesSelector (lines 337-367): when `parsed.direct` is set, the element's immediate `_parentElement` must match the parent selector \u2014 descendant ancestors do NOT count.",
       "supportedValues": [
-        "<parent> > <child> (chained: `div > section > .item` — left-associative reduction in `_parseSelector`)"
+        "<parent> > <child> (chained: `div > section > .item` \u2014 left-associative reduction in `_parseSelector`)"
       ],
       "unsupportedValues": [
-        "adjacent-sibling combinator `+` (e.g. `.a + .b`) — TRACKED in a separate selector-parser extension (not in Tier-1 scope; implementable when a consumer files for it)",
-        "general-sibling combinator `~` (e.g. `.a ~ .b`) — TRACKED in the same selector-parser extension"
+        "adjacent-sibling combinator `+` (e.g. `.a + .b`) \u2014 TRACKED in a separate selector-parser extension (not in Tier-1 scope; implementable when a consumer files for it)",
+        "general-sibling combinator `~` (e.g. `.a ~ .b`) \u2014 TRACKED in the same selector-parser extension"
       ],
       "tests": [
         "test/web-compat/test_selector_matching.cpp",
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add — already implemented. Existing `Selector: JS parser distinguishes child and descendant combinators` test exercises this; the issue-1551 case adds a structural-selector smoke that runs alongside the others. Closure: child combinator `>` pinned by test/web-compat/test_selector_matching.cpp [events][selector] (\"JS parser distinguishes child and descendant combinators\"). Sibling combinators (`+`, `~`) are real CSS features but require a separate selector-parser extension; tracked in a follow-up rather than closed as wontfix.",
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Existing `Selector: JS parser distinguishes child and descendant combinators` test exercises this; the issue-1551 case adds a structural-selector smoke that runs alongside the others. Closure: child combinator `>` pinned by test/web-compat/test_selector_matching.cpp [events][selector] (\"JS parser distinguishes child and descendant combinators\"). Sibling combinators (`+`, `~`) are real CSS features but require a separate selector-parser extension; tracked in a follow-up rather than closed as wontfix.",
       "issue": "1551"
     },
     "css/__selector_class": {
@@ -230,18 +230,15 @@
       "mapsTo": "core/view/js/web-compat-document.js _parseSelector (lines 296-335) tokenises `.foo.bar` into `parsed.classes = ['foo', 'bar']`. _matchesSelector (lines 344-347) requires every class to be present in `el.classList` (Element.classList is the standard contains/add/remove API).",
       "supportedValues": [
         ".foo",
-        ".foo.bar (compound — every listed class must match)",
+        ".foo.bar (compound \u2014 every listed class must match)",
         "tag.class compounds (`button.primary`)"
       ],
-      "unsupportedValues": [
-        "namespace-qualified class selectors",
-        "case-insensitive class matching (matching is case-sensitive — matches CSS spec for non-quirks-mode HTML)"
-      ],
+      "unsupportedValues": [],
       "tests": [
         "test/web-compat/test_selector_matching.cpp",
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add — already implemented. Class selectors are the most common StyleSheet rule shape in Pulp consumers (Spectr's editor.js, FilterBank, react renderer's className-driven styling).",
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Class selectors are the most common StyleSheet rule shape in Pulp consumers (Spectr's editor.js, FilterBank, react renderer's className-driven styling). 2026-05-12 closure (Codex P2-aware honest reclass): both originally-listed unsupportedValues are INTENTIONAL design \u2014 (a) namespace-qualified class selectors require XML namespace context that Pulp's HTML-only document model does not carry; (b) case-sensitive class matching IS the CSS spec for HTML standards mode (the listed \"case-insensitive\" behavior would be quirks-mode-only). Neither is a gap to close.",
       "issue": "1551"
     },
     "css/__selector_descendant": {
@@ -252,13 +249,13 @@
         "chained descendant combinators (`section .row .item`)"
       ],
       "unsupportedValues": [
-        "interleaved descendant + child combinators in the `<style>` text parser (the underlying `_parseSelector` handles them but the inline `<style>` text parser limits to flat selectors) — TRACKED in pulp #1323; not a gap to close on this row"
+        "interleaved descendant + child combinators in the `<style>` text parser (the underlying `_parseSelector` handles them but the inline `<style>` text parser limits to flat selectors) \u2014 TRACKED in pulp #1323; not a gap to close on this row"
       ],
       "tests": [
         "test/web-compat/test_selector_matching.cpp",
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add — already implemented. Closure: ordinary descendant matching pinned by test/web-compat/test_selector_matching.cpp [events][selector] (JS parser distinguishes child and descendant combinators); the text-parser flat-selector limit is honestly tracked in pulp #1323 and is not a per-row closure target.",
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Closure: ordinary descendant matching pinned by test/web-compat/test_selector_matching.cpp [events][selector] (JS parser distinguishes child and descendant combinators); the text-parser flat-selector limit is honestly tracked in pulp #1323 and is not a per-row closure target.",
       "issue": "1551"
     },
     "css/__selector_id": {
@@ -270,14 +267,14 @@
         "[id='foo'] / [id=\"foo\"] / [id=foo] attribute-selector forms (route through the existing _matchesSelector attrs path, verified by [tier1-closure])"
       ],
       "unsupportedValues": [
-        "multiple `#id` tokens in one selector (a CSS spec edge case; the parser keeps only the last `#id` it sees — INTENTIONAL: real CSS spec allows multiple `#id` but matching is over the union, which Pulp's single-slot parser doesn't model; rarely emitted by design tools)."
+        "multiple `#id` tokens in one selector (a CSS spec edge case; the parser keeps only the last `#id` it sees \u2014 INTENTIONAL: real CSS spec allows multiple `#id` but matching is over the union, which Pulp's single-slot parser doesn't model; rarely emitted by design tools)."
       ],
       "tests": [
         "test/web-compat/test_selector_matching.cpp",
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]",
         "test/web-compat/test_selector_matching.cpp [tier1-closure]"
       ],
-      "notes": "pulp #1551 catalog add — already implemented. Note that `document.getElementById` uses a separate `#id`-prefixed lookup table in `__elements__` — the selector path here goes through `_findMatch` via `querySelector` / `querySelectorAll` and StyleSheet `_applyTo`. Closure: [id='foo'] attribute-selector form was already working via the existing _matchesSelector attrs path — confirmed by new test test/web-compat/test_selector_matching.cpp [tier1-closure] (5 assertions: single-quoted, double-quoted, unquoted, negative non-match, compound div[id=…]). Catalog moves [id='foo'] from unsupportedValues to supportedValues to reflect what the code already does. Multiple-#id-in-one-selector is documented INTENTIONAL design (rare in practice).",
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Note that `document.getElementById` uses a separate `#id`-prefixed lookup table in `__elements__` \u2014 the selector path here goes through `_findMatch` via `querySelector` / `querySelectorAll` and StyleSheet `_applyTo`. Closure: [id='foo'] attribute-selector form was already working via the existing _matchesSelector attrs path \u2014 confirmed by new test test/web-compat/test_selector_matching.cpp [tier1-closure] (5 assertions: single-quoted, double-quoted, unquoted, negative non-match, compound div[id=\u2026]). Catalog moves [id='foo'] from unsupportedValues to supportedValues to reflect what the code already does. Multiple-#id-in-one-selector is documented INTENTIONAL design (rare in practice).",
       "issue": "1551"
     },
     "css/__selector_tag": {
@@ -289,23 +286,23 @@
         "span",
         "h1 / h2 / ... / h6",
         "any HTML element name the consumer creates via `document.createElement`",
-        "* (universal selector — matches any element via null-tag fall-through in _matchesSelector; verified by [tier1-closure])"
+        "* (universal selector \u2014 matches any element via null-tag fall-through in _matchesSelector; verified by [tier1-closure])"
       ],
       "unsupportedValues": [
-        "namespace-qualified tag names (`svg|circle`) — INTENTIONAL (Pulp is HTML-only; XML namespace selectors are out of scope by design)",
-        "case-sensitive tag matching — INTENTIONAL (matching is case-insensitive on both sides; matches HTML quirks where `<DIV>` and `<div>` are the same element)"
+        "namespace-qualified tag names (`svg|circle`) \u2014 INTENTIONAL (Pulp is HTML-only; XML namespace selectors are out of scope by design)",
+        "case-sensitive tag matching \u2014 INTENTIONAL (matching is case-insensitive on both sides; matches HTML quirks where `<DIV>` and `<div>` are the same element)"
       ],
       "tests": [
         "test/web-compat/test_selector_matching.cpp",
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]",
         "test/web-compat/test_selector_matching.cpp [tier1-closure]"
       ],
-      "notes": "pulp #1551 catalog add — already implemented. Closure: tag matching pinned by test/web-compat/test_selector_matching.cpp [events][selector] (compound + descendant tests) + new [tier1-closure] test verifying universal `*` matches via null-tag fall-through. Namespace + case-sensitive matching are documented INTENTIONAL (HTML-only by design; case-insensitive matches HTML quirks).",
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Closure: tag matching pinned by test/web-compat/test_selector_matching.cpp [events][selector] (compound + descendant tests) + new [tier1-closure] test verifying universal `*` matches via null-tag fall-through. Namespace + case-sensitive matching are documented INTENTIONAL (HTML-only by design; case-insensitive matches HTML quirks).",
       "issue": "1551"
     },
     "css/__setProperty_var": {
       "status": "supported",
-      "mapsTo": "core/view/js/web-compat-style-decl.js CSSStyleDeclaration.prototype.setProperty (lines 1259-1279): when `name` starts with `--`, slices the prefix and tries `parseCSSLength(value)` first — on success calls `setMotionToken(tokenName, parsed.value)` so the bridge motion-token system picks up the new value. On length-parse failure, tries `parseCSSColor(value)` and on success routes through `applyTokenDiff` as a theme color override. getPropertyValue routes back through `getMotionToken` for `--` names.",
+      "mapsTo": "core/view/js/web-compat-style-decl.js CSSStyleDeclaration.prototype.setProperty (lines 1259-1279): when `name` starts with `--`, slices the prefix and tries `parseCSSLength(value)` first \u2014 on success calls `setMotionToken(tokenName, parsed.value)` so the bridge motion-token system picks up the new value. On length-parse failure, tries `parseCSSColor(value)` and on success routes through `applyTokenDiff` as a theme color override. getPropertyValue routes back through `getMotionToken` for `--` names.",
       "supportedValues": [
         "el.style.setProperty('--accent', '12px')",
         "el.style.setProperty('--accent', '#ff0000')",
@@ -314,14 +311,14 @@
         "el.style.removeProperty('--accent')"
       ],
       "unsupportedValues": [
-        "scoped (per-element) custom property cascading — the bridge motion-token namespace is shared across the document; `--name` is effectively a global token, not a CSS-cascade scoped variable",
+        "scoped (per-element) custom property cascading \u2014 the bridge motion-token namespace is shared across the document; `--name` is effectively a global token, not a CSS-cascade scoped variable",
         "string / list / shadow / gradient values (only length and color tokens are routed)",
         "the `!important` flag on the third argument"
       ],
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
       ],
-      "notes": "pulp #1551 catalog add — already implemented. Pairs with `css/__var` — `setProperty('--name', value)` writes the token, `var(--name)` reads it back through `_resolveVar`. Both share the motion-token bridge so JS-driven token mutation immediately affects the next layout/paint pass.",
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Pairs with `css/__var` \u2014 `setProperty('--name', value)` writes the token, `var(--name)` reads it back through `_resolveVar`. Both share the motion-token bridge so JS-driven token mutation immediately affects the next layout/paint pass.",
       "issue": "1551"
     },
     "css/__var": {
@@ -333,13 +330,13 @@
         "any CSS property assignment (`width`, `color`, `margin`, etc.) whose string value contains a `var(...)` call"
       ],
       "unsupportedValues": [
-        "scoped (per-element) cascading — see notes in css/__setProperty_var"
+        "scoped (per-element) cascading \u2014 see notes in css/__setProperty_var"
       ],
       "tests": [
         "test/web-compat/test_web_compat_prelude.cpp [issue-1551]",
         "test/web-compat/test_web_compat_prelude.cpp [nested-fallback]"
       ],
-      "notes": "pulp #1551 catalog add — already implemented. `var(--name)` is the read side of the bridge motion-token system; `setProperty('--name', value)` is the write side. Together they let consumers parameterise inline styles with named tokens without going through the full CSS-cascade engine. Coverage-gap closure: nested-fallback (var(--a, var(--b, 0))) and var() inside other CSS functions (calc(var(--x) + 10px)) are now supported via the balanced-paren _resolveVar walker (pinned by [nested-fallback]).",
+      "notes": "pulp #1551 catalog add \u2014 already implemented. `var(--name)` is the read side of the bridge motion-token system; `setProperty('--name', value)` is the write side. Together they let consumers parameterise inline styles with named tokens without going through the full CSS-cascade engine. Coverage-gap closure: nested-fallback (var(--a, var(--b, 0))) and var() inside other CSS functions (calc(var(--x) + 10px)) are now supported via the balanced-paren _resolveVar walker (pinned by [nested-fallback]).",
       "issue": "1551"
     },
     "css/alignContent": {
@@ -362,7 +359,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 (sub-agent #12 follow-up): bridge gained 'align_content' setFlex case + FlexStyle.align_content/align_content_space fields. The CSS translator already routed via setFlex(id, 'align_content', _cssToFlex(resolved)) — just needed the bridge backend. Multi-line flex (`flexWrap: 'wrap'`) cross-axis distribution now works.",
+      "notes": "pulp #1434 (sub-agent #12 follow-up): bridge gained 'align_content' setFlex case + FlexStyle.align_content/align_content_space fields. The CSS translator already routed via setFlex(id, 'align_content', _cssToFlex(resolved)) \u2014 just needed the bridge backend. Multi-line flex (`flexWrap: 'wrap'`) cross-axis distribution now works.",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "css/alignItems": {
@@ -434,7 +431,7 @@
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
       "issue": ""
     },
     "css/animationDelay": {
@@ -453,7 +450,7 @@
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
       "issue": ""
     },
     "css/animationDirection": {
@@ -476,7 +473,7 @@
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes. Wave 1 drift cleanup — animation-name resolution + direction enum stored on CssAnimation entries (PR 1 of #1508 ladder); harness verifies all 4 spec values claimed.",
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes. Wave 1 drift cleanup \u2014 animation-name resolution + direction enum stored on CssAnimation entries (PR 1 of #1508 ladder); harness verifies all 4 spec values claimed.",
       "issue": ""
     },
     "css/animationDuration": {
@@ -495,7 +492,7 @@
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
       "issue": ""
     },
     "css/animationFillMode": {
@@ -518,7 +515,7 @@
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes. Wave 1 drift cleanup — fill-mode enum stored on CssAnimation entries (PR 1 of #1508 ladder); harness verifies all 4 spec values claimed.",
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes. Wave 1 drift cleanup \u2014 fill-mode enum stored on CssAnimation entries (PR 1 of #1508 ladder); harness verifies all 4 spec values claimed.",
       "issue": ""
     },
     "css/animationIterationCount": {
@@ -537,7 +534,7 @@
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
       "issue": ""
     },
     "css/animationName": {
@@ -556,16 +553,16 @@
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
       "issue": ""
     },
     "css/animationPlayState": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js forwards `animation-play-state` through setAnimation(id, \"play_state\", value); the bridge stores the keyword on View::animation_play_state_. View::tick_animations(dt) honors the keyword by skipping the timeline advance when value is \"paused\" (web spec semantic) — animations resume on the next tick when the keyword flips back to \"running\".",
+      "mapsTo": "web-compat-style-decl.js forwards `animation-play-state` through setAnimation(id, \"play_state\", value); the bridge stores the keyword on View::animation_play_state_. View::tick_animations(dt) honors the keyword by skipping the timeline advance when value is \"paused\" (web spec semantic) \u2014 animations resume on the next tick when the keyword flips back to \"running\".",
       "supportedValues": [
         "running",
         "paused",
-        "paused (now wired — tick_animations is invoked per-frame on macOS + Android frame loops; honors paused keyword no-op)"
+        "paused (now wired \u2014 tick_animations is invoked per-frame on macOS + Android frame loops; honors paused keyword no-op)"
       ],
       "unsupportedValues": [],
       "tests": [
@@ -574,7 +571,7 @@
         "packages/pulp-react/test/prop-applier-animation.test.ts::\"animationPlayState routes to setAnimation/play_state\"",
         "test/test_widget_bridge.cpp [issue-1668][animationplaystate-paused]"
       ],
-      "notes": "pulp #1434 Wave 3 css.3: status flipped partial → supported. View::tick_animations(dt) advances active_animations_ entries in-place but is a no-op when animation_play_state_ == \"paused\", giving the play-state keyword its full pause/resume semantic without coupling the existing seed-only flow to a frame-driven dispatcher. The per-property tween-to-View commit step is the orthogonal PR-2-of-the-original-ladder follow-up; play-state pause/resume is independently testable today. Wave-5 follow-up audit (post-PR #1616 sweep): walked back to partial. `grep tick_animations` on `core/` shows zero non-test callers — production frame ticks never advance the timeline, so the keyword is stored on View::animation_play_state_ but has no observable effect. Wiring the dispatcher into View::on_frame is the unblock. pulp #1668 — frame-loop integration completed. macOS window_host_mac.mm advance_widget_animations and Android gpu_surface_android.cpp advance_view_animations now call View::tick_animations(dt) on every View in the tree per frame. The recursive walk honors animation_play_state_ (paused → no advance) and is a no-op for Views with no active CSS animations.",
+      "notes": "pulp #1434 Wave 3 css.3: status flipped partial \u2192 supported. View::tick_animations(dt) advances active_animations_ entries in-place but is a no-op when animation_play_state_ == \"paused\", giving the play-state keyword its full pause/resume semantic without coupling the existing seed-only flow to a frame-driven dispatcher. The per-property tween-to-View commit step is the orthogonal PR-2-of-the-original-ladder follow-up; play-state pause/resume is independently testable today. Wave-5 follow-up audit (post-PR #1616 sweep): walked back to partial. `grep tick_animations` on `core/` shows zero non-test callers \u2014 production frame ticks never advance the timeline, so the keyword is stored on View::animation_play_state_ but has no observable effect. Wiring the dispatcher into View::on_frame is the unblock. pulp #1668 \u2014 frame-loop integration completed. macOS window_host_mac.mm advance_widget_animations and Android gpu_surface_android.cpp advance_view_animations now call View::tick_animations(dt) on every View in the tree per frame. The recursive walk honors animation_play_state_ (paused \u2192 no advance) and is a no-op for Views with no active CSS animations.",
       "issue": ""
     },
     "css/animationTimingFunction": {
@@ -593,7 +590,7 @@
         "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-1 — keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
       "issue": ""
     },
     "css/aspectRatio": {
@@ -608,12 +605,12 @@
       "tests": [
         "test/web-compat/test_layout_aspect_ratio.cpp"
       ],
-      "notes": "pulp #1434 — three value forms accepted: plain number ('1.5'), 'width / height' ratio ('16/9' -> 1.778), and 'auto' (clears slot). Both 'aspectRatio' (camelCase) and 'aspect-ratio' (kebab-case) work; setProperty auto-converts kebab to camel.",
+      "notes": "pulp #1434 \u2014 three value forms accepted: plain number ('1.5'), 'width / height' ratio ('16/9' -> 1.778), and 'auto' (clears slot). Both 'aspectRatio' (camelCase) and 'aspect-ratio' (kebab-case) work; setProperty auto-converts kebab to camel.",
       "issue": "1434"
     },
     "css/backdropFilter": {
       "status": "supported",
-      "mapsTo": "parses blur(Npx) → setBackdropFilter(id, blur_px)",
+      "mapsTo": "parses blur(Npx) \u2192 setBackdropFilter(id, blur_px)",
       "supportedValues": [
         "blur(<px>)",
         "none",
@@ -623,16 +620,16 @@
       "tests": [
         "test/web-compat/test_css_translator_gaps_1434.cpp [issue-1434-batch-3]"
       ],
-      "notes": "Blur-only. CSS shim parses the blur(Npx) substring; non-matching filter functions are ignored. None / empty clears the slot. Wave 4 css extensive — non-blur filter functions are arch-blur-only-backdrop (the bridge slot View::backdrop_filter_blur_ is scalar; the multi-function chain that the foreground filter chain uses is queued behind SkImageFilters compose-list parity). Authors who need brightness/saturate stack via the foreground filter property which IS chain-aware.",
+      "notes": "Blur-only. CSS shim parses the blur(Npx) substring; non-matching filter functions are ignored. None / empty clears the slot. Wave 4 css extensive \u2014 non-blur filter functions are arch-blur-only-backdrop (the bridge slot View::backdrop_filter_blur_ is scalar; the multi-function chain that the foreground filter chain uses is queued behind SkImageFilters compose-list parity). Authors who need brightness/saturate stack via the foreground filter property which IS chain-aware.",
       "issue": "1434"
     },
     "css/backfaceVisibility": {
       "status": "wontfix",
-      "mapsTo": "Architectural — Pulp's render is 2D-affine only; backface culling requires the same 3D pipeline as css/perspective + perspectiveOrigin. Same wontfix-arch class as css/perspective.",
+      "mapsTo": "Architectural \u2014 Pulp's render is 2D-affine only; backface culling requires the same 3D pipeline as css/perspective + perspectiveOrigin. Same wontfix-arch class as css/perspective.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1737 (CSS NO-OP audit) — reclassified noop → wontfix. Pre-fix flagged \"noop pending #1026 (3D pipeline)\" but #1026 isn't on the near-term roadmap. Treat consistently with css/perspective family which is already wontfix.",
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Pre-fix flagged \"noop pending #1026 (3D pipeline)\" but #1026 isn't on the near-term roadmap. Treat consistently with css/perspective family which is already wontfix.",
       "issue": "1026"
     },
     "css/background": {
@@ -646,27 +643,27 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Background shorthand supports only color OR a gradient. Wave 1 architectural reclassification — url() / image / conic-gradient / multiple-bg are partial-deferred-image-loader (image src loader and viewport-relative paint not in Pulp's pipeline); color + linear-gradient round-trip end-to-end. Wave 4 css extensive — url() / image() / image-set() are arch-deferred-image-loader (no asset-fetch pipeline at the JS shim — image loading is the orthogonal follow-up). conic-gradient is arch-skia-no-conic-gradient (Skia's SkGradientShader doesn't natively support conical sweeps; angle-sweep emulation would require offscreen rasterization and is an explicit non-goal at this surface). multiple backgrounds + size-in-shorthand are arch-single-bg (the View::background_ slot stores a single background; mirrors the box-shadow single-shadow pattern). Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
+      "notes": "Background shorthand supports only color OR a gradient. Wave 1 architectural reclassification \u2014 url() / image / conic-gradient / multiple-bg are partial-deferred-image-loader (image src loader and viewport-relative paint not in Pulp's pipeline); color + linear-gradient round-trip end-to-end. Wave 4 css extensive \u2014 url() / image() / image-set() are arch-deferred-image-loader (no asset-fetch pipeline at the JS shim \u2014 image loading is the orthogonal follow-up). conic-gradient is arch-skia-no-conic-gradient (Skia's SkGradientShader doesn't natively support conical sweeps; angle-sweep emulation would require offscreen rasterization and is an explicit non-goal at this surface). multiple backgrounds + size-in-shorthand are arch-single-bg (the View::background_ slot stores a single background; mirrors the box-shadow single-shadow pattern). Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
       "issue": ""
     },
     "css/backgroundAttachment": {
       "status": "supported",
       "mapsTo": "web-compat-style-decl.js -> setBackgroundAttachment(id, kw); bridge stores keyword on View::background_attachment_ slot. No paint impact today.",
       "supportedValues": [
-        "scroll (conformant default — pulp's layout is non-scrolling so the spec behavior coincides with our render path)"
+        "scroll (conformant default \u2014 pulp's layout is non-scrolling so the spec behavior coincides with our render path)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1517]"
       ],
-      "notes": "pulp #1517 — accepts the keyword without crashing; paint impact is exactly zero because pulp doesn't model scroll contexts. `scroll` is the spec-conformant default for our case. Status `noop` means the property is wired through but has no rendered effect. Wave 1 architectural reclassification — `fixed` / `local` are arch-no-scroll-context (Pulp's layout is non-scrolling so `scroll` is the spec-conformant default; viewport-relative paint origin and scroll-context coupling are not modeled). Wave 1 drift cleanup — noop status retained; cleared unsupportedValues since `fixed` / `local` are arch-no-scroll-context (Pulp doesn't model scroll contexts; the default `scroll` is the spec-conformant rendering).",
+      "notes": "pulp #1517 \u2014 accepts the keyword without crashing; paint impact is exactly zero because pulp doesn't model scroll contexts. `scroll` is the spec-conformant default for our case. Status `noop` means the property is wired through but has no rendered effect. Wave 1 architectural reclassification \u2014 `fixed` / `local` are arch-no-scroll-context (Pulp's layout is non-scrolling so `scroll` is the spec-conformant default; viewport-relative paint origin and scroll-context coupling are not modeled). Wave 1 drift cleanup \u2014 noop status retained; cleared unsupportedValues since `fixed` / `local` are arch-no-scroll-context (Pulp doesn't model scroll contexts; the default `scroll` is the spec-conformant rendering).",
       "issue": "1517"
     },
     "css/backgroundClip": {
       "status": "supported",
       "mapsTo": "web-compat-style-decl.js -> setBackgroundClip(id, kw); bridge stores keyword on View::background_clip_ slot.",
       "supportedValues": [
-        "border-box (default; pulp paints bg edge-to-edge — same as the spec default)",
+        "border-box (default; pulp paints bg edge-to-edge \u2014 same as the spec default)",
         "padding-box (no-op on solid bg; same visual as border-box)",
         "content-box (no-op on solid bg; same visual as border-box)"
       ],
@@ -674,7 +671,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1517]"
       ],
-      "notes": "pulp #1517 — keyword stored on View; the box-flavor variants are visual no-ops on solid backgrounds (which is what pulp paints today). The `text` variant requires real paint-chain composition and is deferred. Wave 1 architectural reclassification — `text` keyword is partial-deferred-paint-composition (slot stored on View::background_clip_; paint-time SkBlendMode::kSrcIn against text glyphs requires paint-chain composition not in pipeline today). Wave 4 css extensive — text is arch-paint-deferred (paint-time SkBlendMode::kSrcIn against text glyphs is the follow-up; the slot stores the value so the wiring is ready). Reclassified as paint-side gap rather than value-coverage gap.",
+      "notes": "pulp #1517 \u2014 keyword stored on View; the box-flavor variants are visual no-ops on solid backgrounds (which is what pulp paints today). The `text` variant requires real paint-chain composition and is deferred. Wave 1 architectural reclassification \u2014 `text` keyword is partial-deferred-paint-composition (slot stored on View::background_clip_; paint-time SkBlendMode::kSrcIn against text glyphs requires paint-chain composition not in pipeline today). Wave 4 css extensive \u2014 text is arch-paint-deferred (paint-time SkBlendMode::kSrcIn against text glyphs is the follow-up; the slot stores the value so the wiring is ready). Reclassified as paint-side gap rather than value-coverage gap.",
       "issue": "1517"
     },
     "css/backgroundColor": {
@@ -699,7 +696,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up. color-mix() and currentColor remain unsupported (deferred); wide-gamut HDR via Skia SkColor4f is a follow-up — current path converts to sRGB hex.",
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up. color-mix() and currentColor remain unsupported (deferred); wide-gamut HDR via Skia SkColor4f is a follow-up \u2014 current path converts to sRGB hex.",
       "issue": ""
     },
     "css/backgroundImage": {
@@ -713,25 +710,25 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "url() image backgrounds not implemented. Wave 1 architectural reclassification — url() / image-set() / conic-gradient / multiple-bg are partial-deferred-image-loader (image src loader not in Pulp's pipeline); linear-gradient + radial-gradient round-trip end-to-end. Wave 4 css extensive — url() / image-set() are arch-deferred-image-loader (no asset-fetch pipeline at the JS shim). conic-gradient is arch-skia-no-conic-gradient. multiple is arch-single-bg. Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
+      "notes": "url() image backgrounds not implemented. Wave 1 architectural reclassification \u2014 url() / image-set() / conic-gradient / multiple-bg are partial-deferred-image-loader (image src loader not in Pulp's pipeline); linear-gradient + radial-gradient round-trip end-to-end. Wave 4 css extensive \u2014 url() / image-set() are arch-deferred-image-loader (no asset-fetch pipeline at the JS shim). conic-gradient is arch-skia-no-conic-gradient. multiple is arch-single-bg. Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
       "issue": ""
     },
     "css/backgroundOrigin": {
       "status": "supported",
       "mapsTo": "web-compat-style-decl.js -> setBackgroundOrigin(id, kw); bridge stores keyword on View::background_origin_ slot. No paint impact today.",
       "supportedValues": [
-        "border-box / padding-box / content-box — all accepted, all stored, all paint identically because pulp doesn't paint repeating gradient tiles (the only case where this would matter)"
+        "border-box / padding-box / content-box \u2014 all accepted, all stored, all paint identically because pulp doesn't paint repeating gradient tiles (the only case where this would matter)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1517]"
       ],
-      "notes": "pulp #1517 — value stored for round-tripping; paint impact is zero because the property only matters for repeating gradient tiles. When pulp adds gradient-tile paint, the slot is already populated. Wave 1 drift cleanup — noop → supported (wired through web-compat-style-decl.js; the box-flavor variants are visual no-ops on solid backgrounds, which is what Pulp paints today — matches CSS spec default behavior).",
+      "notes": "pulp #1517 \u2014 value stored for round-tripping; paint impact is zero because the property only matters for repeating gradient tiles. When pulp adds gradient-tile paint, the slot is already populated. Wave 1 drift cleanup \u2014 noop \u2192 supported (wired through web-compat-style-decl.js; the box-flavor variants are visual no-ops on solid backgrounds, which is what Pulp paints today \u2014 matches CSS spec default behavior).",
       "issue": "1517"
     },
     "css/backgroundPosition": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js:1418 forwards `background-position` to setBackgroundPosition(id, value); bridge function is registered (widget_bridge.cpp Wave 5 css.5) and stores the keyword on View::background_position_. Storage-only today: pulp's solid-bg paint path doesn't honor position offsets, which only matter for url() / image-set() raster backgrounds (deferred to image-loader slice — see backgroundImage).",
+      "mapsTo": "web-compat-style-decl.js:1418 forwards `background-position` to setBackgroundPosition(id, value); bridge function is registered (widget_bridge.cpp Wave 5 css.5) and stores the keyword on View::background_position_. Storage-only today: pulp's solid-bg paint path doesn't honor position offsets, which only matter for url() / image-set() raster backgrounds (deferred to image-loader slice \u2014 see backgroundImage).",
       "supportedValues": [
         "<keyword>",
         "<percentage>",
@@ -741,12 +738,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 5 css.5 — registered the previously-missing setBackgroundPosition bridge fn so the JS shim no longer no-ops. Storage-only round-trip: keyword stored verbatim on View::background_position_ slot for a future raster-image paint pass to honor without a JS-side change. Solid-bg paint (which is what Pulp paints today) doesn't position because there's no raster image to position. Catalog stays `supported` since the value coverage (keyword / length / percentage) all parse and survive bridge round-trip; the architectural caveat is: with no raster background pipeline (arch-deferred-image-loader), the offsets have no visual effect.",
+      "notes": "Wave 5 css.5 \u2014 registered the previously-missing setBackgroundPosition bridge fn so the JS shim no longer no-ops. Storage-only round-trip: keyword stored verbatim on View::background_position_ slot for a future raster-image paint pass to honor without a JS-side change. Solid-bg paint (which is what Pulp paints today) doesn't position because there's no raster image to position. Catalog stays `supported` since the value coverage (keyword / length / percentage) all parse and survive bridge round-trip; the architectural caveat is: with no raster background pipeline (arch-deferred-image-loader), the offsets have no visual effect.",
       "issue": ""
     },
     "css/backgroundRepeat": {
       "status": "supported",
-      "mapsTo": "setBackgroundRepeat(id, kw) — storage-only on the View; paint-time honoring deferred",
+      "mapsTo": "setBackgroundRepeat(id, kw) \u2014 storage-only on the View; paint-time honoring deferred",
       "supportedValues": [
         "repeat",
         "no-repeat",
@@ -760,12 +757,12 @@
         "test/test_widget_bridge.cpp::WidgetBridge setBackgroundRepeat round-trips keyword on View",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1552: bridge fn registered (widget_bridge.cpp). The keyword round-trips through View::set_background_repeat — the slot is preserved so future paint logic for `background-image: url(...)` / repeating gradients can honor it without an API break. For solid-color backgrounds (today's only painted case) repeat semantics are a no-op, which is why the status remains `partial` rather than `supported`. Mirrors the storage-only strategy used for text-decoration-style (pulp #1434 batch 3). Wave 1 drift cleanup — partial → supported (no unsupported values listed; wired through web-compat-style-decl.js).",
+      "notes": "pulp #1552: bridge fn registered (widget_bridge.cpp). The keyword round-trips through View::set_background_repeat \u2014 the slot is preserved so future paint logic for `background-image: url(...)` / repeating gradients can honor it without an API break. For solid-color backgrounds (today's only painted case) repeat semantics are a no-op, which is why the status remains `partial` rather than `supported`. Mirrors the storage-only strategy used for text-decoration-style (pulp #1434 batch 3). Wave 1 drift cleanup \u2014 partial \u2192 supported (no unsupported values listed; wired through web-compat-style-decl.js).",
       "issue": "1552"
     },
     "css/backgroundSize": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js:1413 forwards `background-size` to setBackgroundSize(id, value); bridge function is registered (widget_bridge.cpp Wave 5 css.5) and stores the keyword on View::background_size_. Storage-only today: same arch-deferred-image-loader caveat as backgroundPosition — `cover` / `contain` / `<length>` only sized-fit a raster image, and pulp paints solid bg / gradients (which auto-fit to the box).",
+      "mapsTo": "web-compat-style-decl.js:1413 forwards `background-size` to setBackgroundSize(id, value); bridge function is registered (widget_bridge.cpp Wave 5 css.5) and stores the keyword on View::background_size_. Storage-only today: same arch-deferred-image-loader caveat as backgroundPosition \u2014 `cover` / `contain` / `<length>` only sized-fit a raster image, and pulp paints solid bg / gradients (which auto-fit to the box).",
       "supportedValues": [
         "cover",
         "contain",
@@ -777,12 +774,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 5 css.5 — registered the previously-missing setBackgroundSize bridge fn so the JS shim no longer no-ops. Storage-only round-trip: keyword stored verbatim on View::background_size_ slot for a future raster-image paint pass. The `cover` / `contain` / `auto` / `<length>` / `<percentage>` value space all round-trip through bridge. Architectural caveat: arch-deferred-image-loader — without a raster bg pipeline these have no visual effect, but the catalog claim is honest because the value is captured and queryable.",
+      "notes": "Wave 5 css.5 \u2014 registered the previously-missing setBackgroundSize bridge fn so the JS shim no longer no-ops. Storage-only round-trip: keyword stored verbatim on View::background_size_ slot for a future raster-image paint pass. The `cover` / `contain` / `auto` / `<length>` / `<percentage>` value space all round-trip through bridge. Architectural caveat: arch-deferred-image-loader \u2014 without a raster bg pipeline these have no visual effect, but the catalog claim is honest because the value is captured and queryable.",
       "issue": ""
     },
     "css/border": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js: 'border' shorthand parses '<width>px solid <color>' and routes to setBorderColor(id, color) + setBorderWidth(id, width) (per-attribute, NOT the unified setBorder, to preserve any prior borderRadius). 'borderColor' / 'borderWidth' / 'borderRadius' route to their respective per-attribute setters too — see pulp #1166/#1169.",
+      "mapsTo": "web-compat-style-decl.js: 'border' shorthand parses '<width>px solid <color>' and routes to setBorderColor(id, color) + setBorderWidth(id, width) (per-attribute, NOT the unified setBorder, to preserve any prior borderRadius). 'borderColor' / 'borderWidth' / 'borderRadius' route to their respective per-attribute setters too \u2014 see pulp #1166/#1169.",
       "supportedValues": [
         "solid (only)",
         "dashed (accepted; rendered as solid per arch-solid-only-pen)",
@@ -799,7 +796,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Fixed 2026-04-26 (#1169 / audit PR #1166 finding #4): per-attribute setters now preserve unset siblings, matching CSS semantics. Setting `borderColor` after `borderRadius` no longer zeros the radius. The unified setBorder(id, color, width, radius) is still available for the React `border` object-prop path. Border style ('solid', 'dashed', 'dotted', 'double') is parsed but only the default solid pen is rendered today. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen — JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
+      "notes": "Fixed 2026-04-26 (#1169 / audit PR #1166 finding #4): per-attribute setters now preserve unset siblings, matching CSS semantics. Setting `borderColor` after `borderRadius` no longer zeros the radius. The unified setBorder(id, color, width, radius) is still available for the React `border` object-prop path. Border style ('solid', 'dashed', 'dotted', 'double') is parsed but only the default solid pen is rendered today. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen \u2014 JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
       "issue": "1166"
     },
     "css/borderBottom": {
@@ -817,7 +814,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 4 css extensive — border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen — JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
+      "notes": "Wave 4 css extensive \u2014 border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen \u2014 JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
       "issue": ""
     },
     "css/borderBottomColor": {
@@ -885,7 +882,7 @@
     },
     "css/borderColor": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js: 'borderColor' -> setBorderColor(id, color) — per-attribute, preserves width and radius.",
+      "mapsTo": "web-compat-style-decl.js: 'borderColor' -> setBorderColor(id, color) \u2014 per-attribute, preserves width and radius.",
       "supportedValues": [
         "#hex",
         "#rgba",
@@ -905,7 +902,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Fixed 2026-04-26 (#1169). Previously routed onto the unified setBorder which clobbered radius. Now uses the dedicated setBorderColor bridge fn. pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up. color-mix() and currentColor remain unsupported (deferred); wide-gamut HDR via Skia SkColor4f is a follow-up — current path converts to sRGB hex.",
+      "notes": "Fixed 2026-04-26 (#1169). Previously routed onto the unified setBorder which clobbered radius. Now uses the dedicated setBorderColor bridge fn. pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up. color-mix() and currentColor remain unsupported (deferred); wide-gamut HDR via Skia SkColor4f is a follow-up \u2014 current path converts to sRGB hex.",
       "issue": "1166"
     },
     "css/borderLeft": {
@@ -923,7 +920,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 4 css extensive — border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen — JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
+      "notes": "Wave 4 css extensive \u2014 border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen \u2014 JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
       "issue": ""
     },
     "css/borderLeftColor": {
@@ -965,7 +962,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — % accepted (parseCSSLength returns the value, forwarded to scalar bridge slot; not box-relative). Fixed 2026-04-26 (#1169). Previously routed onto setBorder and lost color/width on a subsequent borderColor/Width assignment. Wave 1 architectural reclassification — two-value elliptical + `/` separator syntax are arch-skia-rrect-single-radius (Skia rounded-rect uses a single radius today; elliptical RRect requires SkRRect path). Wave 4 css extensive — two-value elliptical + `/` separator are arch-skia-rrect-single-radius (Skia's rounded-rect today uses a single scalar per corner; elliptical RRect with separate x/y radii would require SkRRect path-construction and is an explicit non-goal at this surface).",
+      "notes": "Wave 2 css.2 \u2014 % accepted (parseCSSLength returns the value, forwarded to scalar bridge slot; not box-relative). Fixed 2026-04-26 (#1169). Previously routed onto setBorder and lost color/width on a subsequent borderColor/Width assignment. Wave 1 architectural reclassification \u2014 two-value elliptical + `/` separator syntax are arch-skia-rrect-single-radius (Skia rounded-rect uses a single radius today; elliptical RRect requires SkRRect path). Wave 4 css extensive \u2014 two-value elliptical + `/` separator are arch-skia-rrect-single-radius (Skia's rounded-rect today uses a single scalar per corner; elliptical RRect with separate x/y radii would require SkRRect path-construction and is an explicit non-goal at this surface).",
       "issue": "1166"
     },
     "css/borderRight": {
@@ -983,7 +980,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 4 css extensive — border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen — JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
+      "notes": "Wave 4 css extensive \u2014 border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen \u2014 JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
       "issue": ""
     },
     "css/borderRightColor": {
@@ -1044,7 +1041,7 @@
         "test/test_widget_bridge.cpp::\"dashed border emits set_line_dash command then clears it\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #10 — Skia paint installs SkDashPathEffect for dashed/dotted (CG falls through to solid via the canvas-base no-op set_line_dash). View::BorderStyle enum stores the keyword; bridge maps strings; Skia honors at stroke time. Other named styles (double/groove/ridge/inset/outset) currently degrade to solid — paint-side compositions are a follow-up. none/hidden short-circuit the stroke entirely.",
+      "notes": "pulp #1434 Triage #10 \u2014 Skia paint installs SkDashPathEffect for dashed/dotted (CG falls through to solid via the canvas-base no-op set_line_dash). View::BorderStyle enum stores the keyword; bridge maps strings; Skia honors at stroke time. Other named styles (double/groove/ridge/inset/outset) currently degrade to solid \u2014 paint-side compositions are a follow-up. none/hidden short-circuit the stroke entirely.",
       "issue": ""
     },
     "css/borderTop": {
@@ -1062,7 +1059,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 4 css extensive — border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen — JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
+      "notes": "Wave 4 css extensive \u2014 border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen \u2014 JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
       "issue": ""
     },
     "css/borderTopColor": {
@@ -1090,7 +1087,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — % accepted. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — elliptical x/y form is arch-skia-rrect-single-radius (single scalar slot per corner; elliptical paths require SkRRect rebuild and are an explicit non-goal at this surface).",
+      "notes": "Wave 2 css.2 \u2014 % accepted. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 elliptical x/y form is arch-skia-rrect-single-radius (single scalar slot per corner; elliptical paths require SkRRect rebuild and are an explicit non-goal at this surface).",
       "issue": ""
     },
     "css/borderTopRightRadius": {
@@ -1133,12 +1130,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — thin/medium/thick keyword expansion + % acceptance. Per CSS Backgrounds & Borders L3, thin/medium/thick are author-named widths; canonical browser values are 1/3/5px but pulp picks 1/2/4 for a slightly thinner ladder at 1x DPI (authors who want exact browser parity pass numeric px).",
+      "notes": "Wave 2 css.2 \u2014 thin/medium/thick keyword expansion + % acceptance. Per CSS Backgrounds & Borders L3, thin/medium/thick are author-named widths; canonical browser values are 1/3/5px but pulp picks 1/2/4 for a slightly thinner ladder at 1x DPI (authors who want exact browser parity pass numeric px).",
       "issue": ""
     },
     "css/bottom": {
       "status": "supported",
-      "mapsTo": "setBottom(id, px); JS shim resolves em/rem (× 14px default), vh/vw (× 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
+      "mapsTo": "setBottom(id, px); JS shim resolves em/rem (\u00d7 14px default), vh/vw (\u00d7 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
       "supportedValues": [
         "px",
         "%",
@@ -1151,7 +1148,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
+      "notes": "Wave 2 css.2 \u2014 em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "css/boxShadow": {
@@ -1165,7 +1162,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Single-shadow only. Multiple comma-separated shadows are not split. pulp #1434 Triage #15: catalog status flipped supported→partial — single-shadow with optional inset is wired (web-compat-style-decl.js:565); multi-shadow comma-separated lists are deferred. Wave 4 css extensive — multi-shadow comma-separated lists are arch-single-shadow (View::shadow_ stores a single ShadowSpec; stacking multiple drop-shadows would require a layered SkLayer paint pass and is an explicit non-goal — when authors need two shadows they use boxShadow + filter:drop-shadow).",
+      "notes": "Single-shadow only. Multiple comma-separated shadows are not split. pulp #1434 Triage #15: catalog status flipped supported\u2192partial \u2014 single-shadow with optional inset is wired (web-compat-style-decl.js:565); multi-shadow comma-separated lists are deferred. Wave 4 css extensive \u2014 multi-shadow comma-separated lists are arch-single-shadow (View::shadow_ stores a single ShadowSpec; stacking multiple drop-shadows would require a layered SkLayer paint pass and is an explicit non-goal \u2014 when authors need two shadows they use boxShadow + filter:drop-shadow).",
       "issue": ""
     },
     "css/boxSizing": {
@@ -1174,14 +1171,14 @@
       "supportedValues": [
         "content-box",
         "border-box",
-        "border-box (pulp default; declared width/height includes padding+border — matches Yoga 3.x's own default and what virtually every modern web design expects)",
+        "border-box (pulp default; declared width/height includes padding+border \u2014 matches Yoga 3.x's own default and what virtually every modern web design expects)",
         "content-box (CSS spec default; padding+border are outside declared dimensions, so a 100px-wide box with 10px padding has 120px outer width)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1516]"
       ],
-      "notes": "pulp #1516 — Yoga 3.2.1's native YGNodeStyleSetBoxSizing does the spec-correct math; previously the JS shim silently no-op'd because the bridge didn't register setBoxSizing. The default is `border-box` (matches Yoga 3.x's default + pulp's implicit pre-#1516 behavior + the de-facto `* { box-sizing: border-box }` web reset). Consumers that explicitly want CSS-spec content-box semantics can opt in via `boxSizing: 'content-box'`. High-leverage change for design imports — Figma / v0 / Claude Design HTML exports often emit explicit boxSizing declarations that previously dropped silently.",
+      "notes": "pulp #1516 \u2014 Yoga 3.2.1's native YGNodeStyleSetBoxSizing does the spec-correct math; previously the JS shim silently no-op'd because the bridge didn't register setBoxSizing. The default is `border-box` (matches Yoga 3.x's default + pulp's implicit pre-#1516 behavior + the de-facto `* { box-sizing: border-box }` web reset). Consumers that explicitly want CSS-spec content-box semantics can opt in via `boxSizing: 'content-box'`. High-leverage change for design imports \u2014 Figma / v0 / Claude Design HTML exports often emit explicit boxSizing declarations that previously dropped silently.",
       "issue": "1516"
     },
     "css/captionSide": {
@@ -1208,7 +1205,7 @@
     },
     "css/clipPath": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js parses `clip-path` and forwards path(\"...\") to setClipPath(id, svg_d). Skia parses via SkPath::FromSVGString and the canvas installs the clip on paint (#1540). url() / circle() / inset() / polygon() / ellipse() are deferred — the bridge stores an empty path so previous values don't linger.",
+      "mapsTo": "web-compat-style-decl.js parses `clip-path` and forwards path(\"...\") to setClipPath(id, svg_d). Skia parses via SkPath::FromSVGString and the canvas installs the clip on paint (#1540). url() / circle() / inset() / polygon() / ellipse() are deferred \u2014 the bridge stores an empty path so previous values don't linger.",
       "supportedValues": [
         "path(\"...\")",
         "none"
@@ -1217,7 +1214,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 A4 Bundle 6: status flipped missing → partial. Wiring landed in #1540 (clip_path_svg). Wave 1 architectural reclassification — Pulp wires only SVG `path()` by design (arch-path-only); url() / circle() / ellipse() / inset() / polygon() / box keywords are explicit non-goals (the Skia path is the universal primitive).",
+      "notes": "pulp #1434 A4 Bundle 6: status flipped missing \u2192 partial. Wiring landed in #1540 (clip_path_svg). Wave 1 architectural reclassification \u2014 Pulp wires only SVG `path()` by design (arch-path-only); url() / circle() / ellipse() / inset() / polygon() / box keywords are explicit non-goals (the Skia path is the universal primitive).",
       "issue": ""
     },
     "css/color": {
@@ -1242,7 +1239,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up. color-mix() and currentColor remain unsupported (deferred); wide-gamut HDR via Skia SkColor4f is a follow-up — current path converts to sRGB hex.",
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up. color-mix() and currentColor remain unsupported (deferred); wide-gamut HDR via Skia SkColor4f is a follow-up \u2014 current path converts to sRGB hex.",
       "issue": ""
     },
     "css/columnCount": {
@@ -1258,7 +1255,7 @@
     },
     "css/columnGap": {
       "status": "supported",
-      "mapsTo": "setFlex(id, 'column_gap', px) for numeric, 'NN%' string for percent (best-effort: stored on the scalar FlexStyle.column_gap slot since Yoga has no YGNodeStyleSetGapPercent API yet — treated as px until upstream Yoga ships percent-aware gap).",
+      "mapsTo": "setFlex(id, 'column_gap', px) for numeric, 'NN%' string for percent (best-effort: stored on the scalar FlexStyle.column_gap slot since Yoga has no YGNodeStyleSetGapPercent API yet \u2014 treated as px until upstream Yoga ships percent-aware gap).",
       "supportedValues": [
         "px",
         "% (best-effort scalar)"
@@ -1267,7 +1264,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — % accepted at the JS+bridge layer; honest stored-as-scalar caveat documented above. Status stays partial because Yoga doesn't yet honor percent gaps (px-equivalent only). Wave 4 css extensive — % is best-effort (stored on the scalar slot, treated as px-equivalent) until upstream Yoga ships YGNodeStyleSetGapPercent — tracked as deferred-yoga-percent-gap. Status flipped partial -> supported because every CSS-spec value (px / %) round-trips through the bridge today; the % honoring is the orthogonal Yoga upstream follow-up.",
+      "notes": "Wave 2 css.2 \u2014 % accepted at the JS+bridge layer; honest stored-as-scalar caveat documented above. Status stays partial because Yoga doesn't yet honor percent gaps (px-equivalent only). Wave 4 css extensive \u2014 % is best-effort (stored on the scalar slot, treated as px-equivalent) until upstream Yoga ships YGNodeStyleSetGapPercent \u2014 tracked as deferred-yoga-percent-gap. Status flipped partial -> supported because every CSS-spec value (px / %) round-trips through the bridge today; the % honoring is the orthogonal Yoga upstream follow-up.",
       "issue": ""
     },
     "css/columnRule": {
@@ -1360,7 +1357,7 @@
     },
     "css/cursor": {
       "status": "supported",
-      "mapsTo": "setCursor(id, value) — widget_bridge.cpp maps the full CSS keyword set to View::CursorStyle. col-resize/ew-resize/e-resize/w-resize → horizontal_resize; row-resize/ns-resize/n-resize/s-resize → vertical_resize; nwse/nw/se → top_left_resize; nesw/ne/sw → top_right_resize; move/all-scroll → multi_directional_resize; none/hidden → invisible; pointer/crosshair/text/grab/grabbing/not-allowed/no-drop/vertical-text mapped 1:1.",
+      "mapsTo": "setCursor(id, value) \u2014 widget_bridge.cpp maps the full CSS keyword set to View::CursorStyle. col-resize/ew-resize/e-resize/w-resize \u2192 horizontal_resize; row-resize/ns-resize/n-resize/s-resize \u2192 vertical_resize; nwse/nw/se \u2192 top_left_resize; nesw/ne/sw \u2192 top_right_resize; move/all-scroll \u2192 multi_directional_resize; none/hidden \u2192 invisible; pointer/crosshair/text/grab/grabbing/not-allowed/no-drop/vertical-text mapped 1:1.",
       "supportedValues": [
         "default",
         "pointer",
@@ -1403,12 +1400,12 @@
         "test/test_widget_bridge.cpp::\"setCursor maps the full CSS keyword set\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #7 — cursor enum fan-out. Unknown keywords fall back to default. CSS values without a CursorStyle slot today (alias/copy/cell/zoom-in/zoom-out/help/wait/progress/context-menu) also fall back to default; tracked for a follow-up that adds dedicated CursorStyle slots + platform-specific glyphs. url() cursor images are not supported (browser-specific feature). Wave 1 architectural reclassification — auto/cell/context-menu/help/progress/wait/zoom-in/zoom-out fall back to default by design (arch-platform-cursor-set; Pulp uses pointer/text/grab/grabbing + the resize family by design — adding more requires platform-specific glyphs and is an explicit OOS). Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — auto / cell / context-menu / help / progress / wait / zoom-in / zoom-out are arch-platform-cursor-set (accepted at the bridge — setCursor falls back to the default cursor glyph for unknown keywords). Adding dedicated CursorStyle slots + platform-specific glyph dispatch is the follow-up.",
+      "notes": "pulp #1434 Triage #7 \u2014 cursor enum fan-out. Unknown keywords fall back to default. CSS values without a CursorStyle slot today (alias/copy/cell/zoom-in/zoom-out/help/wait/progress/context-menu) also fall back to default; tracked for a follow-up that adds dedicated CursorStyle slots + platform-specific glyphs. url() cursor images are not supported (browser-specific feature). Wave 1 architectural reclassification \u2014 auto/cell/context-menu/help/progress/wait/zoom-in/zoom-out fall back to default by design (arch-platform-cursor-set; Pulp uses pointer/text/grab/grabbing + the resize family by design \u2014 adding more requires platform-specific glyphs and is an explicit OOS). Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 auto / cell / context-menu / help / progress / wait / zoom-in / zoom-out are arch-platform-cursor-set (accepted at the bridge \u2014 setCursor falls back to the default cursor glyph for unknown keywords). Adding dedicated CursorStyle slots + platform-specific glyph dispatch is the follow-up.",
       "issue": ""
     },
     "css/direction": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js forwards `direction` to setDirection(id, value). The bridge maps to View::WritingDirection; Yoga honors at layout time and Skia paragraph_style at text shape time (#1506). Logical-edge mapping in the JS shim still uses the LTR fast path; direction-aware logical→physical resolution is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js forwards `direction` to setDirection(id, value). The bridge maps to View::WritingDirection; Yoga honors at layout time and Skia paragraph_style at text shape time (#1506). Logical-edge mapping in the JS shim still uses the LTR fast path; direction-aware logical\u2192physical resolution is the follow-up.",
       "supportedValues": [
         "ltr",
         "rtl"
@@ -1417,7 +1414,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 A4 Bundle 6: status flipped missing → partial. Bridge wiring landed in #1506; CSS surface gets the same setDirection routing. Wave 1 drift cleanup — logical-edge mapping verified via Bundle 3 fast-path (#1506).",
+      "notes": "pulp #1434 A4 Bundle 6: status flipped missing \u2192 partial. Bridge wiring landed in #1506; CSS surface gets the same setDirection routing. Wave 1 drift cleanup \u2014 logical-edge mapping verified via Bundle 3 fast-path (#1506).",
       "issue": ""
     },
     "css/display": {
@@ -1441,7 +1438,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Yoga's underlying view model is exclusively flex. 'block' is silently aliased to 'flex'. RN's display enum is {none, flex, contents} which matches us better than CSS. The Display enum on the C++ View has no direct field -- visibility is implemented via View::set_visible. There is no 'partial' display rendering -- non-flex values render as flex with default direction. 2026-04-28 (#1167 / pulp #1147): `display: flex` now defaults flex-direction to 'row' to match CSS web compat (Pulp's underlying widgets default to 'col' / FlexDirection::column from RN convention, so the JS shim emits an explicit 'row' when the consumer didn't declare flexDirection / flex-direction / flex-flow with a direction token). Wave 1 architectural reclassification — non-flex display modes are arch-flex-only per CLAUDE.md design philosophy (Yoga's view model is exclusively flex; 'block' is silently aliased to 'flex'; grid/inline/inline-block/table/contents/inline-flex/inline-grid/list-item won't fix without violating the flex-only design). Wave 4 css extensive — non-flex display modes (inline / inline-block / inline-flex / inline-grid / grid / contents / table / table-row / table-cell) are arch-flex-only (Yoga's view model is exclusively flex; these values round-trip through the JS shim — `block` is silently aliased to `flex`, `none` hides via setVisible(id, false), the rest fall through to flex with default direction). Adding non-flex layout would violate the flex-only design (per CLAUDE.md). Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
+      "notes": "Yoga's underlying view model is exclusively flex. 'block' is silently aliased to 'flex'. RN's display enum is {none, flex, contents} which matches us better than CSS. The Display enum on the C++ View has no direct field -- visibility is implemented via View::set_visible. There is no 'partial' display rendering -- non-flex values render as flex with default direction. 2026-04-28 (#1167 / pulp #1147): `display: flex` now defaults flex-direction to 'row' to match CSS web compat (Pulp's underlying widgets default to 'col' / FlexDirection::column from RN convention, so the JS shim emits an explicit 'row' when the consumer didn't declare flexDirection / flex-direction / flex-flow with a direction token). Wave 1 architectural reclassification \u2014 non-flex display modes are arch-flex-only per CLAUDE.md design philosophy (Yoga's view model is exclusively flex; 'block' is silently aliased to 'flex'; grid/inline/inline-block/table/contents/inline-flex/inline-grid/list-item won't fix without violating the flex-only design). Wave 4 css extensive \u2014 non-flex display modes (inline / inline-block / inline-flex / inline-grid / grid / contents / table / table-row / table-cell) are arch-flex-only (Yoga's view model is exclusively flex; these values round-trip through the JS shim \u2014 `block` is silently aliased to `flex`, `none` hides via setVisible(id, false), the rest fall through to flex with default direction). Adding non-flex layout would violate the flex-only design (per CLAUDE.md). Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
       "issue": "1147"
     },
     "css/emptyCells": {
@@ -1478,7 +1475,7 @@
         "test/test_widget_bridge.cpp::\"setFilter parses brightness/contrast/grayscale/etc\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-4 — full CSS filter chain. setFilter parses the function-call sequence into View::FilterOp[]; view.cpp paint hands off to canvas.save_layer_with_filters; Skia composes via SkImageFilters::Compose + SkColorFilters::Matrix per filter. CG path falls back to blur-only collapse (no SkColorFilter equivalent yet). Full function set: blur / brightness / contrast / grayscale / hue-rotate / invert / opacity / saturate / sepia / drop-shadow. CG canvas backend currently degrades the chain to blur-only collapse (color-matrix filters silently no-op); SkColorFilter-equivalent for CG is a follow-up.",
+      "notes": "pulp #1434 Phase A2-4 \u2014 full CSS filter chain. setFilter parses the function-call sequence into View::FilterOp[]; view.cpp paint hands off to canvas.save_layer_with_filters; Skia composes via SkImageFilters::Compose + SkColorFilters::Matrix per filter. CG path falls back to blur-only collapse (no SkColorFilter equivalent yet). Full function set: blur / brightness / contrast / grayscale / hue-rotate / invert / opacity / saturate / sepia / drop-shadow. CG canvas backend currently degrades the chain to blur-only collapse (color-matrix filters silently no-op); SkColorFilter-equivalent for CG is a follow-up.",
       "issue": ""
     },
     "css/flex": {
@@ -1496,7 +1493,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "The CSS shorthand keywords (auto/none/initial) parse as NaN and silently set flex_grow=0. Wave 1 drift cleanup — 'auto'/'none'/'initial' keywords wired via yoga A4 (#1622); previously parsed as NaN and silently set flex_grow=0.",
+      "notes": "The CSS shorthand keywords (auto/none/initial) parse as NaN and silently set flex_grow=0. Wave 1 drift cleanup \u2014 'auto'/'none'/'initial' keywords wired via yoga A4 (#1622); previously parsed as NaN and silently set flex_grow=0.",
       "issue": ""
     },
     "css/flexBasis": {
@@ -1512,7 +1509,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Yoga supports 'auto' and percentages; Pulp accepts only px float. pulp #1434 rn batch C: % and auto wired via FlexStyle::dim_flex_basis. Wave 4 css extensive — `content` keyword is arch-yoga-no-content-basis (Yoga's flex-basis is a scalar / percent / auto; the `content` keyword would require intrinsic-size resolution which Yoga doesn't model today). Authors use `auto` for the equivalent fall-back behaviour.",
+      "notes": "Yoga supports 'auto' and percentages; Pulp accepts only px float. pulp #1434 rn batch C: % and auto wired via FlexStyle::dim_flex_basis. Wave 4 css extensive \u2014 `content` keyword is arch-yoga-no-content-basis (Yoga's flex-basis is a scalar / percent / auto; the `content` keyword would require intrinsic-size resolution which Yoga doesn't model today). Authors use `auto` for the equivalent fall-back behaviour.",
       "issue": ""
     },
     "css/flexDirection": {
@@ -1533,7 +1530,7 @@
     },
     "css/flexFlow": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js shorthand parser fans out into setFlex(direction, ...) and setFlex(flex_wrap, ...) — supports row / column / row-reverse / column-reverse and wrap / nowrap / wrap-reverse.",
+      "mapsTo": "web-compat-style-decl.js shorthand parser fans out into setFlex(direction, ...) and setFlex(flex_wrap, ...) \u2014 supports row / column / row-reverse / column-reverse and wrap / nowrap / wrap-reverse.",
       "supportedValues": [
         "row|column|row-reverse|column-reverse",
         "nowrap|no-wrap|wrap|wrap-reverse",
@@ -1544,7 +1541,7 @@
         "test/test_widget_bridge.cpp::\"flex-flow shorthand recognizes wrap-reverse\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #14 — extended shorthand parser to recognize -reverse modes.",
+      "notes": "pulp #1434 Triage #14 \u2014 extended shorthand parser to recognize -reverse modes.",
       "issue": ""
     },
     "css/flexGrow": {
@@ -1587,7 +1584,7 @@
         "test/test_widget_bridge.cpp::\"setFlex flex_wrap accepts wrap-reverse keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #14 — FlexStyle.flex_wrap converted from bool to tri-state enum; YGWrapWrapReverse is dispatched for wrap-reverse.",
+      "notes": "pulp #1434 Triage #14 \u2014 FlexStyle.flex_wrap converted from bool to tri-state enum; YGWrapWrapReverse is dispatched for wrap-reverse.",
       "issue": ""
     },
     "css/float": {
@@ -1605,21 +1602,21 @@
     },
     "css/fontFamily": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js + widget_bridge.cpp setFontFamily — both layers split CSS lists on commas, trim, strip outer quotes, and pick the first non-empty family. Bridge stores the value on Label or in the View's inheritable_font_family_ slot (cascade). PR #1174 + pulp #1434 Phase A2-5.",
+      "mapsTo": "web-compat-style-decl.js + widget_bridge.cpp setFontFamily \u2014 both layers split CSS lists on commas, trim, strip outer quotes, and pick the first non-empty family. Bridge stores the value on Label or in the View's inheritable_font_family_ slot (cascade). PR #1174 + pulp #1434 Phase A2-5.",
       "supportedValues": [
         "single font name (quoted or not)",
-        "comma-separated font lists ('JetBrains Mono', ui-monospace, monospace) — first non-empty family wins"
+        "comma-separated font lists ('JetBrains Mono', ui-monospace, monospace) \u2014 first non-empty family wins"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1434-fontfamily]"
       ],
-      "notes": "Wave 2 css.4 — reclassified partial -> partial-deferred-#932 (whole-list fallback is gated on Skia SkFontMgr font registration in pulp #932, not a JS-side gap). Phase A2-5 (pulp #1434) added @pulp/react JSX dispatch and a bridge-side list parser so direct setFontFamily('id', 'A, B, C') calls are now correct. The cascade slot on container Views means container-level fontFamily reaches descendant Labels via parent-walk (mirrors letter_spacing / font_weight). Wave 4 css extensive — drift cleanup — value-coverage is complete (single name + comma-separated list both round-trip; first family wins). The Skia SkFontMgr fallback-chain gating (pulp #932) is documented in mapsTo / notes; reclassified as paint-side architectural gap rather than a value-coverage gap.",
+      "notes": "Wave 2 css.4 \u2014 reclassified partial -> partial-deferred-#932 (whole-list fallback is gated on Skia SkFontMgr font registration in pulp #932, not a JS-side gap). Phase A2-5 (pulp #1434) added @pulp/react JSX dispatch and a bridge-side list parser so direct setFontFamily('id', 'A, B, C') calls are now correct. The cascade slot on container Views means container-level fontFamily reaches descendant Labels via parent-walk (mirrors letter_spacing / font_weight). Wave 4 css extensive \u2014 drift cleanup \u2014 value-coverage is complete (single name + comma-separated list both round-trip; first family wins). The Skia SkFontMgr fallback-chain gating (pulp #932) is documented in mapsTo / notes; reclassified as paint-side architectural gap rather than a value-coverage gap.",
       "issue": "1151"
     },
     "css/fontSize": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js: parseCSSLength + em/rem/% resolution (× default 14px) + smaller/larger keyword expansion (0.83x/1.2x); -> setFontSize(id, px).",
+      "mapsTo": "web-compat-style-decl.js: parseCSSLength + em/rem/% resolution (\u00d7 default 14px) + smaller/larger keyword expansion (0.83x/1.2x); -> setFontSize(id, px).",
       "supportedValues": [
         "px",
         "em",
@@ -1632,7 +1629,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — em/rem/% resolved against the default 14px font-size (matches resolveLength fallback). smaller/larger expand to 0.83x and 1.2x per CSS spec. Multi-level cascade (resolving em against an actual ancestor font-size) is the follow-up; the single-level resolver covers the common case.",
+      "notes": "Wave 2 css.2 \u2014 em/rem/% resolved against the default 14px font-size (matches resolveLength fallback). smaller/larger expand to 0.83x and 1.2x per CSS spec. Multi-level cascade (resolving em against an actual ancestor font-size) is the follow-up; the single-level resolver covers the common case.",
       "issue": ""
     },
     "css/fontStyle": {
@@ -1647,7 +1644,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.4 — oblique alias upgrades a silent no-op (the bridge previously only honored 'italic') to the closest visual approximation. Real oblique requires SkFont variation axes which is the follow-up. Wave 4 css extensive — label cleanup — `oblique` claims the bare keyword (the bridge aliases to italic which is the closest visual approximation today). `oblique <angle>` is arch-paint-deferred (real oblique requires SkFont variation axes which is the documented follow-up).",
+      "notes": "Wave 2 css.4 \u2014 oblique alias upgrades a silent no-op (the bridge previously only honored 'italic') to the closest visual approximation. Real oblique requires SkFont variation axes which is the follow-up. Wave 4 css extensive \u2014 label cleanup \u2014 `oblique` claims the bare keyword (the bridge aliases to italic which is the closest visual approximation today). `oblique <angle>` is arch-paint-deferred (real oblique requires SkFont variation axes which is the documented follow-up).",
       "issue": ""
     },
     "css/fontVariant": {
@@ -1660,12 +1657,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 A4 Bundle 7: status flipped missing → partial. setFontVariant bridge fn now exists; mirrors rn/fontVariant. Wave 4 css extensive — HarfBuzz feature integration is arch-paint-deferred (the bridge stores the value on View::font_variant_; HarfBuzz line-break/feature wiring at paint time is the follow-up tracked in mapsTo). Reclassified as paint-side gap rather than value-coverage gap.",
+      "notes": "pulp #1434 A4 Bundle 7: status flipped missing \u2192 partial. setFontVariant bridge fn now exists; mirrors rn/fontVariant. Wave 4 css extensive \u2014 HarfBuzz feature integration is arch-paint-deferred (the bridge stores the value on View::font_variant_; HarfBuzz line-break/feature wiring at paint time is the follow-up tracked in mapsTo). Reclassified as paint-side gap rather than value-coverage gap.",
       "issue": ""
     },
     "css/fontWeight": {
       "status": "supported",
-      "mapsTo": "translate keyword/numeric → setFontWeight(id, n)",
+      "mapsTo": "translate keyword/numeric \u2192 setFontWeight(id, n)",
       "supportedValues": [
         "100..900 (numeric)",
         "normal",
@@ -1678,12 +1675,12 @@
         "test/web-compat/test_css_translator_gaps_1434.cpp [issue-1434-batch-3]",
         "packages/pulp-react/test/prop-applier-fontweight.test.ts"
       ],
-      "notes": "Keyword-to-numeric: normal→400, bold→700, lighter→300, bolder→700. Numeric keywords parse unchanged. Mirrored in @pulp/react prop-applier (_normalizeFontWeight).",
+      "notes": "Keyword-to-numeric: normal\u2192400, bold\u2192700, lighter\u2192300, bolder\u2192700. Numeric keywords parse unchanged. Mirrored in @pulp/react prop-applier (_normalizeFontWeight).",
       "issue": "1434"
     },
     "css/gap": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js: single-token form -> setFlex(id, 'gap', px); two-token form 'row col' -> setFlex(row_gap) + setFlex(column_gap). % accepted (best-effort scalar — same caveat as rowGap/columnGap).",
+      "mapsTo": "web-compat-style-decl.js: single-token form -> setFlex(id, 'gap', px); two-token form 'row col' -> setFlex(row_gap) + setFlex(column_gap). % accepted (best-effort scalar \u2014 same caveat as rowGap/columnGap).",
       "supportedValues": [
         "px (number)",
         "% (best-effort scalar)",
@@ -1693,7 +1690,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — two-value form fans out to row_gap + column_gap; % accepted at JS+bridge (Yoga gap is scalar-only today, no YGNodeStyleSetGapPercent yet).",
+      "notes": "Wave 2 css.2 \u2014 two-value form fans out to row_gap + column_gap; % accepted at JS+bridge (Yoga gap is scalar-only today, no YGNodeStyleSetGapPercent yet).",
       "issue": ""
     },
     "css/gridArea": {
@@ -1712,7 +1709,7 @@
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridAutoColumns": {
@@ -1731,7 +1728,7 @@
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridAutoFlow": {
@@ -1750,7 +1747,7 @@
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridAutoRows": {
@@ -1769,7 +1766,7 @@
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridColumn": {
@@ -1788,7 +1785,7 @@
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridRow": {
@@ -1807,7 +1804,7 @@
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridTemplateAreas": {
@@ -1826,7 +1823,7 @@
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridTemplateColumns": {
@@ -1845,7 +1842,7 @@
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/gridTemplateRows": {
@@ -1864,7 +1861,7 @@
         "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-2 PR 1 — grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement — multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
       "issue": ""
     },
     "css/height": {
@@ -1884,7 +1881,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1423 wired px + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end (CSS translator forwards 'auto' verbatim; bridge populates FlexStyle.dim_height.unit = auto_; yoga_layout.cpp dispatches to YGNodeStyleSetHeightAuto). Relative units (em/rem/vh/vw) remain deferred. Wave 1 architectural reclassification — min-content / max-content / fit-content are arch-yoga-limit (Yoga doesn't compute content-sized boxes); em/rem are deferred (relative-unit resolver lands later). Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — min-content / max-content / fit-content are arch-yoga-no-intrinsic-sizing (Yoga's flex layout doesn't model intrinsic sizing; use flex / flex-basis for the equivalent shrink-to-fit behaviour). calc() is arch-no-calc-eval (no expression evaluator at the JS shim layer; authors precompute or use JS variables). em/rem resolve against the default 14px font-size at the JS layer (single-level cascade per Wave 2 css.2 fontSize precedent).",
+      "notes": "pulp #1423 wired px + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end (CSS translator forwards 'auto' verbatim; bridge populates FlexStyle.dim_height.unit = auto_; yoga_layout.cpp dispatches to YGNodeStyleSetHeightAuto). Relative units (em/rem/vh/vw) remain deferred. Wave 1 architectural reclassification \u2014 min-content / max-content / fit-content are arch-yoga-limit (Yoga doesn't compute content-sized boxes); em/rem are deferred (relative-unit resolver lands later). Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 min-content / max-content / fit-content are arch-yoga-no-intrinsic-sizing (Yoga's flex layout doesn't model intrinsic sizing; use flex / flex-basis for the equivalent shrink-to-fit behaviour). calc() is arch-no-calc-eval (no expression evaluator at the JS shim layer; authors precompute or use JS variables). em/rem resolve against the default 14px font-size at the JS layer (single-level cascade per Wave 2 css.2 fontSize precedent).",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "css/inset": {
@@ -1902,7 +1899,7 @@
     },
     "css/isolation": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js -> setIsolation(id, kw) -> View::set_isolation slot. Pulp's per-View save_layer_with_blend model (pulp #1549) is structurally isolated by default: each View with mix-blend-mode opens its own composition layer and composites back to its parent normally — no cross-stacking-context blend leakage. Z-index is paint-order scoped to siblings within a parent. Both author intents of `isolation: isolate` (blend-mode containment + stacking-context creation) happen by default.",
+      "mapsTo": "web-compat-style-decl.js -> setIsolation(id, kw) -> View::set_isolation slot. Pulp's per-View save_layer_with_blend model (pulp #1549) is structurally isolated by default: each View with mix-blend-mode opens its own composition layer and composites back to its parent normally \u2014 no cross-stacking-context blend leakage. Z-index is paint-order scoped to siblings within a parent. Both author intents of `isolation: isolate` (blend-mode containment + stacking-context creation) happen by default.",
       "supportedValues": [
         "auto",
         "isolate"
@@ -1940,7 +1937,7 @@
     },
     "css/left": {
       "status": "supported",
-      "mapsTo": "setLeft(id, px); JS shim resolves em/rem (× 14px default), vh/vw (× 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
+      "mapsTo": "setLeft(id, px); JS shim resolves em/rem (\u00d7 14px default), vh/vw (\u00d7 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
       "supportedValues": [
         "px",
         "%",
@@ -1953,12 +1950,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
+      "notes": "Wave 2 css.2 \u2014 em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "css/letterSpacing": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js: parseCSSLength + em resolution (× default 14px) + normal keyword (= 0); -> setLetterSpacing(id, px).",
+      "mapsTo": "web-compat-style-decl.js: parseCSSLength + em resolution (\u00d7 default 14px) + normal keyword (= 0); -> setLetterSpacing(id, px).",
       "supportedValues": [
         "px",
         "em",
@@ -1969,12 +1966,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — em/rem resolved against the default 14px font-size (same caveat as fontSize re: single-level cascade). normal -> 0 per CSS spec.",
+      "notes": "Wave 2 css.2 \u2014 em/rem resolved against the default 14px font-size (same caveat as fontSize re: single-level cascade). normal -> 0 per CSS spec.",
       "issue": ""
     },
     "css/lineClamp": {
       "status": "supported",
-      "mapsTo": "parseInt -> setLineClamp(id, n) — Label paint emits at most N lines + U+2026 ellipsis on the last visible line if source lines were dropped",
+      "mapsTo": "parseInt -> setLineClamp(id, n) \u2014 Label paint emits at most N lines + U+2026 ellipsis on the last visible line if source lines were dropped",
       "supportedValues": [
         "integer"
       ],
@@ -1991,7 +1988,7 @@
     },
     "css/lineHeight": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js: detects bare-number unitless multiplier (× default 14px font-size); resolves em/rem/% against same default; normal = 1.2 × 14; numeric px path unchanged. -> setLineHeight(id, px).",
+      "mapsTo": "web-compat-style-decl.js: detects bare-number unitless multiplier (\u00d7 default 14px font-size); resolves em/rem/% against same default; normal = 1.2 \u00d7 14; numeric px path unchanged. -> setLineHeight(id, px).",
       "supportedValues": [
         "px",
         "unitless multiplier (e.g. 1.5)",
@@ -2004,12 +2001,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — closes the major-gap unitless-multiplier hole. Resolved against the default 14px font-size (same single-level cascade caveat as fontSize). Multi-level cascade is the follow-up.",
+      "notes": "Wave 2 css.2 \u2014 closes the major-gap unitless-multiplier hole. Resolved against the default 14px font-size (same single-level cascade caveat as fontSize). Multi-level cascade is the follow-up.",
       "issue": ""
     },
     "css/listStyle": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js parses the shorthand into the 3 longhands (any order: type / position / image) and dispatches setListStyleType / setListStyleImage / setListStylePosition. Bridge stores values on View::ListStyleType / list_style_image_ / View::ListStylePosition slots. Paint-time marker rendering is deferred — values are stored but not yet drawn.",
+      "mapsTo": "web-compat-style-decl.js parses the shorthand into the 3 longhands (any order: type / position / image) and dispatches setListStyleType / setListStyleImage / setListStylePosition. Bridge stores values on View::ListStyleType / list_style_image_ / View::ListStylePosition slots. Paint-time marker rendering is deferred \u2014 values are stored but not yet drawn.",
       "supportedValues": [
         "shorthand parsing into 3 longhands"
       ],
@@ -2019,7 +2016,7 @@
         "packages/pulp-react/test/prop-applier-list-style.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.4 — reclassified partial -> partial-deferred-paint-time (marker glyph painting is the architectural blocker, not a JS-side gap). pulp #1514 — list-style cluster. Pulp doesn't model <li>/<ul>/<ol> semantics; the bridge stores the values verbatim on the View so a future paint pass (or future semantic-list surface) can honor them. Wave 4 css extensive — drift cleanup — value-coverage is complete (the catalog's only 'unsupported' entry was the paint-time marker glyph rendering, which is an arch-paint-deferred follow-up — moved out of unsupportedValues per the Wave 1 backgroundAttachment precedent).",
+      "notes": "Wave 2 css.4 \u2014 reclassified partial -> partial-deferred-paint-time (marker glyph painting is the architectural blocker, not a JS-side gap). pulp #1514 \u2014 list-style cluster. Pulp doesn't model <li>/<ul>/<ol> semantics; the bridge stores the values verbatim on the View so a future paint pass (or future semantic-list surface) can honor them. Wave 4 css extensive \u2014 drift cleanup \u2014 value-coverage is complete (the catalog's only 'unsupported' entry was the paint-time marker glyph rendering, which is an arch-paint-deferred follow-up \u2014 moved out of unsupportedValues per the Wave 1 backgroundAttachment precedent).",
       "issue": "1514"
     },
     "css/listStyleImage": {
@@ -2035,7 +2032,7 @@
         "packages/pulp-react/test/prop-applier-list-style.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.4 — reclassified partial -> partial-deferred-paint-time (bullet image paint is the architectural blocker, not a JS-side gap). pulp #1514 — Bridge round-trips the URL string. Image fetch + decode + paint is the follow-up. Wave 4 css extensive — drift cleanup — value-coverage is complete (the catalog's only 'unsupported' entry was the paint-time marker glyph rendering, which is an arch-paint-deferred follow-up — moved out of unsupportedValues per the Wave 1 backgroundAttachment precedent).",
+      "notes": "Wave 2 css.4 \u2014 reclassified partial -> partial-deferred-paint-time (bullet image paint is the architectural blocker, not a JS-side gap). pulp #1514 \u2014 Bridge round-trips the URL string. Image fetch + decode + paint is the follow-up. Wave 4 css extensive \u2014 drift cleanup \u2014 value-coverage is complete (the catalog's only 'unsupported' entry was the paint-time marker glyph rendering, which is an arch-paint-deferred follow-up \u2014 moved out of unsupportedValues per the Wave 1 backgroundAttachment precedent).",
       "issue": "1514"
     },
     "css/listStylePosition": {
@@ -2053,12 +2050,12 @@
         "packages/pulp-react/test/prop-applier-list-style.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1514 — Bridge stores the position; marker rendering is the follow-up. Wave 1 drift cleanup — partial → supported (harness verifies all 2 spec values).",
+      "notes": "pulp #1514 \u2014 Bridge stores the position; marker rendering is the follow-up. Wave 1 drift cleanup \u2014 partial \u2192 supported (harness verifies all 2 spec values).",
       "issue": "1514"
     },
     "css/listStyleType": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js forwards the keyword to setListStyleType; bridge stores View::ListStyleType (none / disc / circle / square / decimal). Marker glyph paint is deferred — `decimal` additionally needs sibling-index resolution from the parent's children.",
+      "mapsTo": "web-compat-style-decl.js forwards the keyword to setListStyleType; bridge stores View::ListStyleType (none / disc / circle / square / decimal). Marker glyph paint is deferred \u2014 `decimal` additionally needs sibling-index resolution from the parent's children.",
       "supportedValues": [
         "none",
         "disc",
@@ -2074,7 +2071,7 @@
         "packages/pulp-react/test/prop-applier-list-style.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1514 — Bridge stores the type keyword; marker glyph rendering is the follow-up. Pulp doesn't model HTML <li> semantics yet. Wave 1 drift cleanup — decimal sibling-index + marker glyph paint shipped via #1551 catalog hygiene; lower-roman / upper-roman / lower-alpha remain architectural (no View::ListStyleType enum slot today).",
+      "notes": "pulp #1514 \u2014 Bridge stores the type keyword; marker glyph rendering is the follow-up. Pulp doesn't model HTML <li> semantics yet. Wave 1 drift cleanup \u2014 decimal sibling-index + marker glyph paint shipped via #1551 catalog hygiene; lower-roman / upper-roman / lower-alpha remain architectural (no View::ListStyleType enum slot today).",
       "issue": "1514"
     },
     "css/margin": {
@@ -2090,7 +2087,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — auto + % now honored in the shorthand (parity with the per-edge longhands). Yoga's YGNodeStyleSetMarginAuto centers when both opposing margins are auto.",
+      "notes": "Wave 2 css.2 \u2014 auto + % now honored in the shorthand (parity with the per-edge longhands). Yoga's YGNodeStyleSetMarginAuto centers when both opposing margins are auto.",
       "issue": ""
     },
     "css/marginBlock": {
@@ -2108,7 +2105,7 @@
     },
     "css/marginBlockEnd": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js maps `margin-block-end` → setFlex(margin_bottom) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges — direction-aware mapping is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js maps `margin-block-end` \u2192 setFlex(margin_bottom) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
       "supportedValues": [
         "<length>",
         "<percentage>",
@@ -2118,12 +2115,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 A4 Bundle 3: status flipped missing → partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/marginBlockStart": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js maps `margin-block-start` → setFlex(margin_top) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges — direction-aware mapping is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js maps `margin-block-start` \u2192 setFlex(margin_top) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
       "supportedValues": [
         "<length>",
         "<percentage>",
@@ -2133,7 +2130,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 A4 Bundle 3: status flipped missing → partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/marginBottom": {
@@ -2149,7 +2146,7 @@
         "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
       "issue": ""
     },
     "css/marginHorizontal": {
@@ -2165,7 +2162,7 @@
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "css/marginInline": {
@@ -2183,7 +2180,7 @@
     },
     "css/marginInlineEnd": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js maps `margin-inline-end` → setFlex(margin_right) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges — direction-aware mapping is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js maps `margin-inline-end` \u2192 setFlex(margin_right) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
       "supportedValues": [
         "<length>",
         "<percentage>",
@@ -2193,7 +2190,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 A4 Bundle 3: status flipped missing → partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/marginInlineStart": {
@@ -2204,7 +2201,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 batch 1: status flipped missing → partial. CSS translator at web-compat-style-decl.js:784 maps to setFlex(margin_left) under LTR assumption; RTL not yet wired. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 batch 1: status flipped missing \u2192 partial. CSS translator at web-compat-style-decl.js:784 maps to setFlex(margin_left) under LTR assumption; RTL not yet wired. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/marginLeft": {
@@ -2220,7 +2217,7 @@
         "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
       "issue": ""
     },
     "css/marginRight": {
@@ -2236,7 +2233,7 @@
         "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
       "issue": ""
     },
     "css/marginTop": {
@@ -2252,7 +2249,7 @@
         "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
       "issue": ""
     },
     "css/marginVertical": {
@@ -2268,7 +2265,7 @@
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "css/mask": {
@@ -2284,12 +2281,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 A4 Bundle 6: status flipped missing → partial. Storage landed in #1515 / #1540. Wave 4 css extensive — mask sub-properties (mode/repeat/position/size/origin/clip/composite) are arch-paint-deferred — the shorthand parser routes mask-image to setMaskImage today; the orchestration of the other sub-properties at paint time is the follow-up. Reclassified as paint-side gap rather than value-coverage gap.",
+      "notes": "pulp #1434 A4 Bundle 6: status flipped missing \u2192 partial. Storage landed in #1515 / #1540. Wave 4 css extensive \u2014 mask sub-properties (mode/repeat/position/size/origin/clip/composite) are arch-paint-deferred \u2014 the shorthand parser routes mask-image to setMaskImage today; the orchestration of the other sub-properties at paint time is the follow-up. Reclassified as paint-side gap rather than value-coverage gap.",
       "issue": ""
     },
     "css/maskImage": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js forwards `mask-image` to setMaskImage(id, value) -> View::set_mask_image -> View::paint_all routes through Canvas::save_layer_with_mask -> SkiaCanvas's 2-saveLayer + SkBlendMode::kDstIn composite at restore time. Phase 1 paints linear-gradient masks fully; radial-gradient and url() image masks fall through safely (no mask applied — content unaffected).",
+      "mapsTo": "web-compat-style-decl.js forwards `mask-image` to setMaskImage(id, value) -> View::set_mask_image -> View::paint_all routes through Canvas::save_layer_with_mask -> SkiaCanvas's 2-saveLayer + SkBlendMode::kDstIn composite at restore time. Phase 1 paints linear-gradient masks fully; radial-gradient and url() image masks fall through safely (no mask applied \u2014 content unaffected).",
       "supportedValues": [
         "url(#ref)",
         "linear-gradient(...)",
@@ -2301,12 +2298,12 @@
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]",
         "unit:test_view#issue-1515"
       ],
-      "notes": "pulp #1434 A4 Bundle 6 (initial flip), pulp #1515 (storage landed), pulp #1737 PR-3 (this slice — paint integration via Canvas::save_layer_with_mask + SkiaCanvas's 2-saveLayer + SkBlendMode::kDstIn composite at restore time). The catalog claim at this entry is keyword-coverage: Pulp's mask-image surface accepts every spec value (url, linear-gradient, radial-gradient, none) and round-trips them through View::mask_image_. Paint-time coverage in Phase 1: `linear-gradient(...)` and `none` are honored end-to-end; `radial-gradient(...)` and `url(...)` shapes drop to a no-mask fall-through (the layer opens with content opacity, restore() sees no pending shader, layer closes plainly — matches pre-#1737 behavior, content is unaffected). Phase 2 followup will extend the parser to radial-gradient + url(file_path) via image_cache + url(#elementRef) via the SVG `<defs>` registry shared with rn/fill (#932). That parser-coverage extension does not require a new API surface — Canvas::save_layer_with_mask already accepts all these strings.",
+      "notes": "pulp #1434 A4 Bundle 6 (initial flip), pulp #1515 (storage landed), pulp #1737 PR-3 (this slice \u2014 paint integration via Canvas::save_layer_with_mask + SkiaCanvas's 2-saveLayer + SkBlendMode::kDstIn composite at restore time). The catalog claim at this entry is keyword-coverage: Pulp's mask-image surface accepts every spec value (url, linear-gradient, radial-gradient, none) and round-trips them through View::mask_image_. Paint-time coverage in Phase 1: `linear-gradient(...)` and `none` are honored end-to-end; `radial-gradient(...)` and `url(...)` shapes drop to a no-mask fall-through (the layer opens with content opacity, restore() sees no pending shader, layer closes plainly \u2014 matches pre-#1737 behavior, content is unaffected). Phase 2 followup will extend the parser to radial-gradient + url(file_path) via image_cache + url(#elementRef) via the SVG `<defs>` registry shared with rn/fill (#932). That parser-coverage extension does not require a new API surface \u2014 Canvas::save_layer_with_mask already accepts all these strings.",
       "issue": ""
     },
     "css/maxHeight": {
       "status": "supported",
-      "mapsTo": "setFlex(id, 'max_height', px) for numeric, 'NN%' for percent. Wave 2 css.2 — calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
+      "mapsTo": "setFlex(id, 'max_height', px) for numeric, 'NN%' for percent. Wave 2 css.2 \u2014 calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
       "supportedValues": [
         "px (number)",
         "%",
@@ -2319,12 +2316,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — calc() actually wired in the shim (catalog had previously claimed it shipped; verified + connected). pulp #1434 rn batch C: % values route through FlexStyle::dim_*.unit → Yoga percent API. min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
+      "notes": "Wave 2 css.2 \u2014 calc() actually wired in the shim (catalog had previously claimed it shipped; verified + connected). pulp #1434 rn batch C: % values route through FlexStyle::dim_*.unit \u2192 Yoga percent API. min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
       "issue": ""
     },
     "css/maxWidth": {
       "status": "supported",
-      "mapsTo": "setFlex(id, 'max_width', px) for numeric, 'NN%' for percent. Wave 2 css.2 — calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
+      "mapsTo": "setFlex(id, 'max_width', px) for numeric, 'NN%' for percent. Wave 2 css.2 \u2014 calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
       "supportedValues": [
         "px (number)",
         "%",
@@ -2337,12 +2334,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — calc() actually wired in the shim. 0 = no maximum (semantic differs from CSS where unspecified = none). min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
+      "notes": "Wave 2 css.2 \u2014 calc() actually wired in the shim. 0 = no maximum (semantic differs from CSS where unspecified = none). min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
       "issue": ""
     },
     "css/minHeight": {
       "status": "supported",
-      "mapsTo": "setFlex(id, 'min_height', px) for numeric, 'NN%' for percent. Wave 2 css.2 — calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
+      "mapsTo": "setFlex(id, 'min_height', px) for numeric, 'NN%' for percent. Wave 2 css.2 \u2014 calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
       "supportedValues": [
         "px (number)",
         "%",
@@ -2355,12 +2352,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — calc() actually wired in the shim. min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
+      "notes": "Wave 2 css.2 \u2014 calc() actually wired in the shim. min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
       "issue": ""
     },
     "css/minWidth": {
       "status": "supported",
-      "mapsTo": "setFlex(id, 'min_width', px) for numeric, 'NN%' for percent. Wave 2 css.2 — calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
+      "mapsTo": "setFlex(id, 'min_width', px) for numeric, 'NN%' for percent. Wave 2 css.2 \u2014 calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
       "supportedValues": [
         "px (number)",
         "%",
@@ -2373,7 +2370,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — calc() actually wired in the shim. min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
+      "notes": "Wave 2 css.2 \u2014 calc() actually wired in the shim. min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
       "issue": ""
     },
     "css/mixBlendMode": {
@@ -2396,15 +2393,15 @@
         "saturation",
         "color",
         "luminosity",
-        "plus-lighter (additive — SkBlendMode::kPlus)",
-        "plus-darker (additive — SkBlendMode::kPlus)"
+        "plus-lighter (additive \u2014 SkBlendMode::kPlus)",
+        "plus-darker (additive \u2014 SkBlendMode::kPlus)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp::WidgetBridge setMixBlendMode keyword -> BlendMode mapping",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.9 — plus-lighter/plus-darker now map to BlendMode::lighter (Skia's SkBlendMode::kPlus). plus-darker is technically a multiplicative variant in the W3C draft but Skia/Chromium ship the additive kPlus for both; mirroring that is the closest match without a custom SkBlender. pulp #1434 A4 Bundle 6: original wiring (16 W3C modes).",
+      "notes": "Wave 2 css.9 \u2014 plus-lighter/plus-darker now map to BlendMode::lighter (Skia's SkBlendMode::kPlus). plus-darker is technically a multiplicative variant in the W3C draft but Skia/Chromium ship the additive kPlus for both; mirroring that is the closest match without a custom SkBlender. pulp #1434 A4 Bundle 6: original wiring (16 W3C modes).",
       "issue": ""
     },
     "css/opacity": {
@@ -2418,7 +2415,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "parseFloat strips the % suffix silently. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — percentage strings are accepted at the JS layer (parsed as 0..1 from 'NN%') — the JS shim normalizes percent to numeric before calling setOpacity. The bridge slot is numeric only (arch-numeric-only-bridge); authors who pass numeric strings or numbers hit the same setOpacity path today.",
+      "notes": "parseFloat strips the % suffix silently. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 percentage strings are accepted at the JS layer (parsed as 0..1 from 'NN%') \u2014 the JS shim normalizes percent to numeric before calling setOpacity. The bridge slot is numeric only (arch-numeric-only-bridge); authors who pass numeric strings or numbers hit the same setOpacity path today.",
       "issue": ""
     },
     "css/order": {
@@ -2439,19 +2436,19 @@
       "mapsTo": "web-compat shorthand parser fans out to setOutlineWidth + setOutlineStyle + setOutlineColor (web-compat-style-decl.js:851 since pulp #1519).",
       "supportedValues": [
         "<width> <style> <color> shorthand",
-        "thin/medium/thick keyword for width (parses; currently falls through to numeric — keyword expansion deferred)",
+        "thin/medium/thick keyword for width (parses; currently falls through to numeric \u2014 keyword expansion deferred)",
         "double/groove/ridge/inset/outset (accepted; rendered as solid per arch-solid-only-pen)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1519 — outline cluster now bridge-backed. Shorthand parses `<width>px <style> <color>` and dispatches to the per-attribute setters. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — outline-style values double/groove/ridge/inset/outset are arch-solid-only-pen (mirrors border-style — paint pipeline draws a single solid pen by design; outline-width thin/medium/thick are author-named widths and currently fall through to the numeric path — adding the keyword expansion is queued behind border parity but parses without crashing today).",
+      "notes": "pulp #1519 \u2014 outline cluster now bridge-backed. Shorthand parses `<width>px <style> <color>` and dispatches to the per-attribute setters. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 outline-style values double/groove/ridge/inset/outset are arch-solid-only-pen (mirrors border-style \u2014 paint pipeline draws a single solid pen by design; outline-width thin/medium/thick are author-named widths and currently fall through to the numeric path \u2014 adding the keyword expansion is queued behind border parity but parses without crashing today).",
       "issue": ""
     },
     "css/outlineColor": {
       "status": "supported",
-      "mapsTo": "setOutlineColor(id, color) — registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js:864 routes through it.",
+      "mapsTo": "setOutlineColor(id, color) \u2014 registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js:864 routes through it.",
       "supportedValues": [
         "#hex",
         "#rgba",
@@ -2464,12 +2461,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1519 — outline color now writes to View::outline_color_; Skia paint strokes the inflated rect with this color. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — currentColor keyword is arch-no-cascade-color (the JS shim has no ancestor color resolver; authors pass explicit colors per css/borderColor / css/color precedent — currentColor parses but resolves to the bridge default).",
+      "notes": "pulp #1519 \u2014 outline color now writes to View::outline_color_; Skia paint strokes the inflated rect with this color. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 currentColor keyword is arch-no-cascade-color (the JS shim has no ancestor color resolver; authors pass explicit colors per css/borderColor / css/color precedent \u2014 currentColor parses but resolves to the bridge default).",
       "issue": ""
     },
     "css/outlineOffset": {
       "status": "supported",
-      "mapsTo": "setOutlineOffset(id, px) — registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js routes through it.",
+      "mapsTo": "setOutlineOffset(id, px) \u2014 registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js routes through it.",
       "supportedValues": [
         "<length>px",
         "em/rem/% (resolved to px at the JS layer; falls back to the default 14px font-size for em/rem)"
@@ -2478,12 +2475,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1519 — gap between border-box edge and outline. Skia inflates the stroke rect by (offset + width/2). Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — em/rem/% units are arch-paint-px-only (outline is paint-only; the bridge resolves length at the JS boundary and forwards a numeric px to setOutlineOffset — em/rem/% would require a paint-time resolver hook). Authors precompute at the JS layer.",
+      "notes": "pulp #1519 \u2014 gap between border-box edge and outline. Skia inflates the stroke rect by (offset + width/2). Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 em/rem/% units are arch-paint-px-only (outline is paint-only; the bridge resolves length at the JS boundary and forwards a numeric px to setOutlineOffset \u2014 em/rem/% would require a paint-time resolver hook). Authors precompute at the JS layer.",
       "issue": ""
     },
     "css/outlineStyle": {
       "status": "supported",
-      "mapsTo": "setOutlineStyle(id, keyword) — registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js routes through it; keyword set mirrors borderStyle.",
+      "mapsTo": "setOutlineStyle(id, keyword) \u2014 registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js routes through it; keyword set mirrors borderStyle.",
       "supportedValues": [
         "solid",
         "dashed",
@@ -2500,12 +2497,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1519 — line-style enum reused from View::BorderStyle (CSS spec is identical). Skia installs SkDashPathEffect for dashed/dotted at outline-stroke time. Other named styles currently degrade to solid (paint-side gap, same as borderStyle).",
+      "notes": "pulp #1519 \u2014 line-style enum reused from View::BorderStyle (CSS spec is identical). Skia installs SkDashPathEffect for dashed/dotted at outline-stroke time. Other named styles currently degrade to solid (paint-side gap, same as borderStyle).",
       "issue": ""
     },
     "css/outlineWidth": {
       "status": "supported",
-      "mapsTo": "setOutlineWidth(id, px) — registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js:859 routes through it.",
+      "mapsTo": "setOutlineWidth(id, px) \u2014 registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js:859 routes through it.",
       "supportedValues": [
         "<length>px",
         "thin/medium/thick (parses; rendered as the numeric default per arch-numeric-only)"
@@ -2514,7 +2511,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1519 — outline stroke thickness. width<=0 short-circuits the paint. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — thin/medium/thick keyword forms are arch-numeric-only (the bridge slot is numeric px; the JS shim does not yet expand the keyword set — authors pass numeric px today, mirrors border-width).",
+      "notes": "pulp #1519 \u2014 outline stroke thickness. width<=0 short-circuits the paint. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 thin/medium/thick keyword forms are arch-numeric-only (the bridge slot is numeric px; the JS shim does not yet expand the keyword set \u2014 authors pass numeric px today, mirrors border-width).",
       "issue": ""
     },
     "css/overflow": {
@@ -2531,7 +2528,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "View::Overflow enum has only {visible, hidden}. Scroll requires using the ScrollView intrinsic. Wave 4 css extensive — scroll / auto / clip are arch-scroll-via-scrollview (View::Overflow has only {visible, hidden}; the JS shim parses the keyword without crash and the bridge clamps to the closest behaviour — `scroll` / `auto` / `overlay` are routed to `hidden` clip, matching the no-scroll-context default). Authors who need true scrolling use the dedicated ScrollView intrinsic, mirrors React Native's split. Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
+      "notes": "View::Overflow enum has only {visible, hidden}. Scroll requires using the ScrollView intrinsic. Wave 4 css extensive \u2014 scroll / auto / clip are arch-scroll-via-scrollview (View::Overflow has only {visible, hidden}; the JS shim parses the keyword without crash and the bridge clamps to the closest behaviour \u2014 `scroll` / `auto` / `overlay` are routed to `hidden` clip, matching the no-scroll-context default). Authors who need true scrolling use the dedicated ScrollView intrinsic, mirrors React Native's split. Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
       "issue": ""
     },
     "css/overflowWrap": {
@@ -2546,7 +2543,7 @@
       "tests": [
         "unit:test_widgets#issue-1737"
       ],
-      "notes": "pulp #1434 A4 Bundle 4 (initial flip), pulp #1616 (walked back to partial when audit confirmed paint-path didn't consume the value), pulp #1737 PR-1 (#1795 — added BreakMode + codepoint-break logic to TextShaper::layout_from_segments), pulp #1737 PR-2 (this slice — wired Label::paint multi_line path to TextShaper::layout_with_lines when word_break is break-word/anywhere AND bounds().width > 0). Default `normal` keeps the legacy \\n-only split for zero behavior change. Tested end-to-end in test_widgets [issue-1737]: 'Antidisestablishmentarianism' at width 60 with break-word produces multi-line wrapped output (lossless reconstruction), with line-clamp=2 the second line gets the U+2026 ellipsis, and bounds().width==0 falls through to the legacy path (no shaper invocation). The proportional-split heuristic (seg.width / utf8_codepoints per codepoint) trades pixel-perfect break positions for measure-once-reflow-forever cache reuse — CSS Text Module Level 3 §6.1 doesn't require pixel-perfect break positions for soft-wrap.",
+      "notes": "pulp #1434 A4 Bundle 4 (initial flip), pulp #1616 (walked back to partial when audit confirmed paint-path didn't consume the value), pulp #1737 PR-1 (#1795 \u2014 added BreakMode + codepoint-break logic to TextShaper::layout_from_segments), pulp #1737 PR-2 (this slice \u2014 wired Label::paint multi_line path to TextShaper::layout_with_lines when word_break is break-word/anywhere AND bounds().width > 0). Default `normal` keeps the legacy \\n-only split for zero behavior change. Tested end-to-end in test_widgets [issue-1737]: 'Antidisestablishmentarianism' at width 60 with break-word produces multi-line wrapped output (lossless reconstruction), with line-clamp=2 the second line gets the U+2026 ellipsis, and bounds().width==0 falls through to the legacy path (no shaper invocation). The proportional-split heuristic (seg.width / utf8_codepoints per codepoint) trades pixel-perfect break positions for measure-once-reflow-forever cache reuse \u2014 CSS Text Module Level 3 \u00a76.1 doesn't require pixel-perfect break positions for soft-wrap.",
       "issue": ""
     },
     "css/overflowX": {
@@ -2556,16 +2553,16 @@
         "visible",
         "hidden",
         "per-axis clipping (axis-tied per arch-axis-tied-overflow)",
-        "scroll (arch-scroll-via-scrollview — use ScrollView)",
-        "auto (arch-scroll-via-scrollview — use ScrollView)",
-        "clip (arch-scroll-via-scrollview — clipped at View::overflow_=hidden)",
-        "overlay (arch-scroll-via-scrollview — use ScrollView)"
+        "scroll (arch-scroll-via-scrollview \u2014 use ScrollView)",
+        "auto (arch-scroll-via-scrollview \u2014 use ScrollView)",
+        "clip (arch-scroll-via-scrollview \u2014 clipped at View::overflow_=hidden)",
+        "overlay (arch-scroll-via-scrollview \u2014 use ScrollView)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 A4 Bundle 4: status flipped missing → partial. Pulp's View::Overflow enum doesn't model per-axis clipping; CSS overflow-x routes to the same single-axis setter as `overflow`. Wave 4 css extensive — per-axis clipping is arch-axis-tied-overflow (View::overflow_ is a single enum; both axes clip together — authors who need true per-axis behaviour use the ScrollView intrinsic). scroll/auto/clip/overlay are arch-scroll-via-scrollview (the CSS surface only models visible/hidden — scrollable containers go through the dedicated ScrollView widget, mirrors React Native's split).",
+      "notes": "pulp #1434 A4 Bundle 4: status flipped missing \u2192 partial. Pulp's View::Overflow enum doesn't model per-axis clipping; CSS overflow-x routes to the same single-axis setter as `overflow`. Wave 4 css extensive \u2014 per-axis clipping is arch-axis-tied-overflow (View::overflow_ is a single enum; both axes clip together \u2014 authors who need true per-axis behaviour use the ScrollView intrinsic). scroll/auto/clip/overlay are arch-scroll-via-scrollview (the CSS surface only models visible/hidden \u2014 scrollable containers go through the dedicated ScrollView widget, mirrors React Native's split).",
       "issue": ""
     },
     "css/overflowY": {
@@ -2575,16 +2572,16 @@
         "visible",
         "hidden",
         "per-axis clipping (axis-tied per arch-axis-tied-overflow)",
-        "scroll (arch-scroll-via-scrollview — use ScrollView)",
-        "auto (arch-scroll-via-scrollview — use ScrollView)",
-        "clip (arch-scroll-via-scrollview — clipped at View::overflow_=hidden)",
-        "overlay (arch-scroll-via-scrollview — use ScrollView)"
+        "scroll (arch-scroll-via-scrollview \u2014 use ScrollView)",
+        "auto (arch-scroll-via-scrollview \u2014 use ScrollView)",
+        "clip (arch-scroll-via-scrollview \u2014 clipped at View::overflow_=hidden)",
+        "overlay (arch-scroll-via-scrollview \u2014 use ScrollView)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 A4 Bundle 4: status flipped missing → partial. See overflowX note. Wave 4 css extensive — per-axis clipping is arch-axis-tied-overflow (View::overflow_ is a single enum; both axes clip together — authors who need true per-axis behaviour use the ScrollView intrinsic). scroll/auto/clip/overlay are arch-scroll-via-scrollview (the CSS surface only models visible/hidden — scrollable containers go through the dedicated ScrollView widget, mirrors React Native's split).",
+      "notes": "pulp #1434 A4 Bundle 4: status flipped missing \u2192 partial. See overflowX note. Wave 4 css extensive \u2014 per-axis clipping is arch-axis-tied-overflow (View::overflow_ is a single enum; both axes clip together \u2014 authors who need true per-axis behaviour use the ScrollView intrinsic). scroll/auto/clip/overlay are arch-scroll-via-scrollview (the CSS surface only models visible/hidden \u2014 scrollable containers go through the dedicated ScrollView widget, mirrors React Native's split).",
       "issue": ""
     },
     "css/overscrollBehavior": {
@@ -2599,7 +2596,7 @@
       "tests": [
         "unit:test_widget_bridge#issue-1737"
       ],
-      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from wontfix to supported. CSS spec distinguishes auto (chain to parent) vs contain (stop chain, no overscroll) vs none (same plus suppress glow). Pulp does not implement scroll-chaining and has no overscroll glow today, so all three keywords behave as CSS contain — a valid subset of the spec. Specifying contain or none matches CSS behavior exactly; specifying auto gets the stricter contain behavior, which is a no-op surprise but does not violate the spec.",
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from wontfix to supported. CSS spec distinguishes auto (chain to parent) vs contain (stop chain, no overscroll) vs none (same plus suppress glow). Pulp does not implement scroll-chaining and has no overscroll glow today, so all three keywords behave as CSS contain \u2014 a valid subset of the spec. Specifying contain or none matches CSS behavior exactly; specifying auto gets the stricter contain behavior, which is a no-op surprise but does not violate the spec.",
       "issue": ""
     },
     "css/padding": {
@@ -2613,7 +2610,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — % now honored in the shorthand (parity with the per-edge longhands). auto is intentionally dropped because Yoga padding doesn't support it. Wave 4 css extensive — auto is arch-yoga-no-padding-auto (Yoga's padding API is scalar / percent only; the spec-asymmetric margin-auto behavior doesn't apply to padding). Cleared from unsupportedValues — the spec-equivalent default is 0.",
+      "notes": "Wave 2 css.2 \u2014 % now honored in the shorthand (parity with the per-edge longhands). auto is intentionally dropped because Yoga padding doesn't support it. Wave 4 css extensive \u2014 auto is arch-yoga-no-padding-auto (Yoga's padding API is scalar / percent only; the spec-asymmetric margin-auto behavior doesn't apply to padding). Cleared from unsupportedValues \u2014 the spec-equivalent default is 0.",
       "issue": ""
     },
     "css/paddingBlock": {
@@ -2631,7 +2628,7 @@
     },
     "css/paddingBlockEnd": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js maps `padding-block-end` → setFlex(padding_bottom) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges — direction-aware mapping is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js maps `padding-block-end` \u2192 setFlex(padding_bottom) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
       "supportedValues": [
         "<length>",
         "<percentage>",
@@ -2641,12 +2638,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 A4 Bundle 3: status flipped missing → partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/paddingBlockStart": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js maps `padding-block-start` → setFlex(padding_top) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges — direction-aware mapping is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js maps `padding-block-start` \u2192 setFlex(padding_top) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
       "supportedValues": [
         "<length>",
         "<percentage>",
@@ -2656,7 +2653,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 A4 Bundle 3: status flipped missing → partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/paddingBottom": {
@@ -2671,7 +2668,7 @@
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
       "issue": ""
     },
     "css/paddingHorizontal": {
@@ -2686,7 +2683,7 @@
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "css/paddingInline": {
@@ -2704,7 +2701,7 @@
     },
     "css/paddingInlineEnd": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js maps `padding-inline-end` → setFlex(padding_right) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges — direction-aware mapping is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js maps `padding-inline-end` \u2192 setFlex(padding_right) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
       "supportedValues": [
         "<length>",
         "<percentage>",
@@ -2714,12 +2711,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 A4 Bundle 3: status flipped missing → partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/paddingInlineStart": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js maps `padding-inline-start` → setFlex(padding_left) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges — direction-aware mapping is the follow-up.",
+      "mapsTo": "web-compat-style-decl.js maps `padding-inline-start` \u2192 setFlex(padding_left) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
       "supportedValues": [
         "<length>",
         "<percentage>",
@@ -2729,7 +2726,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 A4 Bundle 3: status flipped missing → partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup — LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
       "issue": ""
     },
     "css/paddingLeft": {
@@ -2744,7 +2741,7 @@
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
       "issue": ""
     },
     "css/paddingRight": {
@@ -2759,7 +2756,7 @@
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
       "issue": ""
     },
     "css/paddingTop": {
@@ -2774,7 +2771,7 @@
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
       "issue": ""
     },
     "css/paddingVertical": {
@@ -2789,7 +2786,7 @@
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "css/pageBreakAfter": {
@@ -2816,20 +2813,20 @@
     },
     "css/perspective": {
       "status": "wontfix",
-      "mapsTo": "Architectural — no 3D transform stack. Pulp's View::setTransform is 2D-affine only (geometry.hpp). Adding 3D would be a major engine rewrite.",
+      "mapsTo": "Architectural \u2014 no 3D transform stack. Pulp's View::setTransform is 2D-affine only (geometry.hpp). Adding 3D would be a major engine rewrite.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1737 (CSS NO-OP audit) — reclassified noop → wontfix. Catalog notes already said \"Architecturally out of scope\"; the noop classification was misleading. Direct parallel to css/willChange (already wontfix).",
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Catalog notes already said \"Architecturally out of scope\"; the noop classification was misleading. Direct parallel to css/willChange (already wontfix).",
       "issue": ""
     },
     "css/perspectiveOrigin": {
       "status": "wontfix",
-      "mapsTo": "Architectural — companion to css/perspective. Same wontfix-arch class.",
+      "mapsTo": "Architectural \u2014 companion to css/perspective. Same wontfix-arch class.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1737 (CSS NO-OP audit) — reclassified noop → wontfix. Bundled with css/perspective.",
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Bundled with css/perspective.",
       "issue": ""
     },
     "css/placeContent": {
@@ -2842,7 +2839,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "align_content half is silently dropped (see css/alignContent). Wave 4 css extensive — shorthand parser fans out to setFlex 'align_content' + 'justify_content' (the only two CSS-spec axes that survive in pulp's flex-only layout). Removed the residual 'all' marker — not a CSS-spec value.",
+      "notes": "align_content half is silently dropped (see css/alignContent). Wave 4 css extensive \u2014 shorthand parser fans out to setFlex 'align_content' + 'justify_content' (the only two CSS-spec axes that survive in pulp's flex-only layout). Removed the residual 'all' marker \u2014 not a CSS-spec value.",
       "issue": ""
     },
     "css/placeItems": {
@@ -2855,7 +2852,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Misnamed -- second token is mapped to justify_content rather than justify_items (which Yoga doesn't support). Wave 1 drift cleanup — partial → supported (non-enum, wired through web-compat-style-decl.js with no unsupported values listed).",
+      "notes": "Misnamed -- second token is mapped to justify_content rather than justify_items (which Yoga doesn't support). Wave 1 drift cleanup \u2014 partial \u2192 supported (non-enum, wired through web-compat-style-decl.js with no unsupported values listed).",
       "issue": ""
     },
     "css/pointerEvents": {
@@ -2876,7 +2873,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #13 — catalog trim. CSS spec lists SVG-specific values (visible-painted / visible-fill / visible-stroke / painted / fill / stroke); pulp doesn't render SVG via the renderer surface (SVG is layout-leaf via SvgPath widgets), so those values would be no-ops. Trimmed from the catalog. Wave 4 css extensive — all / visible / visible-painted / visible-fill / visible-stroke are arch-non-svg-renderer (CSS spec defines these for SVG painted regions; pulp doesn't render SVG via the renderer surface — SVG paths go through the SvgPath layout-leaf widget). The bridge maps unknown keywords to View::PointerEvents::auto.",
+      "notes": "pulp #1434 Triage #13 \u2014 catalog trim. CSS spec lists SVG-specific values (visible-painted / visible-fill / visible-stroke / painted / fill / stroke); pulp doesn't render SVG via the renderer surface (SVG is layout-leaf via SvgPath widgets), so those values would be no-ops. Trimmed from the catalog. Wave 4 css extensive \u2014 all / visible / visible-painted / visible-fill / visible-stroke are arch-non-svg-renderer (CSS spec defines these for SVG painted regions; pulp doesn't render SVG via the renderer surface \u2014 SVG paths go through the SvgPath layout-leaf widget). The bridge maps unknown keywords to View::PointerEvents::auto.",
       "issue": ""
     },
     "css/position": {
@@ -2920,16 +2917,16 @@
     },
     "css/resize": {
       "status": "wontfix",
-      "mapsTo": "Architectural — no CSS-resize-handle paint primitive + no overflow:auto drag-router. Same class as the multi-column / table primitives already wontfix under \"non-Yoga layout\" per CLAUDE.md flex+grid layout-model contract.",
+      "mapsTo": "Architectural \u2014 no CSS-resize-handle paint primitive + no overflow:auto drag-router. Same class as the multi-column / table primitives already wontfix under \"non-Yoga layout\" per CLAUDE.md flex+grid layout-model contract.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1737 (CSS NO-OP audit) — reclassified noop → wontfix. Resize handles fall outside the flex+grid layout primitives Pulp commits to.",
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Resize handles fall outside the flex+grid layout primitives Pulp commits to.",
       "issue": ""
     },
     "css/right": {
       "status": "supported",
-      "mapsTo": "setRight(id, px); JS shim resolves em/rem (× 14px default), vh/vw (× 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
+      "mapsTo": "setRight(id, px); JS shim resolves em/rem (\u00d7 14px default), vh/vw (\u00d7 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
       "supportedValues": [
         "px",
         "%",
@@ -2942,12 +2939,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
+      "notes": "Wave 2 css.2 \u2014 em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "css/rowGap": {
       "status": "supported",
-      "mapsTo": "setFlex(id, 'row_gap', px) for numeric, 'NN%' string for percent (best-effort: stored on the scalar FlexStyle.row_gap slot since Yoga has no YGNodeStyleSetGapPercent API yet — treated as px until upstream Yoga ships percent-aware gap).",
+      "mapsTo": "setFlex(id, 'row_gap', px) for numeric, 'NN%' string for percent (best-effort: stored on the scalar FlexStyle.row_gap slot since Yoga has no YGNodeStyleSetGapPercent API yet \u2014 treated as px until upstream Yoga ships percent-aware gap).",
       "supportedValues": [
         "px",
         "% (best-effort scalar)"
@@ -2956,7 +2953,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — % accepted at the JS+bridge layer; honest stored-as-scalar caveat documented above. Status stays partial because Yoga doesn't yet honor percent gaps (px-equivalent only). Wave 4 css extensive — % is best-effort (stored on the scalar slot, treated as px-equivalent) until upstream Yoga ships YGNodeStyleSetGapPercent — tracked as deferred-yoga-percent-gap. Status flipped partial -> supported because every CSS-spec value (px / %) round-trips through the bridge today; the % honoring is the orthogonal Yoga upstream follow-up.",
+      "notes": "Wave 2 css.2 \u2014 % accepted at the JS+bridge layer; honest stored-as-scalar caveat documented above. Status stays partial because Yoga doesn't yet honor percent gaps (px-equivalent only). Wave 4 css extensive \u2014 % is best-effort (stored on the scalar slot, treated as px-equivalent) until upstream Yoga ships YGNodeStyleSetGapPercent \u2014 tracked as deferred-yoga-percent-gap. Status flipped partial -> supported because every CSS-spec value (px / %) round-trips through the bridge today; the % honoring is the orthogonal Yoga upstream follow-up.",
       "issue": ""
     },
     "css/scrollBehavior": {
@@ -2970,34 +2967,34 @@
       "tests": [
         "unit:test_widget_bridge#issue-1737"
       ],
-      "notes": "pulp #1737 (CSS NO-OP audit) — reclassified noop → wontfix. Same \"scroll-via-ScrollView\" rationale as css/overflow scroll/auto/clip.",
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Same \"scroll-via-ScrollView\" rationale as css/overflow scroll/auto/clip.",
       "issue": ""
     },
     "css/scrollMargin": {
       "status": "wontfix",
-      "mapsTo": "Architectural — needs CSS scroll-container model + scroll-snap engine. Multi-element coordination engine parallel to a CSS cascade engine.",
+      "mapsTo": "Architectural \u2014 needs CSS scroll-container model + scroll-snap engine. Multi-element coordination engine parallel to a CSS cascade engine.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1737 (CSS NO-OP audit) — reclassified noop → wontfix. Bundled with the scroll-snap family.",
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Bundled with the scroll-snap family.",
       "issue": ""
     },
     "css/scrollPadding": {
       "status": "wontfix",
-      "mapsTo": "Architectural — same scroll-snap engine prerequisite as css/scrollMargin.",
+      "mapsTo": "Architectural \u2014 same scroll-snap engine prerequisite as css/scrollMargin.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1737 (CSS NO-OP audit) — reclassified noop → wontfix. Bundled with the scroll-snap family.",
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Bundled with the scroll-snap family.",
       "issue": ""
     },
     "css/scrollSnapType": {
       "status": "wontfix",
-      "mapsTo": "Architectural — scroll-snap engine is a multi-element coordination engine (snap-area resolution + snap-strictness state machine) parallel to a CSS cascade engine.",
+      "mapsTo": "Architectural \u2014 scroll-snap engine is a multi-element coordination engine (snap-area resolution + snap-strictness state machine) parallel to a CSS cascade engine.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1737 (CSS NO-OP audit) — reclassified noop → wontfix. Same shape as the stacking-context engine that justified rn/isolation as wontfix in PR #1785.",
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Same shape as the stacking-context engine that justified rn/isolation as wontfix in PR #1785.",
       "issue": ""
     },
     "css/tableLayout": {
@@ -3046,7 +3043,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Single-keyword only. Cannot express 'underline dashed red'. Wave 4 css extensive — blink is arch-deprecated (CSS Text Decoration L3 explicitly deprecates the keyword; modern browsers no-op it for accessibility). The bridge accepts the keyword and applies no decoration — matches the spec deprecation path.",
+      "notes": "Single-keyword only. Cannot express 'underline dashed red'. Wave 4 css extensive \u2014 blink is arch-deprecated (CSS Text Decoration L3 explicitly deprecates the keyword; modern browsers no-op it for accessibility). The bridge accepts the keyword and applies no decoration \u2014 matches the spec deprecation path.",
       "issue": ""
     },
     "css/textDecorationColor": {
@@ -3108,7 +3105,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 A4 Bundle 5: status flipped missing → partial. Storage-only with a dedicated bridge fn. Wave 4 css extensive — <percentage> / each-line / hanging are arch-paint-deferred (SkParagraph::setTextIndent integration at paint time is queued — the bridge stores the keyword + length on View::text_indent_ today and the paint path applies the stored value as a leading inset, so arbitrary first-line / each-line semantics are pending). Authors can express the leading inset today; per-line dispatch is the follow-up.",
+      "notes": "pulp #1434 A4 Bundle 5: status flipped missing \u2192 partial. Storage-only with a dedicated bridge fn. Wave 4 css extensive \u2014 <percentage> / each-line / hanging are arch-paint-deferred (SkParagraph::setTextIndent integration at paint time is queued \u2014 the bridge stores the keyword + length on View::text_indent_ today and the paint path applies the stored value as a leading inset, so arbitrary first-line / each-line semantics are pending). Authors can express the leading inset today; per-line dispatch is the follow-up.",
       "issue": ""
     },
     "css/textOverflow": {
@@ -3123,12 +3120,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — string custom token is accepted at the bridge — setTextOverflow stores the string verbatim; paint-time application of an arbitrary truncation string (in place of the ellipsis glyph) is queued behind SkParagraph support. The bridge round-trip is complete.",
+      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 string custom token is accepted at the bridge \u2014 setTextOverflow stores the string verbatim; paint-time application of an arbitrary truncation string (in place of the ellipsis glyph) is queued behind SkParagraph support. The bridge round-trip is complete.",
       "issue": ""
     },
     "css/textShadow": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js:1356 parses `<dx>px <dy>px <blur>px <color>` and calls setTextShadow(id, dx, dy, blur, color); bridge function is registered (widget_bridge.cpp Wave 5 css.5) and routes into the existing per-attribute slots (text_shadow_offset / text_shadow_radius / text_shadow_color) — same slots the React-style setTextShadow{Color,Offset,Radius} fan-out uses.",
+      "mapsTo": "web-compat-style-decl.js:1356 parses `<dx>px <dy>px <blur>px <color>` and calls setTextShadow(id, dx, dy, blur, color); bridge function is registered (widget_bridge.cpp Wave 5 css.5) and routes into the existing per-attribute slots (text_shadow_offset / text_shadow_radius / text_shadow_color) \u2014 same slots the React-style setTextShadow{Color,Offset,Radius} fan-out uses.",
       "supportedValues": [
         "[inset] <dx>px <dy>px <blur>px [<spread>px] <color> (parsed at the JS shim; bridge fn registration deferred to paint-time)"
       ],
@@ -3136,7 +3133,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 5 css.5 — registered the previously-missing setTextShadow bridge fn so the JS shim no longer no-ops. Composes into the existing 3 per-attribute slots that already round-trip through bridge (color / offset / radius). Catalog stays `supported`: the round-trip is honest. Multi-shadow comma-separated lists are arch-single-shadow (Pulp's text-shadow model is one SkPaint::Looper per Label, matching box-shadow's single-shadow architecture). Inset is parsed but is invalid for text-shadow per CSS L3 (text-shadow has no inset variant) — the JS shim accepts it for shorthand parity but the bridge ignores.",
+      "notes": "Wave 5 css.5 \u2014 registered the previously-missing setTextShadow bridge fn so the JS shim no longer no-ops. Composes into the existing 3 per-attribute slots that already round-trip through bridge (color / offset / radius). Catalog stays `supported`: the round-trip is honest. Multi-shadow comma-separated lists are arch-single-shadow (Pulp's text-shadow model is one SkPaint::Looper per Label, matching box-shadow's single-shadow architecture). Inset is parsed but is invalid for text-shadow per CSS L3 (text-shadow has no inset variant) \u2014 the JS shim accepts it for shorthand parity but the bridge ignores.",
       "issue": ""
     },
     "css/textTransform": {
@@ -3150,7 +3147,7 @@
       ],
       "unsupportedValues": [
         "full-width (ARCH-DEFERRED: requires ICU/Unicode width-transform support outside Pulp's current Skia text path; would need an ICU subsystem to land before this becomes implementable, not a closeable coverage gap on Pulp's intended surface)",
-        "full-size-kana (ARCH-DEFERRED: same — needs Unicode kana-width transform support outside the current text path)"
+        "full-size-kana (ARCH-DEFERRED: same \u2014 needs Unicode kana-width transform support outside the current text path)"
       ],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]",
@@ -3161,7 +3158,7 @@
     },
     "css/top": {
       "status": "supported",
-      "mapsTo": "setTop(id, px); JS shim resolves em/rem (× 14px default), vh/vw (× 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
+      "mapsTo": "setTop(id, px); JS shim resolves em/rem (\u00d7 14px default), vh/vw (\u00d7 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
       "supportedValues": [
         "px",
         "%",
@@ -3174,12 +3171,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 2 css.2 — em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
+      "notes": "Wave 2 css.2 \u2014 em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "css/touchAction": {
       "status": "wontfix",
-      "mapsTo": "architectural — Pulp's gesture model is platform-native (UIKit/AppKit/Android gesture recognizers, audio-plugin custom gesture handlers). touch-action would require a Web-style per-axis touch-router slice (CSS Pointer Events §6) that splits a single touch stream into pan/zoom/scroll channels — Pulp does not have that pipeline.",
+      "mapsTo": "architectural \u2014 Pulp's gesture model is platform-native (UIKit/AppKit/Android gesture recognizers, audio-plugin custom gesture handlers). touch-action would require a Web-style per-axis touch-router slice (CSS Pointer Events \u00a76) that splits a single touch stream into pan/zoom/scroll channels \u2014 Pulp does not have that pipeline.",
       "supportedValues": [],
       "unsupportedValues": [
         "auto",
@@ -3194,12 +3191,12 @@
         "pinch-zoom"
       ],
       "tests": [],
-      "notes": "Architectural OOS per CLAUDE.md / Pulp input model. **Important clarification (Codex P2 on #1794):** `pointer-events` is NOT a drop-in equivalent for `touch-action`. `View::hit_test()` consulting `pointer-events: none` drops the node entirely from hit-testing — the element receives NO pointer events at all. `touch-action: none` is different: the element keeps receiving pointer events, but the user agent is told NOT to apply default touch behaviors (panning, pinch-zoom). So `pointer-events:none` and `touch-action:none` overlap only in the coarse 'this region is not pannable' read; they diverge when an interactive element wants to receive pointer events (drag, draw, custom gesture handling) while suppressing the user-agent's default scroll/zoom interpretation. Pulp expresses that pattern through platform gesture-recognizer APIs (UIKit `UIPanGestureRecognizer`, etc.) rather than CSS touch-action; the bridge accepts but does not honor the CSS keyword. The fine-grained per-axis modes (manipulation, pan-x, pan-y, pinch-zoom) require the Web-style per-axis touch-router that Pulp's input pipeline doesn't have. Same architectural-ceiling reclassification pattern as #1785 (rn/isolation — no stacking-context engine) and #1790 (9 css NO-OPs — no block-flow / table / multi-column / float / print primitives). Counts as OOS in achievable-ceiling math; closed the last css NO-OP entry. Originally `partial` (#1475 walked back to `noop` when audit confirmed no hit-test consumption); flipped to `wontfix` in #1794 with this entry recording the full architectural rationale.",
+      "notes": "Architectural OOS per CLAUDE.md / Pulp input model. **Important clarification (Codex P2 on #1794):** `pointer-events` is NOT a drop-in equivalent for `touch-action`. `View::hit_test()` consulting `pointer-events: none` drops the node entirely from hit-testing \u2014 the element receives NO pointer events at all. `touch-action: none` is different: the element keeps receiving pointer events, but the user agent is told NOT to apply default touch behaviors (panning, pinch-zoom). So `pointer-events:none` and `touch-action:none` overlap only in the coarse 'this region is not pannable' read; they diverge when an interactive element wants to receive pointer events (drag, draw, custom gesture handling) while suppressing the user-agent's default scroll/zoom interpretation. Pulp expresses that pattern through platform gesture-recognizer APIs (UIKit `UIPanGestureRecognizer`, etc.) rather than CSS touch-action; the bridge accepts but does not honor the CSS keyword. The fine-grained per-axis modes (manipulation, pan-x, pan-y, pinch-zoom) require the Web-style per-axis touch-router that Pulp's input pipeline doesn't have. Same architectural-ceiling reclassification pattern as #1785 (rn/isolation \u2014 no stacking-context engine) and #1790 (9 css NO-OPs \u2014 no block-flow / table / multi-column / float / print primitives). Counts as OOS in achievable-ceiling math; closed the last css NO-OP entry. Originally `partial` (#1475 walked back to `noop` when audit confirmed no hit-test consumption); flipped to `wontfix` in #1794 with this entry recording the full architectural rationale.",
       "issue": ""
     },
     "css/transform": {
       "status": "supported",
-      "mapsTo": "parseTransform (css-parser.js) walks the function set; web-compat-style-decl.js dispatches via setTranslate / setRotation / setScale / setSkew. Walk-once accumulator merges axes (e.g. translateX(10) translateY(20) → ONE setTranslate(10,20)).",
+      "mapsTo": "parseTransform (css-parser.js) walks the function set; web-compat-style-decl.js dispatches via setTranslate / setRotation / setScale / setSkew. Walk-once accumulator merges axes (e.g. translateX(10) translateY(20) \u2192 ONE setTranslate(10,20)).",
       "supportedValues": [
         "translate(x,y)",
         "translateX(x)",
@@ -3212,7 +3209,7 @@
         "scaleY(n)",
         "skewX(deg)",
         "skewY(deg)",
-        "matrix(a,b,c,d,tx,ty) — decomposed to translate+scale+rotate",
+        "matrix(a,b,c,d,tx,ty) \u2014 decomposed to translate+scale+rotate",
         "angle units: deg / rad / turn / grad"
       ],
       "unsupportedValues": [],
@@ -3221,7 +3218,7 @@
         "test/web-compat/test_web_compat_prelude.cpp::\"WebCompat: setSkew bridge fn registered\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #9 fan-out — full CSS transform-function set wired via parseTransform walk-once accumulator. setSkew bridge fn registered; scaleX/scaleY share uniform setScale slot (last-write-wins; bridge gap); matrix() decomposed to translate+scale+rotate. rotateX / rotateY / matrix3d / perspective silently drop (pulp's 2D View has no 3D model). Deferred: rotateX/rotateY/matrix3d/perspective (no 3D model on View — pulp follow-up).",
+      "notes": "pulp #1434 Triage #9 fan-out \u2014 full CSS transform-function set wired via parseTransform walk-once accumulator. setSkew bridge fn registered; scaleX/scaleY share uniform setScale slot (last-write-wins; bridge gap); matrix() decomposed to translate+scale+rotate. rotateX / rotateY / matrix3d / perspective silently drop (pulp's 2D View has no 3D model). Deferred: rotateX/rotateY/matrix3d/perspective (no 3D model on View \u2014 pulp follow-up).",
       "issue": ""
     },
     "css/transformOrigin": {
@@ -3242,7 +3239,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Px values are mishandled -- only % and keywords resolve correctly. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — px is supported via the parseCSSLength path (numeric forwards as scalar to setTransformOrigin). third value (z-axis) is arch-2d-only — pulp's transform pipeline is 2D (Skia matrix is 2D); 3D transforms render in the layer's 2D projection per arch-2d-only.",
+      "notes": "Px values are mishandled -- only % and keywords resolve correctly. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 px is supported via the parseCSSLength path (numeric forwards as scalar to setTransformOrigin). third value (z-axis) is arch-2d-only \u2014 pulp's transform pipeline is 2D (Skia matrix is 2D); 3D transforms render in the layer's 2D projection per arch-2d-only.",
       "issue": ""
     },
     "css/transition": {
@@ -3264,7 +3261,7 @@
         "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-1 — transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
+      "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
       "issue": "1323"
     },
     "css/transitionDelay": {
@@ -3286,7 +3283,7 @@
         "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-1 — transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
+      "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
       "issue": ""
     },
     "css/transitionDuration": {
@@ -3308,7 +3305,7 @@
         "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-1 — transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
+      "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
       "issue": ""
     },
     "css/transitionProperty": {
@@ -3330,7 +3327,7 @@
         "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-1 — transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
+      "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
       "issue": ""
     },
     "css/transitionTimingFunction": {
@@ -3352,7 +3349,7 @@
         "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-1 — transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
+      "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
       "issue": ""
     },
     "css/userSelect": {
@@ -3369,7 +3366,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1656-tier2-userSelect]"
       ],
-      "notes": "pulp #1538 / #1656 Tier-2 follow-up — bridge `setUserSelect` now actually stores the keyword on `View::user_select_` (storage slot for downstream widgets to read). Round-trip verified end-to-end through `CSSStyleDeclaration._applyProperty`. Selection-blocking behavior in TextEditor / Label is the next slice (storage exists; widgets need to read it before suppressing selection events).",
+      "notes": "pulp #1538 / #1656 Tier-2 follow-up \u2014 bridge `setUserSelect` now actually stores the keyword on `View::user_select_` (storage slot for downstream widgets to read). Round-trip verified end-to-end through `CSSStyleDeclaration._applyProperty`. Selection-blocking behavior in TextEditor / Label is the next slice (storage exists; widgets need to read it before suppressing selection events).",
       "issue": ""
     },
     "css/verticalAlign": {
@@ -3391,7 +3388,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 A4 Bundle 5: status flipped missing → partial. Routes to the existing TextVerticalAlign enum on Label. Wave 4 css extensive — sub / super / text-top / text-bottom / <length> / <percentage> are arch-paint-deferred — the bridge stores the keyword on View::vertical_align_ and the paint pipeline today applies the four canonical canvas::TextBaseline values (top / middle / bottom / baseline); the extended set is queued behind SkParagraph baseline shift integration. Round-trip is complete.",
+      "notes": "pulp #1434 A4 Bundle 5: status flipped missing \u2192 partial. Routes to the existing TextVerticalAlign enum on Label. Wave 4 css extensive \u2014 sub / super / text-top / text-bottom / <length> / <percentage> are arch-paint-deferred \u2014 the bridge stores the keyword on View::vertical_align_ and the paint pipeline today applies the four canonical canvas::TextBaseline values (top / middle / bottom / baseline); the extended set is queued behind SkParagraph baseline shift integration. Round-trip is complete.",
       "issue": ""
     },
     "css/visibility": {
@@ -3406,12 +3403,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "setVisibility IS registered (widget_bridge.cpp:1814) so the primary path works. Wave 4 css extensive — collapse is arch-table-only — the CSS spec explicitly defines it as equivalent to `hidden` outside of table-row / table-column contexts; pulp's flex-only layout is non-table by design (arch-flex-only) so the spec-equivalent collapse->hidden mapping is the spec-conformant rendering.",
+      "notes": "setVisibility IS registered (widget_bridge.cpp:1814) so the primary path works. Wave 4 css extensive \u2014 collapse is arch-table-only \u2014 the CSS spec explicitly defines it as equivalent to `hidden` outside of table-row / table-column contexts; pulp's flex-only layout is non-table by design (arch-flex-only) so the spec-equivalent collapse->hidden mapping is the spec-conformant rendering.",
       "issue": ""
     },
     "css/webkitLineClamp": {
       "status": "supported",
-      "mapsTo": "same as lineClamp — both keys funnel through setLineClamp(id, n)",
+      "mapsTo": "same as lineClamp \u2014 both keys funnel through setLineClamp(id, n)",
       "supportedValues": [
         "integer"
       ],
@@ -3428,7 +3425,7 @@
     },
     "css/whiteSpace": {
       "status": "supported",
-      "mapsTo": "setWhiteSpace(id, value) — bridge widget_bridge.cpp:2478 maps the keyword to View::WhiteSpaceMode enum (normal / nowrap / pre / pre_wrap / pre_line / break_spaces). The legacy white_space_nowrap() bool is maintained in lock-step (true for {nowrap, pre}) so existing TextShaper consumers keep working. Label.multi_line is toggled per spec semantics: pre/nowrap → no wrap; normal/pre-wrap/pre-line/break-spaces → wrap.",
+      "mapsTo": "setWhiteSpace(id, value) \u2014 bridge widget_bridge.cpp:2478 maps the keyword to View::WhiteSpaceMode enum (normal / nowrap / pre / pre_wrap / pre_line / break_spaces). The legacy white_space_nowrap() bool is maintained in lock-step (true for {nowrap, pre}) so existing TextShaper consumers keep working. Label.multi_line is toggled per spec semantics: pre/nowrap \u2192 no wrap; normal/pre-wrap/pre-line/break-spaces \u2192 wrap.",
       "supportedValues": [
         "normal",
         "nowrap",
@@ -3442,7 +3439,7 @@
         "test/test_widget_bridge.cpp [issue-1410]",
         "test/test_widget_bridge.cpp [issue-1737]"
       ],
-      "notes": "pulp #1737 — full WhiteSpaceMode enum wired end-to-end. Bridge maps all 6 CSS keywords to the matching enum value; Label.multi_line is toggled per spec (no wrap for nowrap/pre, wrap for the other 4). Whitespace preservation is consumed by the existing Label render path which splits on `\\n` for multi-line modes. break-spaces' extra-break-opportunity refinement degrades to pre-wrap rendering today — same render output, slightly different break behaviour at long-word boundaries — tracked as a paint-side follow-up but not a catalog-level gap because the supportedValues claim is keyword coverage + multi_line semantics. Each keyword has a regression test asserting both white_space_mode() and multi_line() reach the spec-correct values; unknown keywords fall back to normal per CSS forward-compat.",
+      "notes": "pulp #1737 \u2014 full WhiteSpaceMode enum wired end-to-end. Bridge maps all 6 CSS keywords to the matching enum value; Label.multi_line is toggled per spec (no wrap for nowrap/pre, wrap for the other 4). Whitespace preservation is consumed by the existing Label render path which splits on `\\n` for multi-line modes. break-spaces' extra-break-opportunity refinement degrades to pre-wrap rendering today \u2014 same render output, slightly different break behaviour at long-word boundaries \u2014 tracked as a paint-side follow-up but not a catalog-level gap because the supportedValues claim is keyword coverage + multi_line semantics. Each keyword has a regression test asserting both white_space_mode() and multi_line() reach the spec-correct values; unknown keywords fall back to normal per CSS forward-compat.",
       "issue": ""
     },
     "css/width": {
@@ -3463,7 +3460,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1423 wired px + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end (CSS translator forwards 'auto' verbatim; bridge populates FlexStyle.dim_width.unit = auto_; yoga_layout.cpp dispatches to YGNodeStyleSetWidthAuto). Relative units (em/rem/calc) remain deferred. Wave 1 architectural reclassification — min-content / max-content / fit-content are arch-yoga-limit (Yoga doesn't compute content-sized boxes); em/rem/calc() are deferred (relative-unit resolver lands later — calc() shipped via #1576 for min/max sides only). Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — min-content / max-content / fit-content are arch-yoga-no-intrinsic-sizing (Yoga's flex layout doesn't model intrinsic sizing; use flex / flex-basis for the equivalent shrink-to-fit behaviour). calc() is arch-no-calc-eval (no expression evaluator at the JS shim layer; authors precompute or use JS variables). em/rem resolve against the default 14px font-size at the JS layer (single-level cascade per Wave 2 css.2 fontSize precedent).",
+      "notes": "pulp #1423 wired px + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end (CSS translator forwards 'auto' verbatim; bridge populates FlexStyle.dim_width.unit = auto_; yoga_layout.cpp dispatches to YGNodeStyleSetWidthAuto). Relative units (em/rem/calc) remain deferred. Wave 1 architectural reclassification \u2014 min-content / max-content / fit-content are arch-yoga-limit (Yoga doesn't compute content-sized boxes); em/rem/calc() are deferred (relative-unit resolver lands later \u2014 calc() shipped via #1576 for min/max sides only). Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 min-content / max-content / fit-content are arch-yoga-no-intrinsic-sizing (Yoga's flex layout doesn't model intrinsic sizing; use flex / flex-basis for the equivalent shrink-to-fit behaviour). calc() is arch-no-calc-eval (no expression evaluator at the JS shim layer; authors precompute or use JS variables). em/rem resolve against the default 14px font-size at the JS layer (single-level cascade per Wave 2 css.2 fontSize precedent).",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "css/willChange": {
@@ -3505,16 +3502,16 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 batch (catalog hygiene): status flipped missing -> partial. CSS translator at web-compat-style-decl.js:728-729 funnels `wordWrap`, `overflowWrap`, and `wordBreak` through the same setWordBreak case. Bridge function is not yet registered, so values are silently dropped at runtime. Legacy alias of overflow-wrap. Wave 4 css extensive — stale claim — break-word/normal/anywhere all reach setWordBreak via the same shared route as wordBreak/overflowWrap (web-compat-style-decl.js funnels three cases into the same call). The bridge fn IS registered (widget_bridge.cpp:4983); HarfBuzz line-break feature integration is the shared paint-side follow-up.",
+      "notes": "pulp #1434 batch (catalog hygiene): status flipped missing -> partial. CSS translator at web-compat-style-decl.js:728-729 funnels `wordWrap`, `overflowWrap`, and `wordBreak` through the same setWordBreak case. Bridge function is not yet registered, so values are silently dropped at runtime. Legacy alias of overflow-wrap. Wave 4 css extensive \u2014 stale claim \u2014 break-word/normal/anywhere all reach setWordBreak via the same shared route as wordBreak/overflowWrap (web-compat-style-decl.js funnels three cases into the same call). The bridge fn IS registered (widget_bridge.cpp:4983); HarfBuzz line-break feature integration is the shared paint-side follow-up.",
       "issue": ""
     },
     "css/writingMode": {
       "status": "wontfix",
-      "mapsTo": "Architectural — Pulp's TextShaper is horizontal-tb only; vertical writing requires a separate text-layout pipeline in HarfBuzz/SkParagraph.",
+      "mapsTo": "Architectural \u2014 Pulp's TextShaper is horizontal-tb only; vertical writing requires a separate text-layout pipeline in HarfBuzz/SkParagraph.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "pulp #1737 (CSS NO-OP audit) — reclassified noop → wontfix. Catalog text already said \"Architecturally out of scope\"; the noop classification was misleading.",
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Catalog text already said \"Architecturally out of scope\"; the noop classification was misleading.",
       "issue": ""
     },
     "css/zIndex": {
@@ -3528,7 +3525,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "'auto' parses as 0. Wave 1 drift cleanup — supported → partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive — `auto` parses as 0 at the JS layer (the integer slot is 0 by default; auto matches the layout-natural ordering). Round-trip is complete.",
+      "notes": "'auto' parses as 0. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 `auto` parses as 0 at the JS layer (the integer slot is 0 by default; auto matches the layout-natural ordering). Round-trip is complete.",
       "issue": ""
     },
     "css/appearance": {
@@ -3571,12 +3568,12 @@
         "test/test_widget_bridge.cpp [issue-1707-followup-maskSize]",
         "unit:test_view#issue-1515"
       ],
-      "notes": "pulp #1515 (storage), pulp #1737 PR-3 (paint slice). Bridge stores via setMaskSize; View::paint_all forwards the value to Canvas::save_layer_with_mask alongside mask_image. SkiaCanvas parses the value (auto/cover/contain → 1.0 multiplier; <percentage> → /100; <length> in px → /bound) and applies the resulting (width_factor, height_factor) to the gradient endpoint span before building the SkShader. The 2-saveLayer + SkBlendMode::kDstIn composite at restore() time keeps only the alpha the mask permits — same architectural pattern Chromium uses for CSS Masking Module Level 1 §5. Phase 1 paints linear-gradient masks fully; radial-gradient and url() image masks fall through to the no-mask path safely (matches pre-#1737 behavior — content paints unchanged, mask silently bypassed). Tested end-to-end in test_view [issue-1515]: the spy canvas verifies the API dispatch with the exact mask_image + mask_size strings.",
+      "notes": "pulp #1515 (storage), pulp #1737 PR-3 (paint slice). Bridge stores via setMaskSize; View::paint_all forwards the value to Canvas::save_layer_with_mask alongside mask_image. SkiaCanvas parses the value (auto/cover/contain \u2192 1.0 multiplier; <percentage> \u2192 /100; <length> in px \u2192 /bound) and applies the resulting (width_factor, height_factor) to the gradient endpoint span before building the SkShader. The 2-saveLayer + SkBlendMode::kDstIn composite at restore() time keeps only the alpha the mask permits \u2014 same architectural pattern Chromium uses for CSS Masking Module Level 1 \u00a75. Phase 1 paints linear-gradient masks fully; radial-gradient and url() image masks fall through to the no-mask path safely (matches pre-#1737 behavior \u2014 content paints unchanged, mask silently bypassed). Tested end-to-end in test_view [issue-1515]: the spy canvas verifies the API dispatch with the exact mask_image + mask_size strings.",
       "issue": "1515"
     },
     "css/objectFit": {
       "status": "supported",
-      "mapsTo": "el.style.objectFit -> setObjectFit(id, value) -> View::object_fit_. pulp #1737 — ImageView::paint now consumes the value: probes intrinsic image dimensions via Canvas::measure_image_from_file (Skia override consults SkImage header without forcing decode), computes a fit rect per spec, then routes through draw_image_from_file (full src) or draw_image_from_file_rect (cropped src for `none`/`cover` overflow). Backends without measure_image_from_file fall back to the pre-#1737 stretch-to-bounds path (object-fit: fill).",
+      "mapsTo": "el.style.objectFit -> setObjectFit(id, value) -> View::object_fit_. pulp #1737 \u2014 ImageView::paint now consumes the value: probes intrinsic image dimensions via Canvas::measure_image_from_file (Skia override consults SkImage header without forcing decode), computes a fit rect per spec, then routes through draw_image_from_file (full src) or draw_image_from_file_rect (cropped src for `none`/`cover` overflow). Backends without measure_image_from_file fall back to the pre-#1737 stretch-to-bounds path (object-fit: fill).",
       "supportedValues": [
         "fill",
         "contain",
@@ -3589,11 +3586,11 @@
         "test/test_widget_bridge.cpp [issue-1707-followup-objectFit]",
         "test/test_image_view_cache.cpp [object-fit][issue-1737]"
       ],
-      "notes": "pulp #1737 — wired end-to-end: Canvas::measure_image_from_file API + ImageView::paint compute_fit lambda + Skia override using SkImages::DeferredFromEncodedData (peek SkImage header). Per CSS spec: `fill` stretches; `contain` letterboxes preserving AR; `cover` crops to fill the larger axis; `none` paints native size centred (with src-rect crop when image overflows the box); `scale-down` chooses `none` if smaller, else `contain`."
+      "notes": "pulp #1737 \u2014 wired end-to-end: Canvas::measure_image_from_file API + ImageView::paint compute_fit lambda + Skia override using SkImages::DeferredFromEncodedData (peek SkImage header). Per CSS spec: `fill` stretches; `contain` letterboxes preserving AR; `cover` crops to fill the larger axis; `none` paints native size centred (with src-rect crop when image overflows the box); `scale-down` chooses `none` if smaller, else `contain`."
     },
     "css/objectPosition": {
       "status": "supported",
-      "mapsTo": "el.style.objectPosition -> setObjectPosition(id, value) -> View::object_position_. pulp #1737 — ImageView::paint parses `<x> <y>` two-token strings (`%`, bare numbers, or px lengths) and offsets the centred dst rect within the box. CSS percentage form is implemented per spec: `0%` pins to the start, `100%` to the end (slack-relative).",
+      "mapsTo": "el.style.objectPosition -> setObjectPosition(id, value) -> View::object_position_. pulp #1737 \u2014 ImageView::paint parses `<x> <y>` two-token strings (`%`, bare numbers, or px lengths) and offsets the centred dst rect within the box. CSS percentage form is implemented per spec: `0%` pins to the start, `100%` to the end (slack-relative).",
       "supportedValues": [
         "<percentage> <percentage>",
         "<length> <length>",
@@ -3604,11 +3601,11 @@
         "test/test_widget_bridge.cpp [issue-1707-followup-objectPosition]",
         "test/test_image_view_cache.cpp [object-position][issue-1737]"
       ],
-      "notes": "pulp #1737 — paired with object-fit, consumed by ImageView::paint after compute_fit. Slack-based percentage interpretation matches the spec; lengths are converted to a percentage of the slack so they compose with the centred-default fit rect."
+      "notes": "pulp #1737 \u2014 paired with object-fit, consumed by ImageView::paint after compute_fit. Slack-based percentage interpretation matches the spec; lengths are converted to a percentage of the slack so they compose with the centred-default fit rect."
     },
     "css/grid": {
       "status": "supported",
-      "mapsTo": "el.style.grid -> JS-shim parses `<rows> / <cols>` form and fans out to setGrid(id, 'template_rows', ...) + setGrid(id, 'template_columns', ...). Full grid shorthand spec (auto-flow forms, embedded template-areas, dense packing) is deferred — authors can use the existing longhand grid-template-{rows,columns,areas} + grid-auto-{rows,columns,flow} entries directly.",
+      "mapsTo": "el.style.grid -> JS-shim parses `<rows> / <cols>` form and fans out to setGrid(id, 'template_rows', ...) + setGrid(id, 'template_columns', ...). Full grid shorthand spec (auto-flow forms, embedded template-areas, dense packing) is deferred \u2014 authors can use the existing longhand grid-template-{rows,columns,areas} + grid-auto-{rows,columns,flow} entries directly.",
       "supportedValues": [
         "<rows> / <cols>",
         "none",
@@ -3618,7 +3615,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1707-followup-grid]"
       ],
-      "notes": "Common `<rows> / <cols>` form parsed; longhand fan-out to existing grid-template-{rows,columns} entries which are already supported. Status `partial` is honest until full shorthand parser ships. Most imported designs use the simple form; complex auto-flow shorthands are rare in practice. arch-grid-ceiling — `auto-flow [dense]?`, embedded template-areas, and `subgrid` exceed Yoga 3.x grid feature set; they are deferred until Yoga adds the API. Authors needing those forms should use the longhand grid-template-{rows,columns,areas} and grid-auto-{rows,columns,flow} entries directly. The catalog claim of `supported` reflects the basic <rows> / <cols> form which is the common case."
+      "notes": "Common `<rows> / <cols>` form parsed; longhand fan-out to existing grid-template-{rows,columns} entries which are already supported. Status `partial` is honest until full shorthand parser ships. Most imported designs use the simple form; complex auto-flow shorthands are rare in practice. arch-grid-ceiling \u2014 `auto-flow [dense]?`, embedded template-areas, and `subgrid` exceed Yoga 3.x grid feature set; they are deferred until Yoga adds the API. Authors needing those forms should use the longhand grid-template-{rows,columns,areas} and grid-auto-{rows,columns,flow} entries directly. The catalog claim of `supported` reflects the basic <rows> / <cols> form which is the common case."
     }
   },
   "rn": {
@@ -3693,7 +3690,7 @@
         "packages/pulp-react/test/prop-applier-aspect-ratio.test.ts",
         "test/web-compat/test_layout_aspect_ratio.cpp"
       ],
-      "notes": "pulp #1434 — JSX surface accepts numeric aspectRatio (RN parity per oracle 'kind: number'). String forms ('16/9', 'auto') reach FlexStyle through the CSS shim path (web-compat-style-decl.js), not the @pulp/react TS surface.",
+      "notes": "pulp #1434 \u2014 JSX surface accepts numeric aspectRatio (RN parity per oracle 'kind: number'). String forms ('16/9', 'auto') reach FlexStyle through the CSS shim path (web-compat-style-decl.js), not the @pulp/react TS surface.",
       "issue": "1434"
     },
     "rn/backfaceVisibility": {
@@ -3708,7 +3705,7 @@
         "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) — bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
+      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) \u2014 bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
       "issue": ""
     },
     "rn/backgroundColor": {
@@ -3733,7 +3730,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
       "issue": ""
     },
     "rn/borderBottomColor": {
@@ -3758,7 +3755,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
       "issue": ""
     },
     "rn/borderBottomLeftRadius": {
@@ -3773,7 +3770,7 @@
         "packages/pulp-react/test/prop-applier-wave2.test.ts",
         "test/test_widget_bridge.cpp [issue-1663][borderradius-pct]"
       ],
-      "notes": "Same. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues. pulp #1663 wired %: bridge accepts \"NN%\" string, View stores in corner_radius_pct_ slot, paint-time effective_corner_radius() resolves against current bounds. Test backing at [view][bridge][rn][issue-1663][borderradius-pct].",
+      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues. pulp #1663 wired %: bridge accepts \"NN%\" string, View stores in corner_radius_pct_ slot, paint-time effective_corner_radius() resolves against current bounds. Test backing at [view][bridge][rn][issue-1663][borderradius-pct].",
       "issue": ""
     },
     "rn/borderBottomRightRadius": {
@@ -3788,7 +3785,7 @@
         "packages/pulp-react/test/prop-applier-wave2.test.ts",
         "test/test_widget_bridge.cpp [issue-1663][borderradius-pct]"
       ],
-      "notes": "Same. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues. pulp #1663 wired %: bridge accepts \"NN%\" string, View stores in corner_radius_pct_ slot, paint-time effective_corner_radius() resolves against current bounds. Test backing at [view][bridge][rn][issue-1663][borderradius-pct].",
+      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues. pulp #1663 wired %: bridge accepts \"NN%\" string, View stores in corner_radius_pct_ slot, paint-time effective_corner_radius() resolves against current bounds. Test backing at [view][bridge][rn][issue-1663][borderradius-pct].",
       "issue": ""
     },
     "rn/borderBottomWidth": {
@@ -3801,7 +3798,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "RN prop is flat top-level, Pulp uses object shape. Convert: <View style={{borderBottomWidth: 2}} /> -> <View borderBottom={{color:'#000', width:2}} />. Awkward for RN ports. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only — em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
+      "notes": "RN prop is flat top-level, Pulp uses object shape. Convert: <View style={{borderBottomWidth: 2}} /> -> <View borderBottom={{color:'#000', width:2}} />. Awkward for RN ports. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
       "issue": ""
     },
     "rn/borderColor": {
@@ -3826,12 +3823,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
       "issue": ""
     },
     "rn/borderCurve": {
       "status": "supported",
-      "mapsTo": "prop-applier.ts -> setBorderCurve(id, kw) -> View::set_border_curve(BorderCurve::continuous|circular). View::paint_all dispatches between build_per_corner_rounded_rect_path (circular — standard kappa 0.5522 quarter-circle bezier) and build_continuous_corner_rounded_rect_path (continuous — extension 1.528, flatter kappa 0.85 producing the iOS-style squircle approximation).",
+      "mapsTo": "prop-applier.ts -> setBorderCurve(id, kw) -> View::set_border_curve(BorderCurve::continuous|circular). View::paint_all dispatches between build_per_corner_rounded_rect_path (circular \u2014 standard kappa 0.5522 quarter-circle bezier) and build_continuous_corner_rounded_rect_path (continuous \u2014 extension 1.528, flatter kappa 0.85 producing the iOS-style squircle approximation).",
       "supportedValues": [
         "circular",
         "continuous"
@@ -3840,12 +3837,12 @@
       "tests": [
         "unit:test_widget_bridge#issue-1737"
       ],
-      "notes": "pulp #1737 RN-OOS-fixup #1812: walked back from wontfix to supported. `circular` (default) uses Pulp's standard quarter-circle bezier rounded corner — bit-identical to pre-PR behavior. `continuous` switches to a super-ellipse path approximation that extends each corner curve to ~1.528R from the vertex with a flatter cubic profile (kappa 0.85 vs 0.5522 for circular). This is a single-cubic approximation of Apple's continuousCornerShape — Figma uses similar math for its \"smooth corners\" feature. Result is visually a recognizable iOS squircle on large-radius cards (24px+); subtle vs circular below 12px. Pixel-perfect Apple replication would need a multi-cubic path (or a quintic polynomial); the catalog claim is \"Apple-style continuous corner approximation\" not \"bit-identical to native iOS renderer\". When R approaches half-axis, the clamp tightens to half-axis/extension to prevent path self-intersection from the elongated curve.",
+      "notes": "pulp #1737 RN-OOS-fixup #1812: walked back from wontfix to supported. `circular` (default) uses Pulp's standard quarter-circle bezier rounded corner \u2014 bit-identical to pre-PR behavior. `continuous` switches to a super-ellipse path approximation that extends each corner curve to ~1.528R from the vertex with a flatter cubic profile (kappa 0.85 vs 0.5522 for circular). This is a single-cubic approximation of Apple's continuousCornerShape \u2014 Figma uses similar math for its \"smooth corners\" feature. Result is visually a recognizable iOS squircle on large-radius cards (24px+); subtle vs circular below 12px. Pixel-perfect Apple replication would need a multi-cubic path (or a quintic polynomial); the catalog claim is \"Apple-style continuous corner approximation\" not \"bit-identical to native iOS renderer\". When R approaches half-axis, the clamp tightens to half-axis/extension to prevent path self-intersection from the elongated curve.",
       "issue": ""
     },
     "rn/borderEndWidth": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier — End → Right under LTR; routes to setBorderRightWidth.",
+      "mapsTo": "@pulp/react prop-applier \u2014 End \u2192 Right under LTR; routes to setBorderRightWidth.",
       "supportedValues": [
         "number (px)"
       ],
@@ -3854,7 +3851,7 @@
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/borderLeftColor": {
@@ -3879,7 +3876,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
       "issue": ""
     },
     "rn/borderLeftWidth": {
@@ -3892,7 +3889,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Same as borderBottomWidth. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only — em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
+      "notes": "Same as borderBottomWidth. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
       "issue": ""
     },
     "rn/borderRadius": {
@@ -3907,7 +3904,7 @@
         "packages/pulp-react/test/prop-applier-wave2.test.ts",
         "test/test_widget_bridge.cpp [issue-1663][borderradius-pct]"
       ],
-      "notes": "Workaround: <View border={{color:'transparent', width:0, radius:R}} />. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full elliptical rrect rendering is a deferred paint-side gap). pulp #1663 wired %: bridge accepts \"NN%\" string, View stores in corner_radius_pct_ slot, paint-time effective_corner_radius() resolves against current bounds. Test backing at [view][bridge][rn][issue-1663][borderradius-pct].",
+      "notes": "Workaround: <View border={{color:'transparent', width:0, radius:R}} />. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full elliptical rrect rendering is a deferred paint-side gap). pulp #1663 wired %: bridge accepts \"NN%\" string, View stores in corner_radius_pct_ slot, paint-time effective_corner_radius() resolves against current bounds. Test backing at [view][bridge][rn][issue-1663][borderradius-pct].",
       "issue": ""
     },
     "rn/borderRightColor": {
@@ -3932,7 +3929,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
       "issue": ""
     },
     "rn/borderRightWidth": {
@@ -3945,12 +3942,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Same. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only — em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
+      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
       "issue": ""
     },
     "rn/borderStartWidth": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier — Start → Left under LTR; routes to setBorderLeftWidth.",
+      "mapsTo": "@pulp/react prop-applier \u2014 Start \u2192 Left under LTR; routes to setBorderLeftWidth.",
       "supportedValues": [
         "number (px)"
       ],
@@ -3959,7 +3956,7 @@
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/borderStyle": {
@@ -3982,7 +3979,7 @@
         "packages/pulp-react/test/prop-applier-border-style.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #10 — Skia paint installs SkDashPathEffect for dashed/dotted (CG falls through to solid via the canvas-base no-op set_line_dash). View::BorderStyle enum stores the keyword; bridge maps strings; Skia honors at stroke time. Other named styles (double/groove/ridge/inset/outset) currently degrade to solid — paint-side compositions are a follow-up. none/hidden short-circuit the stroke entirely.",
+      "notes": "pulp #1434 Triage #10 \u2014 Skia paint installs SkDashPathEffect for dashed/dotted (CG falls through to solid via the canvas-base no-op set_line_dash). View::BorderStyle enum stores the keyword; bridge maps strings; Skia honors at stroke time. Other named styles (double/groove/ridge/inset/outset) currently degrade to solid \u2014 paint-side compositions are a follow-up. none/hidden short-circuit the stroke entirely.",
       "issue": ""
     },
     "rn/borderTopColor": {
@@ -4007,7 +4004,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
       "issue": ""
     },
     "rn/borderTopLeftRadius": {
@@ -4022,7 +4019,7 @@
         "packages/pulp-react/test/prop-applier-wave2.test.ts",
         "test/test_widget_bridge.cpp [issue-1663][borderradius-pct]"
       ],
-      "notes": "Bridge has setBorderTopLeftRadius -- needs prop wiring. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues. pulp #1663 wired %: bridge accepts \"NN%\" string, View stores in corner_radius_pct_ slot, paint-time effective_corner_radius() resolves against current bounds. Test backing at [view][bridge][rn][issue-1663][borderradius-pct].",
+      "notes": "Bridge has setBorderTopLeftRadius -- needs prop wiring. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues. pulp #1663 wired %: bridge accepts \"NN%\" string, View stores in corner_radius_pct_ slot, paint-time effective_corner_radius() resolves against current bounds. Test backing at [view][bridge][rn][issue-1663][borderradius-pct].",
       "issue": ""
     },
     "rn/borderTopRightRadius": {
@@ -4037,7 +4034,7 @@
         "packages/pulp-react/test/prop-applier-wave2.test.ts",
         "test/test_widget_bridge.cpp [issue-1663][borderradius-pct]"
       ],
-      "notes": "Same. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues. pulp #1663 wired %: bridge accepts \"NN%\" string, View stores in corner_radius_pct_ slot, paint-time effective_corner_radius() resolves against current bounds. Test backing at [view][bridge][rn][issue-1663][borderradius-pct].",
+      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues. pulp #1663 wired %: bridge accepts \"NN%\" string, View stores in corner_radius_pct_ slot, paint-time effective_corner_radius() resolves against current bounds. Test backing at [view][bridge][rn][issue-1663][borderradius-pct].",
       "issue": ""
     },
     "rn/borderTopWidth": {
@@ -4050,7 +4047,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Same as borderBottomWidth. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only — em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
+      "notes": "Same as borderBottomWidth. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
       "issue": ""
     },
     "rn/borderWidth": {
@@ -4063,7 +4060,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "User can call <View border={{color:'#000', width:N}} /> as workaround. pulp #1434: catalog hygiene — flipped missing → supported. Wave 2 rn — dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only — em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
+      "notes": "User can call <View border={{color:'#000', width:N}} /> as workaround. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
       "issue": ""
     },
     "rn/bottom": {
@@ -4097,7 +4094,7 @@
         "packages/pulp-react/test/prop-applier-wave4.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "All forms wired: 'none' (clears), CSS string (single + multi-shadow paren-aware split), object form { offsetX, offsetY, blur?, spread?, color, inset? }, AND RN Fabric BoxShadowValue[] array form (prop-applier.ts:877-894 — clears first, dispatches one setBoxShadow per shadow with blurRadius/spreadDistance preferred over blur/spread). All 4 forms tested in prop-applier-wave4.test.ts. Closes pulp #1664 — catalog was stale citing array form as gap when it was actually wired by Wave 4 #1651.",
+      "notes": "All forms wired: 'none' (clears), CSS string (single + multi-shadow paren-aware split), object form { offsetX, offsetY, blur?, spread?, color, inset? }, AND RN Fabric BoxShadowValue[] array form (prop-applier.ts:877-894 \u2014 clears first, dispatches one setBoxShadow per shadow with blurRadius/spreadDistance preferred over blur/spread). All 4 forms tested in prop-applier-wave4.test.ts. Closes pulp #1664 \u2014 catalog was stale citing array form as gap when it was actually wired by Wave 4 #1651.",
       "issue": ""
     },
     "rn/boxSizing": {
@@ -4137,7 +4134,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #8 — modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
       "issue": ""
     },
     "rn/columnGap": {
@@ -4155,7 +4152,7 @@
     },
     "rn/cursor": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier forwards keyword to setCursor (prop-applier.ts:749 → widget_bridge.cpp:4007); bridge maps CSS keywords onto View::CursorStyle slots.",
+      "mapsTo": "@pulp/react prop-applier forwards keyword to setCursor (prop-applier.ts:749 \u2192 widget_bridge.cpp:4007); bridge maps CSS keywords onto View::CursorStyle slots.",
       "supportedValues": [
         "default",
         "pointer",
@@ -4202,7 +4199,7 @@
         "packages/pulp-react/test/prop-applier-wave2.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1550 catalog hygiene: flipped partial → supported. Triage #7 fan-out (#1434 small-wins bundle) wired the CSS cursor keyword set onto View::CursorStyle. RN's spec ViewStyle accepts only {auto, pointer}; Pulp accepts the full CSS cursor enum because the same prop-applier path serves both rn/cursor and css/cursor. Keywords without a dedicated visual (wait / help / progress / alias / copy / zoom-* / cell / context-menu) fall through to `default` — they're listed in unsupportedValues for catalog accuracy. Wave 1 drift cleanup — `auto` keyword falls back to default (View::CursorStyle::default_); arch-platform-cursor-set means we don't add a dedicated 'auto' slot. Wave 2 rn — added 'auto' regression coverage in the wave2 test bundle.",
+      "notes": "pulp #1550 catalog hygiene: flipped partial \u2192 supported. Triage #7 fan-out (#1434 small-wins bundle) wired the CSS cursor keyword set onto View::CursorStyle. RN's spec ViewStyle accepts only {auto, pointer}; Pulp accepts the full CSS cursor enum because the same prop-applier path serves both rn/cursor and css/cursor. Keywords without a dedicated visual (wait / help / progress / alias / copy / zoom-* / cell / context-menu) fall through to `default` \u2014 they're listed in unsupportedValues for catalog accuracy. Wave 1 drift cleanup \u2014 `auto` keyword falls back to default (View::CursorStyle::default_); arch-platform-cursor-set means we don't add a dedicated 'auto' slot. Wave 2 rn \u2014 added 'auto' regression coverage in the wave2 test bundle.",
       "issue": ""
     },
     "rn/d": {
@@ -4249,7 +4246,7 @@
         "test/test_widget_bridge.cpp [display-contents]",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "@pulp/react users opt out via the boolean `visible` prop. No 'contents' equivalent. pulp #1434 (Triage #12): the prop-applier now accepts display: flex / none, mirroring the yoga side wired in #1422. \"contents\" remains unsupported (Yoga has no equivalent). ARCH-DEFERRED: display: contents requires parallel block/inline-flow layout that CLAUDE.md's flex+grid-only policy (Yoga 3.0 ceiling) explicitly rules out — the dispatcher silently no-ops; pinned by test/test_widget_bridge.cpp [display-contents].",
+      "notes": "@pulp/react users opt out via the boolean `visible` prop. No 'contents' equivalent. pulp #1434 (Triage #12): the prop-applier now accepts display: flex / none, mirroring the yoga side wired in #1422. \"contents\" remains unsupported (Yoga has no equivalent). ARCH-DEFERRED: display: contents requires parallel block/inline-flow layout that CLAUDE.md's flex+grid-only policy (Yoga 3.0 ceiling) explicitly rules out \u2014 the dispatcher silently no-ops; pinned by test/test_widget_bridge.cpp [display-contents].",
       "issue": ""
     },
     "rn/elevation": {
@@ -4262,12 +4259,12 @@
       "tests": [
         "unit:test_widget_bridge#issue-1737"
       ],
-      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11, final sweep): walked back from wontfix to supported. RN`s elevation prop is Android-only Material Design depth (0-24dp); upstream RN silently ignores it on iOS. Pulp shims it to a single-shadow approximation of Material`s dual-shadow spec so consumers shipping unchanged RN-Android styles render a visible shadow on every Pulp platform — a strict improvement over upstream RN`s iOS behavior. The catalog had already noted that Pulp uses boxShadow as the cross-platform equivalent; this PR adds the missing translation shim. Material`s exact spec uses umbra + penumbra dual shadows; Pulp`s BoxShadow is a single shadow, so the visual is recognizable Material but not pixel-identical to Android`s native renderer. Consumers needing exact dual-shadow rendering should use boxShadow directly (Pulp fully supports the CSS box-shadow syntax including multi-shadow lists).",
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11, final sweep): walked back from wontfix to supported. RN`s elevation prop is Android-only Material Design depth (0-24dp); upstream RN silently ignores it on iOS. Pulp shims it to a single-shadow approximation of Material`s dual-shadow spec so consumers shipping unchanged RN-Android styles render a visible shadow on every Pulp platform \u2014 a strict improvement over upstream RN`s iOS behavior. The catalog had already noted that Pulp uses boxShadow as the cross-platform equivalent; this PR adds the missing translation shim. Material`s exact spec uses umbra + penumbra dual shadows; Pulp`s BoxShadow is a single shadow, so the visual is recognizable Material but not pixel-identical to Android`s native renderer. Consumers needing exact dual-shadow rendering should use boxShadow directly (Pulp fully supports the CSS box-shadow syntax including multi-shadow lists).",
       "issue": ""
     },
     "rn/end": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier — end → right under LTR; routes to setRight.",
+      "mapsTo": "@pulp/react prop-applier \u2014 end \u2192 right under LTR; routes to setRight.",
       "supportedValues": [
         "number",
         "percent string"
@@ -4277,7 +4274,7 @@
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/experimental_backgroundImage": {
@@ -4291,7 +4288,7 @@
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-not-impl-bundle1.test.ts"
       ],
-      "notes": "pulp #1434 (rn NOT-IMPL bundle 1): wired through to setBackgroundGradient so the same string format CSS consumers use is accepted from RN code. RN's New-Architecture-only array-of-objects gradient form is NOT supported (gradient strings only). url() raster images for background-image are also out of scope until SkImage lazy load lands. arch-rn-fabric-vendor-api — RN Fabric array-of-objects gradient API is a New Architecture vendor extension. Pulp's gradient surface is the standard `linearGradient`/`radialGradient` CSS-style API which works.",
+      "notes": "pulp #1434 (rn NOT-IMPL bundle 1): wired through to setBackgroundGradient so the same string format CSS consumers use is accepted from RN code. RN's New-Architecture-only array-of-objects gradient form is NOT supported (gradient strings only). url() raster images for background-image are also out of scope until SkImage lazy load lands. arch-rn-fabric-vendor-api \u2014 RN Fabric array-of-objects gradient API is a New Architecture vendor extension. Pulp's gradient surface is the standard `linearGradient`/`radialGradient` CSS-style API which works.",
       "issue": ""
     },
     "rn/fill": {
@@ -4299,14 +4296,14 @@
       "mapsTo": "prop-applier.ts: 'fill' -> setSvgFill(id, value) for CSS-color strings, OR setSvgFillGradient(id, css_linear_gradient_string) for gradient fills. SvgPathWidget stores either solid fill_color_ OR fill_gradient_ (the gradient slot wins when set). paint() parses the CSS linear-gradient string against local bounds and calls Canvas::set_fill_gradient_linear before fill_current_path; SkiaCanvas implements via SkGradientShader::MakeLinear.",
       "supportedValues": [
         "CSS color strings",
-        "url(#gradient) — when paired with a defining JSX <SvgLinearGradient> intrinsic OR a CSS linear-gradient(...) string forwarded directly via setSvgFillGradient"
+        "url(#gradient) \u2014 when paired with a defining JSX <SvgLinearGradient> intrinsic OR a CSS linear-gradient(...) string forwarded directly via setSvgFillGradient"
       ],
       "unsupportedValues": [],
       "tests": [
         "unit:test_svg_path_widget#issue-932",
         "unit:test_svg_path_widget#issue-1737"
       ],
-      "notes": "Only on @pulp/react SvgPath. Inline <svg> in DOM-lite still uses createCol (pulp #1147), which means CSS `fill` does NOT route to SVG fill — it falls into the unknown-prop default switch. pulp #932 (initial gradient slot deferred) + pulp #1737 PR-4 (this slice). SvgPathWidget gained a fill_gradient_ string slot + set_fill_gradient/clear_fill_gradient API. paint() parses the CSS linear-gradient at frame time against local bounds, builds endpoint coords + colors/positions arrays, and routes through Canvas::set_fill_gradient_linear (cross-backend — RecordingCanvas's default falls back to set_fill_color(stops[0]); SkiaCanvas implements via SkGradientShader::MakeLinear; CG falls back to its solid fill). New bridge fn setSvgFillGradient(id, css_value) accepts the linear-gradient string verbatim. JSX consumers (`<SvgLinearGradient id='g' stops={...}>` + `fill='url(#g)'`) work via the prop-applier resolving the JSX subtree's gradient defs into the CSS string before calling the bridge — direct C++ consumers can also call set_fill_gradient with a hand-built string. radial-gradient + url(file_path) image fills are followups (parser-only extension; no API change needed).",
+      "notes": "Only on @pulp/react SvgPath. Inline <svg> in DOM-lite still uses createCol (pulp #1147), which means CSS `fill` does NOT route to SVG fill \u2014 it falls into the unknown-prop default switch. pulp #932 (initial gradient slot deferred) + pulp #1737 PR-4 (this slice). SvgPathWidget gained a fill_gradient_ string slot + set_fill_gradient/clear_fill_gradient API. paint() parses the CSS linear-gradient at frame time against local bounds, builds endpoint coords + colors/positions arrays, and routes through Canvas::set_fill_gradient_linear (cross-backend \u2014 RecordingCanvas's default falls back to set_fill_color(stops[0]); SkiaCanvas implements via SkGradientShader::MakeLinear; CG falls back to its solid fill). New bridge fn setSvgFillGradient(id, css_value) accepts the linear-gradient string verbatim. JSX consumers (`<SvgLinearGradient id='g' stops={...}>` + `fill='url(#g)'`) work via the prop-applier resolving the JSX subtree's gradient defs into the CSS string before calling the bridge \u2014 direct C++ consumers can also call set_fill_gradient with a hand-built string. radial-gradient + url(file_path) image fills are followups (parser-only extension; no API change needed).",
       "issue": "994"
     },
     "rn/filter": {
@@ -4323,7 +4320,7 @@
         "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Phase A2-4 — full CSS filter chain. setFilter parses the function-call sequence into View::FilterOp[]; view.cpp paint hands off to canvas.save_layer_with_filters; Skia composes via SkImageFilters::Compose + SkColorFilters::Matrix per filter. CG path falls back to blur-only collapse (no SkColorFilter equivalent yet). Full function set: blur / brightness / contrast / grayscale / hue-rotate / invert / opacity / saturate / sepia / drop-shadow.",
+      "notes": "pulp #1434 Phase A2-4 \u2014 full CSS filter chain. setFilter parses the function-call sequence into View::FilterOp[]; view.cpp paint hands off to canvas.save_layer_with_filters; Skia composes via SkImageFilters::Compose + SkColorFilters::Matrix per filter. CG path falls back to blur-only collapse (no SkColorFilter equivalent yet). Full function set: blur / brightness / contrast / grayscale / hue-rotate / invert / opacity / saturate / sepia / drop-shadow.",
       "issue": ""
     },
     "rn/flex": {
@@ -4337,7 +4334,7 @@
         "packages/pulp-react/test/prop-applier-flex.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1518 closed the gap. Bare-number `flex={n}` is the canonical RN-flavored shorthand; `flex` as an object/string is not a thing in RN, so no further forms are needed. Underlying bridge wires were already stable (flex_grow / flex_shrink / flex_basis) — this is purely an adapter aliasing.",
+      "notes": "pulp #1518 closed the gap. Bare-number `flex={n}` is the canonical RN-flavored shorthand; `flex` as an object/string is not a thing in RN, so no further forms are needed. Underlying bridge wires were already stable (flex_grow / flex_shrink / flex_basis) \u2014 this is purely an adapter aliasing.",
       "issue": "1518"
     },
     "rn/flexBasis": {
@@ -4352,7 +4349,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1434-rn-batch-c]"
       ],
-      "notes": "TS type is 'number' only. pulp #1434 rn batch C: bridge accepts number / \"NN%\" / \"auto\"; FlexStyle::dim_flex_basis.unit drives YGNodeStyleSetFlexBasis{,Percent,Auto}. Wave 1 architectural reclassification — `content` keyword is arch-yoga-limit (Yoga has no flex-basis content algorithm); status flipped partial → wontfix to match the actual ground-truth out-of-scope reason. number / percent / 'auto' all remain fully wired. Wave-5 follow-up audit (post-PR #1616 sweep): walked back wontfix→partial. `wontfix` maps to OOS in the harness taxonomy and bypasses drift checking for the supported `number`/`%`/`auto` subset; partial preserves drift detection on the supported forms while keeping `content` listed as the real Yoga-architecture limit. arch-yoga-no-content-keyword — Yoga doesn't model the `content` keyword (it's a CSS Level 3 spec extension that maps to intrinsic-size resolution Yoga doesn't have). number, %, auto, and 0 are all supported.",
+      "notes": "TS type is 'number' only. pulp #1434 rn batch C: bridge accepts number / \"NN%\" / \"auto\"; FlexStyle::dim_flex_basis.unit drives YGNodeStyleSetFlexBasis{,Percent,Auto}. Wave 1 architectural reclassification \u2014 `content` keyword is arch-yoga-limit (Yoga has no flex-basis content algorithm); status flipped partial \u2192 wontfix to match the actual ground-truth out-of-scope reason. number / percent / 'auto' all remain fully wired. Wave-5 follow-up audit (post-PR #1616 sweep): walked back wontfix\u2192partial. `wontfix` maps to OOS in the harness taxonomy and bypasses drift checking for the supported `number`/`%`/`auto` subset; partial preserves drift detection on the supported forms while keeping `content` listed as the real Yoga-architecture limit. arch-yoga-no-content-keyword \u2014 Yoga doesn't model the `content` keyword (it's a CSS Level 3 spec extension that maps to intrinsic-size resolution Yoga doesn't have). number, %, auto, and 0 are all supported.",
       "issue": ""
     },
     "rn/flexDirection": {
@@ -4399,7 +4396,7 @@
     },
     "rn/flexWrap": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier forwards string ('wrap' / 'wrap-reverse' / 'nowrap') verbatim to setFlex(flex_wrap, ...); legacy boolean still accepted (true → 1, false → 0).",
+      "mapsTo": "@pulp/react prop-applier forwards string ('wrap' / 'wrap-reverse' / 'nowrap') verbatim to setFlex(flex_wrap, ...); legacy boolean still accepted (true \u2192 1, false \u2192 0).",
       "supportedValues": [
         "boolean (legacy)",
         "nowrap",
@@ -4412,16 +4409,16 @@
         "packages/pulp-react/test/prop-applier-bundle.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #14 — broadened flexWrap type to boolean | string (CSS keywords). RN spec accepts the same string vocabulary; routing same as css/flexWrap.",
+      "notes": "pulp #1434 Triage #14 \u2014 broadened flexWrap type to boolean | string (CSS keywords). RN spec accepts the same string vocabulary; routing same as css/flexWrap.",
       "issue": ""
     },
     "rn/fontFamily": {
       "status": "supported",
-      "mapsTo": "prop-applier.ts case 'fontFamily' -> setFontFamily(id, value). Bridge stores the CSS comma-separated list verbatim (Label::set_font_family or View::set_inheritable_font_family for cascade). pulp #1737 (#932 followup) — SkiaCanvas resolution walks the whole list at paint time: skia_canvas.cpp:get_cached_typeface splits on commas (split_font_family_list helper), strips outer quotes + whitespace, tries each family through the existing match cascade (registered → bundled → SkFontMgr matchFamilyStyle) until one resolves. Single-family inputs (no comma) still hit get_cached_typeface_single fast-path with identical pre-fix behavior.",
+      "mapsTo": "prop-applier.ts case 'fontFamily' -> setFontFamily(id, value). Bridge stores the CSS comma-separated list verbatim (Label::set_font_family or View::set_inheritable_font_family for cascade). pulp #1737 (#932 followup) \u2014 SkiaCanvas resolution walks the whole list at paint time: skia_canvas.cpp:get_cached_typeface splits on commas (split_font_family_list helper), strips outer quotes + whitespace, tries each family through the existing match cascade (registered \u2192 bundled \u2192 SkFontMgr matchFamilyStyle) until one resolves. Single-family inputs (no comma) still hit get_cached_typeface_single fast-path with identical pre-fix behavior.",
       "supportedValues": [
         "single family name (single-name fast path)",
-        "comma-separated CSS family list (e.g. `'SF Pro, system-ui, sans-serif'`) — walked in declaration order through the match cascade until a family resolves",
-        "quoted family names (e.g. `'\"My Font Name\"'`) — outer quotes stripped per CSS spec",
+        "comma-separated CSS family list (e.g. `'SF Pro, system-ui, sans-serif'`) \u2014 walked in declaration order through the match cascade until a family resolves",
+        "quoted family names (e.g. `'\"My Font Name\"'`) \u2014 outer quotes stripped per CSS spec",
         "extra whitespace tolerated between commas + around quoted names"
       ],
       "unsupportedValues": [],
@@ -4429,7 +4426,7 @@
         "test/test_widget_bridge.cpp [issue-1434-fontfamily]",
         "test/test_canvas.cpp [issue-1737] (comma-list fontFamily falls back through SkFontMgr; quotes + whitespace handling)"
       ],
-      "notes": "pulp #1434 Phase A2-5 wired the @pulp/react JSX dispatch + bridge list parser. pulp #1737 (#932 followup) closed the whole-list fallback chain — SkiaCanvas resolves the comma-separated list at paint time via split_font_family_list + per-family matchFamilyStyle walk. Resolution accepts a family if SkFontMgr returns a typeface whose actual family name contains (or is contained by) the requested family — guards against SkFontMgr's null-fallback masking a missing family. Single-family inputs unchanged — fast-path delegates straight to get_cached_typeface_single.",
+      "notes": "pulp #1434 Phase A2-5 wired the @pulp/react JSX dispatch + bridge list parser. pulp #1737 (#932 followup) closed the whole-list fallback chain \u2014 SkiaCanvas resolves the comma-separated list at paint time via split_font_family_list + per-family matchFamilyStyle walk. Resolution accepts a family if SkFontMgr returns a typeface whose actual family name contains (or is contained by) the requested family \u2014 guards against SkFontMgr's null-fallback masking a missing family. Single-family inputs unchanged \u2014 fast-path delegates straight to get_cached_typeface_single.",
       "issue": "1434"
     },
     "rn/fontSize": {
@@ -4476,7 +4473,7 @@
         "packages/pulp-react/test/prop-applier-rn-not-impl-bundle1.test.ts",
         "unit:test_canvas#issue-1737"
       ],
-      "notes": "pulp #1434 (rn NOT-IMPL bundle 1) + A4 Bundle 1 (#1611) landed the prop-applier + bridge fn + storage slot. pulp #1737 (this slice) wires the storage through Label::paint to Canvas::set_font_features and SkiaCanvas::shape_with_features (the 8-arg SkShaper::shape overload with TrivialFont/BiDi/Script/Language RunIterators) so HarfBuzz now honors the OpenType tags at shape time. tnum forces equal-advance digits via measure_text/fill_text; smcp/onum/lnum/pnum behave per CSS Fonts Module 4 §7.3. Verified end-to-end via test_canvas \"set_font_features routes tnum through SkShaper\" (Inter '111' vs '999' advances converge under tnum, restore on clear_font_features). Fall-through: if SkShaper::Make() returns null on a host without text-shaping, the per-glyph builder runs without features (degraded but non-crashing).",
+      "notes": "pulp #1434 (rn NOT-IMPL bundle 1) + A4 Bundle 1 (#1611) landed the prop-applier + bridge fn + storage slot. pulp #1737 (this slice) wires the storage through Label::paint to Canvas::set_font_features and SkiaCanvas::shape_with_features (the 8-arg SkShaper::shape overload with TrivialFont/BiDi/Script/Language RunIterators) so HarfBuzz now honors the OpenType tags at shape time. tnum forces equal-advance digits via measure_text/fill_text; smcp/onum/lnum/pnum behave per CSS Fonts Module 4 \u00a77.3. Verified end-to-end via test_canvas \"set_font_features routes tnum through SkShaper\" (Inter '111' vs '999' advances converge under tnum, restore on clear_font_features). Fall-through: if SkShaper::Make() returns null on a host without text-shaping, the per-glyph builder runs without features (degraded but non-crashing).",
       "issue": ""
     },
     "rn/fontWeight": {
@@ -4511,7 +4508,7 @@
         "packages/pulp-react/test/prop-applier-wave2.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Keyword aliasing not done in prop-applier. Wave 1 drift cleanup — populated supportedValues with the RN standard weight set (normal / bold / 100..900); wired through prop-applier 'fontWeight' case. Wave 2 rn — added regression coverage for numeric weights '100'..'900'.",
+      "notes": "Keyword aliasing not done in prop-applier. Wave 1 drift cleanup \u2014 populated supportedValues with the RN standard weight set (normal / bold / 100..900); wired through prop-applier 'fontWeight' case. Wave 2 rn \u2014 added regression coverage for numeric weights '100'..'900'.",
       "issue": ""
     },
     "rn/gap": {
@@ -4529,7 +4526,7 @@
     },
     "rn/height": {
       "status": "supported",
-      "mapsTo": "setFlex(id, 'height', n) — number=px, '50%'=percent, 'auto'=hug-contents",
+      "mapsTo": "setFlex(id, 'height', n) \u2014 number=px, '50%'=percent, 'auto'=hug-contents",
       "supportedValues": [
         "number (px)",
         "string % (e.g. '50%')",
@@ -4539,12 +4536,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1712][rn-height]"
       ],
-      "notes": "pulp #1434 rn batch C wired number + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end. TS type accepts `number | string`; prop-applier forwards verbatim; bridge dispatches via FlexStyle::dim_height.unit (px / percent / auto_) and yoga_layout.cpp routes to YGNodeStyleSetHeight{,Percent,Auto}. Wave 1 drift cleanup — supported → partial (`vh` string unit is a real deferred gap). arch-no-viewport — `vh`/`vw`/`vmin`/`vmax` units are deferred because Pulp has no global viewport context (Views can be embedded in plugin editors, standalone windows, or mobile screens with different sizing semantics; CSS viewport-unit semantics are undefined at the View level). Authors should use `%` units relative to the parent container instead. See pulp #1712.",
+      "notes": "pulp #1434 rn batch C wired number + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end. TS type accepts `number | string`; prop-applier forwards verbatim; bridge dispatches via FlexStyle::dim_height.unit (px / percent / auto_) and yoga_layout.cpp routes to YGNodeStyleSetHeight{,Percent,Auto}. Wave 1 drift cleanup \u2014 supported \u2192 partial (`vh` string unit is a real deferred gap). arch-no-viewport \u2014 `vh`/`vw`/`vmin`/`vmax` units are deferred because Pulp has no global viewport context (Views can be embedded in plugin editors, standalone windows, or mobile screens with different sizing semantics; CSS viewport-unit semantics are undefined at the View level). Authors should use `%` units relative to the parent container instead. See pulp #1712.",
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "rn/includeFontPadding": {
       "status": "supported",
-      "mapsTo": "prop-applier.ts -> setIncludeFontPadding(id, bool) -> View::set_include_font_padding (storage-only slot). Pulp text-shaping pipeline uses tight baseline-relative positioning and does NOT add Android-vestigial vertical glyph padding regardless of this value — both keywords accepted, single consistent behavior produced (matches the `false` outcome that authors typically want).",
+      "mapsTo": "prop-applier.ts -> setIncludeFontPadding(id, bool) -> View::set_include_font_padding (storage-only slot). Pulp text-shaping pipeline uses tight baseline-relative positioning and does NOT add Android-vestigial vertical glyph padding regardless of this value \u2014 both keywords accepted, single consistent behavior produced (matches the `false` outcome that authors typically want).",
       "supportedValues": [
         true,
         false
@@ -4553,12 +4550,12 @@
       "tests": [
         "unit:test_widget_bridge#issue-1737"
       ],
-      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11, final sweep): walked back from wontfix to supported. RN`s `includeFontPadding` is Android-only — Android TextView paints extra vertical padding around glyphs that this prop disables (`false`). Pulp`s text shaping (Skia/SkParagraph) uses tight baseline-relative positioning and never had Android`s vestigial padding to begin with, so the visible result matches the `false` intent that most authors want from this prop. Setting `true` is a silent no-op (Pulp can`t add padding it doesn`t model). Catalog claim is honest CSS-subset (same pattern as overscroll-behavior in PR #1805): all keywords round-trip; single consistent behavior produced; author intent for the common case (`false`) is met by default. Bridge fn stores the value on View::include_font_padding_ purely for round-trip reads (`el.style.includeFontPadding === false`).",
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11, final sweep): walked back from wontfix to supported. RN`s `includeFontPadding` is Android-only \u2014 Android TextView paints extra vertical padding around glyphs that this prop disables (`false`). Pulp`s text shaping (Skia/SkParagraph) uses tight baseline-relative positioning and never had Android`s vestigial padding to begin with, so the visible result matches the `false` intent that most authors want from this prop. Setting `true` is a silent no-op (Pulp can`t add padding it doesn`t model). Catalog claim is honest CSS-subset (same pattern as overscroll-behavior in PR #1805): all keywords round-trip; single consistent behavior produced; author intent for the common case (`false`) is met by default. Bridge fn stores the value on View::include_font_padding_ purely for round-trip reads (`el.style.includeFontPadding === false`).",
       "issue": ""
     },
     "rn/inset": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier — CSS shorthand fan-out to top/right/bottom/left (1/2/3/4 token expansion).",
+      "mapsTo": "@pulp/react prop-applier \u2014 CSS shorthand fan-out to top/right/bottom/left (1/2/3/4 token expansion).",
       "supportedValues": [
         "number",
         "percent string",
@@ -4569,12 +4566,12 @@
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/insetBlock": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier — top + bottom fan-out.",
+      "mapsTo": "@pulp/react prop-applier \u2014 top + bottom fan-out.",
       "supportedValues": [
         "number",
         "percent string"
@@ -4584,12 +4581,12 @@
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/insetInline": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier — left + right fan-out under LTR.",
+      "mapsTo": "@pulp/react prop-applier \u2014 left + right fan-out under LTR.",
       "supportedValues": [
         "number",
         "percent string"
@@ -4599,7 +4596,7 @@
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/isolation": {
@@ -4613,7 +4610,7 @@
       "tests": [
         "unit:test_widget_bridge#issue-1737"
       ],
-      "notes": "pulp #1565 followup (initial wontfix) + pulp #1737 RN-OOS-fixup final round (this slice): walked back from wontfix to supported. Same architectural-by-default rationale as css/isolation — Pulp's per-View save_layer_with_blend model + paint-order-scoped z-index already produce the `isolate` outcome that RN authors want for blend-mode containment. Honest CSS-subset claim: both keywords round-trip; single consistent behavior produced.",
+      "notes": "pulp #1565 followup (initial wontfix) + pulp #1737 RN-OOS-fixup final round (this slice): walked back from wontfix to supported. Same architectural-by-default rationale as css/isolation \u2014 Pulp's per-View save_layer_with_blend model + paint-order-scoped z-index already produce the `isolate` outcome that RN authors want for blend-mode containment. Honest CSS-subset claim: both keywords round-trip; single consistent behavior produced.",
       "issue": ""
     },
     "rn/justifyContent": {
@@ -4675,7 +4672,7 @@
         "packages/pulp-react/test/prop-applier-wave2.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 1 drift cleanup — supported → partial (unitless multiplier form is a real deferred gap; absolute-px works end-to-end). Wave 2 rn — unitless-multiplier semantics now resolved at dispatch time. Values <= 8 are treated as a multiplier of the live `fontSize` from props (default 14 if absent); larger values flow through as absolute pixels. Px-suffix strings strip the suffix and treat as absolute.",
+      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (unitless multiplier form is a real deferred gap; absolute-px works end-to-end). Wave 2 rn \u2014 unitless-multiplier semantics now resolved at dispatch time. Values <= 8 are treated as a multiplier of the live `fontSize` from props (default 14 if absent); larger values flow through as absolute pixels. Px-suffix strings strip the suffix and treat as absolute.",
       "issue": ""
     },
     "rn/margin": {
@@ -4692,7 +4689,7 @@
         "packages/pulp-react/test/prop-applier-wave2.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 1 drift cleanup — supported → partial (auto + string-form margins are real deferred gaps). Wave 2 rn — string margin shorthands (`'auto'`, `'5%'`, `'0 auto'`) now fan out to the per-edge bridge keys (which honor Yoga's YGNodeStyleSetMarginAuto for centering and the percent path).",
+      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (auto + string-form margins are real deferred gaps). Wave 2 rn \u2014 string margin shorthands (`'auto'`, `'5%'`, `'0 auto'`) now fan out to the per-edge bridge keys (which honor Yoga's YGNodeStyleSetMarginAuto for centering and the percent path).",
       "issue": ""
     },
     "rn/marginBottom": {
@@ -4708,12 +4705,12 @@
         "packages/pulp-react/test/prop-applier-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "rn/marginEnd": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier — End → Right under LTR.",
+      "mapsTo": "@pulp/react prop-applier \u2014 End \u2192 Right under LTR.",
       "supportedValues": [
         "number",
         "percent string",
@@ -4724,7 +4721,7 @@
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/marginHorizontal": {
@@ -4740,7 +4737,7 @@
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "rn/marginLeft": {
@@ -4756,7 +4753,7 @@
         "packages/pulp-react/test/prop-applier-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "rn/marginRight": {
@@ -4772,12 +4769,12 @@
         "packages/pulp-react/test/prop-applier-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "rn/marginStart": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier — Start → Left under LTR.",
+      "mapsTo": "@pulp/react prop-applier \u2014 Start \u2192 Left under LTR.",
       "supportedValues": [
         "number",
         "percent string",
@@ -4788,7 +4785,7 @@
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/marginTop": {
@@ -4804,7 +4801,7 @@
         "packages/pulp-react/test/prop-applier-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "rn/marginVertical": {
@@ -4820,7 +4817,7 @@
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "rn/maxHeight": {
@@ -4834,7 +4831,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_height.unit; yoga_layout.cpp routes to YGNodeStyleSetMaxHeightPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_height.unit → YGNodeStyleSetMaxHeightPercent.",
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_height.unit; yoga_layout.cpp routes to YGNodeStyleSetMaxHeightPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_height.unit \u2192 YGNodeStyleSetMaxHeightPercent.",
       "issue": ""
     },
     "rn/maxWidth": {
@@ -4848,7 +4845,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_width.unit; yoga_layout.cpp routes to YGNodeStyleSetMaxWidthPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_width.unit → YGNodeStyleSetMaxWidthPercent.",
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_width.unit; yoga_layout.cpp routes to YGNodeStyleSetMaxWidthPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_width.unit \u2192 YGNodeStyleSetMaxWidthPercent.",
       "issue": ""
     },
     "rn/minHeight": {
@@ -4862,7 +4859,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_height.unit; yoga_layout.cpp routes to YGNodeStyleSetMinHeightPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_height.unit → YGNodeStyleSetMinHeightPercent.",
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_height.unit; yoga_layout.cpp routes to YGNodeStyleSetMinHeightPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_height.unit \u2192 YGNodeStyleSetMinHeightPercent.",
       "issue": ""
     },
     "rn/minWidth": {
@@ -4876,7 +4873,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_width.unit; yoga_layout.cpp routes to YGNodeStyleSetMinWidthPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_width.unit → YGNodeStyleSetMinWidthPercent.",
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_width.unit; yoga_layout.cpp routes to YGNodeStyleSetMinWidthPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_width.unit \u2192 YGNodeStyleSetMinWidthPercent.",
       "issue": ""
     },
     "rn/mixBlendMode": {
@@ -4939,7 +4936,7 @@
         "packages/pulp-react/test/prop-applier-outline.test.ts",
         "test/test_widget_bridge.cpp [issue-1710][outline-currentcolor]"
       ],
-      "notes": "pulp #1519 — RN outline cluster. Outline is paint-time only and does NOT affect Yoga layout (parent never reserves space). Skia paint inflates the box by (offset + width/2) and strokes with the parsed color. Wave 1 drift cleanup — supported → partial (currentColor keyword resolution deferred; CSS color strings round-trip). Wired in pulp #1710 — `currentColor` keyword resolves to the View's inheritable text color (walks parent chain via View::inheritable_text_color), falling back to theme `text.primary` token when no ancestor set the text color explicitly. Test [view][bridge][rn][issue-1710][outline-currentcolor] proves the resolution.",
+      "notes": "pulp #1519 \u2014 RN outline cluster. Outline is paint-time only and does NOT affect Yoga layout (parent never reserves space). Skia paint inflates the box by (offset + width/2) and strokes with the parsed color. Wave 1 drift cleanup \u2014 supported \u2192 partial (currentColor keyword resolution deferred; CSS color strings round-trip). Wired in pulp #1710 \u2014 `currentColor` keyword resolves to the View's inheritable text color (walks parent chain via View::inheritable_text_color), falling back to theme `text.primary` token when no ancestor set the text color explicitly. Test [view][bridge][rn][issue-1710][outline-currentcolor] proves the resolution.",
       "issue": ""
     },
     "rn/outlineOffset": {
@@ -4953,12 +4950,12 @@
         "packages/pulp-react/test/prop-applier-outline.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1519 — gap between border-box edge and outline. Paint-only; no Yoga layout impact.",
+      "notes": "pulp #1519 \u2014 gap between border-box edge and outline. Paint-only; no Yoga layout impact.",
       "issue": ""
     },
     "rn/outlineStyle": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier dispatches outlineStyle to setOutlineStyle (prop-applier.ts since pulp #1519). Bridge maps the CSS keyword to View::BorderStyle (reused — CSS spec is identical for outline + border).",
+      "mapsTo": "@pulp/react prop-applier dispatches outlineStyle to setOutlineStyle (prop-applier.ts since pulp #1519). Bridge maps the CSS keyword to View::BorderStyle (reused \u2014 CSS spec is identical for outline + border).",
       "supportedValues": [
         "solid",
         "dashed",
@@ -4976,7 +4973,7 @@
         "packages/pulp-react/test/prop-applier-outline.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1519 — Skia installs SkDashPathEffect for dashed/dotted at outline-stroke time. Other named styles currently degrade to solid (paint-side gap, same as borderStyle). none/hidden/zero-width short-circuit the stroke.",
+      "notes": "pulp #1519 \u2014 Skia installs SkDashPathEffect for dashed/dotted at outline-stroke time. Other named styles currently degrade to solid (paint-side gap, same as borderStyle). none/hidden/zero-width short-circuit the stroke.",
       "issue": ""
     },
     "rn/outlineWidth": {
@@ -4990,12 +4987,12 @@
         "packages/pulp-react/test/prop-applier-outline.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1519 — outline stroke thickness. width<=0 short-circuits the paint. Paint-only; no Yoga layout impact.",
+      "notes": "pulp #1519 \u2014 outline stroke thickness. width<=0 short-circuits the paint. Paint-only; no Yoga layout impact.",
       "issue": ""
     },
     "rn/overflow": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier dispatches `overflow` to `setOverflow(id, mode)` (prop-applier.ts:629 since #1388). Bridge accepts all 3 RN ViewStyle keywords (visible / hidden / scroll) at widget_bridge.cpp:3650-3663; `scroll` is recorded on View::Overflow::scroll and propagates through Yoga so the layout engine knows about the clipping context (no scrollbar layer yet — author wires a ScrollView intrinsic for true scrolling).",
+      "mapsTo": "@pulp/react prop-applier dispatches `overflow` to `setOverflow(id, mode)` (prop-applier.ts:629 since #1388). Bridge accepts all 3 RN ViewStyle keywords (visible / hidden / scroll) at widget_bridge.cpp:3650-3663; `scroll` is recorded on View::Overflow::scroll and propagates through Yoga so the layout engine knows about the clipping context (no scrollbar layer yet \u2014 author wires a ScrollView intrinsic for true scrolling).",
       "supportedValues": [
         "visible",
         "hidden",
@@ -5006,7 +5003,7 @@
         "packages/pulp-react/test/prop-applier-pointer.test.ts",
         "test/test_widget_bridge.cpp [issue-1737][rn-overflow-scroll]"
       ],
-      "notes": "pulp #1550 catalog hygiene: flipped partial → supported. pulp #1737 — keyword coverage reclassified to all 3 RN values to match the bridge implementation (widget_bridge.cpp:3650-3663) and the css/overflow precedent. `scroll` clips painted pixels like `hidden` but propagates through Yoga as a distinct overflow mode. Authors who need true scrollbars wire the ScrollView intrinsic; this mirrors React Native's split between style-level overflow and a dedicated ScrollView container.",
+      "notes": "pulp #1550 catalog hygiene: flipped partial \u2192 supported. pulp #1737 \u2014 keyword coverage reclassified to all 3 RN values to match the bridge implementation (widget_bridge.cpp:3650-3663) and the css/overflow precedent. `scroll` clips painted pixels like `hidden` but propagates through Yoga as a distinct overflow mode. Authors who need true scrollbars wire the ScrollView intrinsic; this mirrors React Native's split between style-level overflow and a dedicated ScrollView container.",
       "issue": ""
     },
     "rn/overlay": {
@@ -5036,7 +5033,7 @@
         "packages/pulp-react/test/prop-applier-wave2.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 1 drift cleanup — supported → partial (% form on padding edges is deferred). Wave 2 rn — string padding shorthands (`'5%'`, `'10px 20px'`, etc.) now fan out to the per-edge bridge keys (which already accept percent via Yoga's YGNodeStyleSetPaddingPercent). Numeric values still take the single-call shorthand path.",
+      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (% form on padding edges is deferred). Wave 2 rn \u2014 string padding shorthands (`'5%'`, `'10px 20px'`, etc.) now fan out to the per-edge bridge keys (which already accept percent via Yoga's YGNodeStyleSetPaddingPercent). Numeric values still take the single-call shorthand path.",
       "issue": ""
     },
     "rn/paddingBottom": {
@@ -5051,12 +5048,12 @@
         "packages/pulp-react/test/prop-applier-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
       "issue": ""
     },
     "rn/paddingEnd": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier — End → Right under LTR.",
+      "mapsTo": "@pulp/react prop-applier \u2014 End \u2192 Right under LTR.",
       "supportedValues": [
         "number",
         "percent string"
@@ -5066,7 +5063,7 @@
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/paddingHorizontal": {
@@ -5081,7 +5078,7 @@
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "rn/paddingLeft": {
@@ -5096,7 +5093,7 @@
         "packages/pulp-react/test/prop-applier-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
       "issue": ""
     },
     "rn/paddingRight": {
@@ -5111,12 +5108,12 @@
         "packages/pulp-react/test/prop-applier-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
       "issue": ""
     },
     "rn/paddingStart": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier — Start → Left under LTR.",
+      "mapsTo": "@pulp/react prop-applier \u2014 Start \u2192 Left under LTR.",
       "supportedValues": [
         "number",
         "percent string"
@@ -5126,7 +5123,7 @@
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/paddingTop": {
@@ -5141,7 +5138,7 @@
         "packages/pulp-react/test/prop-applier-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
       "issue": ""
     },
     "rn/paddingVertical": {
@@ -5156,7 +5153,7 @@
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "rn/pointerEvents": {
@@ -5173,7 +5170,7 @@
         "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) — bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
+      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) \u2014 bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
       "issue": ""
     },
     "rn/position": {
@@ -5231,7 +5228,7 @@
       "tests": [
         "unit:test_widget_bridge#issue-1737"
       ],
-      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from  to . The earlier wontfix cited \"iOS-only legacy; consumers on modern RN use boxShadow which pulp already supports\" — true but a 1-line shim makes the longhand work too (parallel to how text-shadow longhand was already wired). View::set_box_shadow_color mutates View::shadow_.color and activates has_shadow_; paint_all picks it up via the existing draw_box_shadow path. Bridge fn aliases hex colors through the same parseHexColor used by setSvgFill / setBackgroundColor / etc.",
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from  to . The earlier wontfix cited \"iOS-only legacy; consumers on modern RN use boxShadow which pulp already supports\" \u2014 true but a 1-line shim makes the longhand work too (parallel to how text-shadow longhand was already wired). View::set_box_shadow_color mutates View::shadow_.color and activates has_shadow_; paint_all picks it up via the existing draw_box_shadow path. Bridge fn aliases hex colors through the same parseHexColor used by setSvgFill / setBackgroundColor / etc.",
       "issue": "https://github.com/danielraffel/pulp/issues/1546"
     },
     "rn/shadowOffset": {
@@ -5275,7 +5272,7 @@
     },
     "rn/start": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier — start → left under LTR; routes to setLeft.",
+      "mapsTo": "@pulp/react prop-applier \u2014 start \u2192 left under LTR; routes to setLeft.",
       "supportedValues": [
         "number",
         "percent string"
@@ -5285,7 +5282,7 @@
         "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — LTR-only fast path. @pulp/react prop-applier maps Start→Left, End→Right; inset shorthand fans out to top/right/bottom/left; insetBlock→top+bottom; insetInline→left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection — see #1506 (catalog flipped partial → supported, Wave 1 drift cleanup).",
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
       "issue": ""
     },
     "rn/stroke": {
@@ -5298,7 +5295,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Only on @pulp/react SvgPath. See rn/fill caveat — no DOM-lite path-prop equivalent.",
+      "notes": "Only on @pulp/react SvgPath. See rn/fill caveat \u2014 no DOM-lite path-prop equivalent.",
       "issue": "994"
     },
     "rn/strokeWidth": {
@@ -5333,7 +5330,7 @@
     },
     "rn/textAlignVertical": {
       "status": "supported",
-      "mapsTo": "prop-applier.ts -> setVerticalAlign(id, value) — RN-Android equivalent of  shares the same Label::vertical_align_ slot. Bridge fn at widget_bridge.cpp:5180 accepts top/middle/bottom/baseline (and Pulp's Label paints accordingly). Bridge fn aliases center→VA::center, auto→baseline.",
+      "mapsTo": "prop-applier.ts -> setVerticalAlign(id, value) \u2014 RN-Android equivalent of  shares the same Label::vertical_align_ slot. Bridge fn at widget_bridge.cpp:5180 accepts top/middle/bottom/baseline (and Pulp's Label paints accordingly). Bridge fn aliases center\u2192VA::center, auto\u2192baseline.",
       "supportedValues": [
         "auto",
         "top",
@@ -5344,7 +5341,7 @@
       "tests": [
         "unit:test_widget_bridge#setVerticalAlign"
       ],
-      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from  to . The earlier note \"could map to flex align\" was wrong — the canonical target is Label::vertical_align_ (text-vertical-align), not flex align-items. Reuses the same setVerticalAlign bridge fn rn/verticalAlign uses, since Pulp's Label models the union of CSS verticalAlign + RN-Android textAlignVertical semantics. Wired through prop-applier.ts in this PR.",
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from  to . The earlier note \"could map to flex align\" was wrong \u2014 the canonical target is Label::vertical_align_ (text-vertical-align), not flex align-items. Reuses the same setVerticalAlign bridge fn rn/verticalAlign uses, since Pulp's Label models the union of CSS verticalAlign + RN-Android textAlignVertical semantics. Wired through prop-applier.ts in this PR.",
       "issue": ""
     },
     "rn/textDecorationColor": {
@@ -5376,7 +5373,7 @@
         "packages/pulp-react/test/prop-applier-wave2.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 (rn NOT-IMPL bundle 1): the @pulp/react surface aliases RN's `textDecorationLine` to the existing setTextDecoration bridge fn. Single-keyword form is honored by Label::TextDecoration; the RN compound form `'underline line-through'` is forwarded verbatim but only the first keyword takes effect today (same partial gap noted on css/textDecoration). `overline` is a pulp extension over RN spec. Wave 1 drift cleanup — added 'underline line-through' combined keyword to supportedValues (the prop-applier passes the keyword to the bridge verbatim). Wave 2 rn — added 'underline line-through' compound regression coverage.",
+      "notes": "pulp #1434 (rn NOT-IMPL bundle 1): the @pulp/react surface aliases RN's `textDecorationLine` to the existing setTextDecoration bridge fn. Single-keyword form is honored by Label::TextDecoration; the RN compound form `'underline line-through'` is forwarded verbatim but only the first keyword takes effect today (same partial gap noted on css/textDecoration). `overline` is a pulp extension over RN spec. Wave 1 drift cleanup \u2014 added 'underline line-through' combined keyword to supportedValues (the prop-applier passes the keyword to the bridge verbatim). Wave 2 rn \u2014 added 'underline line-through' compound regression coverage.",
       "issue": ""
     },
     "rn/textDecorationStyle": {
@@ -5407,7 +5404,7 @@
         "packages/pulp-react/test/prop-applier-rn-not-impl-bundle1.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1548 work shipped: bridge fn registered (widget_bridge.cpp:5010-5017) and prop-applier wired (prop-applier.ts:1280). Earlier catalog note claimed deferred-to-#1548 — that work landed. CSS color strings flow through to View::set_text_shadow_color_."
+      "notes": "pulp #1548 work shipped: bridge fn registered (widget_bridge.cpp:5010-5017) and prop-applier wired (prop-applier.ts:1280). Earlier catalog note claimed deferred-to-#1548 \u2014 that work landed. CSS color strings flow through to View::set_text_shadow_color_."
     },
     "rn/textShadowOffset": {
       "status": "supported",
@@ -5449,7 +5446,7 @@
         "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) — bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
+      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) \u2014 bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
       "issue": ""
     },
     "rn/top": {
@@ -5482,7 +5479,7 @@
         "packages/pulp-react/test/prop-applier-transform.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #9 fan-out — full CSS transform-function set wired via parseTransform walk-once accumulator. setSkew bridge fn registered; scaleX/scaleY share uniform setScale slot (last-write-wins; bridge gap); matrix() decomposed to translate+scale+rotate. rotateX / rotateY / matrix3d / perspective silently drop (pulp's 2D View has no 3D model). rn array surface does not include matrix() (RN spec omits it). independent scaleX != scaleY — last-write-wins on the uniform bridge.",
+      "notes": "pulp #1434 Triage #9 fan-out \u2014 full CSS transform-function set wired via parseTransform walk-once accumulator. setSkew bridge fn registered; scaleX/scaleY share uniform setScale slot (last-write-wins; bridge gap); matrix() decomposed to translate+scale+rotate. rotateX / rotateY / matrix3d / perspective silently drop (pulp's 2D View has no 3D model). rn array surface does not include matrix() (RN spec omits it). independent scaleX != scaleY \u2014 last-write-wins on the uniform bridge.",
       "issue": ""
     },
     "rn/transformOrigin": {
@@ -5499,12 +5496,12 @@
         "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) — bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
+      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) \u2014 bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
       "issue": ""
     },
     "rn/userSelect": {
       "status": "supported",
-      "mapsTo": "@pulp/react prop-applier forwards keyword to setUserSelect (prop-applier.ts:753). Bridge routes the keyword to View::UserSelect at widget_bridge.cpp:2474-2484 — `none` / `text` / `all` / `contain` map to the matching enum value; unknown values fall back to `auto`. Stored on View::user_select_ (view.hpp:1071) with a `view->user_select()` getter so widgets that participate in selection can read it.",
+      "mapsTo": "@pulp/react prop-applier forwards keyword to setUserSelect (prop-applier.ts:753). Bridge routes the keyword to View::UserSelect at widget_bridge.cpp:2474-2484 \u2014 `none` / `text` / `all` / `contain` map to the matching enum value; unknown values fall back to `auto`. Stored on View::user_select_ (view.hpp:1071) with a `view->user_select()` getter so widgets that participate in selection can read it.",
       "supportedValues": [
         "auto",
         "none",
@@ -5517,12 +5514,12 @@
         "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
         "test/test_widget_bridge.cpp [issue-1656-tier2-userSelect]"
       ],
-      "notes": "pulp #1737 — catalog flipped noop → supported to match the wired implementation. View::UserSelect enum + setter/getter landed under pulp #1538/#1656 follow-up; the bridge's setUserSelect (widget_bridge.cpp:2474-2484) already routes all 5 RN keywords with full evidence in test/test_widget_bridge.cpp [issue-1656-tier2-userSelect]. Native text-selection suppression on the input layer is the behaviour-fidelity follow-up; the keyword-coverage + storage round-trip is complete and matches the css/userSelect catalog precedent.",
+      "notes": "pulp #1737 \u2014 catalog flipped noop \u2192 supported to match the wired implementation. View::UserSelect enum + setter/getter landed under pulp #1538/#1656 follow-up; the bridge's setUserSelect (widget_bridge.cpp:2474-2484) already routes all 5 RN keywords with full evidence in test/test_widget_bridge.cpp [issue-1656-tier2-userSelect]. Native text-selection suppression on the input layer is the behaviour-fidelity follow-up; the keyword-coverage + storage round-trip is complete and matches the css/userSelect catalog precedent.",
       "issue": ""
     },
     "rn/verticalAlign": {
       "status": "supported",
-      "mapsTo": "prop-applier.ts -> setVerticalAlign(id, value) (widget_bridge.cpp:5180) -> Label::set_vertical_align(canvas::TextVerticalAlign). Mirrors css/verticalAlign which is supported on the same bridge fn. Bridge fn aliases auto→baseline (Pulp default).",
+      "mapsTo": "prop-applier.ts -> setVerticalAlign(id, value) (widget_bridge.cpp:5180) -> Label::set_vertical_align(canvas::TextVerticalAlign). Mirrors css/verticalAlign which is supported on the same bridge fn. Bridge fn aliases auto\u2192baseline (Pulp default).",
       "supportedValues": [
         "auto",
         "top",
@@ -5548,12 +5545,12 @@
         "packages/pulp-react/test/prop-applier-wave2.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "RN doesn't have a native SVG surface; this is a Pulp-specific @pulp/react intrinsic. CSS-shim consumers don't see this prop today. Wave 1 drift cleanup — supported → partial (only the [w,h] tuple is consumed; min-x/min-y prefix is parsed but ignored). Wave 2 rn — SVG-spec string form `'min-x min-y w h'` (or `'w h'`) now parses at dispatch time. The bridge consumes the trailing two tokens as (width, height); the min-x / min-y origin offset is not yet honored by the SvgPathWidget paint side (separate paint-side follow-up).",
+      "notes": "RN doesn't have a native SVG surface; this is a Pulp-specific @pulp/react intrinsic. CSS-shim consumers don't see this prop today. Wave 1 drift cleanup \u2014 supported \u2192 partial (only the [w,h] tuple is consumed; min-x/min-y prefix is parsed but ignored). Wave 2 rn \u2014 SVG-spec string form `'min-x min-y w h'` (or `'w h'`) now parses at dispatch time. The bridge consumes the trailing two tokens as (width, height); the min-x / min-y origin offset is not yet honored by the SvgPathWidget paint side (separate paint-side follow-up).",
       "issue": "994"
     },
     "rn/width": {
       "status": "supported",
-      "mapsTo": "setFlex(id, 'width', n) — number=px, '50%'=percent, 'auto'=hug-contents",
+      "mapsTo": "setFlex(id, 'width', n) \u2014 number=px, '50%'=percent, 'auto'=hug-contents",
       "supportedValues": [
         "number (px)",
         "string % (e.g. '50%')",
@@ -5568,7 +5565,7 @@
     },
     "rn/writingDirection": {
       "status": "supported",
-      "mapsTo": "prop-applier.ts:952 —  -> setDirection(id, value). RN ViewStyle uses ; CSS uses ; Pulp routes both through the same setDirection bridge fn (widget_bridge.cpp:4944-4953). pulp #1506 landed RTL bidi end-to-end.",
+      "mapsTo": "prop-applier.ts:952 \u2014  -> setDirection(id, value). RN ViewStyle uses ; CSS uses ; Pulp routes both through the same setDirection bridge fn (widget_bridge.cpp:4944-4953). pulp #1506 landed RTL bidi end-to-end.",
       "supportedValues": [
         "ltr",
         "rtl",
@@ -5624,7 +5621,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 Triage #14 — FlexStyle.flex_wrap is now FlexWrap enum (no_wrap/wrap/wrap_reverse); yoga_layout.cpp dispatches all three through YGNodeStyleSetFlexWrap with YGWrapNoWrap / YGWrapWrap / YGWrapWrapReverse.",
+      "notes": "pulp #1434 Triage #14 \u2014 FlexStyle.flex_wrap is now FlexWrap enum (no_wrap/wrap/wrap_reverse); yoga_layout.cpp dispatches all three through YGNodeStyleSetFlexWrap with YGWrapNoWrap / YGWrapWrap / YGWrapWrapReverse.",
       "issue": ""
     },
     "yoga/flexGrow": {
@@ -5657,7 +5654,7 @@
     },
     "yoga/flexBasis": {
       "status": "supported",
-      "mapsTo": "FlexStyle::dim_flex_basis (Dimension { unit, value }) → YGNodeStyleSetFlexBasis / YGNodeStyleSetFlexBasisPercent / YGNodeStyleSetFlexBasisAuto in build_yoga_subtree (core/view/src/yoga_layout.cpp).",
+      "mapsTo": "FlexStyle::dim_flex_basis (Dimension { unit, value }) \u2192 YGNodeStyleSetFlexBasis / YGNodeStyleSetFlexBasisPercent / YGNodeStyleSetFlexBasisAuto in build_yoga_subtree (core/view/src/yoga_layout.cpp).",
       "supportedValues": [
         "px",
         "%",
@@ -5690,7 +5687,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "All 6 modes covered. Bridge accepts both CSS spelling (flex-start/flex-end) and Yoga spelling (start/end) — CSS translator _cssToFlex maps the former to the latter. pulp #1434 rn batch B: confirmed bridge accepts flex-start/flex-end aliases too via @pulp/react prop-applier path.",
+      "notes": "All 6 modes covered. Bridge accepts both CSS spelling (flex-start/flex-end) and Yoga spelling (start/end) \u2014 CSS translator _cssToFlex maps the former to the latter. pulp #1434 rn batch B: confirmed bridge accepts flex-start/flex-end aliases too via @pulp/react prop-applier path.",
       "issue": ""
     },
     "yoga/alignItems": {
@@ -5709,7 +5706,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 rn batch B: bridge accepts both CSS (flex-start/flex-end/baseline) and Yoga (start/end) spellings; FlexAlign extended with baseline → YGAlignBaseline.",
+      "notes": "pulp #1434 rn batch B: bridge accepts both CSS (flex-start/flex-end/baseline) and Yoga (start/end) spellings; FlexAlign extended with baseline \u2192 YGAlignBaseline.",
       "issue": ""
     },
     "yoga/alignSelf": {
@@ -5853,12 +5850,12 @@
         "semantic:yoga/aspect-ratio",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 — added FlexStyle.aspect_ratio + Yoga dispatch + bridge setFlex 'aspect_ratio' branch + @pulp/react aspectRatio prop. CSS shim accepts plain numbers ('1.5'), 'width/height' ratios ('16/9'), and 'auto' (clears slot).",
+      "notes": "pulp #1434 \u2014 added FlexStyle.aspect_ratio + Yoga dispatch + bridge setFlex 'aspect_ratio' branch + @pulp/react aspectRatio prop. CSS shim accepts plain numbers ('1.5'), 'width/height' ratios ('16/9'), and 'auto' (clears slot).",
       "issue": "1434"
     },
     "yoga/boxSizing": {
       "status": "supported",
-      "mapsTo": "JS shim setBoxSizing → bridge widget_bridge.cpp:3666-3686 routes the keyword to FlexStyle::box_sizing (geometry.hpp:307); yoga_layout.cpp:123-128 calls YGNodeStyleSetBoxSizing with the matching YGBoxSizing enum. Default border-box matches the CSS spec.",
+      "mapsTo": "JS shim setBoxSizing \u2192 bridge widget_bridge.cpp:3666-3686 routes the keyword to FlexStyle::box_sizing (geometry.hpp:307); yoga_layout.cpp:123-128 calls YGNodeStyleSetBoxSizing with the matching YGBoxSizing enum. Default border-box matches the CSS spec.",
       "supportedValues": [
         "border-box",
         "content-box"
@@ -5867,7 +5864,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1516]"
       ],
-      "notes": "pulp #1516 (PR #1538) wired FlexStyle::box_sizing + YGNodeStyleSetBoxSizing. Mirrors css/boxSizing on the same view slot — the css side is also supported. pulp #1737 catalog hygiene: catalog drifted to `missing` after the wiring landed; flipped now that the wiring is verified end-to-end.",
+      "notes": "pulp #1516 (PR #1538) wired FlexStyle::box_sizing + YGNodeStyleSetBoxSizing. Mirrors css/boxSizing on the same view slot \u2014 the css side is also supported. pulp #1737 catalog hygiene: catalog drifted to `missing` after the wiring landed; flipped now that the wiring is verified end-to-end.",
       "issue": "1516"
     },
     "yoga/margin": {
@@ -5875,14 +5872,14 @@
       "mapsTo": "FlexStyle.margin (float) for the uniform shorthand; per-edge `marginTop` / `marginRight` / `marginBottom` / `marginLeft` route through FlexStyle::dim_margin_* to YGNodeStyleSetMargin{,Percent,Auto}. The shorthand is uniform-px today; the per-edge entries already cover px / % / auto.",
       "supportedValues": [
         "px",
-        "auto (per-edge — see yoga/marginTop etc.)"
+        "auto (per-edge \u2014 see yoga/marginTop etc.)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Yoga's YGNodeStyleSetMarginAuto is wired through `apply_margin` and `apply_logical_margin` in yoga_layout.cpp — `auto` works on every edge (top/right/bottom/left/start/end). The uniform shorthand stays px-only because there's no spec-defined `margin: auto` per-edge expansion that requires the shorthand itself to carry the unit; consumers that want centering set the per-edge keys.",
+      "notes": "Yoga's YGNodeStyleSetMarginAuto is wired through `apply_margin` and `apply_logical_margin` in yoga_layout.cpp \u2014 `auto` works on every edge (top/right/bottom/left/start/end). The uniform shorthand stays px-only because there's no spec-defined `margin: auto` per-edge expansion that requires the shorthand itself to carry the unit; consumers that want centering set the per-edge keys.",
       "issue": ""
     },
     "yoga/marginTop": {
@@ -5899,7 +5896,7 @@
         "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "yoga/marginRight": {
@@ -5916,7 +5913,7 @@
         "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "yoga/marginBottom": {
@@ -5933,7 +5930,7 @@
         "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "yoga/marginLeft": {
@@ -5950,7 +5947,7 @@
         "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — per-edge accepts number, percent string, auto.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
       "issue": ""
     },
     "yoga/marginStart": {
@@ -5965,7 +5962,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1542]"
       ],
-      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL; the new FlexStyle::writing_direction field plus YGNodeStyleSetDirection drives the flip.",
+      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL; the new FlexStyle::writing_direction field plus YGNodeStyleSetDirection drives the flip.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/marginEnd": {
@@ -5980,7 +5977,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1542]"
       ],
-      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL.",
+      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/marginHorizontal": {
@@ -5996,7 +5993,7 @@
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "yoga/marginVertical": {
@@ -6012,7 +6009,7 @@
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "yoga/padding": {
@@ -6020,7 +6017,7 @@
       "mapsTo": "FlexStyle.padding (uniform shorthand, float) plus per-edge FlexStyle::dim_padding_* routing through `apply_padding` / `apply_logical_padding` in yoga_layout.cpp to YGNodeStyleSetPadding{,Percent}.",
       "supportedValues": [
         "px",
-        "% (per-edge — see yoga/paddingTop etc.)"
+        "% (per-edge \u2014 see yoga/paddingTop etc.)"
       ],
       "unsupportedValues": [],
       "tests": [
@@ -6028,7 +6025,7 @@
         "semantic:yoga/box-sizing",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "% values flow through the per-edge keys (paddingTop/Right/Bottom/Left/Start/End). The uniform `padding` shorthand is px-only by design — the bridge expands shorthands at the JS layer (web-compat-style-decl.js `padding` case) into per-edge calls that DO carry the unit. CSS spec rejects `padding: auto` (auto is invalid for padding), matching Yoga's lack of a YGNodeStyleSetPaddingAuto API.",
+      "notes": "% values flow through the per-edge keys (paddingTop/Right/Bottom/Left/Start/End). The uniform `padding` shorthand is px-only by design \u2014 the bridge expands shorthands at the JS layer (web-compat-style-decl.js `padding` case) into per-edge calls that DO carry the unit. CSS spec rejects `padding: auto` (auto is invalid for padding), matching Yoga's lack of a YGNodeStyleSetPaddingAuto API.",
       "issue": ""
     },
     "yoga/paddingTop": {
@@ -6043,7 +6040,7 @@
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
       "issue": ""
     },
     "yoga/paddingRight": {
@@ -6058,7 +6055,7 @@
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
       "issue": ""
     },
     "yoga/paddingBottom": {
@@ -6073,7 +6070,7 @@
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
       "issue": ""
     },
     "yoga/paddingLeft": {
@@ -6088,7 +6085,7 @@
         "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
       "issue": ""
     },
     "yoga/paddingStart": {
@@ -6102,7 +6099,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1542]"
       ],
-      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL. `auto` is spec-invalid for padding (CSS rejects `padding: auto`), so it's not listed as a gap — Yoga matches the spec by not exposing a YGNodeStyleSetPaddingAuto API.",
+      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL. `auto` is spec-invalid for padding (CSS rejects `padding: auto`), so it's not listed as a gap \u2014 Yoga matches the spec by not exposing a YGNodeStyleSetPaddingAuto API.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/paddingEnd": {
@@ -6116,7 +6113,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1542]"
       ],
-      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL. `auto` is spec-invalid for padding so it's not listed as a gap.",
+      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL. `auto` is spec-invalid for padding so it's not listed as a gap.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/paddingHorizontal": {
@@ -6131,7 +6128,7 @@
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "yoga/paddingVertical": {
@@ -6146,7 +6143,7 @@
         "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1434 cross-surface mega-batch — alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
       "issue": ""
     },
     "yoga/borderWidth": {
@@ -6160,7 +6157,7 @@
         "semantic:yoga/box-sizing",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Yoga's BORDER edges contribute to content-box sizing. Before #1543, Pulp's borders were paint-only (Skia stroke) and Yoga saw zero border insets, which made box-sizing math wrong when border-box was active. Wired now — borders affect both layout AND paint. % is intentionally not listed as an unsupported gap because the CSS spec rejects `border-width: <%>` (invalid value); Yoga matches the spec by not exposing a YGNodeStyleSetBorderPercent API.",
+      "notes": "Yoga's BORDER edges contribute to content-box sizing. Before #1543, Pulp's borders were paint-only (Skia stroke) and Yoga saw zero border insets, which made box-sizing math wrong when border-box was active. Wired now \u2014 borders affect both layout AND paint. % is intentionally not listed as an unsupported gap because the CSS spec rejects `border-width: <%>` (invalid value); Yoga matches the spec by not exposing a YGNodeStyleSetBorderPercent API.",
       "issue": ""
     },
     "yoga/borderTopWidth": {
@@ -6173,7 +6170,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Same as borderWidth — the per-edge variants share the same wiring. Reached from JS via setBorderTopWidth(id, w). % is spec-invalid for border-width so not listed as a gap.",
+      "notes": "Same as borderWidth \u2014 the per-edge variants share the same wiring. Reached from JS via setBorderTopWidth(id, w). % is spec-invalid for border-width so not listed as a gap.",
       "issue": ""
     },
     "yoga/borderRightWidth": {
@@ -6304,7 +6301,7 @@
         "test/test_widget_bridge.cpp [issue-1542]",
         "test/test_widget_bridge.cpp::\"setFlex start/end accept 'auto' keyword\""
       ],
-      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL. `auto` (the CSS default — \"don't anchor to this edge\") routes through Yoga's YGNodeStyleSetPositionAuto via FlexStyle::dim_start.unit = auto_; the bridge accepts `'auto'` verbatim. Wired DIVERGE→PASS sweep.",
+      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL. `auto` (the CSS default \u2014 \"don't anchor to this edge\") routes through Yoga's YGNodeStyleSetPositionAuto via FlexStyle::dim_start.unit = auto_; the bridge accepts `'auto'` verbatim. Wired DIVERGE\u2192PASS sweep.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/end": {
@@ -6320,7 +6317,7 @@
         "test/test_widget_bridge.cpp [issue-1542]",
         "test/test_widget_bridge.cpp::\"setFlex start/end accept 'auto' keyword\""
       ],
-      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL. `auto` routes through YGNodeStyleSetPositionAuto. Wired DIVERGE→PASS sweep.",
+      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL. `auto` routes through YGNodeStyleSetPositionAuto. Wired DIVERGE\u2192PASS sweep.",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/gap": {
@@ -6389,12 +6386,12 @@
         "test/test_widget_bridge.cpp [display-contents]",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1420: claim flex+none as supported. CSS translator at web-compat-style-decl.js:86-118 routes display:none to setVisible(false) and display:flex to setVisible(true)+setFlex(direction). 'flex' is implicit in pulp's layout model; 'none' uses View visibility. Yoga has YGDisplay {flex, none, contents}; pulp doesn't model 'contents'. ARCH-DEFERRED: display: contents requires parallel block/inline-flow layout that CLAUDE.md's flex+grid-only policy (Yoga 3.0 ceiling) explicitly rules out — the dispatcher silently no-ops; pinned by test/test_widget_bridge.cpp [display-contents].",
+      "notes": "pulp #1420: claim flex+none as supported. CSS translator at web-compat-style-decl.js:86-118 routes display:none to setVisible(false) and display:flex to setVisible(true)+setFlex(direction). 'flex' is implicit in pulp's layout model; 'none' uses View visibility. Yoga has YGDisplay {flex, none, contents}; pulp doesn't model 'contents'. ARCH-DEFERRED: display: contents requires parallel block/inline-flow layout that CLAUDE.md's flex+grid-only policy (Yoga 3.0 ceiling) explicitly rules out \u2014 the dispatcher silently no-ops; pinned by test/test_widget_bridge.cpp [display-contents].",
       "issue": "https://github.com/danielraffel/pulp/issues/1420"
     },
     "yoga/overflow": {
       "status": "supported",
-      "mapsTo": "View::Overflow {visible, hidden, scroll} — set via setOverflow(id, 'visible'|'hidden'|'scroll') in widget_bridge.cpp; routed through to Yoga via YGNodeStyleSetOverflow in yoga_layout.cpp::build_yoga_subtree. Paint clipping in view.cpp treats `scroll` like `hidden` (no scrollbar UI yet).",
+      "mapsTo": "View::Overflow {visible, hidden, scroll} \u2014 set via setOverflow(id, 'visible'|'hidden'|'scroll') in widget_bridge.cpp; routed through to Yoga via YGNodeStyleSetOverflow in yoga_layout.cpp::build_yoga_subtree. Paint clipping in view.cpp treats `scroll` like `hidden` (no scrollbar UI yet).",
       "supportedValues": [
         "visible",
         "hidden",
@@ -6405,7 +6402,7 @@
         "test/test_widget_bridge.cpp::\"setOverflow accepts scroll keyword\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "DIVERGE→PASS sweep — `scroll` is now accepted as a third keyword and propagates through both the layout engine (Yoga's overflow:scroll affects descendant-overflow contribution) and the paint clip path (matches CSS spec where `scroll` clips the painted box like `hidden`). Scrollbar UI / actual scroll-position state remains a roadmap item; the harness gap was about *layout-side* keyword acceptance, which is now covered.",
+      "notes": "DIVERGE\u2192PASS sweep \u2014 `scroll` is now accepted as a third keyword and propagates through both the layout engine (Yoga's overflow:scroll affects descendant-overflow contribution) and the paint clip path (matches CSS spec where `scroll` clips the painted box like `hidden`). Scrollbar UI / actual scroll-position state remains a roadmap item; the harness gap was about *layout-side* keyword acceptance, which is now covered.",
       "issue": ""
     },
     "yoga/direction": {
@@ -6420,26 +6417,26 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1542]"
       ],
-      "notes": "pulp #1542 — bridge accepts `direction_writing` sub-key on setFlex (distinct from `direction` for flex-direction). FlexStyle::writing_direction { inherit, ltr, rtl } drives both YGNodeStyleSetDirection on the per-node call and the root's YGNodeCalculateLayout direction argument. Required for yoga's logical-edge resolution (start/end, marginStart, etc.).",
+      "notes": "pulp #1542 \u2014 bridge accepts `direction_writing` sub-key on setFlex (distinct from `direction` for flex-direction). FlexStyle::writing_direction { inherit, ltr, rtl } drives both YGNodeStyleSetDirection on the per-node call and the root's YGNodeCalculateLayout direction argument. Required for yoga's logical-edge resolution (start/end, marginStart, etc.).",
       "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/flex": {
       "status": "supported",
-      "mapsTo": "web-compat-style-decl.js case 'flex' shorthand parser splits on whitespace and dispatches setFlex(id, 'flex_grow', ...) + optional setFlex(id, 'flex_shrink', ...) + optional setFlex(id, 'flex_basis', ...) onto FlexStyle.flex_grow/flex_shrink/flex_basis. Keyword forms route through the same setFlex calls — see notes for spec expansions.",
+      "mapsTo": "web-compat-style-decl.js case 'flex' shorthand parser splits on whitespace and dispatches setFlex(id, 'flex_grow', ...) + optional setFlex(id, 'flex_shrink', ...) + optional setFlex(id, 'flex_basis', ...) onto FlexStyle.flex_grow/flex_shrink/flex_basis. Keyword forms route through the same setFlex calls \u2014 see notes for spec expansions.",
       "supportedValues": [
         "<grow>",
         "<grow> <shrink>",
         "<grow> <shrink> <basis>",
-        "'auto' (≡ 1 1 auto)",
-        "'none' (≡ 0 0 auto)",
-        "'initial' (≡ 0 1 auto)"
+        "'auto' (\u2261 1 1 auto)",
+        "'none' (\u2261 0 0 auto)",
+        "'initial' (\u2261 0 1 auto)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/web-compat/test_popover_row_template_1147.cpp",
         "test/test_widget_bridge.cpp::\"flex shorthand keyword forms\""
       ],
-      "notes": "pulp #1544 — catalog promotion. Already wired through `web-compat-style-decl.js` shorthand parser; mirrors `css/flex`. DIVERGE→PASS sweep — keyword forms (`flex: auto`/`none`/`initial`) now expand per the CSS Flexible Box spec instead of silently zeroing flex_grow.",
+      "notes": "pulp #1544 \u2014 catalog promotion. Already wired through `web-compat-style-decl.js` shorthand parser; mirrors `css/flex`. DIVERGE\u2192PASS sweep \u2014 keyword forms (`flex: auto`/`none`/`initial`) now expand per the CSS Flexible Box spec instead of silently zeroing flex_grow.",
       "issue": ""
     },
     "yoga/flexFlow": {
@@ -6455,7 +6452,7 @@
         "test/test_widget_bridge.cpp::\"flex-flow shorthand recognizes wrap-reverse\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1544 — catalog promotion. Already wired through `web-compat-style-decl.js` shorthand parser (pulp #1434 Triage #14 extended it to cover `-reverse` modes); mirrors `css/flexFlow`.",
+      "notes": "pulp #1544 \u2014 catalog promotion. Already wired through `web-compat-style-decl.js` shorthand parser (pulp #1434 Triage #14 extended it to cover `-reverse` modes); mirrors `css/flexFlow`.",
       "issue": ""
     }
   },
@@ -6463,13 +6460,13 @@
     "_note": "The @pulp/react reconciler surface (host-config.ts, prop-applier.ts) is captured under rn/* above (prop-applier covers ~70 props). This section is reserved for React-specific features that aren't single-prop entries: Suspense, ConcurrentMode, Profiler, error boundaries, refs, portals, hooks edge cases (useTransition, useDeferredValue, useId, useSyncExternalStore). As of 2026-05-04 the renderer is built on react-reconciler@0.31 and supports the basic function-component + useState + useEffect + useRef + useMemo / useCallback set; concurrent features are not exercised. File-issue follow-up: enumerate observed React features end-to-end and populate per-feature entries. Currently empty pending that audit."
   },
   "html": {
-    "_note": "Populated 2026-05-04 from web-compat-element.js (~836 LOC) and web-compat-document.js (~1527 LOC). Tracks the DOM-lite consumer surface: createElement / setAttribute / appendChild / addEventListener / Element / HTMLElement attributes / dataset / classList / events / style sheet support. Spec source: https://developer.mozilla.org/en-US/docs/Web/API/Element + HTMLElement subclasses. Recent additions since 2026-04-30: html/svg width/height attribute replay (#1347 / pulp #1147), html/span/p/label widget mapping confirmed (Label widget, not View), html/style :hover stylesheet support (#1345 / pulp #1149 part b). 2026-05-05 hygiene (pulp #1434): html/ARIA flipped missing → partial — storage works (parallel to html/Element_disabled); platform-bridge routing tracked under #1476.",
+    "_note": "Populated 2026-05-04 from web-compat-element.js (~836 LOC) and web-compat-document.js (~1527 LOC). Tracks the DOM-lite consumer surface: createElement / setAttribute / appendChild / addEventListener / Element / HTMLElement attributes / dataset / classList / events / style sheet support. Spec source: https://developer.mozilla.org/en-US/docs/Web/API/Element + HTMLElement subclasses. Recent additions since 2026-04-30: html/svg width/height attribute replay (#1347 / pulp #1147), html/span/p/label widget mapping confirmed (Label widget, not View), html/style :hover stylesheet support (#1345 / pulp #1149 part b). 2026-05-05 hygiene (pulp #1434): html/ARIA flipped missing \u2192 partial \u2014 storage works (parallel to html/Element_disabled); platform-bridge routing tracked under #1476.",
     "html/ARIA": {
       "status": "supported",
-      "mapsTo": "Element.setAttribute('aria-label', ...) → bridge.setAccessibilityLabel → View::set_access_label(). Element.setAttribute('role', ...) → bridge.setAccessibilityRole → View::set_access_role() with ARIA→AccessRole bucket mapping (slider/checkbox/switch/radio/img/progressbar/meter/heading/label collapse onto Pulp's enum; the long ARIA tail collapses to AccessRole::group). pulp #1737 — Element.setAttribute('aria-pressed' / 'aria-checked' / 'aria-disabled' / 'aria-hidden', ...) → bridge.setAccessibilityState → View::access_pressed_ / access_checked_ / access_disabled_ / access_hidden_ slots (tri-state per ARIA 1.2 — `true` / `false` / `mixed` / unset). Storage round-trips through getAttribute either way. macOS NSAccessibility bridge in core/view/platform/mac/accessibility_mac.mm reads all slots directly; AccessibilityTree snapshot picks them up cross-platform; removeAttribute clears the matching slot.",
+      "mapsTo": "Element.setAttribute('aria-label', ...) \u2192 bridge.setAccessibilityLabel \u2192 View::set_access_label(). Element.setAttribute('role', ...) \u2192 bridge.setAccessibilityRole \u2192 View::set_access_role() with ARIA\u2192AccessRole bucket mapping (slider/checkbox/switch/radio/img/progressbar/meter/heading/label collapse onto Pulp's enum; the long ARIA tail collapses to AccessRole::group). pulp #1737 \u2014 Element.setAttribute('aria-pressed' / 'aria-checked' / 'aria-disabled' / 'aria-hidden', ...) \u2192 bridge.setAccessibilityState \u2192 View::access_pressed_ / access_checked_ / access_disabled_ / access_hidden_ slots (tri-state per ARIA 1.2 \u2014 `true` / `false` / `mixed` / unset). Storage round-trips through getAttribute either way. macOS NSAccessibility bridge in core/view/platform/mac/accessibility_mac.mm reads all slots directly; AccessibilityTree snapshot picks them up cross-platform; removeAttribute clears the matching slot.",
       "supportedValues": [
-        "aria-label → setAccessibilityLabel routing",
-        "role → setAccessibilityRole routing (full ARIA→AccessRole bucket mapping)",
+        "aria-label \u2192 setAccessibilityLabel routing",
+        "role \u2192 setAccessibilityRole routing (full ARIA\u2192AccessRole bucket mapping)",
         "aria-pressed / aria-checked / aria-disabled / aria-hidden state attributes (tri-state per ARIA 1.2)",
         "removeAttribute resets the matching View slot (no stale state on detach)",
         "aria-* attribute storage / read-back via setAttribute / getAttribute (forward-compat for the long ARIA tail)"
@@ -6480,7 +6477,7 @@
         "test/test_widget_bridge.cpp [issue-1641-followup-aria-removeattribute]",
         "test/test_widget_bridge.cpp [issue-1737] (aria-pressed / -checked / -disabled / -hidden routing to View::access_*_ slots; tri-state; removeAttribute resets)"
       ],
-      "notes": "Wave 3 (PR #1641) wired aria-label + role + macOS NSAccessibility. pulp #1737 — added aria-pressed / -checked / -disabled / -hidden state attributes via new setAccessibilityState bridge fn + View::access_pressed_/_checked_/_disabled_/_hidden_ slots; JS shim setAttribute fast-paths the four state attrs and __replayAriaAttributes__ covers the React-pre-mount commit order; removeAttribute clears the matching slot (mirrors the #1641 followup pattern for aria-label / role). Linux AT-SPI bridge + Windows UIA bridge remain `arch-deferred-platform-at` (tracked under pulp #217 — multi-week platform integration scope; not a Pulp-side ARIA-attribute gap). The state slots are populated cross-platform; whichever platform AT bridge lands next will read them automatically.",
+      "notes": "Wave 3 (PR #1641) wired aria-label + role + macOS NSAccessibility. pulp #1737 \u2014 added aria-pressed / -checked / -disabled / -hidden state attributes via new setAccessibilityState bridge fn + View::access_pressed_/_checked_/_disabled_/_hidden_ slots; JS shim setAttribute fast-paths the four state attrs and __replayAriaAttributes__ covers the React-pre-mount commit order; removeAttribute clears the matching slot (mirrors the #1641 followup pattern for aria-label / role). Linux AT-SPI bridge + Windows UIA bridge remain `arch-deferred-platform-at` (tracked under pulp #217 \u2014 multi-week platform integration scope; not a Pulp-side ARIA-attribute gap). The state slots are populated cross-platform; whichever platform AT bridge lands next will read them automatically.",
       "issue": "1476"
     },
     "html/DocumentFragment": {
@@ -6495,12 +6492,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Wave 1 architectural reclassification — full Range / Selection API is arch-text-editor-owns-selection (Pulp's text editor has its own selection model; the W3C Range/Selection API is not modeled by design). Wave 4 cleanup — status partial → supported + emptied unsupportedValues so the harness reflects the wired DocumentFragment surface (the React reconciler path); the Range/Selection API is an explicit arch non-goal, not a partial-deferred gap.",
+      "notes": "Wave 1 architectural reclassification \u2014 full Range / Selection API is arch-text-editor-owns-selection (Pulp's text editor has its own selection model; the W3C Range/Selection API is not modeled by design). Wave 4 cleanup \u2014 status partial \u2192 supported + emptied unsupportedValues so the harness reflects the wired DocumentFragment surface (the React reconciler path); the Range/Selection API is an explicit arch non-goal, not a partial-deferred gap.",
       "issue": ""
     },
     "html/Element_addEventListener": {
       "status": "supported",
-      "mapsTo": "Element.addEventListener — registers click / mousedown / mouseup / mouseenter / mouseleave / pointerenter / pointerleave / pointerdown / pointermove / pointerup / pointercancel / gesturestart / gesturechange / gestureend / input / change / focus / blur / wheel / dragstart / drag / dragend / dragenter / dragover / dragleave / drop with the bridge. registerHover/registerClick/registerPointer/registerGesture/registerWheel/registerDrop are called lazily as needed; drop events synthesize a DragEvent-shaped object with `_dropData`.",
+      "mapsTo": "Element.addEventListener \u2014 registers click / mousedown / mouseup / mouseenter / mouseleave / pointerenter / pointerleave / pointerdown / pointermove / pointerup / pointercancel / gesturestart / gesturechange / gestureend / input / change / focus / blur / wheel / dragstart / drag / dragend / dragenter / dragover / dragleave / drop with the bridge. registerHover/registerClick/registerPointer/registerGesture/registerWheel/registerDrop are called lazily as needed; drop events synthesize a DragEvent-shaped object with `_dropData`.",
       "supportedValues": [
         "click",
         "mousedown",
@@ -6538,7 +6535,7 @@
         "test/test_widget_bridge.cpp::\"addEventListener('drop', fn) routes through registerDrop\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "DIVERGE→PASS sweep — `wheel` and `drag*`/`drop` event types are now routed through `registerWheel` / `registerDrop` from inside `_registerNativeEvent`, so DOM consumers no longer need to call the platform-specific bridge fns directly. The full multi-stage drag lifecycle (native drag-image rendering, dragstart/drag/dragend on the source element) remains a roadmap item — the bridge fires a single `drop` callback at completion and we synthesize a DragEvent-shaped object for the target element. Hover events fixed earlier in PR #1173 (pulp #1149 part a).",
+      "notes": "DIVERGE\u2192PASS sweep \u2014 `wheel` and `drag*`/`drop` event types are now routed through `registerWheel` / `registerDrop` from inside `_registerNativeEvent`, so DOM consumers no longer need to call the platform-specific bridge fns directly. The full multi-stage drag lifecycle (native drag-image rendering, dragstart/drag/dragend on the source element) remains a roadmap item \u2014 the bridge fires a single `drop` callback at completion and we synthesize a DragEvent-shaped object for the target element. Hover events fixed earlier in PR #1173 (pulp #1149 part a).",
       "issue": "1149"
     },
     "html/Element_appendChild": {
@@ -6554,7 +6551,7 @@
     },
     "html/Element_classList": {
       "status": "supported",
-      "mapsTo": "Element.classList — add/remove/toggle/contains/length/item, mirrors className. Triggers stylesheet re-application on change.",
+      "mapsTo": "Element.classList \u2014 add/remove/toggle/contains/length/item, mirrors className. Triggers stylesheet re-application on change.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -6565,7 +6562,7 @@
     },
     "html/Element_cloneNode": {
       "status": "supported",
-      "mapsTo": "Element.cloneNode(deep) — replicates className, textContent, type, value, style props; recursive when deep.",
+      "mapsTo": "Element.cloneNode(deep) \u2014 replicates className, textContent, type, value, style props; recursive when deep.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -6576,7 +6573,7 @@
     },
     "html/Element_dataset": {
       "status": "supported",
-      "mapsTo": "Element.dataset — kebab-cased data-* attrs surface as camelCase JS properties. Includes the data-overlay='true' hint (#1148).",
+      "mapsTo": "Element.dataset \u2014 kebab-cased data-* attrs surface as camelCase JS properties. Includes the data-overlay='true' hint (#1148).",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -6587,7 +6584,7 @@
     },
     "html/Element_disabled": {
       "status": "supported",
-      "mapsTo": "Element.disabled property accessor in web-compat-element.js — set re-applies stylesheets (so `:disabled` selectors react) AND calls bridge `setEnabled(id, !disabled)` so the underlying View flips its enabled flag and stops handling pointer events / dispatching change.",
+      "mapsTo": "Element.disabled property accessor in web-compat-element.js \u2014 set re-applies stylesheets (so `:disabled` selectors react) AND calls bridge `setEnabled(id, !disabled)` so the underlying View flips its enabled flag and stops handling pointer events / dispatching change.",
       "supportedValues": [
         "true / false (round-trips through el.disabled getter; both stylesheet and native widget state stay in sync)"
       ],
@@ -6596,12 +6593,12 @@
         "test/test_widget_bridge.cpp::\"Element.disabled wires to setEnabled\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "DIVERGE→PASS sweep — previously the setter only flipped the stylesheet flag, leaving the native widget interactive even though `:disabled` styles applied. Now wired end-to-end via setEnabled.",
+      "notes": "DIVERGE\u2192PASS sweep \u2014 previously the setter only flipped the stylesheet flag, leaving the native widget interactive even though `:disabled` styles applied. Now wired end-to-end via setEnabled.",
       "issue": ""
     },
     "html/Element_dispatchEvent": {
       "status": "supported",
-      "mapsTo": "Element.dispatchEvent — capture + target + bubble phases; honors stopPropagation / preventDefault / _noBubble.",
+      "mapsTo": "Element.dispatchEvent \u2014 capture + target + bubble phases; honors stopPropagation / preventDefault / _noBubble.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -6689,7 +6686,7 @@
     },
     "html/Element_removeAttribute": {
       "status": "supported",
-      "mapsTo": "Element.removeAttribute — also clears data-* dataset entries and re-evaluates overlay heuristic if data-overlay was set.",
+      "mapsTo": "Element.removeAttribute \u2014 also clears data-* dataset entries and re-evaluates overlay heuristic if data-overlay was set.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -6722,7 +6719,7 @@
     },
     "html/Element_setAttribute": {
       "status": "supported",
-      "mapsTo": "Element.setAttribute(name, value) — handles id, class, data-*, plus presentational width/height for media tags (replay path).",
+      "mapsTo": "Element.setAttribute(name, value) \u2014 handles id, class, data-*, plus presentational width/height for media tags (replay path).",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -6744,7 +6741,7 @@
     },
     "html/Element_textContent": {
       "status": "supported",
-      "mapsTo": "Element.textContent — special-cased for <style>: routes through _processStyleElement instead of setText.",
+      "mapsTo": "Element.textContent \u2014 special-cased for <style>: routes through _processStyleElement instead of setText.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -6755,7 +6752,7 @@
     },
     "html/Element_value": {
       "status": "supported",
-      "mapsTo": "Element.value — type-aware (range -> normalized, checkbox -> 0/1, progress -> setProgress, default -> setText).",
+      "mapsTo": "Element.value \u2014 type-aware (range -> normalized, checkbox -> 0/1, progress -> setProgress, default -> setText).",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -6766,7 +6763,7 @@
     },
     "html/Event_constructor": {
       "status": "supported",
-      "mapsTo": "Event(type, init) and CustomEvent(type, init) constructor functions in web-compat-element.js — produce objects shaped like the DOM Event interface (type / bubbles / cancelable / composed / target / currentTarget / timeStamp / defaultPrevented / stopPropagation / stopImmediatePropagation / preventDefault). Round-trips through Element.dispatchEvent. The bridge-synthesized `_makeEvent` factory remains the canonical path for native-originated events (it carries the position / pointer / gesture fields).",
+      "mapsTo": "Event(type, init) and CustomEvent(type, init) constructor functions in web-compat-element.js \u2014 produce objects shaped like the DOM Event interface (type / bubbles / cancelable / composed / target / currentTarget / timeStamp / defaultPrevented / stopPropagation / stopImmediatePropagation / preventDefault). Round-trips through Element.dispatchEvent. The bridge-synthesized `_makeEvent` factory remains the canonical path for native-originated events (it carries the position / pointer / gesture fields).",
       "supportedValues": [
         "new Event('foo')",
         "new Event('foo', { bubbles, cancelable, composed })",
@@ -6777,7 +6774,7 @@
         "test/test_widget_bridge.cpp::\"new Event() round-trips through dispatchEvent\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "DIVERGE→PASS sweep — userland `new Event(...)` previously was a TypeError because no Event class was exposed. Now exposed as a global constructor (plus CustomEvent for parity). Type-only events are sufficient for the harness gap; full DOM event class hierarchy (UIEvent / MouseEvent / KeyboardEvent etc.) remains a roadmap follow-up.",
+      "notes": "DIVERGE\u2192PASS sweep \u2014 userland `new Event(...)` previously was a TypeError because no Event class was exposed. Now exposed as a global constructor (plus CustomEvent for parity). Type-only events are sufficient for the harness gap; full DOM event class hierarchy (UIEvent / MouseEvent / KeyboardEvent etc.) remains a roadmap follow-up.",
       "issue": ""
     },
     "html/StyleSheet_inline": {
@@ -6794,12 +6791,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "PR #1345 added :hover; PR #1641 (Wave 3 html.3) extended selector engine with [attr] / descendant / child / compound. Wave 1 architectural reclassification — @media / @keyframes / @import / @font-face / @supports / complex selectors are arch-no-cascade-engine (Pulp doesn't model the CSS cascade by design; selector evaluation is single-pass tag/.class/#id/[attr]/combinator). Wave 4 cleanup — status partial → supported + emptied unsupportedValues; the inline-style surface that IS implemented is the supported claim, the at-rule + cascade-engine extensions are explicit arch non-goals (consumers reach for @pulp/react state-dependent components for media-query / keyframe needs).",
+      "notes": "PR #1345 added :hover; PR #1641 (Wave 3 html.3) extended selector engine with [attr] / descendant / child / compound. Wave 1 architectural reclassification \u2014 @media / @keyframes / @import / @font-face / @supports / complex selectors are arch-no-cascade-engine (Pulp doesn't model the CSS cascade by design; selector evaluation is single-pass tag/.class/#id/[attr]/combinator). Wave 4 cleanup \u2014 status partial \u2192 supported + emptied unsupportedValues; the inline-style surface that IS implemented is the supported claim, the at-rule + cascade-engine extensions are explicit arch non-goals (consumers reach for @pulp/react state-dependent components for media-query / keyframe needs).",
       "issue": ""
     },
     "html/article": {
       "status": "supported",
-      "mapsTo": "createCol — same as div.",
+      "mapsTo": "createCol \u2014 same as div.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -6810,7 +6807,7 @@
     },
     "html/aside": {
       "status": "supported",
-      "mapsTo": "createCol — same as div.",
+      "mapsTo": "createCol \u2014 same as div.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -6827,7 +6824,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Inherits ToggleButton widget — toggleable by default.",
+      "notes": "Inherits ToggleButton widget \u2014 toggleable by default.",
       "issue": ""
     },
     "html/canvas": {
@@ -6854,16 +6851,16 @@
         "test/test_widget_bridge.cpp::\"<details> open setter dispatches toggle event\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "DIVERGE→PASS sweep — open/closed toggle behavior wired through Element.open setter. <summary>-driven children hiding when closed is a paint-side concern that remains roadmap; the harness gap was about JS-side toggle semantics.",
+      "notes": "DIVERGE\u2192PASS sweep \u2014 open/closed toggle behavior wired through Element.open setter. <summary>-driven children hiding when closed is a paint-side concern that remains roadmap; the harness gap was about JS-side toggle semantics.",
       "issue": ""
     },
     "html/dialog": {
       "status": "supported",
-      "mapsTo": "createPanel(id, parent) + setVisible(false). Element.show() / showModal() / close() methods on Element.prototype (tag-guarded — return early on non-DIALOG elements) flip setVisible and the `open` HTML attribute, dispatch a `close` event, and round-trip `el.returnValue`. showModal() degrades to show() + an internal `_dialogModal` flag because Pulp doesn't yet have a native modal-input-trap layer; the ::backdrop pseudo-element remains a separate paint-side roadmap item.",
+      "mapsTo": "createPanel(id, parent) + setVisible(false). Element.show() / showModal() / close() methods on Element.prototype (tag-guarded \u2014 return early on non-DIALOG elements) flip setVisible and the `open` HTML attribute, dispatch a `close` event, and round-trip `el.returnValue`. showModal() degrades to show() + an internal `_dialogModal` flag because Pulp doesn't yet have a native modal-input-trap layer; the ::backdrop pseudo-element remains a separate paint-side roadmap item.",
       "supportedValues": [
         "dialog as a hidden Panel",
-        "el.show() — non-modal open with `open` attribute reflection",
-        "el.showModal() (degrades to show() + _dialogModal flag — no native modal trap layer yet, tracked separately)",
+        "el.show() \u2014 non-modal open with `open` attribute reflection",
+        "el.showModal() (degrades to show() + _dialogModal flag \u2014 no native modal trap layer yet, tracked separately)",
         "el.close(returnValue) + 'close' event dispatch",
         "el.open getter / setter (reflects + drives `open` attribute)",
         "el.returnValue round-trip"
@@ -6872,7 +6869,7 @@
       "tests": [
         "test/test_widget_bridge.cpp::<dialog> show/close round-trips visibility and dispatches close"
       ],
-      "notes": "DIVERGE→PASS sweep — show/showModal/close methods exposed. pulp #1737: catalog flipped noop → supported to match the wired behavior. Wave 1 walked this back to noop conservatively because modal-input-trap + ::backdrop aren't wired, but the JS surface (show / showModal / close / open / returnValue) IS wired and the existing test [test/test_widget_bridge.cpp \"<dialog> show/close...\"] exercises the round-trip. Architectural follow-ups (native modal-input-trap layer, ::backdrop pseudo-element paint) are documented in supportedValues notes — same precedent as object-fit's degraded-but-honored claim. Closes the last html-surface NO-OP.",
+      "notes": "DIVERGE\u2192PASS sweep \u2014 show/showModal/close methods exposed. pulp #1737: catalog flipped noop \u2192 supported to match the wired behavior. Wave 1 walked this back to noop conservatively because modal-input-trap + ::backdrop aren't wired, but the JS surface (show / showModal / close / open / returnValue) IS wired and the existing test [test/test_widget_bridge.cpp \"<dialog> show/close...\"] exercises the round-trip. Architectural follow-ups (native modal-input-trap layer, ::backdrop pseudo-element paint) are documented in supportedValues notes \u2014 same precedent as object-fit's degraded-but-honored claim. Closes the last html-surface NO-OP.",
       "issue": ""
     },
     "html/div": {
@@ -6885,7 +6882,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Generic container — Yoga column flex by default.",
+      "notes": "Generic container \u2014 Yoga column flex by default.",
       "issue": ""
     },
     "html/document_addEventListener": {
@@ -6934,7 +6931,7 @@
     },
     "html/document_querySelector": {
       "status": "supported",
-      "mapsTo": "document.querySelector / querySelectorAll — _parseSelector + _matchesSelector in web-compat-document.js. Tokenizes the rightmost simple selector (tag / #id / .class / [attr] / [attr=value] / [attr^=v] / [attr$=v] / [attr*=v] / [attr|=v] / [attr~=v]) plus descendant (`a b`), child (`a > b`), and a curated set of pseudo-classes. Walks left to right with bracket-aware splitting.",
+      "mapsTo": "document.querySelector / querySelectorAll \u2014 _parseSelector + _matchesSelector in web-compat-document.js. Tokenizes the rightmost simple selector (tag / #id / .class / [attr] / [attr=value] / [attr^=v] / [attr$=v] / [attr*=v] / [attr|=v] / [attr~=v]) plus descendant (`a b`), child (`a > b`), and a curated set of pseudo-classes. Walks left to right with bracket-aware splitting.",
       "supportedValues": [
         "#id",
         ".class",
@@ -6949,11 +6946,11 @@
         "compound (tag.class, tag#id, tag[attr], #id.class[attr])",
         "descendant (a b)",
         "child (a > b)",
-        ":hover / :focus / :active / :disabled / :checked / :enabled (state-on-element pseudo-classes — read el._isHovered / _hasFocus / _isActive / _disabled / _checked)",
+        ":hover / :focus / :active / :disabled / :checked / :enabled (state-on-element pseudo-classes \u2014 read el._isHovered / _hasFocus / _isActive / _disabled / _checked)",
         ":first-child / :last-child / :only-child / :empty (DOM-position pseudo-classes)",
-        ":root (matches the body element via _matchesPseudoClass — works for stylesheet `:root { ... }` rules via StyleSheet._applyTo; document.querySelector(':root') returns null because _findMatch starts traversal from root._children, which never includes the root itself)",
+        ":root (matches the body element via _matchesPseudoClass \u2014 works for stylesheet `:root { ... }` rules via StyleSheet._applyTo; document.querySelector(':root') returns null because _findMatch starts traversal from root._children, which never includes the root itself)",
         ":nth-child(N) / :nth-child(2n+1) / :nth-child(odd|even) / :nth-last-child(...) (formula + keyword forms)",
-        ":not(<simple>) (functional negation — recursively dispatches to _matchesSelector)"
+        ":not(<simple>) (functional negation \u2014 recursively dispatches to _matchesSelector)"
       ],
       "unsupportedValues": [],
       "tests": [
@@ -6961,12 +6958,12 @@
         "test/test_widget_bridge.cpp [issue-1641-followup-querySelector-colon]",
         "test/test_widget_bridge.cpp [issue-1737] (pseudo-class evaluation: :hover state, :disabled, :checked, :enabled, :not, :first/:last/:only-child, :nth-child, :empty)"
       ],
-      "notes": "Wave 3 (PR #1641) wired tag/.class/#id/[attr]/[attr=value]/descendant/child. pulp #1641 followup fixed bracket-aware colon scanning. pulp #1737 — pseudo-class state matching now implemented end-to-end: state-on-element forms read the bridge-maintained el._isHovered/_hasFocus/_isActive/_disabled/_checked slots; DOM-position forms walk parent._children; :nth-child(...) supports both keyword (`odd`/`even`) and `An+B` formula syntax; :not(<simple>) recursively dispatches to _matchesSelector. Stylesheet `_applyTo` strips the pseudo before structural matching so the existing :hover/:focus/:active wire-up path keeps firing on style application (the live state evaluation happens via the event listener). Out of scope: `:has()`, `:is()`, `:where()`, attribute namespaces — these need the full CSS Selectors Level 4 cascade engine (arch-no-cascade-engine per CLAUDE.md; use @pulp/react components for state-dependent styling that goes beyond what's wired here).",
+      "notes": "Wave 3 (PR #1641) wired tag/.class/#id/[attr]/[attr=value]/descendant/child. pulp #1641 followup fixed bracket-aware colon scanning. pulp #1737 \u2014 pseudo-class state matching now implemented end-to-end: state-on-element forms read the bridge-maintained el._isHovered/_hasFocus/_isActive/_disabled/_checked slots; DOM-position forms walk parent._children; :nth-child(...) supports both keyword (`odd`/`even`) and `An+B` formula syntax; :not(<simple>) recursively dispatches to _matchesSelector. Stylesheet `_applyTo` strips the pseudo before structural matching so the existing :hover/:focus/:active wire-up path keeps firing on style application (the live state evaluation happens via the event listener). Out of scope: `:has()`, `:is()`, `:where()`, attribute namespaces \u2014 these need the full CSS Selectors Level 4 cascade engine (arch-no-cascade-engine per CLAUDE.md; use @pulp/react components for state-dependent styling that goes beyond what's wired here).",
       "issue": ""
     },
     "html/footer": {
       "status": "supported",
-      "mapsTo": "createCol — same as div.",
+      "mapsTo": "createCol \u2014 same as div.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -7043,7 +7040,7 @@
     },
     "html/header": {
       "status": "supported",
-      "mapsTo": "createCol — same as div.",
+      "mapsTo": "createCol \u2014 same as div.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -7081,38 +7078,38 @@
     },
     "html/input": {
       "status": "supported",
-      "mapsTo": "createTextEditor by default; createFader for type=range, createCheckbox for type=checkbox. Other `type=` values fall through to text-editor — a deliberate design choice that matches how the same DOM element is rendered in environments without specialized native widgets (the value-bearing semantics are uniform, only the chrome differs).",
+      "mapsTo": "createTextEditor by default; createFader for type=range, createCheckbox for type=checkbox. Other `type=` values fall through to text-editor \u2014 a deliberate design choice that matches how the same DOM element is rendered in environments without specialized native widgets (the value-bearing semantics are uniform, only the chrome differs).",
       "supportedValues": [
         "type=text / type=password / type=email / type=number / type=range / type=checkbox",
-        "type=date / type=time / type=datetime-local / type=month / type=week (fall through to text-editor — value typed as ISO-8601 string)",
-        "type=file / type=color (fall through to text-editor — placeholder; native pickers are a roadmap item)",
+        "type=date / type=time / type=datetime-local / type=month / type=week (fall through to text-editor \u2014 value typed as ISO-8601 string)",
+        "type=file / type=color (fall through to text-editor \u2014 placeholder; native pickers are a roadmap item)",
         "type=url / type=search (fall through to text-editor)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "DIVERGE→PASS sweep — fall-through to text-editor is the SUPPORTED behavior for these input types in Pulp's render surface; the catalog previously listed them as gaps but they accept input correctly (the value is just a string typed by the user). Specialized chrome — date pickers, color wheels, file pickers — remains a roadmap item; that's a separate UX concern from compat. Wave 1 drift cleanup — partial → supported (wired through _ensureNative -> bridge createTextEditor / createFader / createCheckbox).",
+      "notes": "DIVERGE\u2192PASS sweep \u2014 fall-through to text-editor is the SUPPORTED behavior for these input types in Pulp's render surface; the catalog previously listed them as gaps but they accept input correctly (the value is just a string typed by the user). Specialized chrome \u2014 date pickers, color wheels, file pickers \u2014 remains a roadmap item; that's a separate UX concern from compat. Wave 1 drift cleanup \u2014 partial \u2192 supported (wired through _ensureNative -> bridge createTextEditor / createFader / createCheckbox).",
       "issue": ""
     },
     "html/label": {
       "status": "supported",
-      "mapsTo": "createLabel + lazy `_installLabelForRouting` in web-compat-element.js — clicking the label inspects the `for` attribute and, if it matches an Element id, routes activation to that target (focus via setFocus when wired; checkbox/radio toggle plus dispatched 'input' event always).",
+      "mapsTo": "createLabel + lazy `_installLabelForRouting` in web-compat-element.js \u2014 clicking the label inspects the `for` attribute and, if it matches an Element id, routes activation to that target (focus via setFocus when wired; checkbox/radio toggle plus dispatched 'input' event always).",
       "supportedValues": [
         "createLabel rendering",
-        "for attribute → click activation routing (toggle on checkbox/radio; setFocus when bridge fn available)"
+        "for attribute \u2192 click activation routing (toggle on checkbox/radio; setFocus when bridge fn available)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp::\"<label for=...> click toggles labeled checkbox\"",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "DIVERGE→PASS sweep — `for` attribute click-routing wired in JS. Full focus-pull (currently bridge has no setFocus) remains a roadmap follow-up; the harness gap was about the wired vs. silently-dropped distinction.",
+      "notes": "DIVERGE\u2192PASS sweep \u2014 `for` attribute click-routing wired in JS. Full focus-pull (currently bridge has no setFocus) remains a roadmap follow-up; the harness gap was about the wired vs. silently-dropped distinction.",
       "issue": ""
     },
     "html/main": {
       "status": "supported",
-      "mapsTo": "createCol — same as div.",
+      "mapsTo": "createCol \u2014 same as div.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -7123,7 +7120,7 @@
     },
     "html/nav": {
       "status": "supported",
-      "mapsTo": "createCol — same as div.",
+      "mapsTo": "createCol \u2014 same as div.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -7134,7 +7131,7 @@
     },
     "html/p": {
       "status": "supported",
-      "mapsTo": "createLabel — same as span.",
+      "mapsTo": "createLabel \u2014 same as span.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -7156,7 +7153,7 @@
     },
     "html/section": {
       "status": "supported",
-      "mapsTo": "createCol — same as div.",
+      "mapsTo": "createCol \u2014 same as div.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -7199,7 +7196,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "PR #1345 / pulp #1149 part b added :hover; PR #1641 (Wave 3 html.3) extended selector engine. Wave 1 architectural reclassification — @media / @keyframes / complex selectors are arch-no-cascade-engine (Pulp's inline <style> parser is single-pass; the cascade engine is an explicit non-goal). Wave 4 cleanup — status partial → supported + emptied unsupportedValues so the harness reflects the wired surface; rides the StyleSheet_inline catalog claim.",
+      "notes": "PR #1345 / pulp #1149 part b added :hover; PR #1641 (Wave 3 html.3) extended selector engine. Wave 1 architectural reclassification \u2014 @media / @keyframes / complex selectors are arch-no-cascade-engine (Pulp's inline <style> parser is single-pass; the cascade engine is an explicit non-goal). Wave 4 cleanup \u2014 status partial \u2192 supported + emptied unsupportedValues so the harness reflects the wired surface; rides the StyleSheet_inline catalog claim.",
       "issue": "1149"
     },
     "html/svg": {
@@ -7213,7 +7210,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "PR #1347 (pulp #1147): <svg> is a leaf container that reserves layout space. For rendered SVG paths use the @pulp/react SvgPath intrinsic. Wave 1 architectural reclassification — full SVG rasterization of children is arch-explicit-non-goal (createCol shim reserves layout space; @pulp/react SvgPath intrinsic is the canonical rendered-path API — the layout-shim surface IS the supported surface). Wave 4 cleanup — status partial → supported + emptied unsupportedValues; child path/rect/circle/text rasterization is arch-non-goal, not a partial-deferred gap.",
+      "notes": "PR #1347 (pulp #1147): <svg> is a leaf container that reserves layout space. For rendered SVG paths use the @pulp/react SvgPath intrinsic. Wave 1 architectural reclassification \u2014 full SVG rasterization of children is arch-explicit-non-goal (createCol shim reserves layout space; @pulp/react SvgPath intrinsic is the canonical rendered-path API \u2014 the layout-shim surface IS the supported surface). Wave 4 cleanup \u2014 status partial \u2192 supported + emptied unsupportedValues; child path/rect/circle/text rasterization is arch-non-goal, not a partial-deferred gap.",
       "issue": "1147"
     },
     "html/textarea": {
@@ -7240,7 +7237,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "PR #1348 fixed a typo where the JS was calling canvasFillRect (which never existed) — now correctly calls canvasRect.",
+      "notes": "PR #1348 fixed a typo where the JS was calling canvasFillRect (which never existed) \u2014 now correctly calls canvasRect.",
       "issue": "1346"
     },
     "canvas2d/strokeRect": {
@@ -7315,7 +7312,7 @@
     },
     "canvas2d/rect": {
       "status": "supported",
-      "mapsTo": "ctx.rect(x,y,w,h) -> moveTo + 4× lineTo back to start (composes a closed subpath).",
+      "mapsTo": "ctx.rect(x,y,w,h) -> moveTo + 4\u00d7 lineTo back to start (composes a closed subpath).",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -7338,7 +7335,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [wave2-canvas2d]"
       ],
-      "notes": "PR #1348 + Wave 2 cheap wiring — confirmed all five radii forms thread through to SkRRect::setRectRadii with 4 distinct SkVector corners.",
+      "notes": "PR #1348 + Wave 2 cheap wiring \u2014 confirmed all five radii forms thread through to SkRRect::setRectRadii with 4 distinct SkVector corners.",
       "issue": "1346"
     },
     "canvas2d/arc": {
@@ -7351,20 +7348,20 @@
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1526]"
       ],
-      "notes": "PR #1348. The bezier approximation is per-quadrant (k = (4/3)·tan(θ/4)); fidelity is visually exact for fill/stroke/clip use cases. Wave 1 drift cleanup — partial → supported (PR #1348 wired path-mode arc as cubic-bezier segments via canvasPathArc; bezier approximation is per-quadrant, visually exact for fill/stroke/clip use cases).",
+      "notes": "PR #1348. The bezier approximation is per-quadrant (k = (4/3)\u00b7tan(\u03b8/4)); fidelity is visually exact for fill/stroke/clip use cases. Wave 1 drift cleanup \u2014 partial \u2192 supported (PR #1348 wired path-mode arc as cubic-bezier segments via canvasPathArc; bezier approximation is per-quadrant, visually exact for fill/stroke/clip use cases).",
       "issue": "1346"
     },
     "canvas2d/arcTo": {
       "status": "supported",
-      "mapsTo": "ctx.arcTo(x1,y1,x2,y2,r) -> canvasPathArcTo. Skia: SkPath::arcTo(p1, p2, radius) — closed-form tangent-arc geometry. CG: CGPathAddArcToPoint(p1, p2, radius). pulp #1521 replaced the conservative lineTo-only fallback with the spec-compliant radius-tangent computation.",
+      "mapsTo": "ctx.arcTo(x1,y1,x2,y2,r) -> canvasPathArcTo. Skia: SkPath::arcTo(p1, p2, radius) \u2014 closed-form tangent-arc geometry. CG: CGPathAddArcToPoint(p1, p2, radius). pulp #1521 replaced the conservative lineTo-only fallback with the spec-compliant radius-tangent computation.",
       "supportedValues": [
-        "arcTo(x1, y1, x2, y2, radius) — geometrically correct on Skia + CG"
+        "arcTo(x1, y1, x2, y2, radius) \u2014 geometrically correct on Skia + CG"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1521 — native SkPath::arcTo (Skia) / CGPathAddArcToPoint (CG). Wave 4 c2d cleanup: catalog reconciled to match wired implementation (prior PR #1348 lineTo fallback was replaced by #1521).",
+      "notes": "pulp #1521 \u2014 native SkPath::arcTo (Skia) / CGPathAddArcToPoint (CG). Wave 4 c2d cleanup: catalog reconciled to match wired implementation (prior PR #1348 lineTo fallback was replaced by #1521).",
       "issue": ""
     },
     "canvas2d/bezierCurveTo": {
@@ -7401,7 +7398,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [wave2-canvas2d]"
       ],
-      "notes": "PR #1521 + Wave 2 cheap wiring — confirmed rotation threads through SkMatrix and CGAffineTransform.",
+      "notes": "PR #1521 + Wave 2 cheap wiring \u2014 confirmed rotation threads through SkMatrix and CGAffineTransform.",
       "issue": "1346"
     },
     "canvas2d/fill": {
@@ -7415,7 +7412,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [wave2-canvas2d]"
       ],
-      "notes": "Wave 2 cheap wiring — added FillRule enum to canvas.hpp, plumbed cmd.int_val from widget_bridge through CanvasWidget::paint into both Skia (SkPathFillType::kEvenOdd) and CG (CGContextEOFillPath) backends. Pre-Wave-2 the rule was read by widget_bridge but discarded by canvas_widget.",
+      "notes": "Wave 2 cheap wiring \u2014 added FillRule enum to canvas.hpp, plumbed cmd.int_val from widget_bridge through CanvasWidget::paint into both Skia (SkPathFillType::kEvenOdd) and CG (CGContextEOFillPath) backends. Pre-Wave-2 the rule was read by widget_bridge but discarded by canvas_widget.",
       "issue": ""
     },
     "canvas2d/stroke": {
@@ -7440,12 +7437,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [wave2-canvas2d]"
       ],
-      "notes": "Backed by SkCanvas::clipPath. (issue-896 added canvasClip; older canvasClipRect is the rect-only path.) Wave 2 cheap wiring — added FillRule enum to canvas.hpp, plumbed cmd.int_val from widget_bridge through CanvasWidget::paint into both Skia (SkPathFillType::kEvenOdd) and CG (CGContextEOClip) backends.",
+      "notes": "Backed by SkCanvas::clipPath. (issue-896 added canvasClip; older canvasClipRect is the rect-only path.) Wave 2 cheap wiring \u2014 added FillRule enum to canvas.hpp, plumbed cmd.int_val from widget_bridge through CanvasWidget::paint into both Skia (SkPathFillType::kEvenOdd) and CG (CGContextEOClip) backends.",
       "issue": ""
     },
     "canvas2d/isPointInPath": {
       "status": "supported",
-      "mapsTo": "ctx.isPointInPath(x, y[, fillRule]) -> JS-side ray-cast against the path mirror. Each path-construction method (moveTo / lineTo / rect / roundRect / arc / arcTo / ellipse / bezierCurveTo / quadraticCurveTo / closePath) appends to `_pathSubpaths` in addition to forwarding to the bridge. Curve segments sample to ~16 line pieces — accurate enough for spec-compliant hit testing.",
+      "mapsTo": "ctx.isPointInPath(x, y[, fillRule]) -> JS-side ray-cast against the path mirror. Each path-construction method (moveTo / lineTo / rect / roundRect / arc / arcTo / ellipse / bezierCurveTo / quadraticCurveTo / closePath) appends to `_pathSubpaths` in addition to forwarding to the bridge. Curve segments sample to ~16 line pieces \u2014 accurate enough for spec-compliant hit testing.",
       "supportedValues": [
         "isPointInPath(x, y) on rect / lineTo polygon / arc / curve paths",
         "rolls back across save / restore via the path-mirror snapshot"
@@ -7454,12 +7451,12 @@
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1527]"
       ],
-      "notes": "pulp #1527 bridge-thin gap-fill. Synchronous return — no bridge round-trip; the bridge owns the canonical SkPath but it's not queryable from JS until paint time. Wave 1 paperwork — synchronous return; no bridge round-trip; bridge-thin gap-fill (pulp #1527). arch-path2d-deferred — Path2D-object first argument requires a separate JS shim object (pulp #1527) that maintains its own subpath mirror. The 2-arg form (x, y) using the canvas's current path is fully wired and matches the spec semantics for the most-used invocation pattern.",
+      "notes": "pulp #1527 bridge-thin gap-fill. Synchronous return \u2014 no bridge round-trip; the bridge owns the canonical SkPath but it's not queryable from JS until paint time. Wave 1 paperwork \u2014 synchronous return; no bridge round-trip; bridge-thin gap-fill (pulp #1527). arch-path2d-deferred \u2014 Path2D-object first argument requires a separate JS shim object (pulp #1527) that maintains its own subpath mirror. The 2-arg form (x, y) using the canvas's current path is fully wired and matches the spec semantics for the most-used invocation pattern.",
       "issue": "1527"
     },
     "canvas2d/isPointInStroke": {
       "status": "supported",
-      "mapsTo": "ctx.isPointInStroke(x, y) -> JS-side closest-point-on-segment distance check against `_pathSubpaths`. Returns true when the test point's distance to any path segment is ≤ lineWidth / 2.",
+      "mapsTo": "ctx.isPointInStroke(x, y) -> JS-side closest-point-on-segment distance check against `_pathSubpaths`. Returns true when the test point's distance to any path segment is \u2264 lineWidth / 2.",
       "supportedValues": [
         "lineWidth-aware hit test on straight + curve segments",
         "respects later assignments to ctx.lineWidth"
@@ -7468,7 +7465,7 @@
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1527]"
       ],
-      "notes": "pulp #1527 bridge-thin gap-fill. Pairs with isPointInPath; uses the same JS path mirror. Wave 1 paperwork — pairs with isPointInPath; same JS path mirror (pulp #1527). arch-cap-join-approximated — lineCap (square) / lineJoin (miter spikes) geometry are approximated as round caps in the JS-side polyline mirror. Spec-compliance for sub-pixel hit-testing on stroke join geometry would need a real path stroker. The common case (round caps + bevel/round joins) works correctly.",
+      "notes": "pulp #1527 bridge-thin gap-fill. Pairs with isPointInPath; uses the same JS path mirror. Wave 1 paperwork \u2014 pairs with isPointInPath; same JS path mirror (pulp #1527). arch-cap-join-approximated \u2014 lineCap (square) / lineJoin (miter spikes) geometry are approximated as round caps in the JS-side polyline mirror. Spec-compliance for sub-pixel hit-testing on stroke join geometry would need a real path stroker. The common case (round caps + bevel/round joins) works correctly.",
       "issue": "1527"
     },
     "canvas2d/save": {
@@ -7528,7 +7525,7 @@
     },
     "canvas2d/setTransform": {
       "status": "supported",
-      "mapsTo": "ctx.setTransform(a,b,c,d,e,f) — also accepts a single DOMMatrix-like arg, shim unpacks. -> canvasSetTransform.",
+      "mapsTo": "ctx.setTransform(a,b,c,d,e,f) \u2014 also accepts a single DOMMatrix-like arg, shim unpacks. -> canvasSetTransform.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -7550,28 +7547,28 @@
     },
     "canvas2d/getTransform": {
       "status": "supported",
-      "mapsTo": "ctx.getTransform() -> returns a DOMMatrix-shaped object reflecting the JS-mirrored 2D affine transform. The shim tracks `_currentTransform` via translate / scale / rotate / setTransform / transform / save / restore so the read is synchronous (no bridge round-trip; the bridge replays draws at paint time and has no queryable 'current matrix' from JS). Per HTML5 Canvas spec, getTransform() returns a NEW DOMMatrix per call (a snapshot — mutating it does not affect the live ctx). DOMMatrix mutation methods (multiplySelf, scaleSelf, etc.) on the returned object are not exposed because they would only mutate the snapshot, not the canvas — same outcome as on the standard browser surface.",
+      "mapsTo": "ctx.getTransform() -> returns a DOMMatrix-shaped object reflecting the JS-mirrored 2D affine transform. The shim tracks `_currentTransform` via translate / scale / rotate / setTransform / transform / save / restore so the read is synchronous (no bridge round-trip; the bridge replays draws at paint time and has no queryable 'current matrix' from JS). Per HTML5 Canvas spec, getTransform() returns a NEW DOMMatrix per call (a snapshot \u2014 mutating it does not affect the live ctx). DOMMatrix mutation methods (multiplySelf, scaleSelf, etc.) on the returned object are not exposed because they would only mutate the snapshot, not the canvas \u2014 same outcome as on the standard browser surface.",
       "supportedValues": [
         "a, b, c, d, e, f (live)",
         "m11/m12/m21/m22/m41/m42 DOMMatrix aliases",
         "is2D, isIdentity flags",
         "toFloat32Array / toFloat64Array readers",
-        "multiplySelf(other) — right-multiply + chain",
-        "scaleSelf(sx, sy?) — post-multiply scale",
-        "rotateSelf(angle) — post-multiply rotation (radians)",
-        "translateSelf(tx, ty) — post-multiply translation",
-        "inverse() — return inverted copy (throws on singular)"
+        "multiplySelf(other) \u2014 right-multiply + chain",
+        "scaleSelf(sx, sy?) \u2014 post-multiply scale",
+        "rotateSelf(angle) \u2014 post-multiply rotation (radians)",
+        "translateSelf(tx, ty) \u2014 post-multiply translation",
+        "inverse() \u2014 return inverted copy (throws on singular)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1527][dommatrix-mutators]"
       ],
-      "notes": "DIVERGE→PASS sweep — clarified that snapshot semantics are spec-compliant (HTML5 Canvas spec: getTransform() returns a NEW DOMMatrix); DOMMatrix mutation methods on a snapshot wouldn't affect the canvas anyway. pulp #1527 bridge-thin gap-fill. Wave-5 follow-up audit (post-PR #1616 sweep): walked back to partial. `_PulpCanvasMatrix` (web-compat-canvas.js) has `a/b/c/d/e/f` getters and `is2D`/`isIdentity` flags but does NOT implement DOMMatrix mutators like `multiplySelf` / `scaleSelf` / `inverse()`. Standard DOM code that does `ctx.getTransform().multiplySelf(other)` will throw at runtime. PR #1527 followup: DOMMatrix mutator methods (multiplySelf / scaleSelf / rotateSelf / translateSelf / inverse) now implemented on the snapshot. Snapshot semantics preserved per HTML5 spec — mutating the returned matrix does NOT affect the live ctx; mutators return `this` for chaining; inverse() returns a NEW matrix (throws TypeError on singular).",
+      "notes": "DIVERGE\u2192PASS sweep \u2014 clarified that snapshot semantics are spec-compliant (HTML5 Canvas spec: getTransform() returns a NEW DOMMatrix); DOMMatrix mutation methods on a snapshot wouldn't affect the canvas anyway. pulp #1527 bridge-thin gap-fill. Wave-5 follow-up audit (post-PR #1616 sweep): walked back to partial. `_PulpCanvasMatrix` (web-compat-canvas.js) has `a/b/c/d/e/f` getters and `is2D`/`isIdentity` flags but does NOT implement DOMMatrix mutators like `multiplySelf` / `scaleSelf` / `inverse()`. Standard DOM code that does `ctx.getTransform().multiplySelf(other)` will throw at runtime. PR #1527 followup: DOMMatrix mutator methods (multiplySelf / scaleSelf / rotateSelf / translateSelf / inverse) now implemented on the snapshot. Snapshot semantics preserved per HTML5 spec \u2014 mutating the returned matrix does NOT affect the live ctx; mutators return `this` for chaining; inverse() returns a NEW matrix (throws TypeError on singular).",
       "issue": "1527"
     },
     "canvas2d/transform": {
       "status": "supported",
-      "mapsTo": "ctx.transform(a,b,c,d,e,f) — multiplies CURRENT transform; bridge only exposes replace (setTransform), not concat. Pure-translation matrices (a===1, b===0, c===0, d===1) fall through to canvasTranslate; everything else is a no-op.",
+      "mapsTo": "ctx.transform(a,b,c,d,e,f) \u2014 multiplies CURRENT transform; bridge only exposes replace (setTransform), not concat. Pure-translation matrices (a===1, b===0, c===0, d===1) fall through to canvasTranslate; everything else is a no-op.",
       "supportedValues": [
         "pure-translation matrices",
         "arbitrary concat (rotate/scale/skew composed onto existing transform)"
@@ -7580,15 +7577,15 @@
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1348][codex-p1]"
       ],
-      "notes": "PR #1348. File a follow-up if a plugin needs strict concat. Wave 1 paperwork — strict concat semantics deferred (PR #1348); pure-translation fast path covers the common case. Wired in PR #1701 — ctx.transform() forwards the composed matrix M' = M * given to canvasSetTransform; JS-side mirror and bridge state stay in sync. Verified via [view][canvas2d][issue-1348][codex-p1] tests.",
+      "notes": "PR #1348. File a follow-up if a plugin needs strict concat. Wave 1 paperwork \u2014 strict concat semantics deferred (PR #1348); pure-translation fast path covers the common case. Wired in PR #1701 \u2014 ctx.transform() forwards the composed matrix M' = M * given to canvasSetTransform; JS-side mirror and bridge state stay in sync. Verified via [view][canvas2d][issue-1348][codex-p1] tests.",
       "issue": "1346"
     },
     "canvas2d/fillText": {
       "status": "supported",
-      "mapsTo": "ctx.fillText(text,x,y,maxWidth) -> _syncGlobalState + _syncShadowState + _syncFilterState + _syncDirectionState + _syncTextState + _applyFillStyle + canvasFillText(id, text, x, y, size, color, maxWidth). pulp #1525 plumbed maxWidth end-to-end (Skia: SkMatrix::Scale around the origin; CG: CGContextScaleCTM). pulp Wave 3 c2d.6 routes gradient/pattern fillStyle through current_fill_paint() on Skia. pulp #1666 — CoreGraphicsCanvas::fill_text now switches to kCGTextClip on the glyph fills then calls fill_with_active_paint(), so the active gradient (set via set_fill_gradient_linear/_radial/_two_circles) paints the glyphs on the CG path too.",
+      "mapsTo": "ctx.fillText(text,x,y,maxWidth) -> _syncGlobalState + _syncShadowState + _syncFilterState + _syncDirectionState + _syncTextState + _applyFillStyle + canvasFillText(id, text, x, y, size, color, maxWidth). pulp #1525 plumbed maxWidth end-to-end (Skia: SkMatrix::Scale around the origin; CG: CGContextScaleCTM). pulp Wave 3 c2d.6 routes gradient/pattern fillStyle through current_fill_paint() on Skia. pulp #1666 \u2014 CoreGraphicsCanvas::fill_text now switches to kCGTextClip on the glyph fills then calls fill_with_active_paint(), so the active gradient (set via set_fill_gradient_linear/_radial/_two_circles) paints the glyphs on the CG path too.",
       "supportedValues": [
-        "fillText(text, x, y) — solid colour fillStyle",
-        "fillText(text, x, y, maxWidth) — squeezed via SkMatrix::Scale (Skia) / CGContextScaleCTM (CG)",
+        "fillText(text, x, y) \u2014 solid colour fillStyle",
+        "fillText(text, x, y, maxWidth) \u2014 squeezed via SkMatrix::Scale (Skia) / CGContextScaleCTM (CG)",
         "gradient fillStyle on Skia (shader flows onto glyph paint via current_fill_paint)",
         "gradient fillStyle on CoreGraphics (kCGTextClip + CGContextDrawLinearGradient/Radial inside the glyph clip)",
         "CanvasPattern fillStyle on Skia (SkShader::MakeImage)"
@@ -7598,7 +7595,7 @@
         "test/test_canvas.cpp [issue-1666]",
         "test/test_widget_bridge.cpp [wave2-canvas2d]"
       ],
-      "notes": "pulp #1525 — maxWidth plumbed end-to-end. pulp Wave 3 c2d.6 — gradient/pattern fillStyle routes through current_fill_paint() on Skia. pulp #1666 — CoreGraphics path now handles gradient fillStyle via kCGTextClip + fill_with_active_paint(). CG pattern fillStyle on glyphs is a separate sub-feature tracked under canvas2d/createPattern follow-ups.",
+      "notes": "pulp #1525 \u2014 maxWidth plumbed end-to-end. pulp Wave 3 c2d.6 \u2014 gradient/pattern fillStyle routes through current_fill_paint() on Skia. pulp #1666 \u2014 CoreGraphics path now handles gradient fillStyle via kCGTextClip + fill_with_active_paint(). CG pattern fillStyle on glyphs is a separate sub-feature tracked under canvas2d/createPattern follow-ups.",
       "issue": ""
     },
     "canvas2d/strokeText": {
@@ -7614,12 +7611,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [wave2-canvas2d]"
       ],
-      "notes": "PR #1525 + Codex P2 follow-up — make_stroke_paint() sets kStroke_Style and apply_stroke_state() propagates sticky stroke state. Wave 2 cheap wiring — confirmed end-to-end and bumped from partial -> supported.",
+      "notes": "PR #1525 + Codex P2 follow-up \u2014 make_stroke_paint() sets kStroke_Style and apply_stroke_state() propagates sticky stroke state. Wave 2 cheap wiring \u2014 confirmed end-to-end and bumped from partial -> supported.",
       "issue": ""
     },
     "canvas2d/measureText": {
       "status": "supported",
-      "mapsTo": "ctx.measureText(text) — when canvasMeasureText is available returns the bridge-side TextMetrics; else returns a coarse char-width estimate.",
+      "mapsTo": "ctx.measureText(text) \u2014 when canvasMeasureText is available returns the bridge-side TextMetrics; else returns a coarse char-width estimate.",
       "supportedValues": [
         "width",
         "actualBoundingBoxLeft/Right/Ascent/Descent",
@@ -7634,17 +7631,17 @@
     },
     "canvas2d/drawImage": {
       "status": "supported",
-      "mapsTo": "ctx.drawImage(img, ...) -> canvasDrawImage(id, src, dx, dy, dw, dh [, sx, sy, sw, sh]). Supports the 3-arg, 5-arg, and 9-arg signatures. pulp #1737 — 9-arg source-rect form (sprite-sheet slicing) is now plumbed end-to-end: JS shim passes sx/sy/sw/sh as args[6..9]; bridge sets has_source_rect on the CanvasDrawCmd; canvas widget routes through Canvas::draw_image_from_file_rect (Skia: SkCanvas::drawImageRect with src+dst).",
+      "mapsTo": "ctx.drawImage(img, ...) -> canvasDrawImage(id, src, dx, dy, dw, dh [, sx, sy, sw, sh]). Supports the 3-arg, 5-arg, and 9-arg signatures. pulp #1737 \u2014 9-arg source-rect form (sprite-sheet slicing) is now plumbed end-to-end: JS shim passes sx/sy/sw/sh as args[6..9]; bridge sets has_source_rect on the CanvasDrawCmd; canvas widget routes through Canvas::draw_image_from_file_rect (Skia: SkCanvas::drawImageRect with src+dst).",
       "supportedValues": [
         "drawImage(img, dx, dy)",
         "drawImage(img, dx, dy, dw, dh)",
-        "drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh) — sprite-sheet slicing"
+        "drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh) \u2014 sprite-sheet slicing"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1737]"
       ],
-      "notes": "pulp #1737 — 9-arg source-rect form wired: Canvas + Skia + RecordingCanvas got draw_image_from_*_rect overrides; CanvasDrawCmd gained has_source_rect + uses x2/y2/x3/y3 for sx/sy/sw/sh.",
+      "notes": "pulp #1737 \u2014 9-arg source-rect form wired: Canvas + Skia + RecordingCanvas got draw_image_from_*_rect overrides; CanvasDrawCmd gained has_source_rect + uses x2/y2/x3/y3 for sx/sy/sw/sh.",
       "issue": ""
     },
     "canvas2d/getImageData": {
@@ -7657,21 +7654,21 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-916]"
       ],
-      "notes": "issue-916. The base64 round-trip avoids passing typed arrays across the JS bridge. Wave 1 paperwork — base64 round-trip avoids typed-array bridge cost (issue-916). arch-recordingcanvas-by-design — RecordingCanvas returns zero-filled pixels by design (it records draw commands; no rasterization). The Skia + CoreGraphics backends both return real pixel data.",
+      "notes": "issue-916. The base64 round-trip avoids passing typed arrays across the JS bridge. Wave 1 paperwork \u2014 base64 round-trip avoids typed-array bridge cost (issue-916). arch-recordingcanvas-by-design \u2014 RecordingCanvas returns zero-filled pixels by design (it records draw commands; no rasterization). The Skia + CoreGraphics backends both return real pixel data.",
       "issue": ""
     },
     "canvas2d/putImageData": {
       "status": "supported",
-      "mapsTo": "ctx.putImageData(imgdata, dx, dy [, dirtyX, dirtyY, dirtyW, dirtyH]) -> base64-encodes and calls canvasPutImageData. pulp #1737 — 7-arg sub-rect form is now plumbed: the JS shim slices the (dirtyX, dirtyY, dirtyW, dirtyH) sub-rect from imageData.data row-by-row, clamps the rect to source bounds (per HTML5 spec), short-circuits to no-op on empty rect, and calls the same canvasPutImageData bridge fn with the sliced buffer + smaller dimensions + adjusted dst (dx + dirtyX, dy + dirtyY).",
+      "mapsTo": "ctx.putImageData(imgdata, dx, dy [, dirtyX, dirtyY, dirtyW, dirtyH]) -> base64-encodes and calls canvasPutImageData. pulp #1737 \u2014 7-arg sub-rect form is now plumbed: the JS shim slices the (dirtyX, dirtyY, dirtyW, dirtyH) sub-rect from imageData.data row-by-row, clamps the rect to source bounds (per HTML5 spec), short-circuits to no-op on empty rect, and calls the same canvasPutImageData bridge fn with the sliced buffer + smaller dimensions + adjusted dst (dx + dirtyX, dy + dirtyY).",
       "supportedValues": [
         "putImageData(img, dx, dy)",
-        "putImageData(img, dx, dy, dirtyX, dirtyY, dirtyW, dirtyH) — sub-rect form"
+        "putImageData(img, dx, dy, dirtyX, dirtyY, dirtyW, dirtyH) \u2014 sub-rect form"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_widget_bridge.cpp [issue-1737]"
       ],
-      "notes": "pulp #1737 — sub-rect form sliced in JS shim (no bridge contract change). Empty dirty rect is a no-op per HTML5 spec; negative dirtyW/dirtyH are normalised; out-of-bounds dirty rect is clamped to source bounds.",
+      "notes": "pulp #1737 \u2014 sub-rect form sliced in JS shim (no bridge contract change). Empty dirty rect is a no-op per HTML5 spec; negative dirtyW/dirtyH are normalised; out-of-bounds dirty rect is clamped to source bounds.",
       "issue": ""
     },
     "canvas2d/createLinearGradient": {
@@ -7729,12 +7726,12 @@
         "test/test_canvas.cpp [canvas][cg][issue-1524]",
         "test/test_canvas2d_shim.cpp [issue-1434][bridge-thin]"
       ],
-      "notes": "pulp #1524. Skia uses SkShader::MakeImage; CG uses CGPatternCreate with a draw callback that emits one tile via CGContextDrawImage. `no_repeat` axes blow up the tile step beyond the clip bbox so only the seed tile lands. Image source decoded via ImageIO (CGImageSourceCreateWithData / WithURL) for both file paths and `data:` URLs. Note: CG stroke patterns are still a no-op (strokes continue with stroke_color_) — file a follow-up if a CG-targeted plugin needs tiled stroke patterns; this entry is for the createPattern fill surface.",
+      "notes": "pulp #1524. Skia uses SkShader::MakeImage; CG uses CGPatternCreate with a draw callback that emits one tile via CGContextDrawImage. `no_repeat` axes blow up the tile step beyond the clip bbox so only the seed tile lands. Image source decoded via ImageIO (CGImageSourceCreateWithData / WithURL) for both file paths and `data:` URLs. Note: CG stroke patterns are still a no-op (strokes continue with stroke_color_) \u2014 file a follow-up if a CG-targeted plugin needs tiled stroke patterns; this entry is for the createPattern fill surface.",
       "issue": "1524"
     },
     "canvas2d/addColorStop": {
       "status": "supported",
-      "mapsTo": "CanvasGradient.addColorStop(offset, color) — accumulates stops on the JS-side gradient object; flushed to bridge via canvasSetLinearGradient / canvasSetRadialGradient when the gradient is assigned to fillStyle.",
+      "mapsTo": "CanvasGradient.addColorStop(offset, color) \u2014 accumulates stops on the JS-side gradient object; flushed to bridge via canvasSetLinearGradient / canvasSetRadialGradient when the gradient is assigned to fillStyle.",
       "supportedValues": [],
       "unsupportedValues": [],
       "tests": [
@@ -7745,7 +7742,7 @@
     },
     "canvas2d/setLineDash": {
       "status": "supported",
-      "mapsTo": "ctx.setLineDash(pattern) -> canvasSetLineDash(id, pattern, lineDashOffset). Bridge does the HTML5-spec odd-length array doubling (`[5, 10, 15]` → `[5, 10, 15, 5, 10, 15]`) in widget_bridge.cpp::canvasSetLineDash before recording the command. Negative / non-finite values drop the pattern (graceful solid-stroke fallback per spec's implementation-defined clause).",
+      "mapsTo": "ctx.setLineDash(pattern) -> canvasSetLineDash(id, pattern, lineDashOffset). Bridge does the HTML5-spec odd-length array doubling (`[5, 10, 15]` \u2192 `[5, 10, 15, 5, 10, 15]`) in widget_bridge.cpp::canvasSetLineDash before recording the command. Negative / non-finite values drop the pattern (graceful solid-stroke fallback per spec's implementation-defined clause).",
       "supportedValues": [
         "even-length pattern arrays",
         "odd-length pattern arrays (spec-doubled by the bridge)",
@@ -7755,7 +7752,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "DIVERGE→PASS sweep — the catalog note about \"shim takes pattern verbatim; bridge handles the spec-doubling\" was describing the architecture, not a gap. The end-to-end behavior is spec-compliant. Wave 1 paperwork — see SKILL canvas2d gotchas; HTML5-spec odd-length doubling is performed internally by canvasSetLineDash before recording.",
+      "notes": "DIVERGE\u2192PASS sweep \u2014 the catalog note about \"shim takes pattern verbatim; bridge handles the spec-doubling\" was describing the architecture, not a gap. The end-to-end behavior is spec-compliant. Wave 1 paperwork \u2014 see SKILL canvas2d gotchas; HTML5-spec odd-length doubling is performed internally by canvasSetLineDash before recording.",
       "issue": ""
     },
     "canvas2d/getLineDash": {
@@ -7780,7 +7777,7 @@
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1526]"
       ],
-      "notes": "Wave 4 c2d cleanup — defineProperty getter/setter pair re-flushes dash on assignment. Pre-Wave-4 the field tracked locally but only sent on the next setLineDash, so phase mutations between draws were silently dropped.",
+      "notes": "Wave 4 c2d cleanup \u2014 defineProperty getter/setter pair re-flushes dash on assignment. Pre-Wave-4 the field tracked locally but only sent on the next setLineDash, so phase mutations between draws were silently dropped.",
       "issue": ""
     },
     "canvas2d/fillStyle": {
@@ -7795,12 +7792,12 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "DIVERGE→PASS sweep — pattern path was already wired (createPattern in PASS list, _applyFillStyle dispatches canvasSetFillPattern); the catalog had a stale gap entry from before pulp #1434's createPattern bridge work. Wave 1 paperwork — CanvasPattern wiring confirmed via createPattern + _applyFillStyle / canvasSetFillPattern (#1625 finding).",
+      "notes": "DIVERGE\u2192PASS sweep \u2014 pattern path was already wired (createPattern in PASS list, _applyFillStyle dispatches canvasSetFillPattern); the catalog had a stale gap entry from before pulp #1434's createPattern bridge work. Wave 1 paperwork \u2014 CanvasPattern wiring confirmed via createPattern + _applyFillStyle / canvasSetFillPattern (#1625 finding).",
       "issue": ""
     },
     "canvas2d/strokeStyle": {
       "status": "supported",
-      "mapsTo": "Settable to a CSS-color string OR a CanvasGradient OR a CanvasPattern. pulp Wave 3 c2d.7 — bridge exposes canvasSetStrokeLinearGradient / canvasSetStrokeRadialGradient / canvasSetStrokeRadialGradientTwoCircles / canvasSetStrokeConicGradient / canvasSetStrokePattern; the JS shim routes gradients per kind in _applyStrokeStyle. Skia populates stroke_shader_; apply_stroke_state attaches it to SkPaint via setShader. pulp #1666 — CoreGraphicsCanvas now implements set_stroke_gradient_linear/_radial/_two_circles/_conic + a stroke_with_active_paint() helper that builds CGGradientRef from the stops, calls CGContextReplacePathWithStrokedPath + CGContextClip, then CGContextDrawLinearGradient/Radial inside the clip. All stroke entry points (stroke_rect, stroke_rounded_rect, stroke_circle, stroke_arc, stroke_line, stroke_path, stroke_current_path, stroke_text via CTFontCreatePathForGlyph) route through that helper when has_stroke_gradient_ is set.",
+      "mapsTo": "Settable to a CSS-color string OR a CanvasGradient OR a CanvasPattern. pulp Wave 3 c2d.7 \u2014 bridge exposes canvasSetStrokeLinearGradient / canvasSetStrokeRadialGradient / canvasSetStrokeRadialGradientTwoCircles / canvasSetStrokeConicGradient / canvasSetStrokePattern; the JS shim routes gradients per kind in _applyStrokeStyle. Skia populates stroke_shader_; apply_stroke_state attaches it to SkPaint via setShader. pulp #1666 \u2014 CoreGraphicsCanvas now implements set_stroke_gradient_linear/_radial/_two_circles/_conic + a stroke_with_active_paint() helper that builds CGGradientRef from the stops, calls CGContextReplacePathWithStrokedPath + CGContextClip, then CGContextDrawLinearGradient/Radial inside the clip. All stroke entry points (stroke_rect, stroke_rounded_rect, stroke_circle, stroke_arc, stroke_line, stroke_path, stroke_current_path, stroke_text via CTFontCreatePathForGlyph) route through that helper when has_stroke_gradient_ is set.",
       "supportedValues": [
         "CSS color strings",
         "CanvasGradient (linear, radial, two-circle radial) on stroke (Skia + CoreGraphics)",
@@ -7811,7 +7808,7 @@
       "tests": [
         "test/test_canvas.cpp [issue-1666]"
       ],
-      "notes": "pulp Wave 3 c2d.7 — stroke gradients wired through dedicated setters. Wave 4 c2d cleanup: catalog reconciled to match wired implementation. PR #1643 added gradient stroke shaders on Skia. pulp #1666 — added native CG stroke gradient implementation (linear/radial/two-circle) using CGContextReplacePathWithStrokedPath + CGContextDrawLinearGradient/Radial. CG conic stroke + CG pattern stroke fall back to first-stop solid; tracked as separate follow-ups under canvas2d/createConicGradient + canvas2d/createPattern.",
+      "notes": "pulp Wave 3 c2d.7 \u2014 stroke gradients wired through dedicated setters. Wave 4 c2d cleanup: catalog reconciled to match wired implementation. PR #1643 added gradient stroke shaders on Skia. pulp #1666 \u2014 added native CG stroke gradient implementation (linear/radial/two-circle) using CGContextReplacePathWithStrokedPath + CGContextDrawLinearGradient/Radial. CG conic stroke + CG pattern stroke fall back to first-stop solid; tracked as separate follow-ups under canvas2d/createConicGradient + canvas2d/createPattern.",
       "issue": ""
     },
     "canvas2d/lineWidth": {
@@ -7857,7 +7854,7 @@
     },
     "canvas2d/miterLimit": {
       "status": "supported",
-      "mapsTo": "ctx.miterLimit -> canvasSetMiterLimit (web-compat-canvas.js _syncLineState). Sticky stroke state. Skia honours via SkPaint::setStrokeMiter; CG via CGContextSetMiterLimit. Spec: assigning ≤ 0 / NaN / Infinity is silently ignored (validated at the shim level).",
+      "mapsTo": "ctx.miterLimit -> canvasSetMiterLimit (web-compat-canvas.js _syncLineState). Sticky stroke state. Skia honours via SkPaint::setStrokeMiter; CG via CGContextSetMiterLimit. Spec: assigning \u2264 0 / NaN / Infinity is silently ignored (validated at the shim level).",
       "supportedValues": [
         "any positive finite number",
         "spec default = 10"
@@ -7866,7 +7863,7 @@
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1434][bridge-thin]"
       ],
-      "notes": "pulp #1434 bridge-thin gap-fill. Side note: this PR also wired SkPaint::setStrokeJoin + setStrokeCap from line_join_/line_cap_ — those were stored but never applied on Skia before.",
+      "notes": "pulp #1434 bridge-thin gap-fill. Side note: this PR also wired SkPaint::setStrokeJoin + setStrokeCap from line_join_/line_cap_ \u2014 those were stored but never applied on Skia before.",
       "issue": "1434"
     },
     "canvas2d/globalAlpha": {
@@ -7933,13 +7930,13 @@
         "weight numerics: 100..900 (3-digit)",
         "style keywords: normal/italic/oblique",
         "stretch keywords: ultra-condensed..ultra-expanded (parsed, dropped)",
-        "lineHeight: number / length / 'normal' (parsed, ignored per Canvas2D spec — canvas uses the font's own line metrics)"
+        "lineHeight: number / length / 'normal' (parsed, ignored per Canvas2D spec \u2014 canvas uses the font's own line metrics)"
       ],
       "unsupportedValues": [],
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1434]"
       ],
-      "notes": "pulp #1434 expanded shim parser to full CSS font shorthand. Family names quoted as 'Inter' or \"Inter\" are unwrapped; comma-separated lists are passed verbatim. font-variant 'small-caps' is the ONLY genuine gap and is architecturally tied: Canvas::set_font_full has no variant field and Skia/CG canvas font pipelines don't expose OpenType variation axes at this layer. Per #1657 discipline this stays as DIVERGE (honest signal of a real value-gap) rather than being moved to notes — the gap IS real and consumers should know. Reclassification would require either (a) extending Canvas::set_font to carry variant flags, or (b) adapter-level architectural-exclusion support. arch-skia-cg-no-small-caps — font-variant 'small-caps' is parsed and tracked but Skia/CG canvas pipeline doesn't honour it (Canvas::set_font_full has no variant field). Architectural — full small-caps rendering would need OpenType glyph substitution which neither backend exposes through the canvas API. The other shorthand fields (size, family, style, weight) all work.",
+      "notes": "pulp #1434 expanded shim parser to full CSS font shorthand. Family names quoted as 'Inter' or \"Inter\" are unwrapped; comma-separated lists are passed verbatim. font-variant 'small-caps' is the ONLY genuine gap and is architecturally tied: Canvas::set_font_full has no variant field and Skia/CG canvas font pipelines don't expose OpenType variation axes at this layer. Per #1657 discipline this stays as DIVERGE (honest signal of a real value-gap) rather than being moved to notes \u2014 the gap IS real and consumers should know. Reclassification would require either (a) extending Canvas::set_font to carry variant flags, or (b) adapter-level architectural-exclusion support. arch-skia-cg-no-small-caps \u2014 font-variant 'small-caps' is parsed and tracked but Skia/CG canvas pipeline doesn't honour it (Canvas::set_font_full has no variant field). Architectural \u2014 full small-caps rendering would need OpenType glyph substitution which neither backend exposes through the canvas API. The other shorthand fields (size, family, style, weight) all work.",
       "issue": "1434"
     },
     "canvas2d/textAlign": {
@@ -8018,12 +8015,12 @@
       "tests": [
         "test/test_canvas2d_shim.cpp [issue-1520]"
       ],
-      "notes": "pulp #1520 — JS shim + bridge + SkShaper direction flag. Real bidi (mixed LTR/RTL paragraphs) shares plumbing with #1506. arch-skparagraph-bidi — Full Unicode Bidi Algorithm for mixed-script paragraphs is deferred to SkParagraph plumbing (pulp #1506); the ltr/rtl/inherit value set the catalog claims is fully wired via SkShaper direction flag.",
+      "notes": "pulp #1520 \u2014 JS shim + bridge + SkShaper direction flag. Real bidi (mixed LTR/RTL paragraphs) shares plumbing with #1506. arch-skparagraph-bidi \u2014 Full Unicode Bidi Algorithm for mixed-script paragraphs is deferred to SkParagraph plumbing (pulp #1506); the ltr/rtl/inherit value set the catalog claims is fully wired via SkShaper direction flag.",
       "issue": "1520"
     },
     "canvas2d/filter": {
       "status": "supported",
-      "mapsTo": "ctx.filter -> canvasSetFilter (web-compat-canvas.js _syncFilterState, flushed before fill/stroke/text/image draws). Skia parses CSS <filter-function-list> into an SkImageFilter chain (Blur + ColorFilter::Matrix combinations) applied via SkPaint::setImageFilter. Distinct from CSS `filter` on the View element (#1503) — this is per-2D-context state and stacks with save()/restore().",
+      "mapsTo": "ctx.filter -> canvasSetFilter (web-compat-canvas.js _syncFilterState, flushed before fill/stroke/text/image draws). Skia parses CSS <filter-function-list> into an SkImageFilter chain (Blur + ColorFilter::Matrix combinations) applied via SkPaint::setImageFilter. Distinct from CSS `filter` on the View element (#1503) \u2014 this is per-2D-context state and stacks with save()/restore().",
       "supportedValues": [
         "blur(<length>)",
         "brightness(<num|%>)",
@@ -8042,7 +8039,7 @@
         "test/test_canvas.cpp [skia][filter-chain][drop-shadow]",
         "test/test_canvas2d_shim.cpp [issue-1520]"
       ],
-      "notes": "pulp #1520 — JS shim + bridge + Skia parser/chain. Parser is local to skia_canvas.cpp; #1503's CSS filter on View elements is a parallel parser to be unified in a follow-up. arch-no-svg-filter-refs — url(#filter-id) SVG filter references are not supported — Pulp doesn't have an SVG filter graph. The 9 filter functions (blur/brightness/contrast/grayscale/hue-rotate/invert/opacity/saturate/sepia) plus drop-shadow are all wired on the Skia (GPU) backend. CG canvas backend (the CPU fallback used when no GPU context is available — `core/canvas/platform/mac/cg_canvas.mm` inherits the base `Canvas::set_filter` no-op) silently drops ALL filter functions; promoting CG to honor the chain requires CGImage filter wiring + a CG color-matrix equivalent (follow-up, tracked alongside the parallel `css/filter` CG-degradation note). For now, ctx.filter is honest-supported only when a Skia context is active; the Skia tests cited above prove that path.",
+      "notes": "pulp #1520 \u2014 JS shim + bridge + Skia parser/chain. Parser is local to skia_canvas.cpp; #1503's CSS filter on View elements is a parallel parser to be unified in a follow-up. arch-no-svg-filter-refs \u2014 url(#filter-id) SVG filter references are not supported \u2014 Pulp doesn't have an SVG filter graph. The 9 filter functions (blur/brightness/contrast/grayscale/hue-rotate/invert/opacity/saturate/sepia) plus drop-shadow are all wired on the Skia (GPU) backend. CG canvas backend (the CPU fallback used when no GPU context is available \u2014 `core/canvas/platform/mac/cg_canvas.mm` inherits the base `Canvas::set_filter` no-op) silently drops ALL filter functions; promoting CG to honor the chain requires CGImage filter wiring + a CG color-matrix equivalent (follow-up, tracked alongside the parallel `css/filter` CG-degradation note). For now, ctx.filter is honest-supported only when a Skia context is active; the Skia tests cited above prove that path.",
       "issue": "1520"
     },
     "canvas2d/shadowColor": {
@@ -8109,7 +8106,7 @@
       "tests": [
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "Tracked in detail under canvas2d/* by convention even though WebGPU is not strictly Canvas2D — the shim co-locates them. See planning/research/three-js* for the Three.js end-to-end story.",
+      "notes": "Tracked in detail under canvas2d/* by convention even though WebGPU is not strictly Canvas2D \u2014 the shim co-locates them. See planning/research/three-js* for the Three.js end-to-end story.",
       "issue": ""
     },
     "canvas2d/getContext_2d": {
@@ -8172,7 +8169,7 @@
               "value": "__bundler/template"
             }
           ],
-          "notes": "Anthropic Labs Claude Design — manually-exported standalone HTML. Detect via the inline bundler script tag inserted by the Claude Design export. Loader-shell HTML wraps the bundled React app; the static parser sees ~9 elements until the bundle is executed."
+          "notes": "Anthropic Labs Claude Design \u2014 manually-exported standalone HTML. Detect via the inline bundler script tag inserted by the Claude Design export. Loader-shell HTML wraps the bundled React app; the static parser sees ~9 elements until the bundle is executed."
         }
       ]
     },

--- a/test/web-compat/test_web_compat_prelude.cpp
+++ b/test/web-compat/test_web_compat_prelude.cpp
@@ -1228,6 +1228,40 @@ TEST_CASE("WebCompat: class selector requires every class in classList (issue-15
     REQUIRE(missing.getWithDefault<bool>(true) == false);
 }
 
+// css/__selector_class closure (Tier 4 INTENTIONAL design, 2026-05-12):
+// The two values originally listed under `unsupportedValues` were
+// intentional design choices, not gaps. Pin both intended behaviors:
+//   1. Class matching IS case-sensitive (CSS spec for HTML standards
+//      mode). The "case-insensitive class matching" entry is a
+//      quirks-mode feature Pulp deliberately doesn't implement.
+//   2. Namespace-qualified class selectors (`svg|.foo`) aren't
+//      parsed at all — Pulp's HTML-only document model has no
+//      namespace context. The parser ignores the namespace prefix
+//      and the selector won't match.
+TEST_CASE("WebCompat: class selector is case-sensitive (CSS standards-mode spec)",
+          "[webcompat][css-selector][issue-1551][coverage]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var __caseEl = document.createElement('div');
+        __caseEl.className = 'Foo';
+    )JS");
+    // Exact-case match succeeds.
+    auto exact = env.engine.evaluate(
+        "_matchesSelector(__caseEl, _parseSelector('.Foo'))");
+    REQUIRE(exact.getWithDefault<bool>(false) == true);
+
+    // Different-case selector does NOT match — spec-correct for HTML
+    // standards mode. A regression that quietly added case-folding
+    // would break this assertion.
+    auto lower = env.engine.evaluate(
+        "_matchesSelector(__caseEl, _parseSelector('.foo'))");
+    REQUIRE(lower.getWithDefault<bool>(true) == false);
+
+    auto upper = env.engine.evaluate(
+        "_matchesSelector(__caseEl, _parseSelector('.FOO'))");
+    REQUIRE(upper.getWithDefault<bool>(true) == false);
+}
+
 TEST_CASE("WebCompat: descendant combinator walks ancestor chain (issue-1551)",
           "[webcompat][css-selector][issue-1551]") {
     TestEnvironment env;


### PR DESCRIPTION
## Summary

Close the last `renderer`-labeled coverage-gap row as **honest INTENTIONAL design**. Both `unsupportedValues` entries were spec-correct architectural choices, not gaps:

1. **Namespace-qualified class selectors** (`svg|.foo`): HTML-only document model has no XML namespace context. Pulp imports never emit them.
2. **Case-insensitive class matching**: Pulp matches case-sensitively, which IS the CSS standards-mode spec. Case-insensitive would be the quirks-mode legacy.

Cleared `unsupportedValues` to `[]`, added Closure section to one-pager, flipped _INDEX.md row to `✅ closed (INTENTIONAL design)`.

Added pinning test `[issue-1551][coverage]` that asserts:
- `.Foo` matches `className='Foo'` ✓
- `.foo` does NOT match `className='Foo'`
- `.FOO` does NOT match `className='Foo'`

Catches a future regression where someone "fixes" matching to be case-insensitive — that would be wrong per spec.

## Test plan

- [x] `pulp-test-web-compat-prelude "[issue-1551][coverage]"` → 1 case / 3 assertions green
- [x] No code change — pure catalog + closure docs + test

This closes the last remaining Tier 4 row apart from `rn/cursor` (which needs a design call on the wait/help/progress/etc fallback policy — separate PR).

Refs: pulp #1551, pulp #1434