### PR TITLE
docs(ci): adopt Shipyard v0.56.2 runner ops toolkit

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -18,9 +18,10 @@ Validate branches and ship code safely. This skill handles all CI workflows for 
 > One-shot recovery is `shipyard rescue <PR>` (Shipyard v0.53.0+).
 > Continuous prevention is `shipyard runner watch --kill-hung-workers`
 > (v0.54.0+). Keep Shipyard itself current with `shipyard update`
-> (v0.55.0+). All three replace the legacy `planning/scripts/runner-
-> watchdog.sh --fix` workflow, which is now an anti-pattern (cancels
-> queued runs but registers `failure` on required checks).
+> (v0.55.0+; Pulp currently pins v0.56.2+). All three replace the
+> legacy `planning/scripts/runner-watchdog.sh --fix` workflow, which is
+> now an anti-pattern (cancels queued runs but registers `failure` on
+> required checks).
 
 ## Pre-flight: plugin ↔ CLI skew check
 
@@ -1266,9 +1267,11 @@ land in `mergeable_state=blocked`.
 
 Shipyard v0.55.0+ ships a complete operational toolkit for this
 class of problem — **prevent → recover → keep current**. Pulp pins
-Shipyard ≥ 0.55.0 in `tools/shipyard.toml`. The authoritative reference
-lives in Shipyard's `skills/ci/SKILL.md`; this section is the Pulp-side
-quick reference + Pulp-specific gotchas.
+Shipyard ≥ 0.56.2 in `tools/shipyard.toml` so recovery, update, and
+`shipyard wait pr` all have REST fallback paths when GraphQL is rate-limited
+or unavailable. The authoritative reference lives in Shipyard's
+`skills/ci/SKILL.md`; this section is the Pulp-side quick reference +
+Pulp-specific gotchas.
 
 ### Recover — `shipyard rescue <PR>` (v0.53.0+)
 
@@ -1287,6 +1290,10 @@ One command replaces the legacy 5-step recipe (`runner-watchdog --fix`
 manual sweep). Safe under load — does not mark required checks as
 `failure`. Cross-link: Shipyard `skills/ci/SKILL.md#rescuing-wedged-
 runners-shipyard-rescue`.
+
+After a rescue, prefer `shipyard wait pr <PR> --state green` over manual
+polling. Shipyard v0.56.2 adds a REST fallback for this wait path; use
+`--no-fallback` only when a caller must fail instead of polling.
 
 ### Prevent — `shipyard runner watch --kill-hung-workers` (v0.54.0+)
 
@@ -1311,7 +1318,7 @@ watch--kill-hung-workers`.
 ```bash
 shipyard update --check --json   # report installed vs available
 shipyard update                  # apply latest stable
