### PR TITLE
feat(view): wire 5 CSS cursor keywords to macOS NSCursor (Tier-4 rn/cursor partial)

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -4187,19 +4187,14 @@
         "wait",
         "help",
         "progress",
-        "alias",
-        "copy",
-        "zoom-in",
-        "zoom-out",
-        "cell",
-        "context-menu"
+        "cell"
       ],
       "tests": [
         "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
         "packages/pulp-react/test/prop-applier-wave2.test.ts",
         "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
       ],
-      "notes": "pulp #1550 catalog hygiene: flipped partial \u2192 supported. Triage #7 fan-out (#1434 small-wins bundle) wired the CSS cursor keyword set onto View::CursorStyle. RN's spec ViewStyle accepts only {auto, pointer}; Pulp accepts the full CSS cursor enum because the same prop-applier path serves both rn/cursor and css/cursor. Keywords without a dedicated visual (wait / help / progress / alias / copy / zoom-* / cell / context-menu) fall through to `default` \u2014 they're listed in unsupportedValues for catalog accuracy. Wave 1 drift cleanup \u2014 `auto` keyword falls back to default (View::CursorStyle::default_); arch-platform-cursor-set means we don't add a dedicated 'auto' slot. Wave 2 rn \u2014 added 'auto' regression coverage in the wave2 test bundle.",
+      "notes": "pulp #1550 catalog hygiene: flipped partial \u2192 supported. Triage #7 fan-out (#1434 small-wins bundle) wired the CSS cursor keyword set onto View::CursorStyle. RN's spec ViewStyle accepts only {auto, pointer}; Pulp accepts the full CSS cursor enum because the same prop-applier path serves both rn/cursor and css/cursor. Keywords without a dedicated visual (wait / help / progress / alias / copy / zoom-* / cell / context-menu) fall through to `default` \u2014 they're listed in unsupportedValues for catalog accuracy. Wave 1 drift cleanup \u2014 `auto` keyword falls back to default (View::CursorStyle::default_); arch-platform-cursor-set means we don't add a dedicated 'auto' slot. Wave 2 rn \u2014 added 'auto' regression coverage in the wave2 test bundle. 2026-05-12 macOS partial (pulp #1550): `alias` (NSCursor.dragLinkCursor), `copy` (NSCursor.dragCopyCursor), `zoom-in` / `zoom-out` (NSCursor.zoomInCursor / zoomOutCursor on macOS 10.15+ with defensive respondsToSelector), `context-menu` (NSCursor.contextualMenuCursor) now wire to real native cursors via View::CursorStyle slots and window_host_mac.mm dispatch. The remaining 4 (`wait`, `help`, `progress`, `cell`) have no native macOS cursor and stay catalog-unsupported \u2014 they fall through to default. Linux / Windows / web-platform-bridge implementations would add their own per-keyword mapping later.",
       "issue": ""
     },
     "rn/d": {

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -1183,7 +1183,17 @@ public:
         top_right_resize,         ///< ↗↙ Diagonal resize (NE-SW)
         bottom_left_resize,       ///< ↗↙ Diagonal resize (alias for top_right)
         bottom_right_resize,      ///< ↖↘ Diagonal resize (alias for top_left)
-        multi_directional_resize  ///< ✥ All-direction move/resize
+        multi_directional_resize, ///< ✥ All-direction move/resize
+        // CSS cursor keywords with native macOS NSCursor mappings
+        // (pulp #1550 Tier-4 macOS partial 2026-05-12). Other CSS
+        // keywords without dedicated visuals (wait / help / progress /
+        // cell) stay catalog-unsupported because no native cursor
+        // exists on macOS.
+        alias,                    ///< CSS `alias` → NSCursor.dragLinkCursor
+        copy,                     ///< CSS `copy` → NSCursor.dragCopyCursor
+        zoom_in,                  ///< CSS `zoom-in` → NSCursor.zoomInCursor (macOS 10.15+)
+        zoom_out,                 ///< CSS `zoom-out` → NSCursor.zoomOutCursor (macOS 10.15+)
+        context_menu              ///< CSS `context-menu` → NSCursor.contextualMenuCursor
     };
     void set_cursor(CursorStyle c) { cursor_ = c; }
     CursorStyle cursor() const { return cursor_; }

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -1012,6 +1012,35 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                         [[NSCursor crosshairCursor] set]; break;
                     case pulp::view::View::CursorStyle::multi_directional_resize:
                         [[NSCursor openHandCursor] set]; break;
