### PR TITLE
fix(react): display:flex defaults to flex-direction:row in flat-prop path (closes #1894)

### DIFF
--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -914,7 +914,32 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         case 'display': {
             const sval = String(value);
             if (sval === 'none') return call('setVisible', id, false);
-            if (sval === 'flex') return call('setVisible', id, true);
+            if (sval === 'flex') {
+                call('setVisible', id, true);
+                // pulp #1894 — CSS web-compat: `display: flex` defaults to
+                // `flex-direction: row`. Pulp's Yoga config defaults to
+                // FlexDirection::column (RN convention), so when neither
+                // flexDirection nor flexFlow-with-direction is also being
+                // set in the same prop batch we must explicitly emit row.
+                // Mirrors the CSS shim path at web-compat-style-decl.js
+                // (display:flex handler). Without this fallback the
+                // flat-prop path used by `style={{ display: 'flex' }}`
+                // JSX silently collapses every flex container to a
+                // vertical stack on import — first seen in Spectr's
+                // editor toolbar post-#1859 re-validation.
+                if (props) {
+                    const hasFlexDirection =
+                        Object.prototype.hasOwnProperty.call(props, 'flexDirection') ||
+                        Object.prototype.hasOwnProperty.call(props, 'flex-direction');
+                    const ff = props.flexFlow;
+                    const flexFlowHasDirection =
+                        typeof ff === 'string' && /\b(row|column)\b/.test(ff);
+                    if (!hasFlexDirection && !flexFlowHasDirection) {
+                        call('setFlex', id, 'direction', 'row');
+                    }
+                }
+                return;
+            }
             return; // unknown display value — leave View at current visibility
         }
         // pulp #1434 (Triage #15) — `boxShadow` accepts:

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -928,9 +928,33 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
                 // vertical stack on import — first seen in Spectr's
                 // editor toolbar post-#1859 re-validation.
                 if (props) {
+                    // pulp #1898 (Codex review P2) — `direction` is a
+                    // third flex-direction alias in this prop-applier
+                    // (see the `case 'direction'` block above: a value
+                    // of 'row' / 'column' / 'row-reverse' / 'column-reverse'
+                    // routes to setFlex(direction); writing-direction
+                    // keywords like 'ltr' / 'rtl' / 'inherit' / 'auto'
+                    // route to setDirection instead). The default-row
+                    // suppression must therefore also honor a caller-
+                    // supplied `direction: 'column'`, otherwise the
+                    // explicit column is overwritten by the default row
+                    // when both `display: 'flex'` and `direction:` land
+                    // in the same prop batch. Restrict the check to
+                    // flex-axis values so `direction: 'rtl'` (writing
+                    // direction, not flex) still picks up the default.
+                    const hasDirectionFlexValue = (() => {
+                        if (!Object.prototype.hasOwnProperty.call(props, 'direction')) return false;
+                        const dv = (props as Record<string, unknown>)['direction'];
+                        if (typeof dv !== 'string') return false;
+                        const norm = dv.trim().toLowerCase();
+                        return norm === 'row' || norm === 'column'
+                            || norm === 'row-reverse' || norm === 'column-reverse'
+                            || norm === 'col' || norm === 'col-reverse';
+                    })();
                     const hasFlexDirection =
                         Object.prototype.hasOwnProperty.call(props, 'flexDirection') ||
-                        Object.prototype.hasOwnProperty.call(props, 'flex-direction');
+                        Object.prototype.hasOwnProperty.call(props, 'flex-direction') ||
+                        hasDirectionFlexValue;
                     const ff = props.flexFlow;
                     const flexFlowHasDirection =
                         typeof ff === 'string' && /\b(row|column)\b/.test(ff);

--- a/packages/pulp-react/test/prop-applier-display.test.ts
+++ b/packages/pulp-react/test/prop-applier-display.test.ts
@@ -167,4 +167,49 @@ describe('prop-applier display: flex default direction (pulp #1894)', () => {
         applyChangedProps(makeInstance(), {}, { display: 'none' });
         expect(flexDirectionCalls(bridge)).toHaveLength(0);
     });
+
+    // pulp #1898 (Codex review P2) — the prop-applier also accepts
+    // `direction` as a flex-direction alias (see the `case 'direction'`
+    // block in src/prop-applier.ts). The default-row suppression must
+    // honor that alias too, otherwise an explicit `direction: 'column'`
+    // gets clobbered by the default-row emit from display:flex.
+    it("explicit direction: 'column' alias suppresses the default", () => {
+        applyChangedProps(makeInstance(), {}, {
+            display: 'flex',
+            direction: 'column',
+        });
+        const dir = flexDirectionCalls(bridge);
+        // Only the explicit column should land — no default row.
+        const fromDisplayDefault = dir.filter((c) => c.args[2] === 'row');
+        expect(fromDisplayDefault).toHaveLength(0);
+        const columnCalls = dir.filter((c) => c.args[2] === 'column');
+        expect(columnCalls).toHaveLength(1);
+    });
+
+    it("direction: 'row-reverse' alias also suppresses the default", () => {
+        applyChangedProps(makeInstance(), {}, {
+            display: 'flex',
+            direction: 'row-reverse',
+        });
+        const fromDisplayDefault = flexDirectionCalls(bridge).filter(
+            (c) => c.args[2] === 'row',
+        );
+        // The explicit row-reverse must win — no plain 'row' emit from
+        // the display:flex default path.
+        expect(fromDisplayDefault).toHaveLength(0);
+    });
+
+    it("direction: 'rtl' (writing direction, not flex) does NOT suppress default", () => {
+        // `direction: 'rtl'` is the CSS writing-direction sense (routes
+        // to setDirection, not setFlex). It should NOT be treated as a
+        // flex-direction signal — the row default still fires.
+        applyChangedProps(makeInstance(), {}, {
+            display: 'flex',
+            direction: 'rtl',
+        });
+        const fromDisplayDefault = flexDirectionCalls(bridge).filter(
+            (c) => c.args[2] === 'row',
+        );
+        expect(fromDisplayDefault).toHaveLength(1);
+    });
 });

