### PR TITLE
feat(import): Figma Make React export parser (Phase 6.6.3)

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -29,6 +29,12 @@ Ask the user or detect from context:
 - Use `com.figma.mcp` to read the current file or selection
 - Extract frames, auto-layout, fills, strokes, effects, text, components
 
+**Figma Make runtime-import parser (Phase 6.6.3)**:
+- The runtime-import lane accepts constrained, sanitized Figma Make React exports through `parse_figma_make_react()` and `source: 'figma'`. It normalizes the TSX file into the same bundle payload shape used by Claude and v0 runtime import.
+- Accepted input is a single `.tsx`/`.jsx` React component with explicit Figma provenance, no `"use client"` directive, React hook imports from `react` only, and inline `style={{ ... }}` objects.
+- Raw Figma Make defaults are intentionally rejected until a preprocessing step exists: unresolved `figma:asset/*` imports, versioned import paths like `<package>@<semver>`, Tailwind `className` utilities, Radix primitives, Code Connect glue files, Next.js wrappers, custom JSX components, non-range inputs, and network/storage/worker APIs.
+- Representative fixtures live under `planning/fixtures/figma/`; the primary one is `level-meter-panel.tsx`. Run `tools/import-validation/figma-roundtrip.sh --parser-only` for the parser/dispatch gate, `tools/import-validation/figma-roundtrip.sh` for parser-emitted screenshot diff, and `tools/import-validation/figma-roundtrip.sh --coverage` before pushing parser PRs.
+
 **Stitch (MCP available)**:
 - Use `mcp__stitch__list_screens` to show available screens
 - Use `mcp__stitch__get_screen` to read the selected screen

--- a/core/view/include/pulp/view/design_import.hpp
+++ b/core/view/include/pulp/view/design_import.hpp
@@ -193,6 +193,13 @@ std::optional<ClaudeBundle> parse_claude_bundle(const std::string& html);
 /// APIs, storage APIs, unsupported JSX tags, etc.).
 std::optional<ClaudeBundle> parse_v0_dev_react(const std::string& tsx_or_envelope);
 
