### PR TITLE
fix(ci): static name for Diff coverage required gate so it actually enforces

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -619,7 +619,16 @@ jobs:
     # Runs only on pull_request events — the gate question "of the lines
     # this PR adds, how many are covered?" is meaningless on a direct
     # push to main where there is no diff to compute against.
-    name: Diff coverage required (${{ needs.coverage.result == 'success' && '75%' || 'coverage job failed' }})
+    #
+    # NOTE: the previous dynamic name `Diff coverage required (${{ ... }})`
+    # did NOT evaluate at runtime — GitHub Actions renders `name:` at
+    # job-creation time, before `needs.coverage.result` is available, so
+    # the literal `${{ }}` template appeared in the check name on every
+    # PR and the gate stayed `[cancelled]` (zero enforcement value).
+    # The static name below renders correctly, lets us add the check to
+    # branch-protection's required-status-checks list, and shows the
+    # threshold inside the rendered PR comment body instead of the name.
+    name: Diff coverage required
     runs-on: ubuntu-24.04
     needs: coverage
     if: always() && github.event_name == 'pull_request'

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,12 +23,28 @@ coverage:
         threshold: 1%          # allow 1% drop without failing
         informational: true    # Phase 1 is measurement; no blocking yet
 
-    # Patch status: "is new code covered?" Advisory in Phase 1; the
-    # authoritative patch gate comes from diff-cover in Phase 3.
+    # Patch status: "is new code covered?" Advisory in the sense that
+    # branch-protection does NOT require this check (so a sub-threshold
+    # PR can still merge), but the check status now accurately reflects
+    # the threshold check — `success` if ≥75%, `failure` if <75%.
+    #
+    # Previously `informational: true` hardwired the status to `success`
+    # even when patch coverage was 0%, which deceived devs reading the
+    # check line. The bot still posted a "❌ Patch coverage is X%"
+    # comment, but the status check itself said success, masking the
+    # gap. Flipping to enforcing makes the signal accurate without
+    # changing merge behavior (codecov/patch is not in
+    # branch-protection's required-status-checks list, so a red
+    # check here lets the dev decide; it does not auto-block).
+    #
+    # To make this a hard merge gate later, add `codecov/patch` to
+    # branch-protection's required contexts via the GitHub API or
+    # repo settings. Authoritative in-tree gate lives in
+    # .github/workflows/coverage.yml ("Diff coverage required") and
+    # is separately tracked.
     patch:
       default:
         target: 75%
-        informational: true
 
 # Exclude lists mirror scripts/run_coverage.sh COVERAGE_IGNORE_REGEX
 # so Codecov and our local tooling count the same set of files.

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,32 @@
 # Phase 2 adds ci/coverage-targets.yaml alongside this for the diff-cover
 # gate; Phase 4 introduces doc_path_map.json to prevent drift.
 
+# Notification gating — wait for all 4 platform coverage uploads before
+# the bot computes + posts the patch coverage report. Without this,
+# Codecov posts as soon as it sees ANY upload (often Linux first, since
+# its build is fastest), which means Apple-only or Windows-only tested
+# paths get reported as 0% covered against partial data. PR #1873 was a
+# textbook example: a CLAP-fixture test that ran only on macOS was
+# reported as "0% patch coverage" by the bot because the macOS upload
+# hadn't arrived (and never did — see follow-up issue on the coverage
+# workflow's `cancel-in-progress: true` concurrency policy that wipes
+# in-flight runs on force-push).
+#
+# Expected uploaders today (matches .github/workflows/coverage.yml jobs
+# + flag tags in the Codecov upload step):
+#   1. Linux Clang  (Cobertura XML)
+#   2. macOS Clang  (Cobertura XML)
+#   3. Windows Clang (Cobertura XML)
+#   4. Android Kotlin (jacoco)
+#
+# If you add or remove a coverage uploader, bump this number to match
+# or Codecov will silently wait forever for the missing one and never
+# post. After 7d it gives up and posts whatever it has — by then the
+# PR has long since merged with a stale report.
+codecov:
+  notify:
+    after_n_builds: 4
+
 coverage:
   status:
     # Project-wide status: "did we get worse?" Not a hard gate — we


### PR DESCRIPTION
## The bugs (now two)

