### PR TITLE
feat(tools): add coordination scripts (health-check, quick-spectr-cycle, capture-webview-baseline)

### DIFF
--- a/tools/coordination/capture-webview-baseline.sh
+++ b/tools/coordination/capture-webview-baseline.sh
@@ -9,10 +9,18 @@
 # regenerable on demand so it doesn't go stale when editor.html changes.
 #
 # Usage:
-#   capture-webview-baseline.sh                  # capture default 1280x800
+#   capture-webview-baseline.sh                  # refresh canonical REFERENCE
 #   capture-webview-baseline.sh --width 1320 --height 860
 #   capture-webview-baseline.sh --output /tmp/foo.png
+#   capture-webview-baseline.sh --timestamped    # write a timestamped file
+#                                                # instead of overwriting the
+#                                                # canonical REFERENCE
 #   capture-webview-baseline.sh --diff           # also diff vs native-latest
+#
+# By default the screenshot is written to the canonical REFERENCE path that
+# quick-spectr-cycle.sh compares against, so a single capture run actually
+# refreshes the baseline. Use --output to override the destination, or
+# --timestamped to keep historical snapshots side-by-side.
 #
 # Env:
 #   PULP_DIR     pulp root (default /Users/danielraffel/Code/pulp)
@@ -35,14 +43,16 @@ WIDTH=1280
 HEIGHT=800
 DO_DIFF=0
 OUT_PNG=""
+TIMESTAMPED=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --width)  WIDTH="$2"; shift 2 ;;
-    --height) HEIGHT="$2"; shift 2 ;;
-    --output) OUT_PNG="$2"; shift 2 ;;
-    --diff)   DO_DIFF=1; shift ;;
-    -h|--help) sed -n '/^# /,/^$/p' "$0"; exit 0 ;;
+    --width)       WIDTH="$2"; shift 2 ;;
+    --height)      HEIGHT="$2"; shift 2 ;;
+    --output)      OUT_PNG="$2"; shift 2 ;;
+    --diff)        DO_DIFF=1; shift ;;
+    --timestamped) TIMESTAMPED=1; shift ;;
+    -h|--help)     sed -n '/^# /,/^$/p' "$0"; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
@@ -50,7 +60,16 @@ done
 EDITOR_HTML="${SPECTR}/resources/editor.html"
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
 SCREENSHOTS_DIR="${PULP}/planning/screenshots"
-OUT_PNG="${OUT_PNG:-${SCREENSHOTS_DIR}/webview-baseline-editor-html-${TS}.png}"
+# Default: overwrite the canonical REFERENCE that quick-spectr-cycle.sh reads,
+# so capturing actually refreshes the baseline. Use --timestamped for the
+# legacy "side-by-side history" behaviour, or --output to pick a custom path.
+if [[ -z "$OUT_PNG" ]]; then
+  if [[ $TIMESTAMPED -eq 1 ]]; then
+    OUT_PNG="${SCREENSHOTS_DIR}/webview-baseline-editor-html-${TS}.png"
+  else
+    OUT_PNG="${SCREENSHOTS_DIR}/REFERENCE-spectr-editor-html.png"
+  fi
+fi
 
 log() { printf '[capture-webview] %s\n' "$*"; }
 die() { printf '[capture-webview] FATAL: %s\n' "$*" >&2; exit 2; }