+/// Normalize a constrained Figma Make React TSX export into the runtime-import
+/// bundle payload shape. C-2 accepts a sanitized single-file TSX component:
+/// Figma Make provenance must be explicit, versions/assets must already be
+/// stripped, and styling must use inline `style={{...}}` objects rather than
+/// Tailwind/Radix/default Figma Make dependencies.
+std::optional<ClaudeBundle> parse_figma_make_react(const std::string& tsx);
+
 /// Options for the `--execute-bundle` import lane.
 struct ClaudeRuntimeOptions {
     /// Hard cap on bytes of bundled JS to evaluate. Bundles larger than

--- a/core/view/src/design_import.cpp
+++ b/core/view/src/design_import.cpp
@@ -1095,6 +1095,18 @@ std::string v0_html_attr_escape(const std::string& s) {
     return out;
 }
 
+std::string replace_all_copy(std::string s,
+                             const std::string& needle,
+                             const std::string& replacement) {
+    if (needle.empty()) return s;
+    size_t pos = 0;
+    while ((pos = s.find(needle, pos)) != std::string::npos) {
+        s.replace(pos, needle.size(), replacement);
+        pos += replacement.size();
+    }
+    return s;
+}
+
 std::string v0_build_runtime_js(const std::string& source,
                                 const std::string& file_name,
                                 const std::string& component_name,
@@ -1210,6 +1222,86 @@ std::string v0_build_runtime_js(const std::string& source,
        << "  ReactDOM.createRoot(mount).render(h(App));\n"
        << "})();\n";
     return js.str();
+}
+
+bool figma_has_source_signal(const std::string& source) {
+    const auto lower = v0_lower(source);
+    return lower.find("source: figma") != std::string::npos ||
+           lower.find("figma make") != std::string::npos ||
+           lower.find("figma-make") != std::string::npos ||
+           lower.find("figma:asset/") != std::string::npos ||
+           lower.find("@figma/code-connect") != std::string::npos;
+}
+
+bool figma_has_versioned_import(const std::string& source) {
+    static const std::regex from_re(
+        R"RX(\bfrom\s*["'][^"']+@[0-9]+(?:\.[0-9]+){1,2}[^"']*["'])RX",
+        std::regex::icase);
+    static const std::regex side_effect_re(
+        R"RX(\bimport\s*["'][^"']+@[0-9]+(?:\.[0-9]+){1,2}[^"']*["'])RX",
+        std::regex::icase);
+    return std::regex_search(source, from_re) ||
+           std::regex_search(source, side_effect_re);
+}
+
+bool figma_uses_only_supported_surfaces(const std::string& source) {
+    if (!figma_has_source_signal(source)) return false;
+
+    const auto lower = v0_lower(source);
+    const char* figma_reject_markers[] = {
+        "\"use client\"", "'use client'", "figma:asset/",
+        "@figma/code-connect", "figma.connect(", "@radix-ui", "radix-ui",
+        "tailwind", "classname", "next/", "next\\", "next/dynamic"
+    };
+    for (const char* marker : figma_reject_markers) {
+        if (lower.find(marker) != std::string::npos) return false;
+    }
+    if (figma_has_versioned_import(source)) return false;
+
+    return v0_uses_only_supported_surfaces(source);
+}
+
+std::string figma_slug_from_component(std::string name) {
+    std::string out = "figma";
+    for (char c : name) {
+        if (std::isupper(static_cast<unsigned char>(c)) && !out.empty() && out.back() != '-') {
+            out += '-';
+        }
+        if (std::isalnum(static_cast<unsigned char>(c))) {
+            out += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        } else if (c == '-' || c == '_') {
+            if (!out.empty() && out.back() != '-') out += '-';
+        }
+    }
+    while (!out.empty() && out.back() == '-') out.pop_back();
+    return out.empty() ? "figma-runtime-import" : out;
+}
+
+std::string figma_extract_root_id(const std::string& source,
+                                  const std::string& component_name) {
+    static const std::regex id_re(R"RX(\bid\s*=\s*(?:"([^"]+)"|'([^']+)'))RX");
+    if (auto m = v0_match_first(source, id_re)) return *m;
+    return figma_slug_from_component(component_name);
+}
+
+std::string figma_build_runtime_js(const std::string& source,
+                                   const std::string& file_name,
+                                   const std::string& component_name,
+                                   const std::string& root_id) {
+    auto js = v0_build_runtime_js(source, file_name, component_name, root_id);
+    js = replace_all_copy(js,
+        "v0.dev runtime import requires host React and ReactDOM",
+        "Figma Make runtime import requires host React and ReactDOM");
+    js = replace_all_copy(js,
+        "v0.dev React runtime import",
+        "Figma Make React runtime import");
+    js = replace_all_copy(js,
+        "'data-pulp-source': 'v0'",
+        "'data-pulp-source': 'figma'");
+    js = replace_all_copy(js,
+        "sourceFile.indexOf('/') >= 0 ? 'v0' : 'OUT'",
+        "sourceFile.indexOf('/') >= 0 ? 'FIGMA' : 'FIG'");
+    return js;
 }
 
 void set_runtime_error(ClaudeRuntimeOptions& opts, const std::string& msg) {
@@ -1701,6 +1793,34 @@ std::optional<ClaudeBundle> parse_v0_dev_react(const std::string& tsx_or_envelop
         "<div id=\"root\" data-pulp-source=\"v0\" data-v0-root=\"" +
         v0_html_attr_escape(root_id) +
         "\"></div><script src=\"v0-runtime-app\"></script>";
+    return bundle;
+}
+
+std::optional<ClaudeBundle> parse_figma_make_react(const std::string& tsx) {
+    auto source = v0_trim(tsx);
+    if (source.empty()) return std::nullopt;
+    if (source.find("export default") == std::string::npos) return std::nullopt;
+    if (!v0_contains_ci(source, "react")) return std::nullopt;
+    if (!figma_uses_only_supported_surfaces(source)) return std::nullopt;
+
+    auto component_name = v0_extract_component_name(source);
+    if (component_name == "V0RuntimeImport") component_name = "FigmaRuntimeImport";
+    const auto root_id = figma_extract_root_id(source, component_name);
+    auto runtime_js = figma_build_runtime_js(
+        source, "App.tsx", component_name, root_id);
+
+    ClaudeBundleAsset app;
+    app.uuid = "figma-runtime-app";
+    app.mime = "text/javascript";
+    app.data.assign(runtime_js.begin(), runtime_js.end());
+
+    ClaudeBundle bundle;
+    bundle.assets.push_back(std::move(app));
+    bundle.javascript_indices.push_back(0);
+    bundle.template_html =
+        "<div id=\"root\" data-pulp-source=\"figma\" data-figma-root=\"" +
+        v0_html_attr_escape(root_id) +
+        "\"></div><script src=\"figma-runtime-app\"></script>";
     return bundle;
 }
 

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -1060,8 +1060,7 @@ void WidgetBridge::install_runtime_import_handlers() {
 
     // __pulpRuntimeImport__(html, source_label) → void
     //
-    // Parses the bundle envelope (Claude format only for now — figma /
-    // stitch / v0 / pencil can layer on later), evaluates inline
+    // Parses the selected runtime-import source bundle, evaluates inline
     // text/javascript + text/babel scripts on THIS engine, dispatches
     // DOMContentLoaded.
     //
@@ -1088,6 +1087,13 @@ void WidgetBridge::install_runtime_import_handlers() {
                     bundle = parse_v0_dev_react(html);
                     if (!bundle) {
                         set_err("__pulpRuntimeImport__: unsupported v0.dev React export (got '"
+                                + src_label + "')");
+                        return choc::value::Value();
+                    }
+                } else if (source_lc == "figma" || source_lc == "figma-make") {
+                    bundle = parse_figma_make_react(html);
+                    if (!bundle) {
+                        set_err("__pulpRuntimeImport__: unsupported Figma Make React export (got '"
                                 + src_label + "')");
                         return choc::value::Value();
                     }

--- a/test/fixtures/figma/level-meter-panel.tsx
+++ b/test/fixtures/figma/level-meter-panel.tsx
@@ -1,0 +1,160 @@
+// Source: Figma Make export (sanitized for Pulp runtime import)
+
+import { useEffect, useRef, useState } from "react";
+
+export default function LevelMeterPanel() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [input, setInput] = useState(0.64);
+  const [output, setOutput] = useState(0.48);
+  const [monitoring, setMonitoring] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    const draw = () => {
+      const canvas = canvasRef.current;
+      if (!canvas) {
+        if (active) requestAnimationFrame(draw);
+        return;
+      }
+
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        if (active) requestAnimationFrame(draw);
+        return;
+      }
+
+      const width = canvas.width;
+      const height = canvas.height;
+      const now = performance.now() / 1000;
+      const inputPeak = monitoring ? Math.min(1, Math.max(0, input + Math.sin(now * 2.2) * 0.12)) : 0.1;
+      const outputPeak = monitoring ? Math.min(1, Math.max(0, output + Math.cos(now * 1.7) * 0.1)) : 0.08;
+      const bars = 18;
+      const gap = 4;
+      const laneHeight = Math.floor((height - 18) / 2);
+      const barWidth = (width - gap * (bars - 1)) / bars;
+
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = "#10131c";
+      ctx.fillRect(0, 0, width, height);
+
+      for (let lane = 0; lane < 2; lane++) {
+        const peak = lane === 0 ? inputPeak : outputPeak;
+        const yBase = lane === 0 ? laneHeight : height - 4;
+        for (let i = 0; i < bars; i++) {
+          const ratio = (i + 1) / bars;
+          const h = Math.max(5, laneHeight * ratio);
+          ctx.fillStyle = ratio <= peak ? (ratio > 0.84 ? "#fb7185" : "#38bdf8") : "#263244";
+          ctx.fillRect(i * (barWidth + gap), yBase - h, barWidth, h);
+        }
+      }
+
+      ctx.fillStyle = "#dbeafe";
+      ctx.font = "12px Inter, sans-serif";
+      ctx.fillText("FIG", 8, 16);
+
+      if (active) requestAnimationFrame(draw);
+    };
+
+    draw();
+    return () => {
+      active = false;
+    };
+  }, [input, output, monitoring]);
+
+  const panelStyle = {
+    width: 428,
+    minHeight: 304,
+    display: "flex",
+    flexDirection: "column" as const,
+    gap: 16,
+    padding: 18,
+    backgroundColor: "#0f172a",
+    color: "#f8fafc",
+    border: "1px solid #334155",
+    borderRadius: 8,
+    fontFamily: "Inter, system-ui, sans-serif",
+  };
+
+  const rowStyle = {
+    display: "flex",
+    flexDirection: "row" as const,
+    gap: 12,
+    alignItems: "center",
+  };
+
+  const controlStyle = {
+    display: "flex",
+    flexDirection: "column" as const,
+    gap: 6,
+    flexGrow: 1,
+  };
+
+  return (
+    <div id="figma-level-meter-panel" style={panelStyle}>
+      <div style={{ ...rowStyle, justifyContent: "space-between" }}>
+        <div>
+          <h2 style={{ margin: 0, fontSize: 22, lineHeight: 1.1 }}>Level Matrix</h2>
+          <p style={{ margin: "6px 0 0", color: "#a5b4fc", fontSize: 13 }}>
+            Input and output monitor from a sanitized Figma Make panel
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setMonitoring(!monitoring)}
+          style={{
+            minWidth: 92,
+            minHeight: 36,
+            borderRadius: 6,
+            border: "1px solid #475569",
+            backgroundColor: monitoring ? "#075985" : "#1f2937",
+            color: "#f8fafc",
+            cursor: "pointer",
+          }}
+        >
+          {monitoring ? "Live" : "Hold"}
+        </button>
+      </div>
+
+      <canvas
+        ref={canvasRef}
+        width={392}
+        height={118}
+        style={{
+          width: "100%",
+          height: 118,
+          borderRadius: 6,
+          border: "1px solid #1f2937",
+          backgroundColor: "#10131c",
+        }}
+      />
+
+      <div style={rowStyle}>
+        <div style={controlStyle}>
+          <span style={{ fontSize: 12, color: "#cbd5e1" }}>Input</span>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={input}
+            onChange={(event) => setInput(Number(event.currentTarget.value))}
+          />
+          <span style={{ fontSize: 12, color: "#94a3b8" }}>{Math.round(input * 100)}%</span>
+        </div>
+        <div style={controlStyle}>
+          <span style={{ fontSize: 12, color: "#cbd5e1" }}>Output</span>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={output}
+            onChange={(event) => setOutput(Number(event.currentTarget.value))}
+          />
+          <span style={{ fontSize: 12, color: "#94a3b8" }}>{Math.round(output * 100)}%</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -1,6 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
+#include <pulp/state/store.hpp>
 #include <pulp/view/design_import.hpp>
+#include <pulp/view/script_engine.hpp>
+#include <pulp/view/widget_bridge.hpp>
 
+#include <cstdlib>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -46,6 +50,114 @@ std::string read_fixture(const std::string& rel_path) {
 
 std::string asset_text(const ClaudeBundleAsset& asset) {
     return std::string(asset.data.begin(), asset.data.end());
+}
+
+const char* minimal_host_react_dom_shim() {
+    return R"JS(
+(function(){
+  function flatten(input, out) {
+    if (input == null || input === false || input === true) return;
+    if (Array.isArray(input)) {
+      for (var i = 0; i < input.length; i++) flatten(input[i], out);
+      return;
+    }
+    out.push(input);
+  }
+
+  function createElement(type, props) {
+    var children = [];
+    for (var i = 2; i < arguments.length; i++) flatten(arguments[i], children);
+    return { type: type, props: props || {}, children: children };
+  }
+
+  function cssValue(key, value) {
+    if (value == null) return "";
+    if (typeof value === "number") {
+      if (key === "flexGrow" || key === "flexShrink" || key === "opacity" ||
+          key === "zIndex" || key === "lineHeight") {
+        return String(value);
+      }
+      return String(value) + "px";
+    }
+    return String(value);
+  }
+
+  function applyProps(el, props) {
+    props = props || {};
+    for (var key in props) {
+      if (key === "children" || key === "key") continue;
+      var value = props[key];
+      if (key === "style" && value) {
+        for (var styleKey in value) el.style[styleKey] = cssValue(styleKey, value[styleKey]);
+      } else if (key === "ref" && value) {
+        value.current = el;
+      } else if (key === "className") {
+        el.setAttribute("class", String(value));
+      } else if (key.slice(0, 2) === "on") {
+        el["__" + key] = value;
+      } else if (value === true) {
+        el.setAttribute(key, "");
+      } else if (value !== false && value != null) {
+        el.setAttribute(key, String(value));
+      }
+    }
+  }
+
+  function renderNode(node) {
+    if (node == null || node === false || node === true) return null;
+    if (typeof node === "string" || typeof node === "number") {
+      return document.createTextNode(String(node));
+    }
+    if (typeof node.type === "function") {
+      var props = Object.assign({}, node.props || {});
+      props.children = node.children;
+      return renderNode(node.type(props));
+    }
+    var el = document.createElement(node.type === globalThis.React.Fragment ? "span" : node.type);
+    applyProps(el, node.props);
+    for (var i = 0; i < node.children.length; i++) {
+      var child = renderNode(node.children[i]);
+      if (child) el.appendChild(child);
+    }
+    return el;
+  }
+
+  var effects = [];
+  globalThis.React = {
+    Fragment: "__fragment",
+    createElement: createElement,
+    useCallback: function(fn) { return fn; },
+    useEffect: function(fn) { effects.push(fn); },
+    useMemo: function(fn) { return fn(); },
+    useRef: function(value) { return { current: value == null ? null : value }; },
+    useState: function(initial) {
+      var value = initial;
+      return [value, function(next) { value = (typeof next === "function") ? next(value) : next; }];
+    }
+  };
+  globalThis.ReactDOM = {
+    createRoot: function(mount) {
+      return {
+        render: function(element) {
+          var node = renderNode(element);
+          if (node) mount.appendChild(node);
+          for (var i = 0; i < effects.length; i++) effects[i]();
+        }
+      };
+    },
+    flushSync: function(fn) { return fn(); }
+  };
+})();
+)JS";
+}
+
+void maybe_write_figma_runtime_script(const std::string& runtime_js) {
+    const char* out = std::getenv("PULP_FIGMA_RUNTIME_JS_OUT");
+    if (out == nullptr || *out == '\0') return;
+
+    std::ofstream file(out, std::ios::binary);
+    REQUIRE(file.good());
+    file << minimal_host_react_dom_shim() << "\n" << runtime_js << "\n";
 }
 
 } // namespace
@@ -1184,6 +1296,151 @@ TEST_CASE("parse_v0_dev_react rejects out-of-matrix v0 default surfaces",
     for (const auto& sample : rejected) {
         CAPTURE(sample);
         REQUIRE_FALSE(parse_v0_dev_react(sample).has_value());
+    }
+}
+
+// ── Figma Make React parsing ────────────────────────────────────────────
+
+TEST_CASE("parse_figma_make_react parses staged Figma runtime fixture",
+          "[view][import][parser][figma][phase-6.6.3]") {
+    const auto primary = read_fixture("planning/fixtures/figma/level-meter-panel.tsx");
+    auto bundle = parse_figma_make_react(primary);
+    REQUIRE(bundle.has_value());
+    REQUIRE(bundle->assets.size() == 1);
+    REQUIRE(bundle->javascript_indices.size() == 1);
+    REQUIRE(bundle->javascript_indices.front() == 0);
+    REQUIRE(bundle->assets.front().uuid == "figma-runtime-app");
+    REQUIRE(bundle->assets.front().mime == "text/javascript");
+    REQUIRE(bundle->template_html.find("data-pulp-source=\"figma\"") != std::string::npos);
+    REQUIRE(bundle->template_html.find("figma-level-meter-panel") != std::string::npos);
+
+    const auto js = asset_text(bundle->assets.front());
+    REQUIRE(js.find("figma-level-meter-panel") != std::string::npos);
+    REQUIRE(js.find("Figma Make runtime import requires host React and ReactDOM") != std::string::npos);
+    REQUIRE(js.find("'data-pulp-source': 'figma'") != std::string::npos);
+    REQUIRE(js.find("ReactDOM.createRoot") != std::string::npos);
+    REQUIRE(js.find("requestAnimationFrame") != std::string::npos);
+    REQUIRE(js.find("performance.now") != std::string::npos);
+    REQUIRE(js.find("canvas.getContext('2d')") != std::string::npos);
+    REQUIRE(js.find("type: 'range'") != std::string::npos);
+}
+
+TEST_CASE("parse_figma_make_react runtime bundle materializes with host React shim",
+          "[view][import][parser][figma][render][phase-6.6.3]") {
+    const auto primary = read_fixture("planning/fixtures/figma/level-meter-panel.tsx");
+    auto bundle = parse_figma_make_react(primary);
+    REQUIRE(bundle.has_value());
+    const auto runtime_js = asset_text(bundle->assets.front());
+    maybe_write_figma_runtime_script(runtime_js);
+
+    pulp::state::StateStore store;
+    ScriptEngine engine;
+    View root;
+    WidgetBridge bridge(engine, root, store);
+
+    REQUIRE_NOTHROW(bridge.load_script(minimal_host_react_dom_shim()));
+    REQUIRE_NOTHROW(bridge.load_script(runtime_js));
+    bridge.service_frame_callbacks();
+
+    REQUIRE(root.child_count() > 0);
+    REQUIRE(engine.evaluate("!!document.getElementById('figma-level-meter-panel')")
+                .getWithDefault<bool>(false));
+    REQUIRE_FALSE(engine.evaluate(
+        "(function(){ var el = document.getElementById('figma-level-meter-panel');"
+        "return el ? String(el._id || '') : ''; })()").toString().empty());
+}
+
+TEST_CASE("parse_figma_make_react accepts sanitized Figma Make TSX",
+          "[view][import][parser][figma][phase-6.6.3]") {
+    const std::string sanitized = R"(
+        // Source: Figma Make export (sanitized for Pulp runtime import)
+        import {
+          useState
+        } from "react";
+        export default function MultiLineFigmaPanel() {
+          const [level, setLevel] = useState(0.5);
+          return (
+            <div id="figma-multi-line-react-import" style={{ display: "flex", flexDirection: "column" }}>
+              <span>Level</span>
+              <input type="range" value={level} onChange={(event) => setLevel(Number(event.currentTarget.value))} />
+            </div>
+          );
+        }
+    )";
+
+    auto bundle = parse_figma_make_react(sanitized);
+    REQUIRE(bundle.has_value());
+    REQUIRE(bundle->template_html.find("figma-multi-line-react-import") != std::string::npos);
+    REQUIRE(asset_text(bundle->assets.front()).find("figma-multi-line-react-import") != std::string::npos);
+}
+
+TEST_CASE("parse_figma_make_react rejects out-of-matrix Figma defaults",
+          "[view][import][parser][figma][phase-6.6.3]") {
+    const std::vector<std::string> rejected = {
+        R"(
+            "use client";
+            // Source: Figma Make export
+            import { useState } from "react";
+            export default function NextFigmaPanel() {
+              return <div id="figma-next-panel">Next path</div>;
+            }
+        )",
+        R"(
+            // Source: Figma Make export
+            import { useState } from "react";
+            import hero from "figma:asset/a1b2c3d4.png";
+            export default function FigmaAssetPanel() {
+              return <div id="figma-asset-panel">Asset {hero}</div>;
+            }
+        )",
+        R"(
+            // Source: Figma Make export
+            import { Dialog } from "@radix-ui/react-dialog@1.1.6";
+            export default function VersionedImportPanel() {
+              return <div id="figma-versioned-panel">Versioned</div>;
+            }
+        )",
+        R"(
+            import figma from "@figma/code-connect/react";
+            figma.connect(Button, "https://figma.com/file/example", {
+              example: () => <Button />
+            });
+        )",
+        R"(
+            // Source: Figma Make export
+            import { useState } from "react";
+            export default function TailwindPanel() {
+              return <div className="flex rounded-lg">Tailwind</div>;
+            }
+        )",
+        R"(
+            // Source: Figma Make export
+            import { useState } from "react";
+            import Link from "next/link";
+            export default function NextImportPanel() {
+              return <Link href="/">Next</Link>;
+            }
+        )",
+        R"(
+            import { useState } from "react";
+            export default function GenericReactPanel() {
+              const [level, setLevel] = useState(0.5);
+              return <input type="range" value={level} onChange={(event) => setLevel(Number(event.currentTarget.value))} />;
+            }
+        )",
+        R"(
+            // Source: Figma Make export
+            import { useState } from "react";
+            export default function TextInputPanel() {
+              const [value, setValue] = useState("");
+              return <input type="text" value={value} onChange={(event) => setValue(event.currentTarget.value)} />;
+            }
+        )"
+    };
+
+    for (const auto& sample : rejected) {
+        CAPTURE(sample);
+        REQUIRE_FALSE(parse_figma_make_react(sample).has_value());
     }
 }
 

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -12665,6 +12665,49 @@ TEST_CASE("WidgetBridge __pulpRuntimeImport__ dispatches v0 parser by source lab
     REQUIRE(err_str.find("host React and ReactDOM") != std::string::npos);
 }
 