+                    // pulp #1550 Tier-4 macOS partial 2026-05-12 — 5
+                    // CSS cursor keywords with native NSCursor backings.
+                    //   alias → dragLinkCursor (macOS 10.6+).
+                    //   copy → dragCopyCursor (macOS 10.6+).
+                    //   zoom-in / zoom-out → zoomInCursor / zoomOutCursor
+                    //     (macOS 10.15+; defensive respondsToSelector
+                    //     check in case the symbol is weak-linked or
+                    //     unavailable on the runtime OS).
+                    //   context-menu → contextualMenuCursor (macOS 10.6+).
+                    case pulp::view::View::CursorStyle::alias:
+                        [[NSCursor dragLinkCursor] set]; break;
+                    case pulp::view::View::CursorStyle::copy:
+                        [[NSCursor dragCopyCursor] set]; break;
+                    case pulp::view::View::CursorStyle::zoom_in:
+                        if ([NSCursor respondsToSelector:@selector(zoomInCursor)]) {
+                            [[NSCursor performSelector:@selector(zoomInCursor)] set];
+                        } else {
+                            [[NSCursor arrowCursor] set];
+                        }
+                        break;
+                    case pulp::view::View::CursorStyle::zoom_out:
+                        if ([NSCursor respondsToSelector:@selector(zoomOutCursor)]) {
+                            [[NSCursor performSelector:@selector(zoomOutCursor)] set];
+                        } else {
+                            [[NSCursor arrowCursor] set];
+                        }
+                        break;
+                    case pulp::view::View::CursorStyle::context_menu:
+                        [[NSCursor contextualMenuCursor] set]; break;
                     default:
                         [[NSCursor arrowCursor] set]; break;
                 }

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -5220,16 +5220,18 @@ void WidgetBridge::register_api() {
         if (!v) return choc::value::Value();
         // pulp #1434 Triage #7 — cursor enum fan-out. Map the full CSS
         // cursor keyword set to the View::CursorStyle slots that exist
-        // today (4 base + 7 resize + invisible + multi-directional =
-        // ~12 distinct visuals). Where multiple CSS keywords map to the
+        // today (4 base + 7 resize + invisible + multi-directional = 12
+        // distinct visuals). Where multiple CSS keywords map to the
         // same visual (n/s/e/w-resize all map to the axis-aligned
-        // resize cursor; help/wait/progress all alias to default until
-        // OS-specific glyphs are wired), we collapse to the closest
-        // existing slot. CSS keywords with no semantic match (alias,
-        // copy, no-drop, all-scroll, zoom-*, cell, vertical-text,
-        // context-menu) currently fall back to default — tracked for a
-        // follow-up that adds dedicated CursorStyle slots and
-        // platform-specific glyph dispatch.
+        // resize cursor), we collapse to the closest existing slot.
+        //
+        // pulp #1550 Tier-4 macOS partial 2026-05-12 — added dedicated
+        // slots for `alias` / `copy` / `zoom-in` / `zoom-out` /
+        // `context-menu` (5 keywords with real NSCursor backings on
+        // macOS — see core/view/platform/mac/window_host_mac.mm).
+        // `wait` / `help` / `progress` / `cell` stay routed to default
+        // because macOS has no native cursor for them — listed in
+        // compat.json unsupportedValues for honesty.
         using CS = View::CursorStyle;
         if (c == "pointer")              v->set_cursor(CS::pointer);
         else if (c == "crosshair")       v->set_cursor(CS::crosshair);
@@ -5257,6 +5259,12 @@ void WidgetBridge::register_api() {
         else if (c == "move" || c == "all-scroll") {
             v->set_cursor(CS::multi_directional_resize);
         }
+        // pulp #1550 — 5 CSS cursor keywords with macOS NSCursor backings.
+        else if (c == "alias")           v->set_cursor(CS::alias);
+        else if (c == "copy")            v->set_cursor(CS::copy);
+        else if (c == "zoom-in")         v->set_cursor(CS::zoom_in);
+        else if (c == "zoom-out")        v->set_cursor(CS::zoom_out);
+        else if (c == "context-menu")    v->set_cursor(CS::context_menu);
         else                             v->set_cursor(CS::default_);
         return choc::value::Value();
     });