--- a/tools/coordination/capture-webview-baseline.sh
+++ b/tools/coordination/capture-webview-baseline.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# capture-webview-baseline.sh — render editor.html in Chrome headless and
+# capture a fresh webview baseline screenshot. Pair with the native render
+# from spectr-roundtrip.sh and diff_against_reference.py to detect deltas
+# between "what the webview rendering of editor.html looks like" and "what
+# our GPU-native runtime-import produces from the same HTML."
+#
+# The webview is the gold standard. This script makes the baseline
+# regenerable on demand so it doesn't go stale when editor.html changes.
+#
+# Usage:
+#   capture-webview-baseline.sh                  # capture default 1280x800
+#   capture-webview-baseline.sh --width 1320 --height 860
+#   capture-webview-baseline.sh --output /tmp/foo.png
+#   capture-webview-baseline.sh --diff           # also diff vs native-latest
+#
+# Env:
+#   PULP_DIR     pulp root (default /Users/danielraffel/Code/pulp)
+#   SPECTR_DIR   spectr root (default /Users/danielraffel/Code/spectr)
+#   CHROME       path to Chrome binary (default macOS Google Chrome)
+#
+# Exit codes:
+#   0  success (capture wrote a PNG; optional diff produced a score)
+#   1  capture failed
+#   2  config error (Chrome missing, editor.html missing, etc.)
+
+set -euo pipefail
+
+PULP="${PULP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+SPECTR="${SPECTR_DIR:-$(cd "$PULP/.." && pwd)/spectr}"
+[[ -d "$SPECTR/resources" ]] || { echo "[capture-webview] FATAL: SPECTR_DIR=$SPECTR has no resources/; set SPECTR_DIR env var" >&2; exit 2; }
+CHROME="${CHROME:-/Applications/Google Chrome.app/Contents/MacOS/Google Chrome}"
+
+WIDTH=1280
+HEIGHT=800
+DO_DIFF=0
+OUT_PNG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --width)  WIDTH="$2"; shift 2 ;;
+    --height) HEIGHT="$2"; shift 2 ;;
+    --output) OUT_PNG="$2"; shift 2 ;;
+    --diff)   DO_DIFF=1; shift ;;
+    -h|--help) sed -n '/^# /,/^$/p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+EDITOR_HTML="${SPECTR}/resources/editor.html"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+SCREENSHOTS_DIR="${PULP}/planning/screenshots"
+OUT_PNG="${OUT_PNG:-${SCREENSHOTS_DIR}/webview-baseline-editor-html-${TS}.png}"
+
+log() { printf '[capture-webview] %s\n' "$*"; }
+die() { printf '[capture-webview] FATAL: %s\n' "$*" >&2; exit 2; }
+
+[[ -x "$CHROME" ]] || die "Chrome not found at $CHROME"
+[[ -f "$EDITOR_HTML" ]] || die "editor.html not found at $EDITOR_HTML"
+mkdir -p "$SCREENSHOTS_DIR"
+
+log "Rendering $EDITOR_HTML in Chrome headless at ${WIDTH}x${HEIGHT}…"
+
+# --force-device-scale-factor=2 to match the @2x scale pulp-screenshot uses
+# so the diff math compares like-for-like resolutions. --hide-scrollbars
+# avoids the right-edge scrollbar polluting the pixel comparison.
+"$CHROME" \
+  --headless=new \
+  --disable-gpu \
+  --hide-scrollbars \
+  --force-device-scale-factor=2 \
+  --window-size="${WIDTH},${HEIGHT}" \
+  --screenshot="$OUT_PNG" \
+  --virtual-time-budget=5000 \
+  "file://${EDITOR_HTML}" \
+  >/tmp/chrome-headless.log 2>&1 || {
+    log "ERROR: Chrome headless failed; see /tmp/chrome-headless.log"
+    tail -10 /tmp/chrome-headless.log
+    exit 1
+  }
+
+[[ -s "$OUT_PNG" ]] || { log "ERROR: screenshot file is empty"; exit 1; }
+log "Webview baseline: $OUT_PNG ($(stat -f%z "$OUT_PNG") bytes)"
+
+if [[ $DO_DIFF -eq 1 ]]; then
+  NATIVE_LATEST="$(ls -t "${SCREENSHOTS_DIR}"/spectr-1894-flex-fix-REAL-port-*.png 2>/dev/null | head -1)"
+  if [[ -z "$NATIVE_LATEST" ]]; then
+    NATIVE_LATEST="$(ls -t "${SCREENSHOTS_DIR}"/spectr-native-latest.png 2>/dev/null | head -1)"
+  fi
+  if [[ -z "$NATIVE_LATEST" || ! -f "$NATIVE_LATEST" ]]; then
+    log "WARN: no native screenshot found to diff against"
+    exit 0
+  fi
+  log "Diffing native ($NATIVE_LATEST) vs webview baseline ($OUT_PNG)…"
+  python3 "${PULP}/tools/import-validation/diff_against_reference.py" \
+    "$OUT_PNG" "$NATIVE_LATEST" --threshold 0.85 || true
+fi

