### PR TITLE
fix(view+screenshot): drive runtime-import event loop in pulp-screenshot for headless React captures

### DIFF
--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -2697,9 +2697,21 @@ void WidgetBridge::register_api() {
     });
 
     // getLayoutRect(id) -> {x, y, width, height, top, right, bottom, left}
-    // Returns layout-resolved bounds in root-relative coordinates
+    // Returns layout-resolved bounds in root-relative coordinates.
+    //
+    // pulp #1899 — force a fresh layout pass before reading bounds.
+    // Spectr's editor (and any React-imported tree) calls this via
+    // Element.getBoundingClientRect() in mount-time effects to size
+    // a canvas / SVG / drawing surface. If the JS commit that mounted
+    // the React tree hasn't yet been followed by a yoga_layout pass,
+    // the bounds read back as the View's stale default (0×0) — which
+    // gates the entire canvas paint pipeline (drawSpectrum/drawRulers
+    // bail at getBoundingClientRect == 0). Forcing layout here closes
+    // that timing gap. Layout is internally idempotent if nothing has
+    // changed, so the cost is bounded to one tree walk per call.
     engine_.register_function("getLayoutRect", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
+        root_.layout_children();
         View* v = id.empty() ? &root_ : widget(id);
         return make_layout_rect_value(v);
     });
@@ -6151,8 +6163,14 @@ void WidgetBridge::register_api() {
     // Shell exec (for Claude CLI)
     // Ensures PATH includes common tool locations (homebrew, npm global, etc.)
     // getLayoutRect(id) → {x, y, width, height, top, left, right, bottom}
+    // pulp #1899 — see the matching note on the earlier getLayoutRect
+    // registration. Both bindings must force a layout pass; whichever
+    // wins the engine_.register_function override needs the same
+    // semantics so React-imported trees get correct bounds in mount-
+    // time effects.
     engine_.register_function("getLayoutRect", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
+        root_.layout_children();
         auto* v = widget(id);
         return make_layout_rect_value(v);
     });

--- a/tools/screenshot/pulp_screenshot.cpp
+++ b/tools/screenshot/pulp_screenshot.cpp
@@ -88,6 +88,16 @@ int main(int argc, char* argv[]) {
     else if (theme_name == "pro_audio") root.set_theme(Theme::pro_audio());
     else root.set_theme(Theme::dark());
 
+    // pulp #1899 — apply --width/--height to the root's bounds BEFORE
+    // any script runs. Without this, root.local_bounds() is (0,0,0,0)
+    // when yoga_layout reads it; YGNodeStyleSetWidth/Height(root) then
+    // gets 0, and every position:absolute + inset:0 child computes to
+    // 0×0 — blanking any chain of absolute-positioned containers (the
+    // canonical "fill containing block" CSS pattern). First surfaced
+    // via Spectr's editor.generated.tsx: Editor / FilterBank / canvas /
+    // Chrome hierarchy is exactly this chain.
+    root.set_bounds({0, 0, static_cast<float>(width), static_cast<float>(height)});
+
     root.flex().direction = FlexDirection::column;
     // Only set padding/gap for demo mode — scripts manage their own layout
     if (demo) {
@@ -98,6 +108,14 @@ int main(int argc, char* argv[]) {
     // Set up scripting
     ScriptEngine engine;
     WidgetBridge bridge(engine, root, store);
+
+    // pulp #1899 — install runtime-import handlers so React-imported
+    // trees (Spectr's editor.js et al.) can register & drain useEffect /
+    // requestAnimationFrame / setTimeout callbacks. These are registered
+    // conditionally because plain createKnob / createFader scripts don't
+    // need them. Always install in pulp-screenshot since the tool's
+    // raison d'etre includes capturing React-driven imports.
+    bridge.install_runtime_import_handlers();
 
     if (demo) {
         // Built-in demo UI
@@ -128,6 +146,19 @@ int main(int argc, char* argv[]) {
         }
         bridge.load_script(code);
     }
+
+    // pulp #1899 — drain React's useEffect callbacks, requestAnimationFrame
+    // queue, and setTimeout/setInterval timers BEFORE rendering. Without
+    // this, headless captures of React-imported trees show only what
+    // mounts synchronously — any drawing that lives inside useEffect
+    // (canvas paint, dB axis labels, frequency labels, grid lines) never
+    // runs because the underlying message loop doesn't tick between
+    // script-load and render. Spectr's editor uses this pattern for
+    // drawSpectrum / drawRulers; the live host's NSRunLoop ticks them
+    // naturally, but pulp-screenshot's headless path has to pump
+    // explicitly. __pulpRuntimeSettle__ is registered by WidgetBridge
+    // exactly for this case (see widget_bridge.cpp:1144).
+    bridge.load_script("if (typeof __pulpRuntimeSettle__ === 'function') __pulpRuntimeSettle__(64);");
 
     // Render
     if (output_base64) {


### PR DESCRIPTION
## Summary

Headless captures of React-imported trees (Spectr `editor.js` et al.) via `pulp-screenshot` showed only what mounted synchronously — top toolbar correct, but spectrum canvas + dB scale + frequency labels + grid + "IIR · analog" all blank. `drawSpectrum()` lives in a React `useEffect`; pulp-screenshot never ticked the message loop between `bridge.load_script(...)` and `render_to_png()`, so effects never fired.

Live hosts hit this naturally via their NSRunLoop. The bridge already exposes `__pulpRuntimeSettle__(rounds)` for exactly this case (`widget_bridge.cpp:1144`), registered inside `install_runtime_import_handlers()`. **pulp-screenshot wasn't calling that installer**, so the pump function was undefined.

## Changes

- `tools/screenshot/pulp_screenshot.cpp`:
  - `bridge.install_runtime_import_handlers()` right after construction (registers `__pulpRuntimeImport__`, `__pulpRuntimeSettle__`, and runtime-import error sinks)
  - `bridge.load_script("__pulpRuntimeSettle__(64)")` after the user script loads, before `render_to_png()`
  - Defensive `root.set_bounds({0, 0, width, height})` (no-op on macOS where `screenshot_mac.mm` already sets it; matters on the stub path used by non-Apple platforms)
- `core/view/src/widget_bridge.cpp`:
  - Force a `root_.layout_children()` pass at the top of `getLayoutRect` handlers so JS callers of `getBoundingClientRect()` see fresh bounds after a tree mutation. Yoga layout is idempotent if nothing changed.

## Validation

Screenshot diff vs the user-confirmed webview baseline (`planning/screenshots/REFERENCE-spectr-editor-html.png`):
- **Before**: 0.588 (FAIL, tier=`blank` — canvas paint never fires)
- **After**: 0.681 (FAIL, tier=`wrong-variant` — spectrum + grid render; deeper layer-3 layout gap still cuts off the chart bottom and duplicates the top chrome)

The diagnosis flip from `blank` → `wrong-variant` is the signal that the runtime-import paint pipeline now executes. Remaining gap is layer-3 work tracked under #1899.

Closes: partial #1899 (layer-2 event-loop pump). Remaining #1899 work: chart vertical clipping + top-chrome duplication post-mount + dB scale / frequency labels / "IIR · analog" sub-label rendering.

Owner: Agent A.