+TEST_CASE("WidgetBridge __pulpRuntimeImport__ dispatches Figma parser by source label",
+          "[view][bridge][runtime-import-dispatch][figma][phase-6.6.3]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.install_runtime_import_handlers();
+
+    const std::string figma_tsx = R"(
+        // Source: Figma Make export (sanitized for Pulp runtime import)
+        import { useState } from "react";
+        export default function DispatchProbe() {
+          const [level, setLevel] = useState(0.5);
+          return (
+            <div id="figma-dispatch-probe" style={{ display: "flex", flexDirection: "column" }}>
+              <span>Level</span>
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.01}
+                value={level}
+                onChange={(event) => setLevel(Number(event.currentTarget.value))}
+              />
+            </div>
+          );
+        }
+    )";
+
+    engine.evaluate(
+        "globalThis.__pulpRuntimeImportErr__ = null;"
+        "try { __pulpRuntimeImport__('" + js_single_quoted(figma_tsx) + "', 'figma'); }"
+        "catch (e) { globalThis.__pulpRuntimeImportErr__ = 'threw:' + String(e); }");
+
+    const auto err_str = engine.evaluate(
+        "String(globalThis.__pulpRuntimeImportErr__ || '')")
+        .getWithDefault<std::string>("");
+
+    REQUIRE(err_str.find("threw:") == std::string::npos);
+    REQUIRE(err_str.find("claude bundle") == std::string::npos);
+    REQUIRE(err_str.find("Figma Make runtime import requires host React and ReactDOM") != std::string::npos);
+}
+
 TEST_CASE("WidgetBridge __pulpRuntimeSettle__ pumps without crashing",
           "[view][bridge][runtime-import]") {
     ScriptEngine engine;

--- a/tools/import-validation/figma-roundtrip.sh
+++ b/tools/import-validation/figma-roundtrip.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Phase 6.6.3 Figma Make runtime-import validation harness.
+#
+# The parser lane is local-first: parser/dispatch tests, a parser-emitted
+# runtime render, and diff coverage must pass before a PR is pushed.
+# Screenshot comparison runs when a reference is available.
+
+set -euo pipefail
+
+PULP_DIR="${PULP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+DEFAULT_PLANNING_FIXTURE="$PULP_DIR/planning/fixtures/figma/level-meter-panel.tsx"
+DEFAULT_TEST_FIXTURE="$PULP_DIR/test/fixtures/figma/level-meter-panel.tsx"
+if [[ -n "${PULP_FIGMA_FIXTURE:-}" ]]; then
+  FIXTURE="$PULP_FIGMA_FIXTURE"
+elif [[ -f "$DEFAULT_PLANNING_FIXTURE" ]]; then
+  FIXTURE="$DEFAULT_PLANNING_FIXTURE"
+else
+  FIXTURE="$DEFAULT_TEST_FIXTURE"
+fi
+BUILD_DIR="${PULP_BUILD_DIR:-$PULP_DIR/build-figma-import}"
+BUILD_TYPE="${PULP_BUILD_TYPE:-Debug}"
+BUILD_JOBS="${PULP_BUILD_JOBS:-1}"
+REFERENCE="${PULP_FIGMA_REFERENCE:-$PULP_DIR/planning/screenshots/REFERENCE-figma-level-meter-panel.png}"
+OUT="${PULP_FIGMA_OUT:-$PULP_DIR/planning/screenshots/figma-level-meter-panel-latest.png}"
+THRESHOLD="${PULP_HARNESS_THRESHOLD:-0.85}"
+PARSER_ONLY=0
+SKIP_BUILD=0
+COVERAGE=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  tools/import-validation/figma-roundtrip.sh [--parser-only] [--skip-build]
+  tools/import-validation/figma-roundtrip.sh --coverage
+  tools/import-validation/figma-roundtrip.sh --reference path/to/reference.png
+
+Env:
+  PULP_DIR              Pulp checkout path
+  PULP_BUILD_DIR        CMake build dir
+  PULP_BUILD_TYPE       CMake build type (default: Debug)
+  PULP_BUILD_JOBS       CMake build parallelism (default: 1)
+  PULP_FIGMA_FIXTURE    Figma TSX fixture path (defaults to planning fixture,
+                        falls back to test fixture when planning is unavailable)
+  PULP_FIGMA_REFERENCE  reference screenshot path
+  PULP_FIGMA_OUT        candidate screenshot path
+  PULP_HARNESS_THRESHOLD screenshot similarity threshold
+  PULP_DIFF_COVER_CTEST_REGEX override the focused coverage CTest regex
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --parser-only) PARSER_ONLY=1; shift ;;
+    --skip-build) SKIP_BUILD=1; shift ;;
+    --coverage) COVERAGE=1; shift ;;
+    --reference) REFERENCE="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+red() { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+
+[[ -f "$FIXTURE" ]] || { red "missing Figma fixture: $FIXTURE"; exit 2; }
+command -v cmake >/dev/null || { red "cmake is required"; exit 2; }
+
+if [[ $COVERAGE -eq 1 ]]; then
+  default_ctest_regex='parse_figma_make_react|WidgetBridge __pulpRuntimeImport__ dispatches Figma|WidgetBridge __pulpRuntimeImport__ surfaces parse failure'
+  export PULP_DIFF_COVER_CTEST_REGEX="${PULP_DIFF_COVER_CTEST_REGEX:-$default_ctest_regex}"
+  bash "$PULP_DIR/tools/scripts/local_diff_cover.sh" \
+    pulp-test-design-import pulp-test-widget-bridge
+  green "Figma parser diff coverage passed"
+  exit 0
+fi
+
+find_test_exe() {
+  local name="$1"
+  local candidate
+  for candidate in "$BUILD_DIR/test/$name" "$BUILD_DIR/test/$BUILD_TYPE/$name"; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  red "missing built test executable: $name"
+  exit 2
+}
+
+if [[ $SKIP_BUILD -eq 0 ]]; then
+  cmake -S "$PULP_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+  build_targets=(pulp-test-design-import pulp-test-widget-bridge)
+  if [[ $PARSER_ONLY -eq 0 ]]; then
+    build_targets+=(pulp-screenshot)
+  fi
+  cmake --build "$BUILD_DIR" --parallel "$BUILD_JOBS" \
+    --target "${build_targets[@]}"
+fi
+
+DESIGN_IMPORT_TEST="$(find_test_exe pulp-test-design-import)"
+WIDGET_BRIDGE_TEST="$(find_test_exe pulp-test-widget-bridge)"
+
+"$DESIGN_IMPORT_TEST" '[phase-6.6.3]'
+"$WIDGET_BRIDGE_TEST" '[phase-6.6.3]'
+
+if [[ $PARSER_ONLY -eq 1 ]]; then
+  green "Figma parser tests passed (parser-only)"
+  exit 0
+fi
+
+find_tool_exe() {
+  local rel="$1"
+  local candidate
+  for candidate in "$BUILD_DIR/$rel" "$BUILD_DIR/$BUILD_TYPE/$rel"; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  red "missing built tool: $rel"
+  exit 2
+}
+
+SCREENSHOT_BIN="$(find_tool_exe tools/screenshot/pulp-screenshot)"
+TMP_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/pulp-figma-runtime.XXXXXX.js")"
+trap 'rm -f "$TMP_SCRIPT"' EXIT
+PULP_FIGMA_RUNTIME_JS_OUT="$TMP_SCRIPT" \
+  "$DESIGN_IMPORT_TEST" 'parse_figma_make_react runtime bundle materializes with host React shim'
+
+mkdir -p "$(dirname "$OUT")"
+"$SCREENSHOT_BIN" \
+  --script "$TMP_SCRIPT" \
+  --output "$OUT" \
+  --width 520 \
+  --height 380 \
+  --theme dark
+green "captured Figma runtime render: $OUT"
+
+if [[ ! -f "$REFERENCE" ]]; then
+  yellow "reference screenshot not found: $REFERENCE"
+  yellow "Phase 6.6.3 screenshot diff skipped; use the captured render as the reference once reviewed."
+  exit 77
+fi
+
+if [[ ! -f "$OUT" ]]; then
+  yellow "candidate screenshot not found: $OUT"
+  yellow "Run the runtime-import demo/capture step first, then re-run this harness."
+  exit 77
+fi
+
+python3 "$PULP_DIR/tools/import-validation/diff_against_reference.py" \
+  "$REFERENCE" "$OUT" --threshold "$THRESHOLD"


