### PR TITLE
fix(pulp-react): widen listStyle shorthand typeSet to 15 counter-style keywords (closes #1878 shorthand gap)

### DIFF
--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -823,8 +823,23 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         case 'listStyle': {
             const sval = String(value).trim();
             const tokens = sval.split(/\s+/);
+            // pulp #1878 follow-up (2026-05-12, carve-out approved
+            // by A 21:50Z): widened from the original 5 keywords to
+            // the 15 counter-style keywords that landed in #1878's
+            // longhand `setListStyleType` keyword table. Without this
+            // widening, `style={{ listStyle: 'lower-roman' }}` silently
+            // drops the type token at the shorthand parser even
+            // though the longhand `listStyleType: 'lower-roman'` path
+            // works correctly. Keep aligned with widget_bridge.cpp
+            // setListStyleType's keyword set.
             const typeSet: Record<string, true> = {
                 none: true, disc: true, circle: true, square: true, decimal: true,
+                'decimal-leading-zero': true,
+                'lower-roman': true, 'upper-roman': true,
+                'lower-alpha': true, 'upper-alpha': true,
+                'lower-latin': true, 'upper-latin': true,
+                'lower-greek': true,
+                armenian: true, georgian: true,
             };
             const posSet: Record<string, true> = { inside: true, outside: true };
             let sawType = false, sawImage = false;

--- a/packages/pulp-react/test/prop-applier-list-style.test.ts
+++ b/packages/pulp-react/test/prop-applier-list-style.test.ts
@@ -110,4 +110,51 @@ describe('prop-applier list-style cluster (pulp #1514)', () => {
         expect(callsFor(bridge, 'setListStyleType').map((c) => c.args[1])).toEqual(['disc']);
         expect(callsFor(bridge, 'setListStylePosition').map((c) => c.args[1])).toEqual(['inside']);
     });
+
+    // pulp #1878 follow-up (2026-05-12): the shorthand parser's typeSet
+    // was widened from 5 keywords to the 15 counter-style keywords
+    // landed in #1878's longhand. Without this widening,
+    // `style={{ listStyle: 'lower-roman' }}` silently dropped the type
+    // token at the shorthand parser even though the longhand path
+    // worked. Pin every new keyword so the routing can't regress.
+    it('listStyle shorthand routes counter-style type keywords (decimal-leading-zero, roman, alpha, latin, greek, armenian, georgian)', () => {
+        const counterStyleKeywords = [
+            'decimal-leading-zero',
+            'lower-roman', 'upper-roman',
+            'lower-alpha', 'upper-alpha',
+            'lower-latin', 'upper-latin',
+            'lower-greek',
+            'armenian', 'georgian',
+        ];
+        for (const kw of counterStyleKeywords) {
+            applyChangedProps(makeInstance(kw), {}, { listStyle: kw });
+        }
+        const dispatched = callsFor(bridge, 'setListStyleType').map((c) => c.args[1]);
+        expect(dispatched).toEqual(counterStyleKeywords);
+    });
+
+    it('listStyle shorthand routes counter-style with position (e.g. "lower-roman inside")', () => {
+        applyChangedProps(makeInstance('roman-inside'), {}, {
+            listStyle: 'lower-roman inside',
+        });
+        expect(callsFor(bridge, 'setListStyleType').map((c) => c.args[1])).toEqual(['lower-roman']);
+        expect(callsFor(bridge, 'setListStylePosition').map((c) => c.args[1])).toEqual(['inside']);
+    });
+
+    it('listStyle shorthand routes counter-style with image (e.g. "upper-alpha url(bullet.png)")', () => {
+        applyChangedProps(makeInstance('alpha-img'), {}, {
+            listStyle: 'upper-alpha url(bullet.png)',
+        });
+        expect(callsFor(bridge, 'setListStyleType').map((c) => c.args[1])).toEqual(['upper-alpha']);
+        expect(callsFor(bridge, 'setListStyleImage').map((c) => c.args[1])).toEqual(['url(bullet.png)']);
+    });
+
+    it('listStyle shorthand still drops genuinely-unknown counter-style keywords', () => {
+        // `tibetan`, `cjk-decimal`, `hebrew`, `hiragana`, `katakana` etc. are
+        // CSS Counter Styles Level 3 keywords NOT yet wired in #1878's
+        // longhand set. The shorthand parser must continue to drop them
+        // until the longhand list is extended (separate follow-up).
+        applyChangedProps(makeInstance('tibetan'), {}, { listStyle: 'tibetan' });
+        expect(callsFor(bridge, 'setListStyleType')).toHaveLength(0);
+    });
 });


### PR DESCRIPTION
## Summary

Closes Codex P2 on PR #1878 — the React shorthand parser `prop-applier.ts::typeSet` still had only the old 5-value set, so `style={{ listStyle: 'lower-roman' }}` silently dropped the type token even though `style={{ listStyleType: 'lower-roman' }}` worked correctly via the longhand path.

**Carve-out**: agent A approved touching `prop-applier.ts::typeSet` + its matching vitest at 2026-05-12T21:50Z (strict scope — no other `pulp-react/src/*` edits). This PR honors that scope: 2 files, 62 insertions, 0 deletions.

## Fix

Widen `typeSet` to the same 15 keywords `setListStyleType` recognizes: `none`, `disc`, `circle`, `square`, `decimal`, `decimal-leading-zero`, `lower-roman`, `upper-roman`, `lower-alpha`, `upper-alpha`, `lower-latin`, `upper-latin`, `lower-greek`, `armenian`, `georgian`. The longhand and shorthand paths now have identical routing behavior.

## Tests

4 new vitest cases in `packages/pulp-react/test/prop-applier-list-style.test.ts`:
- All 10 new counter-style keywords route correctly
- Counter-style + position (`'lower-roman inside'`)
- Counter-style + image (`'upper-alpha url(...)'`)
- Still drops genuinely-unknown CSS Counter Styles Level 3 keywords (`tibetan` canary — not yet in the longhand set)

`npx vitest run test/prop-applier-list-style.test.ts` → 12 tests pass (was 8 before this change).

Refs: pulp #1878, pulp #1514