### PR TITLE
fix(view+web-compat): route <path> to SvgPathWidget; <input type=range> defaults horizontal (closes gaps #4+#5 of #1899)

### DIFF
--- a/core/view/js/web-compat-dom-ops.js
+++ b/core/view/js/web-compat-dom-ops.js
@@ -35,7 +35,24 @@ if (!Element.prototype.appendChild ||
         child._parentElement = this;
         this._children.push(child);
         this._ensureNative();
-        __domAppend(this._id, child._id, child.tagName.toLowerCase());
+        // pulp #1899 — pass an optional widget-type hint to the C++
+        // __domAppend fast path so it can route `<input>` to the right
+        // native widget (Fader for type=range, Checkbox for type=checkbox).
+        // Computing the hint here is cheaper than re-entering JS from C++
+        // and avoids the QuickJS stack-overflow risk that motivated the
+        // __domAppend fast path in the first place.
+        var __domAppendHint = "";
+        if (child.tagName === "INPUT") {
+            if (child._type === "range") {
+                __domAppendHint = "range:" +
+                    ((typeof __resolveRangeOrientation__ === "function")
+                        ? __resolveRangeOrientation__(child)
+                        : "horizontal");
+            } else if (child._type === "checkbox") {
+                __domAppendHint = "checkbox";
+            }
+        }
+        __domAppend(this._id, child._id, child.tagName.toLowerCase(), __domAppendHint);
         child._nativeCreated = true;
         if (child._textContent) setText(child._id, child._textContent);
         // pulp #1147 — replay presentational `width`/`height` HTML
@@ -68,6 +85,14 @@ if (!Element.prototype.appendChild ||
         }
         if (typeof __replaySvgCircleAttributes__ === "function") {
             __replaySvgCircleAttributes__(child);
+        }
+        // pulp #1899 — replay SvgPath attributes (d / stroke /
+        // stroke-width / fill / viewBox-from-parent) for `<path>`
+        // elements. React commits these via setAttribute BEFORE the
+        // appendChild that materializes the native widget, so the
+        // SvgPathWidget is empty until this replay runs.
+        if (typeof __replaySvgPathAttributes__ === "function") {
+            __replaySvgPathAttributes__(child);
         }
         child.style._flushAll();
         child._reapplyStylesheets();
@@ -141,6 +166,10 @@ if (!Element.prototype.appendChild ||
         }
         if (typeof __replaySvgCircleAttributes__ === "function") {
             __replaySvgCircleAttributes__(newChild);
+        }
+        // pulp #1899 — see appendChild for rationale.
+        if (typeof __replaySvgPathAttributes__ === "function") {
+            __replaySvgPathAttributes__(newChild);
         }
         newChild.style._flushAll();
         newChild._reapplyStylesheets();

--- a/core/view/js/web-compat-element.js
+++ b/core/view/js/web-compat-element.js
@@ -102,6 +102,22 @@ Element.prototype._ensureNative = function() {
         } else {
             createCol(id, "");
         }
+    } else if (tag === "path") {
+        // pulp #1899 — Spectr's React-rendered icon glyphs emit raw
+        // `<svg><path d="..." stroke="currentColor" .../></svg>` JSX. The
+        // SvgPath native widget + bridge surface (createSvgPath /
+        // setSvgPath / setSvgStroke / setSvgFill / setSvgStrokeWidth)
+        // already exist (pulp #994 / #1416), but the web-compat shim
+        // routed `<path>` into the unknown-tag default (createCol),
+        // producing an empty box. Wire <path> directly to createSvgPath
+        // and replay `d` / `stroke` / `stroke-width` / `fill` /
+        // `viewBox` (inherited from the parent <svg>) through
+        // __replaySvgPathAttributes__ at the end of this function.
+        if (typeof createSvgPath === "function") {
+            createSvgPath(id, "");
+        } else {
+            createCol(id, "");
+        }
     } else if (tag === "h1") {
         createLabel(id, "", "");
         setFontSize(id, 32); setFontWeight(id, 700);
@@ -125,7 +141,19 @@ Element.prototype._ensureNative = function() {
     } else if (tag === "input") {
         var t = this._type || "text";
         if (t === "range") {
-            createFader(id, "vertical", "");
+            // pulp #1899 — `<input type="range">` defaults to HORIZONTAL.
+            // HTML semantics (and Spectr's MorphSlider, Web Audio demos,
+            // CSS-Tricks / MDN examples) treat the range slider as
+            // horizontal unless an explicit hint says otherwise. Pulp
+            // previously hard-coded "vertical" which collapsed every
+            // imported web slider to a tall fader, painting nothing in
+            // the typical 90px-wide flex row.
+            //
+            // Heuristic (in priority order):
+            //   1. `aria-orientation="vertical"` → vertical
+            //   2. inline `style.height > style.width` → vertical
+            //   3. otherwise → horizontal (HTML default)
+            createFader(id, __resolveRangeOrientation__(this), "");
         } else if (t === "checkbox") {
             createCheckbox(id, "");
         } else {
@@ -198,7 +226,40 @@ Element.prototype._ensureNative = function() {
     if (typeof __replaySvgCircleAttributes__ === "function") {
         __replaySvgCircleAttributes__(this);
     }
+    // pulp #1899 — replay <path> SVG attributes captured pre-mount
+    // (React/JSX commits attributes before appendChild materializes the
+    // node, so by the time setAttribute('d', ...) lands the bridge has
+    // no native id yet). __replaySvgPathAttributes__ flushes d / stroke
+    // / stroke-width / fill from _attributes and inherits viewBox from
+    // the parent <svg>.
+    if (typeof __replaySvgPathAttributes__ === "function") {
+        __replaySvgPathAttributes__(this);
+    }
 };
+
+// pulp #1899 — orientation heuristic for <input type="range">. Returns
+// "horizontal" (HTML default) or "vertical". Priority:
+//   1. aria-orientation attribute explicitly says "vertical"
+//   2. inline style.height > style.width — author shaped it as a tall
+//      column, so render as a vertical fader
+//   3. otherwise horizontal (the HTML / Web-Audio convention)
+function __resolveRangeOrientation__(el) {
+    if (!el) return "horizontal";
+    var aria = el._attributes && el._attributes["aria-orientation"];
+    if (aria === "vertical") return "vertical";
+    if (aria === "horizontal") return "horizontal";
+    // Read pre-mount inline-style props captured on the CSSStyleDeclaration.
+    var s = el.style && el.style._props;
+    if (s) {
+        var w = parseFloat(s.width);
+        var h = parseFloat(s.height);
+        var hasW = w === w && w > 0;          // NaN-safe
+        var hasH = h === h && h > 0;
+        if (hasH && hasW && h > w) return "vertical";
+        if (hasH && !hasW)         return "vertical";
+    }
+    return "horizontal";
+}
 
 // pulp #1147 — shared helper that maps presentational HTML attributes
 // (width, height) on layout-leaf media tags (<svg>, <img>, <canvas>,
@@ -368,6 +429,71 @@ function __replaySvgCircleAttributes__(el) {
     if (sw !== undefined && typeof setSvgStrokeWidth === "function") {
         var psw = parseFloat(sw);
         if (psw === psw) setSvgStrokeWidth(el._id, psw);
+    }
+}
+
+// pulp #1899 — replay <path> SVG attributes captured pre-mount through
+// the SvgPathWidget bridge surface. React/JSX commits attributes before
+// `appendChild` materializes the node, mirroring the aria / media-attr
+// patterns above. Idempotent — safe to call from _ensureNative AND from
+// the appendChild fast path. Also inherits the parent <svg>'s viewBox
+// when set, matching the SVG spec (path coordinates live in the parent
+// viewBox's coordinate space).
+//
+// Attribute name handling: HTML attribute names lowercase via
+// setAttribute, but JSX often serializes camelCase `strokeWidth`. We
+// accept either spelling so the host-config (React intrinsic) and the
+// raw HTML/JSX path both work.
+function __replaySvgPathAttributes__(el) {
+    if (!el || !el._nativeCreated || !el._attributes) return;
+    if (el.tagName !== "PATH") return;
+    var a = el._attributes;
+
+    // d — required for the path to paint at all.
+    if (a.d !== undefined && typeof setSvgPath === "function") {
+        setSvgPath(el._id, String(a.d));
+    }
+    // stroke — color string. "none" / "" clears the stroke.
+    if (a.stroke !== undefined && typeof setSvgStroke === "function") {
+        setSvgStroke(el._id, String(a.stroke));
+    }
+    // stroke-width / strokeWidth — width in viewBox units.
+    var sw = a["stroke-width"];
+    if (sw === undefined) sw = a.strokeWidth;
+    if (sw !== undefined && typeof setSvgStrokeWidth === "function") {
+        var psw = parseFloat(sw);
+        if (psw === psw) setSvgStrokeWidth(el._id, psw);
+    }
+    // fill — color string. "none" clears.
+    if (a.fill !== undefined && typeof setSvgFill === "function") {
+        setSvgFill(el._id, String(a.fill));
+    }
+    // viewBox — inherited from the parent <svg>. The SVG spec attaches
+    // viewBox to the outer <svg>, but the SvgPathWidget needs the (w,h)
+    // pair to scale path coordinates into widget bounds. Walk up until
+    // we hit an <svg> ancestor (or the root) and lift its viewBox.
+    if (typeof setSvgViewBox === "function") {
+        var anc = el._parentElement;
+        while (anc) {
+            if (anc.tagName === "SVG") break;
+            anc = anc._parentElement;
+        }
+        if (anc && anc._attributes) {
+            var vb = anc._attributes.viewBox;
+            if (typeof vb === "string") {
+                var toks = vb.trim().split(/[\s,]+/).map(parseFloat);
+                var clean = [];
+                for (var ti = 0; ti < toks.length; ti++) {
+                    if (toks[ti] === toks[ti]) clean.push(toks[ti]);
+                }
+                if (clean.length === 4) {
+                    // SVG-spec form `min-x min-y w h` — bridge consumes w + h.
+                    setSvgViewBox(el._id, clean[2], clean[3]);
+                } else if (clean.length === 2) {
+                    setSvgViewBox(el._id, clean[0], clean[1]);
+                }
+            }
+        }
     }
 }
 
@@ -860,6 +986,28 @@ Element.prototype.setAttribute = function(name, value) {
             setAccessibilityState(this._id, name.slice(5), String(value));
         }
     }
+    // pulp #1899 — `<path d=... stroke=... stroke-width=... fill=...>`
+    // routes through the SvgPathWidget bridge. Idempotent: also replayed
+    // by __replaySvgPathAttributes__ in the appendChild-after-setAttribute
+    // path. We forward immediately if the widget already exists, and let
+    // the replay flush from _attributes for the pre-mount case.
+    else if (this.tagName === "PATH" &&
+             (name === "d" || name === "stroke" || name === "fill" ||
+              name === "stroke-width" || name === "strokeWidth")) {
+        if (this._nativeCreated) {
+            if (name === "d" && typeof setSvgPath === "function") {
+                setSvgPath(this._id, String(value));
+            } else if (name === "stroke" && typeof setSvgStroke === "function") {
+                setSvgStroke(this._id, String(value));
+            } else if (name === "fill" && typeof setSvgFill === "function") {
+                setSvgFill(this._id, String(value));
+            } else if ((name === "stroke-width" || name === "strokeWidth") &&
+                       typeof setSvgStrokeWidth === "function") {
+                var p = parseFloat(value);
+                if (p === p) setSvgStrokeWidth(this._id, p);
+            }
+        }
+    }
 };
 
 Element.prototype.getAttribute = function(name) {
@@ -1309,11 +1457,21 @@ function _reparentNative(child, parentId) {
         // attach. The width/height attributes are replayed by the
         // shared helper at the end of this function.
         createCol(id, parentId);
+    } else if (tag === "path") {
+        // pulp #1899 — `<path>` reparent path mirrors _ensureNative.
+        // SvgPath attribute replay runs at the end of this function.
+        if (typeof createSvgPath === "function") {
+            createSvgPath(id, parentId);
+        } else {
+            createCol(id, parentId);
+        }
     } else if (tag === "button") {
         createToggleButton(id, parentId);
     } else if (tag === "input") {
         var t = child._type || "text";
-        if (t === "range") createFader(id, "vertical", parentId);
+        // pulp #1899 — horizontal-by-default range slider. See
+        // __resolveRangeOrientation__ in _ensureNative.
+        if (t === "range") createFader(id, __resolveRangeOrientation__(child), parentId);
         else if (t === "checkbox") createCheckbox(id, parentId);
         else createTextEditor(id, parentId);
     } else if (tag === "textarea") {
@@ -1352,6 +1510,12 @@ function _reparentNative(child, parentId) {
     // pulp Wave 3 html.2 / #1476 — replay ARIA attributes after reparent.
     if (typeof __replayAriaAttributes__ === "function") {
         __replayAriaAttributes__(child);
+    }
+    // pulp #1899 — replay SvgPath attributes after reparent so the
+    // SvgPathWidget bridge sees d / stroke / stroke-width / fill /
+    // viewBox even if the path was constructed before mount.
+    if (typeof __replaySvgPathAttributes__ === "function") {
+        __replaySvgPathAttributes__(child);
     }
 
     // Recursively reparent children

--- a/core/view/js/web-compat-element.js
+++ b/core/view/js/web-compat-element.js
@@ -239,16 +239,23 @@ Element.prototype._ensureNative = function() {
 
 // pulp #1899 — orientation heuristic for <input type="range">. Returns
 // "horizontal" (HTML default) or "vertical". Priority:
-//   1. aria-orientation attribute explicitly says "vertical"
-//   2. inline style.height > style.width — author shaped it as a tall
-//      column, so render as a vertical fader
-//   3. otherwise horizontal (the HTML / Web-Audio convention)
+//   1. aria-orientation attribute explicitly says "vertical" (or "horizontal")
+//   2. inline style.height > inline style.width — BOTH must be inline-set;
+//      otherwise width may come from a flex parent (not visible here) and
+//      the comparison is meaningless. The earlier "hasH && !hasW → vertical"
+//      shortcut regressed horizontal sliders whose width came from layout
+//      (Codex P1 review of #1917).
+//   3. otherwise horizontal (the HTML / Web-Audio convention).
+// TODO: add test for #1917 P1 regression (horizontal slider with
+//       inline style.height but width supplied by flex parent).
 function __resolveRangeOrientation__(el) {
     if (!el) return "horizontal";
     var aria = el._attributes && el._attributes["aria-orientation"];
     if (aria === "vertical") return "vertical";
     if (aria === "horizontal") return "horizontal";
     // Read pre-mount inline-style props captured on the CSSStyleDeclaration.
+    // Both width AND height must be inline-explicit before we trust the
+    // comparison — see header comment for the flex-width regression.
     var s = el.style && el.style._props;
     if (s) {
         var w = parseFloat(s.width);
@@ -256,9 +263,29 @@ function __resolveRangeOrientation__(el) {
         var hasW = w === w && w > 0;          // NaN-safe
         var hasH = h === h && h > 0;
         if (hasH && hasW && h > w) return "vertical";
-        if (hasH && !hasW)         return "vertical";
     }
     return "horizontal";
+}
+
+// pulp #1917 (Codex P1) — SVG `currentColor` resolution.
+//
+// The SVG spec resolves `stroke="currentColor"` / `fill="currentColor"`
+// to the element's CSS `color` property at render time. The C++
+// SvgPathWidget bridge does not parse the literal token, so without
+// resolution the stroke renders transparent/black/garbage depending on
+// the backend. Walk up the parent chain looking for an inline
+// `style.color` (color is inherited per CSS); fall back to "black" per
+// SVG spec when nothing is set anywhere on the chain.
+function __resolveCurrentColor__(el) {
+    var anc = el;
+    while (anc) {
+        var col = anc.style && anc.style._props && anc.style._props.color;
+        if (typeof col === "string" && col.length > 0 && col !== "inherit") {
+            return col;
+        }
+        anc = anc._parentElement;
+    }
+    return "black"; // SVG spec default
 }
 
 // pulp #1147 — shared helper that maps presentational HTML attributes
@@ -454,8 +481,15 @@ function __replaySvgPathAttributes__(el) {
         setSvgPath(el._id, String(a.d));
     }
     // stroke — color string. "none" / "" clears the stroke.
+    // pulp #1917 (Codex P1) — resolve `currentColor` against the CSS
+    // color cascade before dispatch; the C++ widget doesn't parse the
+    // literal token. Fallback is "black" per SVG spec.
     if (a.stroke !== undefined && typeof setSvgStroke === "function") {
-        setSvgStroke(el._id, String(a.stroke));
+        var strokeVal = String(a.stroke);
+        if (strokeVal === "currentColor") {
+            strokeVal = __resolveCurrentColor__(el);
+        }
+        setSvgStroke(el._id, strokeVal);
     }
     // stroke-width / strokeWidth — width in viewBox units.
     var sw = a["stroke-width"];
@@ -464,9 +498,13 @@ function __replaySvgPathAttributes__(el) {
         var psw = parseFloat(sw);
         if (psw === psw) setSvgStrokeWidth(el._id, psw);
     }
-    // fill — color string. "none" clears.
+    // fill — color string. "none" clears. Same currentColor handling as stroke.
     if (a.fill !== undefined && typeof setSvgFill === "function") {
-        setSvgFill(el._id, String(a.fill));
+        var fillVal = String(a.fill);
+        if (fillVal === "currentColor") {
+            fillVal = __resolveCurrentColor__(el);
+        }
+        setSvgFill(el._id, fillVal);
     }
     // viewBox — inherited from the parent <svg>. The SVG spec attaches
     // viewBox to the outer <svg>, but the SvgPathWidget needs the (w,h)

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -2764,6 +2764,41 @@ void WidgetBridge::register_api() {
             auto svg = std::make_unique<SvgPathWidget>();
             svg->set_id(childId);
             child = std::move(svg);
+        } else if (tag == "path") {
+            // pulp #1899 — mirror the JS-side _ensureNative routing:
+            // `<path>` (typically inside an `<svg>`) materializes as the
+            // SvgPathWidget so the d / stroke / stroke-width / fill /
+            // viewBox attribute replay actually paints. Without this
+            // branch the React/JSX commit path (which goes through
+            // __domAppend, bypassing _ensureNative) would silently
+            // create a plain View and the SVG glyph never renders.
+            auto svg = std::make_unique<SvgPathWidget>();
+            svg->set_id(childId);
+            child = std::move(svg);
+        } else if (tag == "input") {
+            // pulp #1899 — `<input>` needs the JS-side `_type` to pick a
+            // widget. JS callers pass it through the optional 4th `hint`
+            // arg ("range:horizontal", "range:vertical", "checkbox").
+            // Without the hint, fall back to a plain View so the element
+            // still receives child/style ops (text inputs are not yet
+            // first-class on the bridge).
+            auto hint = args.get<std::string>(3, "");
+            if (hint == "range:horizontal" || hint == "range:vertical") {
+                auto fader = std::make_unique<Fader>();
+                fader->set_id(childId);
+                if (hint == "range:horizontal") {
+                    fader->set_orientation(Fader::Orientation::horizontal);
+                }
+                child = std::move(fader);
+            } else if (hint == "checkbox") {
+                auto cb = std::make_unique<Checkbox>();
+                cb->set_id(childId);
+                child = std::move(cb);
+            } else {
+                auto v = std::make_unique<View>();
+                v->set_id(childId);
+                child = std::move(v);
+            }
         } else {
             auto v = std::make_unique<View>();
             v->set_id(childId);

--- a/test/web-compat/CMakeLists.txt
+++ b/test/web-compat/CMakeLists.txt
@@ -189,3 +189,19 @@ elseif(UNIX)
     target_link_options(pulp-test-svg-primitives-1926 PRIVATE -Wl,-z,stacksize=16777216)
 endif()
 catch_discover_tests(pulp-test-svg-primitives-1926)
+
+# #1899 regression: Spectr import-flow gaps #4 + #5 — `<path>` must
+# route to SvgPathWidget with d / stroke / stroke-width / fill /
+# viewBox replay, and `<input type=range>` must default to horizontal.
+add_executable(pulp-test-svg-path-range-orientation-1899 test_svg_path_range_orientation_1899.cpp)
+target_link_libraries(pulp-test-svg-path-range-orientation-1899 PRIVATE pulp::view Catch2::Catch2WithMain)
+target_include_directories(pulp-test-svg-path-range-orientation-1899 PRIVATE ${WEBCOMPAT_INCLUDE_DIR})
+target_compile_definitions(pulp-test-svg-path-range-orientation-1899 PRIVATE
+    PULP_TEST_SOURCE_DIR="${CMAKE_SOURCE_DIR}/test"
+)
+if(APPLE)
+    target_link_options(pulp-test-svg-path-range-orientation-1899 PRIVATE -Wl,-stack_size,0x2000000)
+elseif(UNIX)
+    target_link_options(pulp-test-svg-path-range-orientation-1899 PRIVATE -Wl,-z,stacksize=16777216)
+endif()
+catch_discover_tests(pulp-test-svg-path-range-orientation-1899)

--- a/test/web-compat/test_svg_path_range_orientation_1899.cpp
+++ b/test/web-compat/test_svg_path_range_orientation_1899.cpp
@@ -1,0 +1,167 @@
+// pulp #1899 — Spectr import-flow visual gap fixes #4 and #5.
+//
+// (#4) The web-compat shim previously routed `<path>` into the
+// unknown-tag default (createCol), producing an empty layout box.
+// Spectr's React-rendered icon glyphs emit raw `<svg viewBox="0 0 24 24">
+// <path d="M..." stroke="currentColor" stroke-width="2" fill="none"/></svg>`
+// markup, so every glyph painted blank. This test pins the new routing
+// (createSvgPath under the hood) plus the d / stroke / stroke-width /
+// fill / viewBox attribute replay.
+//
+// (#5) `<input type="range">` was hard-coded to "vertical" orientation
+// in the createFader call, which is the wrong default for HTML. The
+// HTML / MDN / Web-Audio convention is horizontal-by-default; Spectr's
+// MorphSlider, FilterBank, and almost every imported web slider expect
+// a 90px-wide horizontal fader. This test pins the new heuristic:
+// default horizontal, vertical only when an explicit hint (aria-
+// orientation or style.height > style.width) says so.
+//
+// Both gaps are part of the Spectr webview-baseline visual chase
+// (#1899). Closing them is expected to bump the native-vs-webview
+// diff score from ~0.662 toward 0.70+.
+
+#include <catch2/catch_test_macros.hpp>
+#include "test_helpers.hpp"
+#include <pulp/view/svg_path_widget.hpp>
+#include <pulp/view/widgets.hpp>
+
+using namespace pulp::test;
+using namespace pulp::view;
+
+namespace {
+
+inline std::string js_id(TestEnvironment& env, const std::string& js_var) {
+    return std::string(env.engine.evaluate(js_var + "._id")
+                            .getWithDefault<std::string_view>(""));
+}
+
+inline View* resolve(TestEnvironment& env, const std::string& js_var) {
+    auto id = js_id(env, js_var);
+    REQUIRE_FALSE(id.empty());
+    auto* w = env.widget(id);
+    REQUIRE(w != nullptr);
+    return w;
+}
+
+} // namespace
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gap #4 — `<path>` routes to SvgPathWidget; d / stroke / stroke-width /
+// fill / viewBox propagate through the bridge.
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("svg-1899 (#4): <svg><path>...</path></svg> creates an SvgPathWidget",
+          "[svg][import][spectr][issue-1899]") {
+    TestEnvironment env(400, 200);
+    env.eval(R"JS(
+        var __svg = document.createElement('svg');
+        __svg.setAttribute('viewBox', '0 0 24 24');
+        __svg.setAttribute('width',  '22');
+        __svg.setAttribute('height', '16');
+
+        var __path = document.createElement('path');
+        __path.setAttribute('d', 'M 2 12 C 8 12 8 4 12 4');
+        __path.setAttribute('stroke', '#ffffff');
+        __path.setAttribute('stroke-width', '2');
+        __path.setAttribute('fill', 'none');
+
+        __svg.appendChild(__path);
+        document.body.appendChild(__svg);
+    )JS");
+    env.root.layout_children();
+
+    auto* path = resolve(env, "__path");
+    auto* svg_widget = dynamic_cast<SvgPathWidget*>(path);
+    REQUIRE(svg_widget != nullptr);                       // routed, not createCol
+    REQUIRE(svg_widget->path_data() == "M 2 12 C 8 12 8 4 12 4");
+    REQUIRE(svg_widget->has_stroke());                    // stroke="#ffffff" applied
+    REQUIRE(svg_widget->stroke_width() == 2.0f);
+    REQUIRE_FALSE(svg_widget->has_fill());                // fill="none" → cleared
+    REQUIRE(svg_widget->viewbox_width()  == 24.0f);       // inherited from parent <svg>
+    REQUIRE(svg_widget->viewbox_height() == 24.0f);
+}
+
+TEST_CASE("svg-1899 (#4): camelCase strokeWidth attribute also routes",
+          "[svg][import][spectr][issue-1899]") {
+    // JSX historically passes `strokeWidth` rather than the HTML
+    // `stroke-width`. Either spelling must reach setSvgStrokeWidth so
+    // raw-React imports without a build-time prop-applier still work.
+    TestEnvironment env(400, 200);
+    env.eval(R"JS(
+        var __svg = document.createElement('svg');
+        __svg.setAttribute('viewBox', '0 0 16 16');
+        var __path = document.createElement('path');
+        __path.setAttribute('d', 'M0 0 L 16 16');
+        __path.setAttribute('stroke', '#ff0000');
+        __path.setAttribute('strokeWidth', '3');
+        __svg.appendChild(__path);
+        document.body.appendChild(__svg);
+    )JS");
+    env.root.layout_children();
+
+    auto* widget = dynamic_cast<SvgPathWidget*>(resolve(env, "__path"));
+    REQUIRE(widget != nullptr);
+    REQUIRE(widget->stroke_width() == 3.0f);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gap #5 — `<input type="range">` defaults to horizontal orientation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("range-1899 (#5): <input type=range> defaults to HORIZONTAL",
+          "[input][range][spectr][issue-1899]") {
+    TestEnvironment env(400, 200);
+    env.eval(R"JS(
+        var __slider = document.createElement('input');
+        __slider.type = 'range';
+        __slider.min  = '0';
+        __slider.max  = '1';
+        __slider.value = '0.5';
+        __slider.style.width = '90px';
+        document.body.appendChild(__slider);
+    )JS");
+    env.root.layout_children();
+
+    auto* fader = dynamic_cast<Fader*>(resolve(env, "__slider"));
+    REQUIRE(fader != nullptr);
+    REQUIRE(fader->orientation() == Fader::Orientation::horizontal);
+}
+
+TEST_CASE("range-1899 (#5): aria-orientation=vertical opts into vertical",
+          "[input][range][spectr][issue-1899]") {
+    // An explicit `aria-orientation="vertical"` is the only documented
+    // way for an author to flip the slider to vertical. Pin that hook
+    // so vertical mixer-style faders keep working.
+    TestEnvironment env(400, 400);
+    env.eval(R"JS(
+        var __slider = document.createElement('input');
+        __slider.type = 'range';
+        __slider.setAttribute('aria-orientation', 'vertical');
+        __slider.style.height = '160px';
+        document.body.appendChild(__slider);
+    )JS");
+    env.root.layout_children();
+
+    auto* fader = dynamic_cast<Fader*>(resolve(env, "__slider"));
+    REQUIRE(fader != nullptr);
+    REQUIRE(fader->orientation() == Fader::Orientation::vertical);
+}
+
+TEST_CASE("range-1899 (#5): style.height > style.width also flips to vertical",
+          "[input][range][spectr][issue-1899]") {
+    // Authors who shape the input element as a tall column without
+    // setting aria-orientation should still get a vertical fader.
+    TestEnvironment env(400, 400);
+    env.eval(R"JS(
+        var __slider = document.createElement('input');
+        __slider.type = 'range';
+        __slider.style.width = '20px';
+        __slider.style.height = '200px';
+        document.body.appendChild(__slider);
+    )JS");
+    env.root.layout_children();
+
+    auto* fader = dynamic_cast<Fader*>(resolve(env, "__slider"));
+    REQUIRE(fader != nullptr);
+    REQUIRE(fader->orientation() == Fader::Orientation::vertical);
+}

--- a/test/web-compat/test_svg_path_range_orientation_1899.cpp
+++ b/test/web-compat/test_svg_path_range_orientation_1899.cpp
@@ -165,3 +165,91 @@ TEST_CASE("range-1899 (#5): style.height > style.width also flips to vertical",
     REQUIRE(fader != nullptr);
     REQUIRE(fader->orientation() == Fader::Orientation::vertical);
 }
+
+// pulp #1917 (Codex P1 review of #1899). Pre-fix, the predicate
+// `hasH && !hasW → vertical` flipped any slider with inline height
+// but flex-supplied width into vertical orientation. The new
+// predicate requires BOTH height and width inline-explicit before
+// comparing, so a horizontal slider whose width comes from flex
+// layout stays horizontal.
+TEST_CASE("range-1917 (P1): inline height without inline width stays HORIZONTAL",
+          "[input][range][issue-1917][regression]") {
+    TestEnvironment env(400, 200);
+    env.eval(R"JS(
+        var __slider = document.createElement('input');
+        __slider.type = 'range';
+        // Author sets height inline (control row height) but lets the
+        // parent flex container determine width. Pre-fix this snapped
+        // to vertical; post-fix it stays horizontal (HTML default).
+        __slider.style.height = '24px';
+        document.body.appendChild(__slider);
+    )JS");
+    env.root.layout_children();
+
+    auto* fader = dynamic_cast<Fader*>(resolve(env, "__slider"));
+    REQUIRE(fader != nullptr);
+    REQUIRE(fader->orientation() == Fader::Orientation::horizontal);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// pulp #1917 (Codex P1) — SVG `currentColor` resolution.
+//
+// Pre-fix, `stroke="currentColor"` was forwarded to the C++ widget as the
+// literal token, which the bridge does not parse. Post-fix the JS shim
+// resolves it against the element's CSS `color` cascade before dispatch,
+// falling back to "black" per the SVG spec when no `color` is set.
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("svg-1917 (P1): stroke=currentColor resolves to inline style.color",
+          "[svg][currentColor][issue-1917]") {
+    TestEnvironment env(400, 200);
+    env.eval(R"JS(
+        var __svg = document.createElement('svg');
+        __svg.setAttribute('viewBox', '0 0 24 24');
+        __svg.style.color = '#ff8800'; // CSS color cascade source (orange)
+        var __path = document.createElement('path');
+        __path.setAttribute('d', 'M0 0 L 24 24');
+        __path.setAttribute('stroke', 'currentColor');
+        __path.setAttribute('stroke-width', '2');
+        __svg.appendChild(__path);
+        document.body.appendChild(__svg);
+    )JS");
+    env.root.layout_children();
+
+    auto* widget = dynamic_cast<SvgPathWidget*>(resolve(env, "__path"));
+    REQUIRE(widget != nullptr);
+    REQUIRE(widget->has_stroke());
+    // Pre-fix, the literal "currentColor" token reached parseColor in the
+    // bridge, which fell through and returned the default (white 1,1,1,1).
+    // Post-fix, the JS shim resolves to #ff8800 (orange) before dispatch.
+    auto c = widget->stroke_color();
+    REQUIRE(c.r > 0.95f);                 // 0xff
+    REQUIRE((c.g > 0.45f && c.g < 0.60f)); // 0x88 ≈ 0.533
+    REQUIRE(c.b < 0.05f);                  // 0x00
+}
+
+TEST_CASE("svg-1917 (P1): stroke=currentColor with no cascade defaults to black",
+          "[svg][currentColor][issue-1917]") {
+    TestEnvironment env(400, 200);
+    env.eval(R"JS(
+        var __svg = document.createElement('svg');
+        __svg.setAttribute('viewBox', '0 0 24 24');
+        var __path = document.createElement('path');
+        __path.setAttribute('d', 'M0 0 L 24 24');
+        __path.setAttribute('stroke', 'currentColor');
+        __svg.appendChild(__path);
+        document.body.appendChild(__svg);
+    )JS");
+    env.root.layout_children();
+
+    auto* widget = dynamic_cast<SvgPathWidget*>(resolve(env, "__path"));
+    REQUIRE(widget != nullptr);
+    REQUIRE(widget->has_stroke());
+    // SVG spec: when `color` is unset anywhere in the cascade, currentColor
+    // defaults to black. The JS shim substitutes "black" before dispatch;
+    // parseColor's named-color table maps "black" → 0x000000.
+    auto c = widget->stroke_color();
+    REQUIRE(c.r < 0.05f);
+    REQUIRE(c.g < 0.05f);
+    REQUIRE(c.b < 0.05f);
+}


### PR DESCRIPTION
## Summary
Closes two layered visual gaps in the Spectr import-flow chase (#1899):

- **Gap #4 — `<path>` routing**: routes lowercase `<path>` to the existing SvgPathWidget in both the `_ensureNative` (createElement) and `__domAppend` (React commit) paths. Replays `d` / `stroke` / `stroke-width` / `fill` from pre-mount `_attributes` plus inherits `viewBox` from the parent `<svg>`. Accepts both kebab-case and camelCase.
- **Gap #5 — `<input type=range>` orientation**: defaults to horizontal (HTML / MDN / Web-Audio convention). New `__resolveRangeOrientation__()` honors `aria-orientation` then `style.height > style.width`. Threaded as an optional 4th hint arg through `__domAppend` so the React fast-path materializes a Fader (not a plain View).

## Test plan
- 5 new tests in `test/web-compat/test_svg_path_range_orientation_1899.cpp`, 25 assertions, all pass locally.
- pulp-screenshot against Spectr's editor.js renders the top bar correctly.
- Independent of PR #1906; both required for full visual parity.

Note: opened via REST after `gh pr create` hit a GraphQL rate-limit; reset at 17:09Z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)