--- a/docs/reference/compat/rn.md
+++ b/docs/reference/compat/rn.md
@@ -26,6 +26,25 @@ Spec walk:
 
 ## Recently changed
 
+- **2026-05-12 (pulp #1550 Tier-4 macOS partial — `rn/cursor` 5 of 9
+  keywords)** — five CSS cursor keywords previously listed as
+  unsupported now wire to dedicated `View::CursorStyle` slots backed
+  by real `NSCursor` objects on macOS:
+  * `alias` → `NSCursor.dragLinkCursor` (10.6+)
+  * `copy` → `NSCursor.dragCopyCursor` (10.6+)
+  * `zoom-in` → `NSCursor.zoomInCursor` (10.15+, defensive
+    `respondsToSelector:` check with `arrowCursor` fallback)
+  * `zoom-out` → `NSCursor.zoomOutCursor` (same defensive pattern)
+  * `context-menu` → `NSCursor.contextualMenuCursor` (10.6+)
+  The remaining 4 (`wait`, `help`, `progress`, `cell`) stay in
+  `unsupportedValues` for honesty — macOS has no native `NSCursor`
+  for any of them (`wait`/`progress` are owned by the system spinning
+  beachball, not exposable as a settable cursor; `help` and `cell`
+  have no AppKit counterpart). They continue to fall through to
+  `default_`. Linux + Windows + web platform bridges would add their
+  own per-keyword mappings later; iOS / Android don't have visible
+  cursors so the question doesn't apply.
+
 - **2026-05-07 (Wave 4 extensive DIVERGE sweep)** — closes the rn
   drift bundle (16 DIVERGE → 0 DIVERGE; PASS 89 → 105; 74.2% → 87.5%
   PASS, no remaining drift). Two real wires + reclassification:

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -6313,6 +6313,51 @@ TEST_CASE("setCursor maps the full CSS keyword set",
     REQUIRE(bridge.widget("j")->cursor() == CS::default_);
 }
 
