### PR TITLE
feat(view): support text-align: match-parent via paint-time parent walk

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -3018,15 +3018,15 @@
         "start",
         "end",
         "auto",
-        "justify"
-      ],
-      "unsupportedValues": [
+        "justify",
         "match-parent"
       ],
+      "unsupportedValues": [],
       "tests": [
-        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]",
+        "test/test_widget_bridge.cpp [issue-1434][coverage]"
       ],
-      "notes": "RN supports auto/justify; we don't. pulp #1434 Triage #11: bridge accepts start/end (LTR-only aliases for left/right), auto (LTR fallback), and justify. start/end map symmetrically; auto/justify mirror the rn surface wiring.",
+      "notes": "RN supports auto/justify; we don't. pulp #1434 Triage #11: bridge accepts start/end (LTR-only aliases for left/right), auto (LTR fallback), and justify. pulp #1434 follow-up: match-parent resolves at paint time by walking the View parent chain via inheritable_text_align(); falls back to left when no ancestor set a value (CSS spec default for text-align).",
       "issue": ""
     },
     "css/textDecoration": {

--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -26,7 +26,14 @@ namespace pulp::view {
 /// existing canvas backends treat it as `left` until then. Both values
 /// are claimed in the rn/css catalog (Figma exports + Tailwind classes
 /// emit `auto` and `justify` routinely).
-enum class LabelAlign { left, center, right, auto_, justify };
+/// `match_parent` (pulp #1434 follow-up) resolves at paint time by
+/// walking the View parent chain (via `inheritable_text_align()`) and
+/// adopting the first ancestor's resolved value. If no ancestor set
+/// one, falls back to `left` (the CSS spec default for `text-align`).
+/// Symmetric with `auto_` in that the resolution is paint-time, not
+/// setter-time — matches CSS `match-parent` semantics which inherit
+/// from the parent's *computed* (not specified) value.
+enum class LabelAlign { left, center, right, auto_, justify, match_parent };
 
 class Label : public View {
 public:

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -3223,30 +3223,38 @@ void WidgetBridge::register_api() {
         auto* v = widget(args.get<std::string>(0, ""));
         auto a = args.get<std::string>(1, "left");
         if (!v) return choc::value::Value();
-        // pulp #1434 — accept all five CSS / RN textAlign values:
-        //   "left"/"start"   → LabelAlign::left   (0)
-        //   "center"         → LabelAlign::center (1)
-        //   "right"/"end"    → LabelAlign::right  (2)
-        //   "auto"           → LabelAlign::auto_  (3, paint-time resolved
-        //                      to left under LTR; pulp doesn't model RTL
-        //                      yet so this is currently equivalent to left)
-        //   "justify"        → LabelAlign::justify (4, canvas TextAlign::
-        //                      justify; SkParagraph kJustify lands in a
-        //                      follow-up — backends fall back to left-
-        //                      alignment math today)
+        // pulp #1434 — accept all six CSS / RN textAlign values:
+        //   "left"/"start"     → LabelAlign::left         (0)
+        //   "center"           → LabelAlign::center       (1)
+        //   "right"/"end"      → LabelAlign::right        (2)
+        //   "auto"             → LabelAlign::auto_        (3, paint-time
+        //                        resolved to left under LTR; pulp doesn't
+        //                        model RTL yet so this is currently
+        //                        equivalent to left)
+        //   "justify"          → LabelAlign::justify      (4, canvas
+        //                        TextAlign::justify; SkParagraph kJustify
+        //                        lands in a follow-up — backends fall back
+        //                        to left-alignment math today)
+        //   "match-parent"     → LabelAlign::match_parent (5, paint-time
+        //                        resolved by walking the View parent chain
+        //                        via inheritable_text_align(); falls back
+        //                        to `left` when no ancestor set a value.
+        //                        Matches CSS spec: inherit the parent's
+        //                        *computed* text-align value).
         int aligned;
         LabelAlign label_a;
         if      (a == "center")               { aligned = 1; label_a = LabelAlign::center; }
         else if (a == "right" || a == "end")  { aligned = 2; label_a = LabelAlign::right; }
         else if (a == "auto")                 { aligned = 3; label_a = LabelAlign::auto_; }
         else if (a == "justify")              { aligned = 4; label_a = LabelAlign::justify; }
+        else if (a == "match-parent")         { aligned = 5; label_a = LabelAlign::match_parent; }
         else                                  { aligned = 0; label_a = LabelAlign::left; }
         if (auto* l = dynamic_cast<Label*>(v)) {
             l->set_text_align(label_a);
         } else {
             // issue-969: container Views store the alignment in the
             // inheritable slot for descendant Labels. Encoding extends
-            // 0..4 to cover the new auto / justify cases — Label::paint
+            // 0..5 to cover auto / justify / match-parent — Label::paint
             // decodes the slot via the same numeric mapping.
             v->set_inheritable_text_align(aligned);
         }

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -534,8 +534,66 @@ void Label::paint(canvas::Canvas& canvas) {
             else if (v == 2) effective_text_align = LabelAlign::right;
             else if (v == 3) effective_text_align = LabelAlign::auto_;
             else if (v == 4) effective_text_align = LabelAlign::justify;
+            else if (v == 5) effective_text_align = LabelAlign::match_parent;
             else effective_text_align = LabelAlign::left;
         }
+    }
+
+    // pulp #1434 — resolve `match-parent` at paint time. CSS spec: the
+    // computed value matches the parent's resolved `text-align`. We walk
+    // the View parent chain via `inheritable_text_align()` starting from
+    // `parent_` (NOT the Label itself — the Label's own value IS
+    // match-parent, which would loop). If no ancestor set a value, fall
+    // back to `left` (the CSS spec default for `text-align`).
+    //
+    // If the parent's resolved value is itself `start`/`end` (encoded as
+    // `left`/`right` here since pulp aliases them at the setter), the
+    // existing LTR-only writing-direction policy applies — same as `auto`.
+    if (effective_text_align == LabelAlign::match_parent) {
+        // Walk ancestor chain manually, skipping any intermediate
+        // View whose own inh_text_align_ is also 5 (match-parent).
+        // `View::inheritable_text_align()` is unsuitable here because
+        // it returns the first SET value, not the first NON-match-parent
+        // value — if the immediate parent is also match-parent, the
+        // walk has to continue. Codex P1 on PR #1879 (2026-05-12).
+        //
+        // Example chain we now resolve correctly:
+        //   grandparent  text-align: center        (slot = 1)
+        //   parent       text-align: match-parent  (slot = 5)
+        //   child Label  text-align: match-parent  → renders center
+        //
+        // Previous code stopped at parent.inheritable_text_align()
+        // returning 5 and degraded to `left`.
+        LabelAlign parent_resolved = LabelAlign::left;
+        for (auto* anc = parent(); anc != nullptr; anc = anc->parent()) {
+            auto inh = anc->inheritable_text_align();
+            if (!inh.has_value()) continue;
+            int v = inh.value();
+            if (v == 5) {
+                // Intermediate match-parent ancestor — keep walking.
+                // Note: `inheritable_text_align()` already walks up
+                // until it finds a SET value. We need the loop here
+                // because the SET value might itself be 5; we want
+                // the first non-5 SET value in the chain.
+                //
+                // To skip past this anc's own slot in the next
+                // iteration, we must continue from its parent and
+                // re-enter inheritable_text_align() — but since
+                // inheritable walks again from there, we need to
+                // explicitly bypass anc's slot. Easiest: peek at
+                // anc->parent() directly and re-loop.
+                continue;
+            }
+            if      (v == 1) parent_resolved = LabelAlign::center;
+            else if (v == 2) parent_resolved = LabelAlign::right;
+            else if (v == 3) parent_resolved = LabelAlign::auto_;
+            else if (v == 4) parent_resolved = LabelAlign::justify;
+            else             parent_resolved = LabelAlign::left;
+            break;
+        }
+        // If every ancestor stored 5 (or no ancestor set anything),
+        // CSS spec says fall back to `start` ≡ `left` under LTR.
+        effective_text_align = parent_resolved;
     }
 
     // pulp #1434 — resolve `auto` at paint time. `auto` is CSS
@@ -550,7 +608,8 @@ void Label::paint(canvas::Canvas& canvas) {
     float x = 0;
     switch (effective_text_align) {
         case LabelAlign::left:
-        case LabelAlign::auto_: // unreachable — resolved above; keeps switch exhaustive
+        case LabelAlign::auto_:         // unreachable — resolved above; keeps switch exhaustive
+        case LabelAlign::match_parent:  // unreachable — resolved above; keeps switch exhaustive
             canvas.set_text_align(canvas::TextAlign::left);
             break;
         case LabelAlign::center:

--- a/docs/reference/compat/css.md
+++ b/docs/reference/compat/css.md
@@ -652,6 +652,19 @@ specifics are out of scope.
   `css/animationPlayState` stays `missing` because its `mapsTo` is
   `"no branch"` — the bridge has no entry point for it at all, which
   is NOT_IMPL semantics, not NO-OP.
+- **2026-05-12 (pulp #1434 follow-up)** — `css/textAlign` now also
+  accepts `match-parent`, closing the last value gap on this property.
+  CSS spec: `match-parent` resolves to the parent's *computed*
+  `text-align`. Implementation reuses the existing View parent-chain
+  walker (`View::inheritable_text_align()`, originally wired for
+  issue-969 typography inheritance): at paint time, a Label set to
+  `LabelAlign::match_parent` walks from `parent()` up the ancestor chain
+  and adopts the first ancestor's resolved value, falling back to `left`
+  when no ancestor set one (the CSS spec default for `text-align`).
+  Symmetric with the existing paint-time `auto` resolution. Bridge
+  encoding extends 0..4 → 0..5 to cover container Views storing the new
+  value in the inheritable slot. `unsupportedValues` for `css/textAlign`
+  now empty — coverage-gap closed.
 - **2026-05-05 (pulp #1434 Triage #11)** — `css/textAlign` now accepts
   `start`, `end`, `auto`, and `justify` alongside the existing `left`,
   `center`, `right`. `start`/`end` map symmetrically to `left`/`right`
@@ -659,7 +672,8 @@ specifics are out of scope.
   gracefully until pulp's RTL slice lands). `justify` reaches canvas
   `TextAlign::justify`; full SkParagraph kJustify rendering is a
   follow-up (backends approximate as left until then). `match-parent`
-  remains unsupported. Reclassified DIVERGE → PASS.
+  remains unsupported (closed in the follow-up entry dated 2026-05-12).
+  Reclassified DIVERGE → PASS.
 - **2026-05-05 (pulp #1434 Triage #15)** — `css/boxShadow` status
   flipped `supported` → `partial`. The single-shadow CSS-spec format
   (`[inset] <dx>px <dy>px <blur>px [<spread>px] <color>`) has been

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -5729,6 +5729,182 @@ TEST_CASE("Label paints with TextAlign::left when textAlign='auto' (LTR fallback
     REQUIRE(saw_left);
 }
 
+// ── pulp #1434 follow-up (css/textAlign coverage gap) — match-parent ─────
+//
+// CSS spec: `match-parent` resolves to the parent's *computed*
+// `text-align`. Pulp wires this at paint time by walking the View parent
+// chain via `inheritable_text_align()`. If no ancestor set a value, falls
+// back to `left` (CSS spec default for `text-align`).
+//
+// Implementation lives in:
+//   - widget_bridge.cpp setTextAlign — accepts "match-parent" string
+//   - widgets.hpp LabelAlign::match_parent — new enum value (5)
+//   - widgets.cpp Label::paint — paint-time parent-chain walk
+
+TEST_CASE("setTextAlign accepts match-parent on a Label",
+          "[view][bridge][css][issue-1434][coverage]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createLabel('a','match text', '');  setTextAlign('a','match-parent');
+    )");
+
+    REQUIRE(dynamic_cast<Label*>(bridge.widget("a"))->text_align()
+            == LabelAlign::match_parent);
+}
+
+TEST_CASE("Label with textAlign='match-parent' adopts parent's resolved value (center)",
+          "[view][widget][css][issue-1434][coverage]") {
+    // Parent View carries an inheritable text-align (center = 1). Label
+    // child set to match-parent should paint with TextAlign::center.
+    View parent;
+    parent.set_inheritable_text_align(1);  // 1 == LabelAlign::center
+
+    auto child = std::make_unique<Label>("inherited");
+    child->set_bounds({0, 0, 200, 24});
+    child->set_text_align(LabelAlign::match_parent);
+    auto* child_raw = child.get();
+    parent.add_child(std::move(child));
+
+    pulp::canvas::RecordingCanvas canvas;
+    child_raw->paint(canvas);
+
+    bool saw_center = false;
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::set_text_align) {
+            const auto enc = static_cast<pulp::canvas::TextAlign>(static_cast<int>(cmd.f[0]));
+            if (enc == pulp::canvas::TextAlign::center) saw_center = true;
+        }
+    }
+    REQUIRE(saw_center);
+}
+
+TEST_CASE("Label with textAlign='match-parent' falls back to left when no ancestor set a value",
+          "[view][widget][css][issue-1434][coverage]") {
+    // CSS spec: `text-align` defaults to `start` (≡ left under LTR) when
+    // no value is inherited. A match-parent Label with no parent (or a
+    // parent chain that never called set_inheritable_text_align) must
+    // paint left-aligned.
+    Label label("orphan");
+    label.set_bounds({0, 0, 200, 24});
+    label.set_text_align(LabelAlign::match_parent);
+
+    pulp::canvas::RecordingCanvas canvas;
+    label.paint(canvas);
+
+    bool saw_left = false;
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::set_text_align) {
+            const auto enc = static_cast<pulp::canvas::TextAlign>(static_cast<int>(cmd.f[0]));
+            if (enc == pulp::canvas::TextAlign::left) saw_left = true;
+        }
+    }
+    REQUIRE(saw_left);
+}
+
+// Codex P1 on PR #1879 (2026-05-12): when an INTERMEDIATE ancestor in
+// the chain has text-align: match-parent itself, the walk must
+// continue past it to find the first non-match-parent value upstream.
+// The original implementation stopped at parent.inheritable_text_align()
+// returning 5 and degraded the child to `left` — wrong for a chain
+// like grandparent=center → parent=match-parent → label=match-parent
+// which should resolve to center.
+TEST_CASE("Label with match-parent walks past intermediate match-parent ancestor",
+          "[view][widget][css][issue-1434][issue-1879][coverage]") {
+    // Build: grandparent(center) → parent(match-parent) → label(match-parent).
+    View grandparent;
+    grandparent.set_bounds({0, 0, 600, 200});
+    grandparent.set_inheritable_text_align(1);  // center
+
+    auto parent_owned = std::make_unique<View>();
+    auto* parent_v = parent_owned.get();
+    parent_v->set_bounds({0, 0, 600, 200});
+    parent_v->set_inheritable_text_align(5);    // match-parent
+
+    auto label_owned = std::make_unique<Label>("hi");
+    auto* label = label_owned.get();
+    label->set_bounds({0, 0, 600, 24});
+    label->set_text_align(LabelAlign::match_parent);
+
+    parent_v->add_child(std::move(label_owned));
+    grandparent.add_child(std::move(parent_owned));
+
+    pulp::canvas::RecordingCanvas canvas;
+    label->paint(canvas);
+
+    // Should resolve through parent (match-parent → keep walking) →
+    // grandparent (center). Paint must emit a center text-align.
+    bool saw_center = false;
+    bool saw_left   = false;
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::set_text_align) {
+            const auto enc = static_cast<pulp::canvas::TextAlign>(static_cast<int>(cmd.f[0]));
+            if (enc == pulp::canvas::TextAlign::center) saw_center = true;
+            if (enc == pulp::canvas::TextAlign::left)   saw_left   = true;
+        }
+    }
+    REQUIRE(saw_center);
+    REQUIRE_FALSE(saw_left);  // regression guard for the old fall-back-to-left bug
+}
+
+TEST_CASE("Label with match-parent through chain of all match-parent ancestors falls back to left",
+          "[view][widget][css][issue-1434][issue-1879][coverage]") {
+    // Pathological case: every ancestor in the chain has match-parent.
+    // CSS spec says fall back to `start` (≡ left under LTR).
+    View root;
+    root.set_bounds({0, 0, 600, 200});
+    root.set_inheritable_text_align(5);  // match-parent
+
+    auto mid_owned = std::make_unique<View>();
+    auto* mid = mid_owned.get();
+    mid->set_bounds({0, 0, 600, 200});
+    mid->set_inheritable_text_align(5);  // match-parent
+
+    auto label_owned = std::make_unique<Label>("hi");
+    auto* label = label_owned.get();
+    label->set_bounds({0, 0, 600, 24});
+    label->set_text_align(LabelAlign::match_parent);
+
+    mid->add_child(std::move(label_owned));
+    root.add_child(std::move(mid_owned));
+
+    pulp::canvas::RecordingCanvas canvas;
+    label->paint(canvas);
+
+    bool saw_left = false;
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::set_text_align) {
+            const auto enc = static_cast<pulp::canvas::TextAlign>(static_cast<int>(cmd.f[0]));
+            if (enc == pulp::canvas::TextAlign::left) saw_left = true;
+        }
+    }
+    REQUIRE(saw_left);
+}
+
+TEST_CASE("setTextAlign on a container View accepts match-parent (encoded as 5)",
+          "[view][bridge][css][issue-1434][coverage]") {
+    // Non-Label Views store the alignment in the inheritable slot so
+    // descendant Labels pick it up. The match-parent encoding (5) must
+    // round-trip through inheritable_text_align().
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('p', '');  setTextAlign('p','match-parent');
+    )");
+
+    auto* panel = bridge.widget("p");
+    REQUIRE(panel != nullptr);
+    auto inh = panel->inheritable_text_align();
+    REQUIRE(inh.has_value());
+    REQUIRE(inh.value() == 5);
+}
+
 // ── pulp #1434 (cross-surface mega-batch) — per-edge margin/padding
 // accept percent strings + auto (margin only). Mirrors width/height
 // (#1426) and top/right/bottom/left (#1451) percent patterns. Yoga


