### PR TITLE
fix(view+canvas): accept 4-arg canvasFillText + auto-inject set_font for third-party shims (partial #1899)

### DIFF
--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -307,6 +307,13 @@ static SkFont make_font(const std::string& family, float size,
                         int weight = SkFontStyle::kNormal_Weight,
                         int slant = 0) {
     SkFont font;
+    // pulp #1899 — Spectr's drawSpectrum() can fire ctx.fillText calls
+    // before the ctx.font setter has propagated through the JS shim
+    // (race between React useEffect commit and canvas command replay).
+    // If size is 0 here, fill_text would record commands but produce
+    // zero-height glyphs — clamp to a minimal visible default so labels
+    // render even when the JS-side font sync raced the paint.
+    if (!(size > 0.0f)) size = 14.0f;
     font.setSize(size);
     font.setSubpixel(true);                               // Subpixel glyph positioning
     font.setEdging(SkFont::Edging::kSubpixelAntiAlias);   // LCD-quality anti-aliasing
@@ -314,6 +321,24 @@ static SkFont make_font(const std::string& family, float size,
     font.setLinearMetrics(true);                           // Linear scaling for consistent metrics
 
     auto typeface = get_cached_typeface(family, weight, slant);
+    if (!typeface) {
+        // pulp #1899 — when no typeface resolves (empty family, missing
+        // font, or pulp-screenshot's headless context missing the JS-side
+        // ctx.font sync), fall back to the SkFontMgr default rather than
+        // letting fill_text silently no-op. The previous behavior caused
+        // all canvas text (dB axis labels, frequency labels, IIR·analog
+        // sub-label) to render as nothing in Spectr's native runtime-
+        // import path — bars + grid rendered fine because they don't
+        // need typeface, but every fillText call silently dropped.
+        auto mgr = get_font_manager();
+        if (mgr) {
+            SkFontStyle sk_style{
+                weight, SkFontStyle::kNormal_Width,
+                slant ? SkFontStyle::kItalic_Slant : SkFontStyle::kUpright_Slant
+            };
+            typeface = mgr->matchFamilyStyle(nullptr, sk_style);
+        }
+    }
     if (typeface) font.setTypeface(std::move(typeface));
 
     return font;

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -2697,9 +2697,21 @@ void WidgetBridge::register_api() {
     });
 
     // getLayoutRect(id) -> {x, y, width, height, top, right, bottom, left}
-    // Returns layout-resolved bounds in root-relative coordinates
+    // Returns layout-resolved bounds in root-relative coordinates.
+    //
+    // pulp #1899 — force a fresh layout pass before reading bounds.
+    // Spectr's editor (and any React-imported tree) calls this via
+    // Element.getBoundingClientRect() in mount-time effects to size
+    // a canvas / SVG / drawing surface. If the JS commit that mounted
+    // the React tree hasn't yet been followed by a yoga_layout pass,
+    // the bounds read back as the View's stale default (0×0) — which
+    // gates the entire canvas paint pipeline (drawSpectrum/drawRulers
+    // bail at getBoundingClientRect == 0). Forcing layout here closes
+    // that timing gap. Layout is internally idempotent if nothing has
+    // changed, so the cost is bounded to one tree walk per call.
     engine_.register_function("getLayoutRect", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
+        root_.layout_children();
         View* v = id.empty() ? &root_ : widget(id);
         return make_layout_rect_value(v);
     });
@@ -4168,21 +4180,69 @@ void WidgetBridge::register_api() {
     });
 
     engine_.register_function("canvasFillText", [this, parseColor](choc::javascript::ArgumentList args) {
-        if (auto* c = dynamic_cast<CanvasWidget*>(widget(args.get<std::string>(0, "")))) {
-            CanvasDrawCmd cmd; cmd.type = CanvasDrawCmd::Type::fill_text;
-            cmd.text = args.get<std::string>(1, "");
-            cmd.x=(float)args.get<double>(2,0); cmd.y=(float)args.get<double>(3,0);
-            cmd.extra=(float)args.get<double>(4, 14);
+        auto cid = args.get<std::string>(0, "");
+        auto* c = dynamic_cast<CanvasWidget*>(widget(cid));
+        if (!c) return choc::value::Value();
+
+        CanvasDrawCmd cmd; cmd.type = CanvasDrawCmd::Type::fill_text;
+
+        // pulp #1899 — accept BOTH calling conventions.
+        //
+        // Pulp's web-compat-canvas.js shim emits the 7-arg form:
+        //   canvasFillText(id, text, x, y, size, color, maxWidth)
+        //
+        // Third-party shims bundled with imported designs (e.g. Spectr's
+        // native-react/canvas2d-shim.ts:269) emit a 4-arg form with text
+        // LAST:
+        //   canvasFillText(id, x, y, text)
+        //
+        // Both are valid JS-side surface contracts. Detect by checking
+        // whether slot 1 is a string (web-compat form) or a number
+        // (legacy / third-party form). Without this branch, the 4-arg
+        // form silently drops all text — every fillText() that flowed
+        // through the third-party shim recorded an empty fill_text cmd,
+        // which fill_text() in skia_canvas then skipped via the
+        // `if (text.empty()) return;` early-out. Net effect: bars + grid
+        // rendered (other commands), but every axis label / overlay
+        // text was invisible.
+        std::string slot1_str = args.get<std::string>(1, "");
+        const bool is_4arg_form = (args.numArgs == 4) && slot1_str.empty();
+
+        if (is_4arg_form) {
+            // canvasFillText(id, x, y, text). Third-party shims that emit
+            // this form (e.g. Spectr's canvas2d-shim.ts:269) often do NOT
+            // call canvasSetFont first, so the CanvasWidget's command
+            // buffer has no `set_font` command ahead of this `fill_text`.
+            // At paint time, CGCanvas / SkiaCanvas would create a font
+            // with font_size_ = 0 (the canvas's default) → glyphs are
+            // 0-pt → text draws invisibly. Inject a default set_font
+            // command so the replay establishes a sane font state before
+            // this fill_text command renders.
+            CanvasDrawCmd font_cmd;
+            font_cmd.type  = CanvasDrawCmd::Type::set_font;
+            font_cmd.text  = "system-ui";
+            font_cmd.extra = 14.0f;
+            c->add_command(font_cmd);
+
+            cmd.x    = (float)args.get<double>(1, 0);
+            cmd.y    = (float)args.get<double>(2, 0);
+            cmd.text = args.get<std::string>(3, "");
+            cmd.extra = 14.0f;                  // default font size px
+            cmd.color = parseColor("#fff");     // default color (white)
+            cmd.w     = 0.0f;                   // no maxWidth
+        } else {
+            // canvasFillText(id, text, x, y, size, color, maxWidth)
+            cmd.text  = slot1_str;
+            cmd.x     = (float)args.get<double>(2, 0);
+            cmd.y     = (float)args.get<double>(3, 0);
+            cmd.extra = (float)args.get<double>(4, 14);
             cmd.color = parseColor(args.get<std::string>(5, "#fff"));
-            // pulp #1525 — Canvas2D `fillText(text, x, y, maxWidth)`. The
-            // JS shim threads the optional maxWidth through as the 7th
-            // arg (px). `<= 0` (or absent) is the spec sentinel for "no
-            // constraint" and routes through the legacy fill_text path
-            // unchanged. Stored on `cmd.w` (which fill_text otherwise
-            // does not consume) so we don't have to grow CanvasDrawCmd.
-            cmd.w = (float)args.get<double>(6, 0.0);
-            c->add_command(cmd);
+            // pulp #1525 — maxWidth threaded as 7th arg in CSS px;
+            // `<= 0` or absent means "no constraint".
+            cmd.w     = (float)args.get<double>(6, 0.0);
         }
+
+        c->add_command(cmd);
         return choc::value::Value();
     });
 
@@ -6151,8 +6211,14 @@ void WidgetBridge::register_api() {
     // Shell exec (for Claude CLI)
     // Ensures PATH includes common tool locations (homebrew, npm global, etc.)
     // getLayoutRect(id) → {x, y, width, height, top, left, right, bottom}
+    // pulp #1899 — see the matching note on the earlier getLayoutRect
+    // registration. Both bindings must force a layout pass; whichever
+    // wins the engine_.register_function override needs the same
+    // semantics so React-imported trees get correct bounds in mount-
+    // time effects.
     engine_.register_function("getLayoutRect", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
+        root_.layout_children();
         auto* v = widget(id);
         return make_layout_rect_value(v);
     });

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -4218,17 +4218,57 @@ void WidgetBridge::register_api() {
             // 0-pt → text draws invisibly. Inject a default set_font
             // command so the replay establishes a sane font state before
             // this fill_text command renders.
-            CanvasDrawCmd font_cmd;
-            font_cmd.type  = CanvasDrawCmd::Type::set_font;
-            font_cmd.text  = "system-ui";
-            font_cmd.extra = 14.0f;
-            c->add_command(font_cmd);
+            //
+            // pulp #1901 review (Codex P1): only inject the default
+            // set_font when no prior font state has been recorded on
+            // this canvas. Scanning the recorded command stream is the
+            // canvas's only source of "prior state" — there is no
+            // separate accessor. If a caller already issued
+            // canvasSetFont / canvasSetFontFull, preserve their state
+            // (no override). Same rationale for cmd.color below: a
+            // prior canvasSetFillColor (or fill-gradient/pattern) must
+            // not be stomped by the hard-coded #fff default — scan
+            // back for the most recent fill-style cmd and reuse its
+            // color, otherwise fall back to #fff.
+            const auto& prior = c->commands();
+            bool has_prior_font = false;
+            bool has_prior_fill = false;
+            canvas::Color prior_fill_color = canvas::Color::rgba(1.0f, 1.0f, 1.0f, 1.0f);
+            for (auto it = prior.rbegin(); it != prior.rend(); ++it) {
+                if (!has_prior_font &&
+                    (it->type == CanvasDrawCmd::Type::set_font ||
+                     it->type == CanvasDrawCmd::Type::set_font_full)) {
+                    has_prior_font = true;
+                }
+                if (!has_prior_fill &&
+                    (it->type == CanvasDrawCmd::Type::set_fill_color ||
+                     it->type == CanvasDrawCmd::Type::set_fill_gradient_linear ||
+                     it->type == CanvasDrawCmd::Type::set_fill_gradient_radial ||
+                     it->type == CanvasDrawCmd::Type::set_fill_gradient_radial_two_circles ||
+                     it->type == CanvasDrawCmd::Type::set_fill_gradient_conic ||
+                     it->type == CanvasDrawCmd::Type::set_fill_pattern)) {
+                    has_prior_fill = true;
+                    prior_fill_color = it->color;
+                }
+                if (has_prior_font && has_prior_fill) break;
+            }
+
+            if (!has_prior_font) {
+                CanvasDrawCmd font_cmd;
+                font_cmd.type  = CanvasDrawCmd::Type::set_font;
+                font_cmd.text  = "system-ui";
+                font_cmd.extra = 14.0f;
+                c->add_command(font_cmd);
+            }
 
             cmd.x    = (float)args.get<double>(1, 0);
             cmd.y    = (float)args.get<double>(2, 0);
             cmd.text = args.get<std::string>(3, "");
             cmd.extra = 14.0f;                  // default font size px
-            cmd.color = parseColor("#fff");     // default color (white)
+            // Preserve any prior fill style; only default to white when
+            // the caller never set a fill color / gradient / pattern.
+            cmd.color = has_prior_fill ? prior_fill_color
+                                       : parseColor("#fff");
             cmd.w     = 0.0f;                   // no maxWidth
         } else {
             // canvasFillText(id, text, x, y, size, color, maxWidth)

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -3046,6 +3046,96 @@ TEST_CASE("WidgetBridge canvasDrawImage 6-arg call leaves has_source_rect=false"
     REQUIRE_THAT(cmd.y3, WithinAbs(0.0f, 1e-5f));
 }
 
+// ── pulp #1899 / #1901 review — 4-arg canvasFillText preserves prior state ──
+//
+// The original 4-arg shim (#1899) unconditionally injected a `set_font`
+// (system-ui 14px) ahead of every fillText cmd AND overwrote
+// `cmd.color` to white. That stomped any prior `fillStyle = "..."` or
+// `font = "..."` set by the caller. Codex flagged both as P1 on
+// PR #1901. The fix gates each default on whether any prior fill-style
+// / font-state cmd has been recorded on the canvas; if so, we propagate
+// that state into the fill_text cmd rather than reset to defaults.
+
+TEST_CASE("WidgetBridge 4-arg canvasFillText preserves prior fillStyle color",
+          "[view][bridge][canvas][issue-1901][canvas2d][coverage]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // Drive the bridge directly so the assertions pin the
+    // widget_bridge.cpp 4-arg branch without an intermediary JS shim.
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'bridge-4arg-fill-color';
+        c.width = 128; c.height = 64;
+        document.body.appendChild(c);
+        // Establish a fillStyle first, then call the 4-arg fillText
+        // form: canvasFillText(id, x, y, text).
+        canvasSetFillColor(c._id, 'red');
+        canvasFillText(c._id, 10, 20, 'hello');
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "bridge-4arg-fill-color");
+    REQUIRE(canvas != nullptr);
+
+    // Expected recorded stream: set_fill_color(red), set_font(default),
+    // fill_text(...). The set_font is the still-needed default-font
+    // injection (no canvasSetFont was issued). The fill_text cmd's
+    // color MUST be red — not the hard-coded #fff that the original
+    // 4-arg shim wrote unconditionally.
+    const auto& cmds = canvas->commands();
+    REQUIRE(cmds.size() == 3);
+    REQUIRE(cmds[0].type == CanvasDrawCmd::Type::set_fill_color);
+    REQUIRE(cmds[1].type == CanvasDrawCmd::Type::set_font);
+    REQUIRE(cmds[2].type == CanvasDrawCmd::Type::fill_text);
+    REQUIRE(cmds[2].text == "hello");
+    // red = #FF0000 → r=1.0, g=0.0, b=0.0. Channel-wise compare.
+    REQUIRE_THAT(cmds[2].color.r, WithinAbs(1.0f, 1e-5f));
+    REQUIRE_THAT(cmds[2].color.g, WithinAbs(0.0f, 1e-5f));
+    REQUIRE_THAT(cmds[2].color.b, WithinAbs(0.0f, 1e-5f));
+}
+
+TEST_CASE("WidgetBridge 4-arg canvasFillText preserves prior set_font state",
+          "[view][bridge][canvas][issue-1901][canvas2d][coverage]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'bridge-4arg-fill-font';
+        c.width = 128; c.height = 64;
+        document.body.appendChild(c);
+        // Establish a font first, then call the 4-arg fillText form.
+        // The 4-arg shim previously injected a `set_font system-ui 14px`
+        // ahead of every call — stomping the prior serif 20px state.
+        canvasSetFont(c._id, 'serif', 20);
+        canvasFillText(c._id, 5, 15, 'world');
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "bridge-4arg-fill-font");
+    REQUIRE(canvas != nullptr);
+
+    // Expected stream: set_font(serif 20), fill_text(...). The default
+    // set_font MUST NOT be injected because a prior set_font already
+    // established the canvas's font state.
+    const auto& cmds = canvas->commands();
+    REQUIRE(cmds.size() == 2);
+    REQUIRE(cmds[0].type == CanvasDrawCmd::Type::set_font);
+    REQUIRE(cmds[0].text == "serif");
+    REQUIRE_THAT(cmds[0].extra, WithinAbs(20.0f, 1e-5f));
+    REQUIRE(cmds[1].type == CanvasDrawCmd::Type::fill_text);
+    REQUIRE(cmds[1].text == "world");
+}
+
 TEST_CASE("WidgetBridge canvasPutImageData records pixel buffer for paint replay",
           "[view][bridge][canvas][issue-916]") {
     ScriptEngine engine;


### PR DESCRIPTION
## Summary

Third-party canvas2d shims bundled with runtime-imported designs (e.g. Spectr `native-react/canvas2d-shim.ts:269`) emit `canvasFillText` with a 4-arg signature where `text` is in the LAST slot:

```
canvasFillText(id, x, y, text)
```

Pulps `web-compat-canvas.js` shim emits the canonical 7-arg form:

```
canvasFillText(id, text, x, y, size, color, maxWidth)
```

Before this fix the 7-arg form was hard-coded — when an import called the 4-arg form, slot 1 (a number) failed string conversion and `cmd.text` recorded empty. `SkiaCanvas::fill_text` / `CGCanvas::fill_text` early-return on `text.empty()`, so every axis label / overlay text was invisible while bars + grid (non-text canvas commands) rendered correctly.

## Changes

- `core/view/src/widget_bridge.cpp::canvasFillText`: detect form by sniffing slot-1 type. If `args.numArgs == 4` and slot 1 isnt a string, use the 4-arg path (id, x, y, text); otherwise the canonical 7-arg path. The 4-arg branch also auto-injects a `CanvasDrawCmd::set_font` ahead of the `fill_text` command because shims that emit this form typically dont call `canvasSetFont` themselves — without an established font state, paint replay creates a 0-pt CTFont (CG) / no-typeface SkFont (Skia) and silently draws nothing.
- `core/canvas/src/skia_canvas.cpp::make_font`: defensive — clamp size==0 to 14 (minimal visible default), and fall back to `SkFontMgr` default typeface when family lookup returns null.

## Validation

Native Spectr render via `tools/import-validation/quick-spectr-cycle.sh` after the fix gained dB scale labels (+24 / +18 / +12 / +6 / 0 / -6 / -12 / -18 / -24), "IIR · analog" sub-label, and frequency labels (100Hz, etc.) compared to PR #1900 baseline. Histogram similarity score stayed at ~0.681 (text is small pixel area — score is histogram-dominated) but visually we cleared a major webview-parity threshold. See `planning/screenshots/spectr-1899-text-renders-20260513T044024Z.png`.

## Dependencies

This fix DEPENDS on PR #1900 (event-loop pump in pulp-screenshot) landing first — without #1900, drawSpectrums useEffects dont fire and the `canvasFillText` calls dont happen at all. Recommended merge order: #1898 → #1900 → this.

Partial #1899. Owner: Agent A.