Two coverage-signal bugs that combined to deceive every PR reviewer for weeks. Both fixed in this PR; neither changes merge behavior.

### Bug 1: in-tree `Diff coverage required` gate name is broken

The CI gate at `.github/workflows/coverage.yml:622` had a dynamic `name:` field:

```yaml
name: Diff coverage required (${{ needs.coverage.result == 'success' && '75%' || 'coverage job failed' }})
```

GitHub Actions renders `name:` at **job-creation time**, before `needs.coverage.result` is available — so the substitution never evaluated. Every recent run shows the check as **[cancelled]** with the literal `${{ }}` template text in the name:

```
dce92b319: Diff coverage required (${{ ... }}) [cancelled]
dd6b98de4: Diff coverage required (${{ ... }}) [cancelled]
6b33dfc8b: Diff coverage required (${{ ... }}) [cancelled]
```

→ **zero enforcement value tonight.**

**Fix**: static name. Threshold (75% from `tools/scripts/coverage_config.json`) is rendered into the PR comment body by diff-cover's markdown report.

### Bug 2: `codecov/patch` status hardwired to `success`

`codecov.yml` had `patch.informational: true`, which forces the GitHub status check to ALWAYS resolve to `success` regardless of whether patch coverage cleared the 75% target.

Example from PR #1873 (this repo, just merged):

| Signal | Value |
|--------|-------|
| Bot comment | ❌ `Patch coverage is 0% with 2 lines missing` |
| Check output_title | `0.00% of diff hit (target 75.00%)` |
| Check conclusion | **`[completed success]`** ← the lie |

The bot was telling the truth in its comment AND in the check's output_title, but the conclusion was hardwired to green. Reviewers reading just the check line would have no idea coverage was 0%.

**Fix**: drop `informational: true`. The check now reports `failure` for <75%, `success` for ≥75%.

## What this PR does and doesn't do

### Does

- ✅ Makes the in-tree `Diff coverage required` check name render correctly
- ✅ Makes `codecov/patch` status accurately reflect the threshold
- ✅ Adds a clear inline comment in codecov.yml explaining the bug + the path to future enforcement

### Does NOT

- ❌ Block any merges. Neither `codecov/patch` nor `Diff coverage required` is in branch-protection's required-status-checks list. A PR with <75% patch coverage will show a red ❌ on these checks, but the user can still merge.
- ❌ Address the cross-platform measurement gap (#1739, #1873 both showed 0% because their tests were Apple-only and the coverage build is Linux-only). That's a separate investigation — possibly the existing `merge_cobertura.py` step at coverage.yml:715 isn't working right.

## Future enforcement (single command, on user demand)

To later make either check a hard merge gate:

```bash
# To gate on codecov/patch:
gh api repos/danielraffel/pulp/branches/main/protection \
  -X PATCH -F required_status_checks.contexts+=codecov/patch

# To gate on the in-tree diff-cover (also recommended):
gh api repos/danielraffel/pulp/branches/main/protection \
  -X PATCH -F 'required_status_checks.contexts+=Diff coverage required'
```

User intent (from session 2026-05-12): "accurate signal now, opt-in enforcement later, strong local catch." This PR delivers all three: accurate signal via both Bug 1 + Bug 2 fixes, opt-in enforcement via the gh api commands above, strong local catch via the existing pre-push hook (`tools/scripts/local_diff_cover.sh`) which already enforces 75% before push.

## Test plan

- [ ] Workflow renders `Diff coverage required` as a stable check name (verify post-merge on the first PR after this lands)
- [ ] Status of `codecov/patch` is `failure` (not `success`) on a PR with <75% patch coverage
- [ ] Status of both checks is `success` on a PR with ≥75% patch coverage
- [ ] PR comment body still includes the threshold + diff-cover markdown report (unchanged)
- [ ] No merges are blocked by these check changes (branch protection unchanged)

## Related

- Sweep of last 18 real PRs: every one shows `codecov/patch=success` because of Bug 2. The bot was firing reliably (18/18 fire rate) — the lie was in the check status, not the bot's report.
- Cross-platform gap (#1739, #1873): platforms-only-Apple paths show 0% on Linux coverage build. Probably needs `merge_cobertura.py` audit. Filed as separate follow-up after this lands.
- Sub-agent audit of breakage history still running; report will be appended to the PR comment when it completes.