### PR DESCRIPTION
## Summary

Closes the last value gap on `css/textAlign` — `match-parent` was the only remaining unsupported value (`planning/coverage-gaps/css-textAlign.md`).

- **What shipped**: `LabelAlign::match_parent` enum value + `widget_bridge.cpp::setTextAlign` accepts the `"match-parent"` string + `Label::paint` resolves at paint time by walking `parent()->inheritable_text_align()`, falling back to `left` (CSS spec default) when no ancestor set a value.
- **Architectural note**: reuses the existing View parent-chain walker originally wired for issue-969 typography inheritance (`color` / `fontSize` / `fontFamily` / etc.). No new infrastructure required — the parent-walk path was already in place, just not consumed by `text-align` resolution until now.
- **Symmetric with existing `auto` resolution**: both are paint-time, not setter-time. CSS spec for `match-parent` says "compute to the parent's resolved value"; spec for `auto` says "compute based on writing direction." Same shape, different resolver.
- **Container Views**: encode `5` in the inheritable slot so descendant Labels pick it up through the same issue-969 typography-inheritance walk. Bridge encoding extends `0..4` → `0..5`.

## Test plan

- [x] `test/test_widget_bridge.cpp [issue-1434][coverage]` — 4 new Catch2 cases:
  - setter accepts the `"match-parent"` string
  - Label adopts a center-aligned parent's value at paint time (`set_inheritable_text_align(1)` on parent → Label paints `TextAlign::center`)
  - orphan Label (no parent) falls back to `TextAlign::left`
  - container View round-trips encoding `5` through the inheritable slot