--- a/tools/coordination/health-check.sh
+++ b/tools/coordination/health-check.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# health-check.sh — one-screen status of A/B/C autonomous coordination.
+#
+# Run this when you want to know "is this working?" — fast, idempotent,
+# inspects only planning history + remote PR state, never modifies anything.
+#
+# Verdict at the end:
+#   🟢 GREEN  — all 3 agents ticking within recent window, progress visible
+#   🟡 YELLOW — partial: some active, others silent
+#   🔴 RED    — no agents active or coordination not yet started
+#
+# Usage:
+#   tools/coordination/health-check.sh
+#
+# Tunables (env):
+#   COORD_WINDOW_MIN — minutes for "active" window per agent (default 20)
+#   PULP_DIR         — override pulp root
+
+set -uo pipefail
+
+PULP="${PULP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+PLAN="${PULP}/planning"
+WIN="${COORD_WINDOW_MIN:-20}"
+NOW="$(date -u +%FT%TZ)"
+
+# Color helpers — only when stdout is a TTY
+if [ -t 1 ]; then
+  G=$'\033[32m'; Y=$'\033[33m'; R=$'\033[31m'; B=$'\033[1m'; D=$'\033[0m'
+else
+  G=""; Y=""; R=""; B=""; D=""
+fi
+
+echo "${B}=== Coordination health check — ${NOW} (window=${WIN} min) ===${D}"
+echo
+
+# Refresh planning from origin so we see other agents' commits
+git -C "$PLAN" fetch origin main --quiet 2>/dev/null || echo "${Y}WARN: planning fetch failed${D}"
+git -C "$PLAN" pull --rebase --quiet 2>/dev/null || true
+
+# ── 1. Halt status ────────────────────────────────────────────────────────
+echo "${B}## 1. Halt status${D}"
+if head -5 "$PLAN/AGENT-STATUS.md" 2>/dev/null | grep -qE "^HALT ALL"; then
+  echo "  ${R}🛑 HALT ALL detected at top of AGENT-STATUS — agents should be exiting${D}"
+else
+  echo "  ${G}✅ no HALT — agents should be active${D}"
+fi
+echo
+
+# ── 2. Last tick per agent ────────────────────────────────────────────────
+echo "${B}## 2. Last planning commit per agent${D}"
+
+last_tick() {
+  local agent="$1"
+  git -C "$PLAN" log --since="6 hours ago" \
+    --format="%cI|%h|%s" \
+    --grep="agent-${agent}:" -1 2>/dev/null
+}
+
+minutes_since() {
+  local iso="$1"
+  python3 -c "
+from datetime import datetime, timezone
+try:
+    t = datetime.fromisoformat('$iso'.replace('Z', '+00:00'))
+    n = datetime.now(timezone.utc)
+    print(int((n - t).total_seconds() / 60))
+except Exception:
+    print(99999)
+"
+}
+
+A_TICK=$(last_tick a)
+B_TICK=$(last_tick b)
+C_TICK=$(last_tick c)
+
+for entry in "A|$A_TICK" "B|$B_TICK" "C|$C_TICK"; do
+  AGENT=$(echo "$entry" | cut -d'|' -f1)
+  REST=$(echo "$entry" | cut -d'|' -f2-)
+  if [ -z "$REST" ]; then
+    echo "  Agent ${AGENT}: ${R}❌ no commit in last 6h${D}"
+    continue
+  fi
+  TS=$(echo "$REST" | cut -d'|' -f1)
+  SHA=$(echo "$REST" | cut -d'|' -f2)
+  MSG=$(echo "$REST" | cut -d'|' -f3-)
+  MIN_AGO=$(minutes_since "$TS")
+  if [ "$MIN_AGO" -le "$WIN" ]; then
+    echo "  Agent ${AGENT}: ${G}✅ ${MIN_AGO} min ago${D} — $SHA $MSG"
+  else
+    echo "  Agent ${AGENT}: ${Y}⚠️  ${MIN_AGO} min ago (>$WIN min)${D} — $SHA $MSG"
+  fi
+done
+echo
+
+# ── 3. Recent planning commits (last 30 min) ──────────────────────────────
+echo "${B}## 3. Recent planning commits (last 30 min)${D}"
+COMMITS=$(git -C "$PLAN" log --since="30 min ago" --format="  %cI %an: %s" 2>/dev/null | head -8)
+if [ -z "$COMMITS" ]; then
+  echo "  ${Y}(none in last 30 min)${D}"
+else
+  echo "$COMMITS"
+fi
+echo
+
+# ── 4. Open PRs from this session ─────────────────────────────────────────
+echo "${B}## 4. PR status (REST API — GraphQL skipped to avoid rate limits)${D}"
+for PR in 1897 1898 1900; do
+  STATE=$(gh api "repos/danielraffel/pulp/pulls/$PR" \
+    --jq '"state=\(.state) mergeable_state=\(.mergeable_state) updated=\(.updated_at)"' \
+    2>/dev/null || echo "?? rate-limited or missing")
+  echo "  #$PR: $STATE"
+done
+echo
+
+# ── 5. Agent C status doc ─────────────────────────────────────────────────
+echo "${B}## 5. Agent C autonomous status (planning/AGENT-C-STATUS.md)${D}"
+if [ -f "$PLAN/AGENT-C-STATUS.md" ]; then
+  C_DOC_AGE_MIN=$(python3 -c "
+import os, time
+try:
+    mtime = os.path.getmtime('$PLAN/AGENT-C-STATUS.md')
+    print(int((time.time() - mtime) / 60))
+except Exception:
+    print(99999)
+")
+  if [ "$C_DOC_AGE_MIN" -le "$WIN" ]; then
+    echo "  ${G}✅ updated ${C_DOC_AGE_MIN} min ago${D}"
+  else
+    echo "  ${Y}⚠️  last updated ${C_DOC_AGE_MIN} min ago (>$WIN min — C may be idle)${D}"
+  fi
+  echo "  Last 4 entries:"
+  tail -8 "$PLAN/AGENT-C-STATUS.md" | sed 's/^/    /'
+else
+  echo "  ${Y}⚠️  doc not yet created (C hasn't started or has never ticked)${D}"
+  C_DOC_AGE_MIN=99999
+fi
+echo
+
+# ── 6. STALLED tags + escalations ─────────────────────────────────────────
+echo "${B}## 6. STALLED / escalation indicators${D}"
+STALLS=$(grep -nE "STALLED ON|Round 3 missed|escalat" "$PLAN/AGENT-STATUS.md" 2>/dev/null | tail -5)
+if [ -z "$STALLS" ]; then
+  echo "  ${G}✅ no STALLED tags or escalation notes${D}"
+else
+  echo "$STALLS" | sed 's/^/  /'
+fi
+echo
+
+# ── 7. Latest visual diff score (from screenshot filenames) ───────────────
+echo "${B}## 7. Visual diff score trajectory${D}"
+LATEST_PNG=$(ls -t "$PLAN/screenshots/"*.png 2>/dev/null | head -3)
+if [ -n "$LATEST_PNG" ]; then
+  echo "  3 most recent screenshots in planning/screenshots/:"
+  echo "$LATEST_PNG" | while IFS= read -r f; do
+    NAME=$(basename "$f")
+    AGE_MIN=$(python3 -c "
+import os, time
+print(int((time.time() - os.path.getmtime('$f')) / 60))
+")
+    echo "    ${AGE_MIN}m ago — $NAME"
+  done
+else
+  echo "  ${Y}(no screenshots yet)${D}"
+fi
+REF="$PLAN/screenshots/REFERENCE-spectr-editor-html.png"
+LATEST=$(ls -t "$PLAN/screenshots/spectr-"*.png 2>/dev/null | head -1)
+if [ -f "$REF" ] && [ -f "$LATEST" ] && [ -x "$(command -v python3)" ]; then
+  echo "  Current score (vs locked REFERENCE):"
+  python3 "$PULP/tools/import-validation/diff_against_reference.py" \
+    "$REF" "$LATEST" --threshold 0.85 2>/dev/null | head -3 | sed 's/^/    /'
+fi
+echo
+
+# ── 8. Verdict ────────────────────────────────────────────────────────────
+echo "${B}## 8. Verdict${D}"
+
+# An agent is "active" if it ticked within COORD_WINDOW_MIN
+agent_active() {
+  local tick_line="$1"
+  [ -z "$tick_line" ] && return 1
+  local ts; ts=$(echo "$tick_line" | cut -d'|' -f1)
+  local ago; ago=$(minutes_since "$ts")
+  [ "$ago" -le "$WIN" ]
+}
+
+A_OK=0; B_OK=0; C_OK=0
+agent_active "$A_TICK" && A_OK=1
+agent_active "$B_TICK" && B_OK=1
+[ "$C_DOC_AGE_MIN" -le "$WIN" ] && C_OK=1
+
+TOTAL=$((A_OK + B_OK + C_OK))
+
+if [ "$TOTAL" -eq 3 ]; then
+  echo "  ${G}🟢 GREEN — ALL THREE agents ticking within last ${WIN} min, coordination flowing${D}"
+elif [ "$TOTAL" -ge 1 ]; then
+  echo "  ${Y}🟡 YELLOW — partial:${D}"
+  [ "$A_OK" -eq 0 ] && echo "    ${R}❌ Agent A silent (no tick in last ${WIN} min)${D}"
+  [ "$B_OK" -eq 0 ] && echo "    ${R}❌ Agent B silent (no tick in last ${WIN} min)${D}"
+  [ "$C_OK" -eq 0 ] && echo "    ${R}❌ Agent C silent (AGENT-C-STATUS.md not updated in last ${WIN} min)${D}"
+else
+  echo "  ${R}🔴 RED — no agents active. Either coordination not yet started, all sessions died, or HALT was issued.${D}"
+fi
+
+echo
+echo "${B}=== Done ===${D}"

--- a/tools/coordination/quick-spectr-cycle.sh
+++ b/tools/coordination/quick-spectr-cycle.sh
@@ -85,12 +85,18 @@ log "[4/4] Capturing native render → $OUT_PNG"
   || { log "FATAL: pulp-screenshot failed; see /tmp/pulp-screenshot.log"; exit 2; }
 
 log "Diffing vs webview baseline…"
-SCORE_LINE="$(python3 "${PULP}/tools/import-validation/diff_against_reference.py" \
-  "$REFERENCE" "$OUT_PNG" --threshold "$THRESHOLD" 2>&1 || true)"
+# Run the diff and capture its real exit status. We deliberately avoid `|| true`
+# here so $? reflects the python script's verdict (0 = PASS, non-zero = FAIL).
+# `set -e` is suspended for this single command via `if`, so a failing diff
+# does not abort the script before we print the summary.
+if SCORE_LINE="$(python3 "${PULP}/tools/import-validation/diff_against_reference.py" \
+  "$REFERENCE" "$OUT_PNG" --threshold "$THRESHOLD" 2>&1)"; then
+  RESULT=0
+else
+  RESULT=$?
+fi
 echo "$SCORE_LINE"
 
-# Pull just the score line for a one-line summary
-RESULT=$?
 echo ""
 echo "=== quickcycle summary ==="
 echo "Worktree: $WORKTREE"

--- a/tools/coordination/quick-spectr-cycle.sh
+++ b/tools/coordination/quick-spectr-cycle.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# quick-spectr-cycle.sh — ONE command, ~10 seconds: rebuild pulp-react in the
+# current worktree, rebuild Spectr's editor.js, capture native screenshot,
+# diff vs the cached webview baseline. Print PASS/FAIL + similarity score.
+#
+# This is the tight visual-iteration loop. Run it on every pulp-react edit
+# during the Spectr import-flow chase. The webview baseline is captured
+# once (cached in planning/screenshots/REFERENCE-spectr-editor-html.png);
+# we only re-capture if editor.html changes.
+#
+# Usage:
+#   quick-spectr-cycle.sh                         # use current $PWD worktree's pulp-react
+#   quick-spectr-cycle.sh --worktree /tmp/foo     # explicit worktree
+#   quick-spectr-cycle.sh --label flex-fix        # label the output PNG
+#   quick-spectr-cycle.sh --no-build              # skip the pulp-react rebuild
+#
+# Exit codes:
+#   0  similarity ≥ threshold (PASS)
+#   1  similarity below threshold (FAIL — gap is real)
+#   2  pipeline broke
+
+set -euo pipefail
+
+PULP="${PULP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+SPECTR="${SPECTR_DIR:-$(cd "$PULP/.." && pwd)/spectr}"
+[[ -d "$SPECTR/native-react" ]] || { echo "[quickcycle] FATAL: SPECTR_DIR=$SPECTR has no native-react/; set SPECTR_DIR env var" >&2; exit 2; }
+REFERENCE="${PULP}/planning/screenshots/REFERENCE-spectr-editor-html.png"
+SCREENSHOTS="${PULP}/planning/screenshots"
+THRESHOLD="${PULP_HARNESS_THRESHOLD:-0.85}"
+WORKTREE=""
+LABEL="iter"
+DO_BUILD=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --worktree) WORKTREE="$2"; shift 2 ;;
+    --label)    LABEL="$2"; shift 2 ;;
+    --no-build) DO_BUILD=0; shift ;;
+    -h|--help)  sed -n '/^# /,/^$/p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Auto-detect worktree from $PWD if not given
+if [[ -z "$WORKTREE" ]]; then
+  if [[ -d "${PWD}/packages/pulp-react" ]]; then
+    WORKTREE="$PWD"
+  else
+    WORKTREE="$PULP"
+  fi
+fi
+
+PULP_REACT="${WORKTREE}/packages/pulp-react"
+[[ -d "$PULP_REACT" ]] || { echo "FATAL: no pulp-react at $PULP_REACT" >&2; exit 2; }
+[[ -f "$REFERENCE" ]] || { echo "FATAL: missing $REFERENCE" >&2; exit 2; }
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT_PNG="${SCREENSHOTS}/spectr-quickcycle-${LABEL}-${TS}.png"
+SPECTR_NODE_MODULES="${SPECTR}/native-react/node_modules/@pulp/react"
+
+log() { printf '[quickcycle] %s\n' "$*"; }
+
+if [[ $DO_BUILD -eq 1 ]]; then
+  log "[1/4] Building @pulp/react from $WORKTREE…"
+  ( cd "$PULP_REACT" && npm run build >/tmp/pulp-react-build.log 2>&1 ) \
+    || { log "FATAL: pulp-react build failed; see /tmp/pulp-react-build.log"; exit 2; }
+
+  log "[2/4] Syncing dist → Spectr node_modules…"
+  cp -R "${PULP_REACT}/dist/." "${SPECTR_NODE_MODULES}/dist/" \
+    || { log "FATAL: dist sync failed"; exit 2; }
+
+  log "[3/4] Rebundling Spectr editor.js (build:port — real Spectr port)…"
+  ( cd "${SPECTR}/native-react" && npm run build:port >/tmp/spectr-bundle.log 2>&1 ) \
+    || { log "FATAL: Spectr bundle failed; see /tmp/spectr-bundle.log"; exit 2; }
+else
+  log "[1-3/4] Skipped (--no-build)."
+fi
+
+log "[4/4] Capturing native render → $OUT_PNG"
+"${PULP}/build/tools/screenshot/pulp-screenshot" \
+  --script "${SPECTR}/native-react/dist/editor.js" \
+  --output "$OUT_PNG" \
+  --width 1280 --height 800 --scale 2.0 --theme dark \
+  >/tmp/pulp-screenshot.log 2>&1 \
+  || { log "FATAL: pulp-screenshot failed; see /tmp/pulp-screenshot.log"; exit 2; }
+
+log "Diffing vs webview baseline…"
+SCORE_LINE="$(python3 "${PULP}/tools/import-validation/diff_against_reference.py" \
+  "$REFERENCE" "$OUT_PNG" --threshold "$THRESHOLD" 2>&1 || true)"
+echo "$SCORE_LINE"
+
+# Pull just the score line for a one-line summary
+RESULT=$?
+echo ""
+echo "=== quickcycle summary ==="
+echo "Worktree: $WORKTREE"
+echo "Native:   $OUT_PNG"
+echo "Baseline: $REFERENCE"
+echo "Threshold: $THRESHOLD"
+exit "$RESULT"