--- a/packages/pulp-react/test/prop-applier-display.test.ts
+++ b/packages/pulp-react/test/prop-applier-display.test.ts
@@ -80,3 +80,91 @@ describe('prop-applier display: flex / none (pulp #1434 Triage #12)', () => {
         expect(calls[1].args).toEqual(['k', true]);
     });
 });
+
+// pulp #1894 — `display: 'flex'` without an explicit `flexDirection`
+// must default to row (CSS spec), not column (Yoga / RN default).
+// Without this fallback, every `style={{ display: 'flex' }}` JSX
+// container imported via the flat-prop path collapses to a vertical
+// stack — first seen in Spectr's editor toolbar post-#1859.
+describe('prop-applier display: flex default direction (pulp #1894)', () => {
+    function flexDirectionCalls(b: MockBridge) {
+        return b.calls.filter(
+            (c) => c.fn === 'setFlex' && c.args[1] === 'direction',
+        );
+    }
+
+    it("display: 'flex' alone emits setFlex(direction, 'row')", () => {
+        applyChangedProps(makeInstance(), {}, { display: 'flex' });
+        const dir = flexDirectionCalls(bridge);
+        expect(dir).toHaveLength(1);
+        expect(dir[0].args).toEqual(['k', 'direction', 'row']);
+    });
+
+    it('explicit flexDirection: column suppresses the default', () => {
+        applyChangedProps(makeInstance(), {}, {
+            display: 'flex',
+            flexDirection: 'column',
+        });
+        const dir = flexDirectionCalls(bridge);
+        // Only one direction call — the explicit one. No extra 'row'
+        // emitted from the display:flex default path.
+        expect(dir).toHaveLength(1);
+        expect(dir[0].args).toEqual(['k', 'direction', 'column']);
+    });
+
+    it('explicit flexDirection: row matches the default (single emit)', () => {
+        applyChangedProps(makeInstance(), {}, {
+            display: 'flex',
+            flexDirection: 'row',
+        });
+        const dir = flexDirectionCalls(bridge);
+        // Should only emit once — the explicit row, NOT a duplicate
+        // from the display:flex default. The hasOwnProperty guard skips
+        // the default when flexDirection is in the props bag.
+        expect(dir).toHaveLength(1);
+        expect(dir[0].args).toEqual(['k', 'direction', 'row']);
+    });
+
+    it('kebab-case flex-direction also suppresses the default', () => {
+        applyChangedProps(makeInstance(), {}, {
+            display: 'flex',
+            'flex-direction': 'column',
+        });
+        const dir = flexDirectionCalls(bridge);
+        // The kebab-case key path is what CSS-shim emissions use.
+        // The default-suppression must check both spellings.
+        const fromDisplayDefault = dir.filter(
+            (c) => c.args[2] === 'row',
+        );
+        expect(fromDisplayDefault).toHaveLength(0);
+    });
+
+    it('flexFlow with direction token suppresses the default', () => {
+        applyChangedProps(makeInstance(), {}, {
+            display: 'flex',
+            flexFlow: 'column wrap',
+        });
+        const fromDisplayDefault = flexDirectionCalls(bridge).filter(
+            (c) => c.args[2] === 'row',
+        );
+        expect(fromDisplayDefault).toHaveLength(0);
+    });
+
+    it('flexFlow without direction (just "wrap") does NOT suppress default', () => {
+        applyChangedProps(makeInstance(), {}, {
+            display: 'flex',
+            flexFlow: 'wrap',
+        });
+        const fromDisplayDefault = flexDirectionCalls(bridge).filter(
+            (c) => c.args[2] === 'row',
+        );
+        // CSS spec: when flex-flow has no direction component, direction
+        // still defaults to row — same as bare display:flex.
+        expect(fromDisplayDefault).toHaveLength(1);
+    });
+
+    it("display: 'none' does not emit the default direction", () => {
+        applyChangedProps(makeInstance(), {}, { display: 'none' });
+        expect(flexDirectionCalls(bridge)).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
The CSS web spec defaults `display: flex` to `flex-direction: row`, but
Pulp's Yoga config defaults to FlexDirection::column (RN convention).
The CSS-shim path at web-compat-style-decl.js already handles this
mismatch when consumers go through `el.style.display`. The flat-prop
path used by `style={{ display: 'flex' }}` JSX did not — so every
import that emitted shorthand display:flex without an explicit
flexDirection silently collapsed into a vertical stack.

First seen in Spectr's editor toolbar post-#1859 re-validation: every
toolbar row stacked vertically full-width instead of horizontal. After
this fix, the toolbar lays out row-wise as the reference webview
rendering of editor.html shows.

This is a general React-import bug, not Spectr-specific — every v0.dev /
Figma / Stitch / Pencil / RN export that uses display:flex shorthand
benefited the moment this lands.

Mirrors the CSS-shim suppression logic: an explicit flexDirection /
flex-direction prop in the same batch OR a flexFlow prop carrying a
direction token suppresses the default. Bare display:flex (or
display:flex with flexFlow:'wrap' / 'nowrap' which omit direction)
emits row per the spec.