### PR TITLE
ci(shipyard): exclude ctest LABELS slow from PR validation (closes drift from #1589)

### DIFF
--- a/.shipyard/config.toml
+++ b/.shipyard/config.toml
@@ -49,7 +49,14 @@ stages = ["setup", "configure", "build", "test"]
 setup     = "./setup.sh --ci --deps-only"
 configure = "cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=ON"
 build     = "cmake --build build --parallel"
-test      = "ctest --test-dir build --output-on-failure --exclude-regex AudioWorkgroup"
+# `--label-exclude slow` skips ctest entries tagged LABELS slow — currently
+# `cmake-ios-auv3-configure` (test/CMakeLists.txt:23, ~25-30 min fresh-cache
+# Xcode/iOS try-compile + FetchContent bootstrap). #1589 added the label
+# for PR validation exclusion; the shipyard test command never picked up
+# the flag, so every PR was paying the slow-iOS cost. Full-CI (push to
+# main, nightly, workflow_dispatch) can still run it via a different
+# stage if needed — this only excludes from per-PR validation.
+test      = "ctest --test-dir build --output-on-failure --exclude-regex AudioWorkgroup --label-exclude slow"
 
 # Per-target overrides — ssh-windows needs `cmake --build` with the
 # Visual Studio multi-config generator's --config flag. The base
@@ -76,7 +83,7 @@ build     = "cmake --build build --config Release --parallel"
 # undiagnosable crashes. Timing-sensitive tests (EventLoop,
 # BufferingReader, VisualizationBridge) were fixed with proper
 # wait_until patterns and longer timeouts — no longer excluded.
-test      = "ctest --test-dir build -C Release --output-on-failure --exclude-regex \"AudioWorkgroup|Toolbar add items\""
+test      = "ctest --test-dir build -C Release --output-on-failure --exclude-regex \"AudioWorkgroup|Toolbar add items\" --label-exclude slow"
 
 [validation.gates]
 # Layer-3 authoritative gates — same scripts CI runs via


### PR DESCRIPTION
## Summary

`cmake-ios-auv3-configure` was tagged `LABELS slow` in #1589 with the explicit intent that PR/fast-CI validation skip it (`test/CMakeLists.txt:23`):

> Tagged `slow` for fast-CI exclusion (#1589): a fresh-cache configure spends ~3 minutes downloading + unpacking iOS-leg FetchContent sources before the actual smoke fires. **Full-CI (push to main / nightly / workflow_dispatch) still runs it.**

But the shipyard test command never picked up the flag, so every PR was paying the iOS auv3 cost (~25-30 min fresh cache, ~5-10 min warm) for ~6 months.

Adds `--label-exclude slow` to ctest invocations in both `[validation.default]` and `[validation.default.overrides.windows]`.

## Test plan

- [x] Local sanity: `ctest --test-dir build-cov -N` lists 759 tests; `ctest --test-dir build-cov -N --label-exclude slow` lists 756. The 3 filtered tests include `cmake-ios-auv3-configure` at Test #680.
- [ ] Validate that PR validation still runs the non-slow ctest suite (this PR's own validation should be ~25 min faster than baseline)
- [ ] CI lanes green

## Impact

With ~8 PRs queued through the macOS local runner, this recovers ~3-4 hours of runner time across the queue. Critical for unblocking the Spectr runtime-import landing path (#1859 + #1872) which are currently sitting in queue.

## What still runs the slow tests

Full-CI (push to main, nightly, workflow_dispatch) can still invoke ctest without `--label-exclude slow` via a dedicated stage if needed. This change is per-PR-validation only — main branch protection isn't affected.