+// pulp #1550 Tier-4 macOS partial 2026-05-12: five CSS cursor keywords
+// (`alias` / `copy` / `zoom-in` / `zoom-out` / `context-menu`) now
+// route to dedicated `View::CursorStyle` slots so the macOS dispatch
+// in `window_host_mac.mm` can pick a real `NSCursor`. The other four
+// previously-unsupported keywords (`wait` / `help` / `progress` /
+// `cell`) stay collapsed to `default_` because macOS has no native
+// cursor for them. Pin both halves.
+TEST_CASE("setCursor wires 5 macOS-backed keywords to dedicated CursorStyle slots",
+          "[view][bridge][issue-1550][coverage]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        // The 5 keywords with native NSCursor mappings.
+        createPanel('al', ''); setCursor('al', 'alias');
+        createPanel('cp', ''); setCursor('cp', 'copy');
+        createPanel('zi', ''); setCursor('zi', 'zoom-in');
+        createPanel('zo', ''); setCursor('zo', 'zoom-out');
+        createPanel('cm', ''); setCursor('cm', 'context-menu');
+        // The 4 keywords that genuinely have no macOS cursor — these
+        // must STAY collapsed to default_ (catalog still lists them
+        // as unsupported for honesty).
+        createPanel('wt', ''); setCursor('wt', 'wait');
+        createPanel('hp', ''); setCursor('hp', 'help');
+        createPanel('pg', ''); setCursor('pg', 'progress');
+        createPanel('cl', ''); setCursor('cl', 'cell');
+    )");
+
+    using CS = View::CursorStyle;
+    // Newly-wired keywords route to dedicated slots.
+    REQUIRE(bridge.widget("al")->cursor() == CS::alias);
+    REQUIRE(bridge.widget("cp")->cursor() == CS::copy);
+    REQUIRE(bridge.widget("zi")->cursor() == CS::zoom_in);
+    REQUIRE(bridge.widget("zo")->cursor() == CS::zoom_out);
+    REQUIRE(bridge.widget("cm")->cursor() == CS::context_menu);
+    // No-native-cursor keywords stay at default_ — pinning prevents
+    // a future change from silently flipping them.
+    REQUIRE(bridge.widget("wt")->cursor() == CS::default_);
+    REQUIRE(bridge.widget("hp")->cursor() == CS::default_);
+    REQUIRE(bridge.widget("pg")->cursor() == CS::default_);
+    REQUIRE(bridge.widget("cl")->cursor() == CS::default_);
+}
+
 TEST_CASE("setCursor accepts axis-aligned aliases",
           "[view][bridge][css][issue-1434-bundle]") {
     ScriptEngine engine;
@@ -11209,14 +11254,26 @@ TEST_CASE("Wave5 css/cursor maps CSS keywords to View::CursorStyle",
     auto* p = bridge.widget("p");
     REQUIRE(p->cursor() == View::CursorStyle::pointer);
 
-    // arch-platform-cursor-set caveat — alias / copy / cell / zoom-in /
-    // zoom-out / help / wait map onto `default` since pulp's enum
-    // doesn't model them. Must not crash.
+    // pulp #1550 Tier-4 macOS partial 2026-05-12: `alias`, `copy`,
+    // `zoom-in`, `zoom-out`, `context-menu` now route to dedicated
+    // CursorStyle slots (NSCursor-backed on macOS). The remaining
+    // `wait` / `help` / `progress` / `cell` keywords still fall
+    // through to `default_` — no native macOS cursor exists for them.
+    // Pin BOTH halves to catch regressions either way.
     bridge.load_script(R"(
         var s2 = new CSSStyleDeclaration({ _id: 'p', _nativeCreated: true });
         s2.cursor = 'zoom-in';
     )");
-    // Falls through to default per arch caveat.
+    // Now routes to the dedicated slot (was: fell through to default_).
+    REQUIRE(p->cursor() == View::CursorStyle::zoom_in);
+
+    // `cell` is one of the 4 that genuinely has no macOS NSCursor —
+    // still falls through to `default_`. Pin so a future "fix" doesn't
+    // silently route it somewhere else.
+    bridge.load_script(R"(
+        var s3 = new CSSStyleDeclaration({ _id: 'p', _nativeCreated: true });
+        s3.cursor = 'cell';
+    )");
     REQUIRE(p->cursor() == View::CursorStyle::default_);
 }
 


### PR DESCRIPTION
## Summary

Tier-4 macOS partial closure on `rn/cursor`. Five of the nine previously-unsupported CSS cursor keywords now route to real native cursors on macOS via dedicated `View::CursorStyle` slots:

| CSS keyword | View slot | NSCursor |
|---|---|---|
| `alias` | `CursorStyle::alias` | `dragLinkCursor` (10.6+) |
| `copy` | `CursorStyle::copy` | `dragCopyCursor` (10.6+) |
| `zoom-in` | `CursorStyle::zoom_in` | `zoomInCursor` (10.15+, defensive respondsToSelector) |
| `zoom-out` | `CursorStyle::zoom_out` | `zoomOutCursor` (10.15+, defensive respondsToSelector) |
| `context-menu` | `CursorStyle::context_menu` | `contextualMenuCursor` (10.6+) |

The remaining 4 (`wait`/`help`/`progress`/`cell`) stay in `unsupportedValues` because they have no native macOS NSCursor — fall through to `default_`. Linux + Windows + web platform bridges would add per-keyword mappings later; iOS / Android don't have visible cursors.

## Hot-file carve-out

Agent A approved touching the cursor-dispatch region of `widget_bridge.cpp` for this slice (per `planning/AGENT-STATUS.md` 2026-05-12T20:55Z). The 5-line setCursor extension lives at line ~5142, far from `install_runtime_import_handlers()` (~1030-1140) and its JS aggregator (~1115-1140) which are still A's active surface.

## Test plan

- [x] `pulp-test-widget-bridge "[issue-1550][coverage]"` → 1 case / 9 assertions green
- [x] `pulp-test-widget-bridge "[issue-1434-bundle]"` → 5 cases / 25 assertions green (no regression on existing 18 keyword routings)
- [x] Manual macOS sanity deferred — NSCursor symbols are stable AppKit and dispatch is mechanical

Refs: pulp #1550, pulp #1434