-shipyard update --to v0.53.0     # pin / rollback
+shipyard update --to v0.56.2     # pin / rollback to Pulp's minimum
 shipyard update --dry-run        # plan only
 ```
 

--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -208,6 +208,11 @@ shipyard cleanup --ship-state --apply     # prune closed-PR + aged state
 shipyard run --targets windows --smoke    # fast Windows-only check
 shipyard run --resume-from test           # skip configure+build, run tests only
 shipyard cloud run build <branch>         # dispatch to Namespace
+shipyard rescue <PR>                      # recover a wedged PR by redispatching queued runs
+shipyard rescue <PR> --rerun-failed       # also re-arm cancelled/failed runs
+shipyard runner watch --kill-hung-workers # host-side prevention daemon for self-hosted runners
+shipyard update --check --json            # installed vs latest Shipyard drift report
+shipyard update                           # apply latest stable Shipyard
 
 # Target management
 shipyard targets                          # list targets with reachability

--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1345,12 +1345,11 @@ drift; humans run `shipyard update` to apply.
   PR may need a fresh push to retrigger the version-skill-sync check
   too.
 
-### Anti-pattern (legacy, do not use)
+### Anti-pattern (legacy)
 
-- `planning/scripts/runner-watchdog.sh --fix` — kept for reference but
-  obsolete. Cancels queued runs without redispatching, registering
-  `failure` on required checks. Use `shipyard rescue` (PR-side) or
-  `shipyard runner watch --kill-hung-workers` (host-side) instead.
+- `planning/scripts/runner-watchdog.sh --fix` — superseded. Use
+  `shipyard rescue` (recover, PR-side) or `shipyard runner watch
+  --kill-hung-workers` (prevent, host-side).
 
 ### Composition with `Version-Bump` gate
 

--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -12,6 +12,16 @@ requires:
 
 Validate branches and ship code safely. This skill handles all CI workflows for Pulp across local machines and VMs.
 
+> **If a PR's required `macos` check has been queued >30 min** or the
+> repo's PRs are all in `mergeable_state=blocked` with no movement,
+> jump to **"Self-hosted runner ops"** near the end of this file.
+> One-shot recovery is `shipyard rescue <PR>` (Shipyard v0.53.0+).
+> Continuous prevention is `shipyard runner watch --kill-hung-workers`
+> (v0.54.0+). Keep Shipyard itself current with `shipyard update`
+> (v0.55.0+). All three replace the legacy `planning/scripts/runner-
+> watchdog.sh --fix` workflow, which is now an anti-pattern (cancels
+> queued runs but registers `failure` on required checks).
+
 ## Pre-flight: plugin ↔ CLI skew check
 
 Before shelling out to `pulp` (or `shipyard pr`, which ultimately
@@ -1239,3 +1249,125 @@ In all three cases, set `PULP_VIA_SHIPYARD=1` on the direct-push
 command to record the push as supervised AND suppress the warning.
 
 After the obstacle clears, resume `shipyard pr` on the next PR.
+
+## Self-hosted runner ops
+
+Pulp's required `macos` branch-protection check on `main` routes
+through the local self-hosted `sanitizer` runner (via the
+`PULP_LOCAL_MACOS_RUNS_ON_JSON` repo variable, consumed by
+`.github/workflows/build.yml` → `resolve-provider`). When that runner
+wedges, every PR's `macos` check sits queued indefinitely and all PRs
+land in `mergeable_state=blocked`.
+
+Shipyard v0.55.0+ ships a complete operational toolkit for this
+class of problem — **prevent → recover → keep current**. Pulp pins
+Shipyard ≥ 0.55.0 in `tools/shipyard.toml`. The authoritative reference
+lives in Shipyard's `skills/ci/SKILL.md`; this section is the Pulp-side
+quick reference + Pulp-specific gotchas.
+
+### Recover — `shipyard rescue <PR>` (v0.53.0+)
+
+```bash
+shipyard rescue <PR>                # cancel queued runs + redispatch
+                                    # to github-hosted (default)
+shipyard rescue <PR> --rerun-failed # also re-arm completed/cancelled
+                                    # runs (watchdog-cancellation case)
+shipyard rescue <PR> --dry-run      # preview without acting
+shipyard rescue --all-stuck         # repo-wide sweep
+shipyard rescue <PR> --to github-hosted   # explicit provider
+```
+
+One command replaces the legacy 5-step recipe (`runner-watchdog --fix`
+→ `gh run rerun --failed` → `shipyard cloud handoff run --apply`
+manual sweep). Safe under load — does not mark required checks as
+`failure`. Cross-link: Shipyard `skills/ci/SKILL.md#rescuing-wedged-
+runners-shipyard-rescue`.
+
+### Prevent — `shipyard runner watch --kill-hung-workers` (v0.54.0+)
+
+```bash
+# One-time setup on a self-hosted runner host (Daniels-MacBook-Pro):
+shipyard runner watch --kill-hung-workers
+# Pair with launchd / systemd for unattended ops.
+```
+
+Host-side daemon that auto-cancels stale queued runs AND auto-kills
+hung `Runner.Worker` processes (snapshot → SIGTERM → grace → SIGKILL
+→ reap children → quarantine partial builds → verify Runner.Listener
+→ optionally wait for GitHub status flip). Implies `--fix`. Emits
+`runner.watch` JSON envelopes (`event=auto_kill_worker`,
+`phase ∈ {attempt, killed, failed, no-pid-found}`) for telemetry.
+
+Cross-link: Shipyard `skills/ci/SKILL.md#preventing-wedges-runner-
+watch--kill-hung-workers`.
+
+### Keep current — `shipyard update` (v0.55.0+)
+
+```bash
+shipyard update --check --json   # report installed vs available
+shipyard update                  # apply latest stable
+shipyard update --to v0.53.0     # pin / rollback
+shipyard update --dry-run        # plan only
+```
+
+Replaces the bootstrap-only `curl … install.sh | sh` workflow. Pulp's
+CI / daily cron should run `shipyard update --check --json` to surface
+drift; humans run `shipyard update` to apply.
+
+### Pulp-specific gotchas (real wedge patterns)
+
+- **iOS AUv3 try-compile hangs.** `test/cmake/test_ios_auv3_configure.sh`
+  shells `xcodebuild CMAKE_TRY_COMPILE.xcodeproj build` which can
+  deadlock on `simctl` / keychain / codesign on the self-hosted host
+  (observed 2026-05-13). The `runner watch --kill-hung-workers` daemon
+  detects the stall via `Runner.Worker` not making progress for >5 min
+  and kills it cleanly.
+- **Test binaries open real windows on the dev mac.** Several
+  `pulp-test-*` binaries (auval validation, headless-view variants,
+  iOS AUv3 try-compile, visual-harness tests) create macOS surfaces
+  during CI. Because the runner runs as the human's user account,
+  those windows pop on the dev mac's display. Either move the runner
+  to a dedicated user account, or accept the brief popups.
+- **PRs that touch CI/runner workflows need a manual handoff.** If the
+  PR's macOS lane was cancelled by the wedge, even after `rescue` the
+  PR may need a fresh push to retrigger the version-skill-sync check
+  too.
+
+### Anti-pattern (legacy, do not use)
+
+- `planning/scripts/runner-watchdog.sh --fix` — kept for reference but
+  obsolete. Cancels queued runs without redispatching, registering
+  `failure` on required checks. Use `shipyard rescue` (PR-side) or
+  `shipyard runner watch --kill-hung-workers` (host-side) instead.
+
+### Composition with `Version-Bump` gate
+
+`shipyard rescue` does not interact with the `Enforce version & skill
+sync` check. If a PR title starts with `fix:` / `feat:` and the branch
+lacks either a `chore: bump versions` commit OR a
+`Version-Bump: skip reason="..."` trailer on the tip commit, the
+version-skill-sync check fails independently. The trailer block must
+be CONTIGUOUS (no blank line between `Version-Bump:` and any other
+trailer like `Co-Authored-By:`) or git's `interpret-trailers` won't
+recognize it. Verify with
+`tools/scripts/version_bump_check.py --mode=report --base=origin/main
+--require-bump-for-fix-feat --pr-title="..."` which prints
+`bypass honored` when the trailer parses correctly.
+
+### Manual machine-side recovery (true last resort)
+
+If `shipyard rescue` doesn't help (e.g. the runner's host OS itself is
+unresponsive, not just the Worker), the machine-side recovery is:
+
+1. SSH the runner host (or open Terminal locally if it's the dev mac).
+2. `ps -ef | grep '[R]unner.Worker'` — confirm orphan Worker PIDs.
+3. `kill <pid>` (gentle), `kill -9` after 30 s grace.
+4. Restart via `~/actions-runner/svc.sh restart` or `launchctl
+   kickstart -k gui/$(id -u)/actions.runner.<owner>-<repo>.<name>`.
+5. After restart: `shipyard runner watch --kill-hung-workers` (one-time
+   foreground) verifies the host is healthy before enabling the
+   permanent daemon.
+
+Agents should NOT do step 1–4 themselves; ask the human via
+`PushNotification`. Agents CAN and SHOULD run `shipyard rescue` for
+the PR-side recovery without waiting.

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -260,13 +260,14 @@ Pulp's release automation depends on the pinned Shipyard CLI in two places:
   carry a `SHIPYARD_VERSION` env used by the release-side workflows.
 
 If you bump the Shipyard pin, update both workflows in the same PR and keep the
-existing string format in each file (`v0.55.0` in `tools/shipyard.toml`,
-`0.55.0` in the workflow envs — the `v` prefix is intentional only on the
+existing string format in each file (`v0.56.2` in `tools/shipyard.toml`,
+`0.56.2` in the workflow envs — the `v` prefix is intentional only on the
 toml). Otherwise local shipping and tag-time release jobs quietly diverge
 onto different Shipyard versions, which is how release-only behavior
 changes get missed. Shipyard v0.55.0+ also ships `shipyard update`; use
-`shipyard update --check --json` to report local drift and `shipyard update`
-to apply the latest stable CLI before cutting or debugging release jobs.
+`shipyard update --check --json` to report local drift and
+`shipyard update --to v0.56.2` (or newer) before cutting or debugging release
+jobs.
 
 ### VST3 SDK tag drift in `sign-and-release.yml`
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -260,11 +260,13 @@ Pulp's release automation depends on the pinned Shipyard CLI in two places:
   carry a `SHIPYARD_VERSION` env used by the release-side workflows.
 
 If you bump the Shipyard pin, update both workflows in the same PR and keep the
-existing string format in each file (`v0.29.0` in `tools/shipyard.toml`,
-`0.29.0` in the workflow envs — the `v` prefix is intentional only on the
+existing string format in each file (`v0.55.0` in `tools/shipyard.toml`,
+`0.55.0` in the workflow envs — the `v` prefix is intentional only on the
 toml). Otherwise local shipping and tag-time release jobs quietly diverge
 onto different Shipyard versions, which is how release-only behavior
-changes get missed.
+changes get missed. Shipyard v0.55.0+ also ships `shipyard update`; use
+`shipyard update --check --json` to report local drift and `shipyard update`
+to apply the latest stable CLI before cutting or debugging release jobs.
 
 ### VST3 SDK tag drift in `sign-and-release.yml`
 

--- a/.github/workflows/post-tag-sync.yml
+++ b/.github/workflows/post-tag-sync.yml
@@ -20,7 +20,7 @@ permissions:
   contents: write
 
 env:
-  SHIPYARD_VERSION: "0.55.0"
+  SHIPYARD_VERSION: "0.56.2"
 
 jobs:
   sync:

--- a/.github/workflows/post-tag-sync.yml
+++ b/.github/workflows/post-tag-sync.yml
@@ -20,7 +20,7 @@ permissions:
   contents: write
 
 env:
-  SHIPYARD_VERSION: "0.46.0"
+  SHIPYARD_VERSION: "0.55.0"
 
 jobs:
   sync:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -24,7 +24,7 @@ env:
   # same output as the hook that writes CHANGELOG.md. Must track
   # tools/shipyard.toml to avoid split behavior between local flows
   # and release-time jobs (Codex P1 on PR #719).
-  SHIPYARD_VERSION: "0.55.0"
+  SHIPYARD_VERSION: "0.56.2"
 
 jobs:
   build-cli:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -24,7 +24,7 @@ env:
   # same output as the hook that writes CHANGELOG.md. Must track
   # tools/shipyard.toml to avoid split behavior between local flows
   # and release-time jobs (Codex P1 on PR #719).
-  SHIPYARD_VERSION: "0.46.0"
+  SHIPYARD_VERSION: "0.55.0"
 
 jobs:
   build-cli:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -820,7 +820,10 @@ Pulp ships as a Claude Code plugin with slash commands (`/build`, `/test`, `/cre
 
 Use Shipyard for all merges. Current Pulp branch protection requires the
 macOS lane; Linux and Windows still run in GitHub Actions but are advisory
