### PR TITLE
diag(view/yoga): PULP_DUMP_BOUNDS env + Spectr-shape regression anchor (#1899)

### DIFF
--- a/core/view/src/yoga_layout.cpp
+++ b/core/view/src/yoga_layout.cpp
@@ -7,8 +7,38 @@
 #include <yoga/Yoga.h>
 #include <vector>
 #include <algorithm>
+#include <cstdio>
+#include <cstdlib>
 
 namespace pulp::view {
+
+// pulp #1899 — diagnostic: dump computed bounds tree after Yoga layout.
+// Gated by PULP_DUMP_BOUNDS env var so it never runs in production.
+static void dump_bounds_tree(const View& view, int depth) {
+    auto b = view.bounds();
+    const char* pos_str = "static";
+    switch (view.position()) {
+        case View::Position::absolute: pos_str = "abs"; break;
+        case View::Position::fixed:    pos_str = "fix"; break;
+        case View::Position::relative: pos_str = "rel"; break;
+        case View::Position::sticky:   pos_str = "sticky"; break;
+        default: break;
+    }
+    std::fprintf(stderr, "[bounds] %*s%-3s bounds=(%.0f,%.0f,%.0fx%.0f)",
+                 depth * 2, "", pos_str, b.x, b.y, b.width, b.height);
+    if (view.has_top())    std::fprintf(stderr, " top=%.0f%s",    view.top(),    view.top_unit()==DimensionUnit::percent?"%":"");
+    if (view.has_right())  std::fprintf(stderr, " right=%.0f%s",  view.right(),  view.right_unit()==DimensionUnit::percent?"%":"");
+    if (view.has_bottom()) std::fprintf(stderr, " bottom=%.0f%s", view.bottom(), view.bottom_unit()==DimensionUnit::percent?"%":"");
+    if (view.has_left())   std::fprintf(stderr, " left=%.0f%s",   view.left(),   view.left_unit()==DimensionUnit::percent?"%":"");
+    if (view.flex().preferred_width > 0)  std::fprintf(stderr, " pw=%.0f", view.flex().preferred_width);
+    if (view.flex().preferred_height > 0) std::fprintf(stderr, " ph=%.0f", view.flex().preferred_height);
+    if (view.flex().dim_width.value != 0)  std::fprintf(stderr, " dw=%.0f%s", view.flex().dim_width.value, view.flex().dim_width.unit==DimensionUnit::percent?"%":"px");
+    if (view.flex().dim_height.value != 0) std::fprintf(stderr, " dh=%.0f%s", view.flex().dim_height.value, view.flex().dim_height.unit==DimensionUnit::percent?"%":"px");
+    std::fprintf(stderr, " children=%zu\n", view.child_count());
+    for (size_t i = 0; i < view.child_count(); ++i) {
+        dump_bounds_tree(*view.child_at(i), depth + 1);
+    }
+}
 
 // Map Pulp FlexDirection to Yoga.
 // pulp #1434 (rn batch B) — row_reverse / column_reverse now route
@@ -553,6 +583,13 @@ void yoga_layout(View& root) {
     }
     YGNodeCalculateLayout(ygRoot, rootBounds.width, rootBounds.height, rootDir);
     apply_yoga_results(root, ygRoot);
+
+    if (std::getenv("PULP_DUMP_BOUNDS")) {
+        std::fprintf(stderr, "\n=== [PULP_DUMP_BOUNDS] root @ %.0fx%.0f ===\n",
+                     rootBounds.width, rootBounds.height);
+        dump_bounds_tree(root, 0);
+        std::fprintf(stderr, "=== [PULP_DUMP_BOUNDS] end ===\n\n");
+    }
 
     YGNodeFreeRecursive(ygRoot);
 }

--- a/test/web-compat/test_layout_position.cpp
+++ b/test/web-compat/test_layout_position.cpp
@@ -331,6 +331,61 @@ TEST_CASE("Yoga: layered absolute canvases (filterbank+overlay) both fill parent
     REQUIRE(overlayPtr->bounds().height == 860.0f);
 }
 
+// pulp #1899 — documents Spectr's actual mount shape. The App component
+// in `spectr-editor-extracted.js:4140` is a literal-CSS hardcoded
+// `position:absolute; top:0; left:0; width:1320; height:860`. When pulp-
+// screenshot renders into a smaller viewport (e.g. the default 1280x800
+// at @2x to match the captured webview baseline), Spectr's App
+// overflows by 40 horizontally and 60 vertically, clipping the bottom
+// action rail (App-y=804..860 → viewport-y=804..860 → off-screen).
+//
+// This test pins the current Yoga behaviour so a future fix that
+// changes viewport-vs-content reconciliation (e.g. flex-centering body-
+// equivalent, or auto-clamping oversize absolute children to viewport)
+// has a regression anchor. Today the App is placed at (0,0,1320,860)
+// inside a 1280x800 viewport — overflowing, not centered.
+TEST_CASE("Yoga: Spectr-shape — hardcoded-size App inside smaller viewport overflows",
+          "[layout][yoga][absolute][spectr][issue-1899]") {
+    View viewport;
+    viewport.set_bounds({0, 0, 1280, 800});
+
+    // Spectr's App: position:absolute, top:0, left:0, hardcoded 1320x860
+    auto app = std::make_unique<View>();
+    app->set_position(View::Position::absolute);
+    app->set_top(0);
+    app->set_left(0);
+    app->flex().preferred_width = 1320;
+    app->flex().preferred_height = 860;
+    auto* appPtr = app.get();
+
+    // Bottom action rail inside the App
+    auto rail = std::make_unique<View>();
+    rail->set_position(View::Position::absolute);
+    rail->set_bottom(0);
+    rail->set_left(0);
+    rail->set_right(0);
+    rail->flex().preferred_height = 56;
+    auto* railPtr = rail.get();
+    app->add_child(std::move(rail));
+
+    viewport.add_child(std::move(app));
+    viewport.layout_children();
+
+    // App lands at viewport (0,0,1320,860) — overflowing
+    REQUIRE(appPtr->bounds().x == 0.0f);
+    REQUIRE(appPtr->bounds().y == 0.0f);
+    REQUIRE(appPtr->bounds().width == 1320.0f);
+    REQUIRE(appPtr->bounds().height == 860.0f);
+
+    // Rail is correctly anchored at bottom:0 of the App (App-y=804) —
+    // proves Yoga DOES propagate position:absolute + bottom:0 + height
+    // correctly. The visual bug is purely the viewport mismatch.
+    REQUIRE(railPtr->bounds().x == 0.0f);
+    REQUIRE(railPtr->bounds().y == 804.0f);
+    REQUIRE(railPtr->bounds().width == 1320.0f);
+    REQUIRE(railPtr->bounds().height == 56.0f);
+}
+
 TEST_CASE("Yoga: absolute child does not consume flex-line space from siblings",
           "[layout][yoga][absolute][issue-1379]") {
     // Inverse check: if absolute children leak into the flex line, the


### PR DESCRIPTION
## Summary

Adds an env-gated tree dump after `YGNodeCalculateLayout` so we can empirically observe what bounds Yoga computes for each View in a live import. Zero cost when `PULP_DUMP_BOUNDS` is unset; runs through stderr otherwise.

## The reveal

The dump immediately revealed the actual root cause of the remaining Spectr visual gap (missing bottom toolbar, missing 1kHz/10kHz freq labels):

**Spectr's App component literal-CSS-hardcodes `position:absolute top:0 left:0 width:1320 height:860`** (spectr-editor-extracted.js:4140). When pulp-screenshot's viewport is 1280x800 (matching the captured webview baseline), the App overflows by 40 horizontally and 60 vertically — the bottom action rail (App-y=804..860) lands entirely off-screen.

```
[bounds]   abs bounds=(0,0,1320x860) top=0 left=0 pw=1320 ph=860 children=4
[bounds]     abs bounds=(0,804,1320x56) right=0 bottom=0 left=0 pw=1320 ph=56  ← off-screen
```

The earlier suspected fix layer (CSS absolute-fill semantics for chained `inset:0`) turned out NOT to be the bug — the existing `[issue-1379]` tests already cover it and they pass.

## What's next (for a future PR)

The fix is viewport-vs-content reconciliation: when imported content is sized larger than the screenshot viewport, either centre-flex-style (mirroring `editor.html`'s `body { display:flex; align-items:center; justify-content:center; min-height:100vh }`) or clamp-to-viewport. Chrome's headless renders the same 1320x860 App into a 1280x800 viewport and shows the toolbar — Pulp needs to emulate that.

## Test plan

- [x] `ctest --test-dir build -R pulp-test-web-compat-layout` — new `[spectr][issue-1899]` test passes (8 assertions); the four existing `[issue-1379]` chained-absolute tests still pass.
- [x] `PULP_DUMP_BOUNDS=1 pulp-screenshot --script editor.js --width 1280 --height 800` — emits the tree, no behaviour change.
- [x] Unset env: no behaviour change in any other path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)