### PR DESCRIPTION
## Summary
- add `parse_figma_make_react()` for sanitized Figma Make React TSX exports
- dispatch `renderFromDesign({ source: "figma" })` / `figma-make` through runtime import
- add focused parser/dispatch tests, fixture docs, and a screenshot roundtrip harness

## Validation
- `tools/import-validation/figma-roundtrip.sh --parser-only --skip-build`
- `tools/import-validation/figma-roundtrip.sh --skip-build` (screenshot diff score 1.000, threshold 0.85)
- `tools/import-validation/figma-roundtrip.sh --coverage` (diff coverage 81%, threshold 75%)
- `git diff --check`
- `bash -n tools/import-validation/figma-roundtrip.sh`
- Shipyard local preflight: skill-sync/version/compat gates passed; PR creation hit GraphQL rate limit, so this PR was opened via REST fallback

Version-Bump: skip reason="Phase 6.6.3 source parser and tests do not need a public release bump"
Version-Bump: sdk=skip reason="source parser and tests do not change shipped SDK/API behavior outside runtime-import ingestion"
Version-Bump: plugin=skip reason="import-design skill text updated in-repo; no Claude plugin package release needed"
Compat-Update: skip prefix=css reason="parser rejects out-of-matrix CSS surfaces; no CSS compat matrix change"
Compat-Update: skip prefix=rn reason="runtime-import source parser does not change RN compatibility rows"
Compat-Update: skip prefix=yoga reason="runtime-import source parser does not change Yoga layout compatibility rows"
Compat-Update: skip prefix=react reason="runtime-import source parser does not change React host compatibility rows"
Compat-Update: skip prefix=html reason="parser accepts only existing supported HTML subset; no HTML compat matrix change"
Compat-Update: skip prefix=canvas2d reason="fixture exercises canvas but adds no canvas2d compat surface"
Compat-Update: skip prefix=imports reason="new Figma source coverage is documented in planning spec and skill; compat.json unchanged"