### PR TITLE
test(view): pin 15 Yoga-arch CSS no-op properties + close 15 coverage-gap rows (Bundle-A)

### DIFF
--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -4726,6 +4726,76 @@ TEST_CASE("CSSStyleDeclaration display: contents is a safe arch-deferred no-op",
     REQUIRE(p_contents->flex().direction == FlexDirection::row);
 }
 
+// ── pulp #1434 / Tier-4 — Yoga-arch CSS-property no-op pin ───────────────────
+//
+// Closes 15 arch-deferred coverage-gap rows (planning/coverage-gaps/) by
+// pinning their silent-accept behavior. The bundle covers everything Pulp
+// deliberately doesn't ship per CLAUDE.md's flex+grid-only Yoga layout
+// policy: block-flow (clear, float), table layout (borderCollapse,
+// borderSpacing, captionSide, emptyCells, tableLayout), multi-column
+// (columnCount, columnRule, columnWidth, columns), print pagination
+// (pageBreakAfter, pageBreakBefore, printMargin), and writingMode.
+//
+// Until this regression test, the silent-accept guarantee was implicit —
+// a future refactor of `core/view/js/web-compat-style-decl.js` could have
+// started throwing for unknown properties without anyone noticing, and
+// import sources that emit these properties (e.g. legacy HTML scraped
+// into Pulp) would break loudly. This pins the contract.
+TEST_CASE("CSSStyleDeclaration silent-accepts 15 Yoga-arch CSS properties as no-ops",
+          "[view][bridge][css][issue-1434][arch-deferred][yoga-arch]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // Baseline: panel with display:flex + row direction. Apply 15 arch-deferred
+    // properties in sequence; assert state is untouched after the last write.
+    bridge.load_script(R"((function(){
+        createPanel('p_yoga_arch', '');
+        var el = { _id: 'p_yoga_arch', _nativeCreated: true };
+        var sd = new CSSStyleDeclaration(el);
+        sd._applyProperty('display', 'flex');
+        sd._applyProperty('flexDirection', 'row');
+
+        // Block flow:
+        sd._applyProperty('clear', 'both');
+        sd._applyProperty('float', 'left');
+        // Table layout:
+        sd._applyProperty('borderCollapse', 'collapse');
+        sd._applyProperty('borderSpacing', '4px');
+        sd._applyProperty('captionSide', 'top');
+        sd._applyProperty('emptyCells', 'show');
+        sd._applyProperty('tableLayout', 'fixed');
+        // Multi-column:
+        sd._applyProperty('columnCount', '3');
+        sd._applyProperty('columnRule', '1px solid black');
+        sd._applyProperty('columnWidth', '120px');
+        sd._applyProperty('columns', '3 120px');
+        // Print pagination:
+        sd._applyProperty('pageBreakAfter', 'always');
+        sd._applyProperty('pageBreakBefore', 'avoid');
+        sd._applyProperty('printMargin', '1cm');
+        // Writing mode (has explicit documented-no-op case):
+        sd._applyProperty('writingMode', 'vertical-rl');
+    })();)");
+
+    auto* p = dynamic_cast<Panel*>(bridge.widget("p_yoga_arch"));
+    REQUIRE(p != nullptr);
+
+    // Invariants after 15 no-op writes:
+    //  - bridge didn't crash (would fail dynamic_cast / widget() lookup)
+    //  - panel still visible (no property touched setVisible)
+    //  - flex direction unchanged from row baseline (no property touched
+    //    Yoga's flex_direction slot)
+    //
+    // If any of the 15 grows a real implementation that touches these state
+    // slots, this assertion fails and the change can be reviewed for arch
+    // alignment per CLAUDE.md's layout-model section.
+    REQUIRE(p->visible());
+    REQUIRE(p->flex().direction == FlexDirection::row);
+}
+
 // ── pulp #1416 — SvgRectWidget + SvgLineWidget JS bridge integration ─────────
 //
 // Mirrors the #965 SvgPath bridge tests. Closes Spectr [G] preset


### PR DESCRIPTION
## Summary

Tier-4 honest reclass — **Bundle-A** of the arch-deferred coverage-gap sweep. Closes **15 CSS coverage-gap rows** that have no Yoga / paint / canvas pathway and are silently accepted as no-ops by `web-compat-style-decl.js` (default-switch path).

Surface groups:

| Group | Rows |
|---|---|
| block-flow (2) | `clear`, `float` |
| table (5) | `borderCollapse`, `borderSpacing`, `captionSide`, `emptyCells`, `tableLayout` |
| multi-column (4) | `columnCount`, `columnRule`, `columnWidth`, `columns` |
| print pagination (3) | `pageBreakAfter`, `pageBreakBefore`, `printMargin` |
| writing mode (1) | `writingMode` |

## What ships

1. **New Catch2 TEST_CASE** in `test/test_widget_bridge.cpp` tagged `[view][bridge][css][issue-1434][arch-deferred][yoga-arch]`. Pins the silent-accept contract: applies all 15 properties via `CSSStyleDeclaration._applyProperty`, asserts the bridge doesn't crash AND that the pre-existing `display:flex` / `flexDirection:row` baseline survives all 15 writes (no property accidentally touches Yoga slots).

2. **Planning submodule bump** (sha `44015fe → bc01c0d`) including:
   - 15 one-pager `## Closure` sections (`planning/coverage-gaps/css-*.md`)
   - `_INDEX.md` Kind column flipped to `✅ closed in #TBD (arch-deferred)` for all 15 rows

## Why

All 15 rows retain `compat.json status=wontfix` (correctly classified). This PR documents the CLAUDE.md flex+grid-only architectural constraint and pins the no-op behavior so a future refactor of the JS style-decl can't silently start throwing for unknown properties — which would loudly break import sources (legacy HTML, design tools that emit table/column/print CSS) that currently round-trip cleanly.

## Verification

Both Explore sub-agents launched during tick 2-3 confirmed:

- **Parser path**: 14 properties hit the default-switch silent-accept; `writingMode` has an explicit documented-no-op case. None throw. None have setters in `widget_bridge.cpp`. None are consumed by Yoga / paint / canvas.
- **One-pager state**: all 15 files exist with `hardening_hint: arch-deferred`, none were already closed, `_INDEX.md` Kind columns were `arch-deferred`.

## Test plan

- [ ] `pulp-test-widget-bridge` runs the new TEST_CASE green
- [ ] No regression on existing `[issue-1420][display-contents]` arch-deferred test (mirrors this pattern)
- [ ] Planning closure markers retro-update from `#TBD` to real PR number after open

Refs: pulp #1434 (coverage hardening umbrella), CLAUDE.md layout-model section.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — agent B