- [x] Existing `[issue-1434-textalign-11]` tests still green (3 cases, 9 assertions) — no regression in left/center/right/start/end/auto/justify
- [x] Full `pulp-test-widget-bridge` suite green: **2123 assertions in 370 cases**

## Coverage

- `compat.json` `css/textAlign`: `unsupportedValues: ["match-parent"]` → `unsupportedValues: []`. `supportedValues` appends `"match-parent"`.
- `docs/reference/compat/css.md`: new 2026-05-12 entry under "Recently changed" explaining the resolution + the architectural reuse.
- `planning/coverage-gaps/css-textAlign.md`: `## Closure` section added.
- `planning/coverage-gaps/_INDEX.md`: row flipped to ✅ closed.

## Notes

- Coordination: agent B working under agent A's 2026-05-12T20:55Z hot-file carve-out for the `widget_bridge.cpp` style/cursor surface. The `setTextAlign` setter at line ~3104 is far from agent A's runtime-import region (lines ~1030-1140). No conflict expected.
- Per `feedback_version_bump_no_surface_for_fix_feat`, both surface-specific `Version-Bump: <surface>=skip` AND a no-surface `Version-Bump: skip` trailer are present on the tip commit (the no-surface form is what bypasses the fix/feat-needs-bump gate).

Agent: B
Refs: pulp #1434