-unless branch protection changes.
+unless branch protection changes. When the macOS lane wedges or
+Shipyard itself drifts, see the `ci` skill's *Self-hosted runner ops*
+section for the v0.55.0+ toolkit (`shipyard rescue` / `runner watch
+--kill-hung-workers` / `update`).
 
 #### The `ship` workflow (primary path for all agents)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -822,7 +822,7 @@ Use Shipyard for all merges. Current Pulp branch protection requires the
 macOS lane; Linux and Windows still run in GitHub Actions but are advisory
 unless branch protection changes. When the macOS lane wedges or
 Shipyard itself drifts, see the `ci` skill's *Self-hosted runner ops*
-section for the v0.55.0+ toolkit (`shipyard rescue` / `runner watch
+section for the v0.56.2+ toolkit (`shipyard rescue` / `runner watch
 --kill-hung-workers` / `update`).
 
 #### The `ship` workflow (primary path for all agents)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ If you're interested in the rationale behind these rules, see [Astral's open-sou
 
 1. Fork the repo (or create a feature branch if you have write access).
 2. Make your changes on a branch named `feature/short-description` or `fix/short-description`.
-3. **Pre-PR validation** (optional but recommended): install the pinned source-checkout Shipyard tool with `./tools/install-shipyard.sh`, then run `shipyard run` to validate on macOS + Linux + Windows without creating a PR.
+3. **Pre-PR validation** (optional but recommended): install the pinned source-checkout Shipyard tool with `./tools/install-shipyard.sh` (after the first install, `shipyard update` is the preferred in-tool upgrade path), then run `shipyard run` to validate on macOS + Linux + Windows without creating a PR.
 4. Open and ship the PR with `shipyard pr`. This is the canonical path because it runs Pulp's skill-sync and version-bump gates, pushes the branch, creates the PR, records Shipyard tracking state, validates, and merges on green.
 5. Avoid `gh pr create` for normal work. Use it only when the maintainer explicitly chooses an emergency/manual bypass; in that case, call out that the PR may not appear in Shipyard-managed state until it is reconciled or re-shipped through Shipyard. Contributors who do not want Shipyard in their local checkout can make that explicit with `pulp config set pr.workflow github` or `pulp config set pr.workflow manual`; `pulp status` reports the active choice.
 6. CI will run automatically on macOS, Linux, and Windows.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ shipyard run                              # validate current branch
 shipyard pr                               # create, track, validate, and merge on green
 ```
 
-Pulp uses [Shipyard](https://github.com/danielraffel/Shipyard) for cross-platform CI — it validates on macOS (local), Linux (SSH), and Windows (SSH), and gates merges on per-SHA evidence across all three platforms. Public Pulp installs include the Pulp CLI only. Source-checkout contributors install the pinned Shipyard tool with `./tools/install-shipyard.sh`; GitHub CLI (`gh`) is only needed for GitHub-facing contributor workflows. See [docs/guides/local-ci.md](docs/guides/local-ci.md) for setup and [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor expectations.
+Pulp uses [Shipyard](https://github.com/danielraffel/Shipyard) for cross-platform CI — it validates on macOS (local), Linux (SSH), and Windows (SSH), and gates merges on per-SHA evidence across all three platforms. Public Pulp installs include the Pulp CLI only. Source-checkout contributors install the pinned Shipyard tool with `./tools/install-shipyard.sh` for the first install, then use `shipyard update` (Shipyard v0.55.0+) as the preferred in-tool upgrade path; GitHub CLI (`gh`) is only needed for GitHub-facing contributor workflows. See [docs/guides/local-ci.md](docs/guides/local-ci.md) for setup and [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor expectations.
 
 ### Security & CI policy
 

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -17,6 +17,9 @@ Pulp validates branches on macOS (local), Ubuntu (SSH), and Windows (SSH) before
 shipyard run                              # validate current branch
 shipyard pr                               # create, track, validate, and merge on green
 shipyard cloud run build <branch>         # dispatch to Namespace
+shipyard rescue <PR>                      # recover a wedged PR
+shipyard runner watch --kill-hung-workers # prevent self-hosted runner wedges
+shipyard update --check --json            # report installed vs latest
 ```
 
 Pulp intentionally pins Shipyard in `tools/shipyard.toml` even if your daily
@@ -289,6 +292,50 @@ launchctl unload ~/Library/LaunchAgents/com.danielraffel.pulp.macos-reroute-watc
 ```
 
 The watcher is **safe to run alongside the overflow probe in `build.yml`** — they cooperate. The probe decides *where to dispatch initially*; the watcher *opportunistically reroutes* dispatches that landed on cloud while local was busy, once local frees up before the cloud runner has picked up the job. If the cloud runner has already started, the watcher takes no action.
+
+### Self-hosted runner operations: prevent, recover, maintain
+
+Shipyard v0.55.0+ is the minimum pin for the full self-hosted-runner
+operational toolkit. The commands are discoverable from `shipyard --help` and
+replace the legacy `planning/scripts/runner-watchdog.sh` + manual reinstall
+workflow.
+
+```bash
+# Recover one PR whose required macOS check is wedged or stale
+shipyard rescue <PR>                      # cancel queued runs + redispatch to github-hosted
+shipyard rescue <PR> --rerun-failed       # also re-arm cancelled/failed runs
+shipyard rescue <PR> --dry-run            # preview without acting
+shipyard rescue --all-stuck               # repo-wide stuck-run sweep
+shipyard rescue <PR> --to github-hosted   # explicit destination provider
+
+# Prevent future wedges on a self-hosted runner host
+shipyard runner watch --kill-hung-workers # implies --fix; pair with launchd/systemd
+
+# Keep the installed Shipyard CLI current
+shipyard update --check --json            # report installed vs available
+shipyard update                           # apply latest stable
+shipyard update --to v0.53.0              # pin or roll back
+shipyard update --dry-run                 # plan only
+```
+
+Use `shipyard rescue` when a PR is otherwise ready but blocked by queued,
+cancelled, or failed runner contexts caused by a self-hosted-runner wedge. It is
+the PR-side recovery path and avoids the old failure mode where cancelling
+queued runs left required checks stuck as `failure`.
+
+Use `shipyard runner watch --kill-hung-workers` on the runner host itself. It
+auto-cancels stale queued runs and kills hung `Runner.Worker` processes through
+Shipyard's safe recovery sequence: snapshot, SIGTERM, grace period, SIGKILL,
+child reaping, partial-build quarantine, Listener verification, and optional
+wait for GitHub status to flip. Its JSON output uses `runner.watch` envelopes
+with `event=auto_kill_worker` and `phase` values of `attempt`, `killed`,
+`failed`, or `no-pid-found`.
+
+Use `shipyard update` instead of the old ad hoc `curl install.sh | sh` path
+once a machine already has Shipyard installed. Pulp still records the canonical
+repo pin in `tools/shipyard.toml`; `shipyard update --check --json` is the
+machine-local drift check, while `shipyard pin bump --to vX.Y.Z` is the repo
+pin-change workflow.
 
 ## Required Merge Process (All Agents)
 

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -296,9 +296,10 @@ The watcher is **safe to run alongside the overflow probe in `build.yml`** — t
 ### Self-hosted runner operations: prevent, recover, maintain
 
 Shipyard v0.55.0+ is the minimum pin for the full self-hosted-runner
-operational toolkit. The commands are discoverable from `shipyard --help` and
-replace the legacy `planning/scripts/runner-watchdog.sh` + manual reinstall
-workflow.
+operational toolkit, and Pulp pins v0.56.2+ so rescue, update, and
+`shipyard wait pr` have REST fallback paths when GraphQL is rate-limited. The
+commands are discoverable from `shipyard --help` and replace the legacy
+`planning/scripts/runner-watchdog.sh` + manual reinstall workflow.
 
 ```bash
 # Recover one PR whose required macOS check is wedged or stale
@@ -314,8 +315,11 @@ shipyard runner watch --kill-hung-workers # implies --fix; pair with launchd/sys
 # Keep the installed Shipyard CLI current
 shipyard update --check --json            # report installed vs available
 shipyard update                           # apply latest stable
-shipyard update --to v0.53.0              # pin or roll back
+shipyard update --to v0.56.2              # pin or roll back to Pulp's minimum
 shipyard update --dry-run                 # plan only
+
+# Wait after handoff/rescue without depending solely on GraphQL
+shipyard wait pr <PR> --state green       # REST fallback as of v0.56.2
 ```
 
 Use `shipyard rescue` when a PR is otherwise ready but blocked by queued,

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -160,7 +160,7 @@ std::string pinned_shipyard_version_for_test() {
             return value.substr(first + 1, last - first - 1);
         }
     }
-    return "v0.46.0";
+    return "v0.56.2";
 }
 
 fs::path write_fake_shipyard(const fs::path& dir, const std::string& version) {

--- a/tools/install-shipyard.sh
+++ b/tools/install-shipyard.sh
@@ -16,8 +16,12 @@
 # supply-chain story as any other pinned dep.
 #
 # Usage:
-#   ./tools/install-shipyard.sh           # install pinned version
+#   ./tools/install-shipyard.sh           # install pinned version (first-time setup)
 #   ./tools/install-shipyard.sh --status  # show installed vs pinned
+#
+# After the first install, `shipyard update` (Shipyard v0.55.0+) is
+# the preferred in-tool upgrade path. This wrapper is only needed
+# for the initial bootstrap and for `--status` checks against the pin.
 #
 # Exit codes:
 #   0   success (or already installed and matching pin)

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -250,6 +250,39 @@
 # in `tools/install-shipyard.sh` (v0.22.1+ `SHIPYARD_VERSION` support).
 # The older `~/.pulp/bin/shipyard` path is cleaned up on install to
 # prevent shadow-on-PATH bugs.
+#
+# v0.56.2 (current pin) — completes and hardens the self-hosted-runner
+# operational toolkit (prevent → recover → maintain) shipped 2026-05-13:
+#   v0.53.0 — `shipyard rescue <PR>`: one-shot recovery for queued runs.
+#             Replaces the legacy 5-step `runner-watchdog --fix` →
+#             `gh run rerun --failed` → `shipyard cloud handoff run
+#             --apply` manual sweep. Safe under load — does NOT mark
+#             required checks as `failure`. Modes: `--rerun-failed`,
+#             `--dry-run`, `--all-stuck`, `--to <provider>`.
+#             (Shipyard#286 / PR#287.)
+#   v0.54.0 — `shipyard runner watch --kill-hung-workers`: host-side
+#             daemon that auto-kills hung `Runner.Worker` processes
+#             (snapshot → SIGTERM → grace → SIGKILL → reap children
+#             → quarantine → verify Listener). Implies `--fix`. Pair
+#             with launchd / systemd for unattended ops. JSON envelopes
+#             `event=auto_kill_worker, phase ∈ {attempt,killed,failed,
+#             no-pid-found}`. (Shipyard#288 / PR#291.)
+#   v0.55.0 — `shipyard update`: self-update path. Replaces the legacy
+#             `curl … install.sh | sh` bootstrap-only flow. Subcommands:
+#             `--check --json`, `--to vX.Y.Z`, `--dry-run`. Future pin
+#             bumps after the v0.55.0 bootstrap are one command.
+#             (Shipyard#292 / PR#293.) Phase 2 (native non-install.sh
+#             apply, --channel main, release-notes diff) is upstream
+#             follow-up.
+#   v0.56.0 — hardens the runner toolkit with REST fallback, config.toml
+#             fixes, and daemon idle gating follow-ups.
+#   v0.56.2 — adds REST fallback for `shipyard wait pr`, so post-rescue
+#             waiting keeps working when GraphQL is rate-limited.
+#
+# See `.agents/skills/ci/SKILL.md#self-hosted-runner-ops` for the
+# Pulp-side quick-reference + Pulp-specific wedge gotchas (iOS AUv3
+# try-compile, dev-mac window popups). Authoritative reference lives
+# in Shipyard's own `skills/ci/SKILL.md`.
 version = "v0.56.2"
 
 # Public release source. The bootstrap script downloads from


### PR DESCRIPTION
## Summary

Updates Pulp's Shipyard-facing docs and pin for the full self-hosted-runner toolkit through `v0.56.2`:

- `shipyard rescue <PR>` for PR-side recovery when required macOS/self-hosted checks wedge
- `shipyard runner watch --kill-hung-workers` for host-side prevention on self-hosted runner machines
- `shipyard update` for maintaining the installed Shipyard CLI
- `shipyard wait pr <PR> --state green` with the v0.56.2 REST fallback for post-rescue polling

Also bumps Pulp's Shipyard pin to `v0.56.2`, keeps release workflow `SHIPYARD_VERSION` envs aligned at `0.56.2`, and updates the CLI shellout fake Shipyard version fixture.

## Files updated

- `.agents/skills/ci/SKILL.md`
- `.agents/skills/ship/SKILL.md`
- `docs/guides/local-ci.md`
- `tools/shipyard.toml`
- `.github/workflows/release-cli.yml`
- `.github/workflows/post-tag-sync.yml`
- `test/test_cli_shellout.cpp` fake Shipyard version fixture
- `CLAUDE.md` CI pointer

## Validation

- `shipyard pin bump --to v0.56.2 --no-pr`
- `./tools/install-shipyard.sh --status`
- `shipyard --version` → `shipyard 0.56.2`
- `shipyard update --check --json`
- `shipyard update --dry-run --json`
- `shipyard doctor --json --rate-limit`
- `shipyard rescue 1908 --dry-run --json`
- `shipyard rescue 1910 --dry-run --json`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report`
- YAML parse for `release-cli.yml` and `post-tag-sync.yml`
- `git diff --check`
- `cmake --build build --target pulp-test-cli-shellout --parallel`
- `ctest --test-dir build --output-on-failure -R "pulp pr delegates to shipyard with forwarded arguments"`