### PR DESCRIPTION
## Summary

Lands the three coordination scripts developed during the 2026-05-12/13 multi-agent push as a permanent part of the repo, so they ship with future checkouts instead of living as untracked working-tree files.

- `tools/coordination/health-check.sh` — one-screen agent status (planning cadence per agent, PR state, screenshot trajectory, stalled-tag detection, 🟢/🟡/🔴 verdict). Read-only.
- `tools/coordination/quick-spectr-cycle.sh` — the tight visual-iteration loop. Rebuild `@pulp/react` + rebundle Spectr + capture native screenshot + diff vs locked webview baseline. ~10s/cycle warm.
- `tools/coordination/capture-webview-baseline.sh` — Chrome headless capture of `editor.html` at any viewport, regenerates the webview baseline when source HTML changes.

## Portability

All three scripts resolve PULP root via `git rev-parse --show-toplevel`, falling back to `PULP_DIR` env var (no hardcoded `/Users/danielraffel` paths). `SPECTR_DIR` heuristic: `$PULP/../spectr`, overridable via env var. Quickcycle + capture-webview both fail-fast with a clear message if the SPECTR dir doesn't look right.

## Why they complement (don't replace) `tools/import-validation/`

`tools/import-validation/` already has the build/diff primitives (`diff_against_reference.py`, parser roundtrip scripts, etc.). `tools/coordination/` is the multi-session orchestration layer on top — it answers "is this working?" across A/B/C agents and packages the import-validation primitives into a 10-second iteration cycle.

## Test plan

- [x] Each script runs successfully from a fresh `git rev-parse --show-toplevel`-based checkout (verified locally).
- [x] `health-check.sh` returns 🟢 GREEN when all 3 agents are ticking; 🔴 RED with HALT detected.
- [x] `quick-spectr-cycle.sh --no-build` captures a screenshot and emits a diff score against `planning/screenshots/REFERENCE-spectr-editor-html.png`.
- [x] `capture-webview-baseline.sh --width X --height Y` regenerates baseline at the specified viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)