### PR TITLE
fix(canvas+pulp-react): disable LCD subpixel AA inside non-opaque layers; resolve var() in React fontFamily/color (closes gap #3 of #1899)

### DIFF
--- a/.agents/skills/engine/SKILL.md
+++ b/.agents/skills/engine/SKILL.md
@@ -280,3 +280,35 @@ state, follow this checklist or you'll land a silent no-op:
 This pattern landed for shadow* (#1434), miter / image-smoothing
 (#1434 bridge-thin), and direction / filter (#1520). Copy the same
 shape for the next canvas2d catalog setter.
+
+### String-valued custom CSS properties (`var(--mono)` etc., #1899)
+
+`setProperty('--name', value)` in `web-compat-style-decl.js` (and the
+mirror in `web-compat.js`) has THREE tiers, not the original two:
+
+1. **Length** (`parseCSSLength`) → `setMotionToken` writes
+   `theme.dimensions[name]`.
+2. **Color** (`parseCSSColor`) → `applyTokenDiff` writes
+   `theme.colors[color.name]`.
+3. **String fallback** → `setStringToken(name, value)` writes
+   `theme.strings[name]`. This is what catches font families
+   (`--mono: "JetBrains Mono"`) and any other arbitrary string.
+
+Without tier 3, font-family-shaped custom properties were silently
+dropped at set time and `var(--mono)` resolved to `0` (the
+`getMotionToken` empty-token return). `getPropertyValue` mirrors the
+same tier order — string token first, then numeric — so the
+round-trip works.
+
+`getStringToken` and `setStringToken` are bridge fns registered in
+`core/view/src/widget_bridge.cpp` next to `getMotionToken` /
+`setMotionToken`.
+
+The React-side mirror lives in `packages/pulp-react/src/prop-applier.ts`
+as `_resolveVar(value)`, with the same lookup tiers (developer-set
+`__pulpCssVars` registry → `getStringToken` → `getMotionToken` →
+fallback). Call it from every string-valued style prop case that
+might receive `var(--name)` from JSX — see the `fontFamily` /
+`color` / `borderColor*` / `outlineColor` / `textDecorationColor` /
+`textShadowColor` / `shadowColor` / `background` cases for the
+canonical wiring.

--- a/core/canvas/include/pulp/canvas/skia_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/skia_canvas.hpp
@@ -384,6 +384,30 @@ private:
         int save_count_after_open;     // canvas_->getSaveCount() AFTER saveLayer
     };
     std::vector<PendingMask> pending_masks_;
+
+public:
+    // pulp #1899 (gap #3 — text edging in opacity layers) — returns true
+    // when at least one currently-open save_layer* has alpha < 1 on its
+    // layer-paint. Text paint paths (fill_text, stroke_text) consult
+    // this at paint time and select greyscale AA over LCD subpixel AA
+    // — Skia's LCD subpixel patterns can't antialias correctly into a
+    // partially transparent pixel, so glyphs render faint inside
+    // CSS-opacity layers without this flip. Browsers (Blink / WebKit)
+    // do the same. Exposed publicly so tests can assert the stack-
+    // tracking around nested save_layer / restore / restore_to_count.
+    bool inside_non_opaque_layer() const {
+        return !non_opaque_layer_stack_.empty();
+    }
+
+private:
+    // pulp #1899 (gap #3) — each entry is Skia's getSaveCount() AFTER
+    // the layer was opened. restore() pops the top entry if its save
+    // count matches the canvas's current save count; restore_to_count()
+    // pops any entries strictly above the target (mirrors
+    // SkCanvas::restoreToCount). Plain save() / save_layer with
+    // opacity == 1 do not push.
+    std::vector<int> non_opaque_layer_stack_;
+
     TextAlign text_align_ = TextAlign::left;
 
     // Gradient state

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -305,11 +305,23 @@ static sk_sp<SkTypeface> get_cached_typeface(const std::string& family) {
 
 static SkFont make_font(const std::string& family, float size,
                         int weight = SkFontStyle::kNormal_Weight,
-                        int slant = 0) {
+                        int slant = 0,
+                        bool non_opaque_dst = false) {
     SkFont font;
     font.setSize(size);
     font.setSubpixel(true);                               // Subpixel glyph positioning
-    font.setEdging(SkFont::Edging::kSubpixelAntiAlias);   // LCD-quality anti-aliasing
+    // pulp #1899 (gap #3) — LCD subpixel AA visibly degrades when the
+    // destination surface isn't opaque: Skia's documented behavior is
+    // that subpixel patterns can't antialias correctly into a partially
+    // transparent pixel, so glyphs come out faint inside save_layer
+    // contexts that carry alpha < 1 (e.g. an ancestor View opens
+    // saveLayer(opacity = 0.6) for CSS opacity). Browsers
+    // (Blink / WebKit) flip the same way — greyscale AA inside
+    // non-opaque layers. Callers pass `non_opaque_dst=true` when any
+    // currently-open SkiaCanvas layer was opened with alpha < 1.
+    font.setEdging(non_opaque_dst
+        ? SkFont::Edging::kAntiAlias            // Greyscale AA (browser parity inside opacity layers)
+        : SkFont::Edging::kSubpixelAntiAlias);  // LCD-quality AA on opaque destinations
     font.setHinting(SkFontHinting::kSlight);               // Light hinting preserves glyph shapes
     font.setLinearMetrics(true);                           // Linear scaling for consistent metrics
 
@@ -377,6 +389,14 @@ void SkiaCanvas::restore() {
         }
         // Falls through to the outer restore() below.
     }
+    // pulp #1899 (gap #3) — pop the non-opaque layer stack if the
+    // layer we're about to close was tracked. Save count is captured
+    // before delegating to canvas_->restore() so it matches the depth
+    // recorded at push time.
+    if (!non_opaque_layer_stack_.empty() &&
+        non_opaque_layer_stack_.back() == canvas_->getSaveCount()) {
+        non_opaque_layer_stack_.pop_back();
+    }
     canvas_->restore();
 }
 
@@ -397,7 +417,15 @@ void SkiaCanvas::restore_to_count(int target) {
     // match that contract so a CanvasWidget that captured save_count()
     // == 4 at entry and got back depth 7 (three leaked saves) returns
     // to exactly 4 at exit. SkCanvas guards target == 0 internally.
-    canvas_->restoreToCount(target < 1 ? 1 : target);
+    const int safe_target = target < 1 ? 1 : target;
+    // pulp #1899 (gap #3) — drop any tracked non-opaque layers whose
+    // save count is strictly above the target, since SkCanvas is about
+    // to close all of them in one shot.
+    while (!non_opaque_layer_stack_.empty() &&
+           non_opaque_layer_stack_.back() > safe_target) {
+        non_opaque_layer_stack_.pop_back();
+    }
+    canvas_->restoreToCount(safe_target);
 }
 
 void SkiaCanvas::translate(float x, float y) { GUARD_CANVAS; canvas_->translate(x, y); }
@@ -1306,7 +1334,12 @@ void SkiaCanvas::fill_text(const std::string& text, float x, float y) {
     GUARD_CANVAS;
     if (text.empty()) return;
 
-    SkFont font = make_font(font_family_, font_size_, font_weight_, font_slant_);
+    // pulp #1899 (gap #3) — when any currently-open save_layer carries
+    // alpha < 1, Skia's LCD subpixel AA degrades on the non-opaque
+    // destination and glyphs render faint. make_font() falls back to
+    // greyscale AA in that case (browser parity).
+    SkFont font = make_font(font_family_, font_size_, font_weight_, font_slant_,
+                            inside_non_opaque_layer());
     if (!font.getTypeface()) return;
 
     // pulp Wave 3 c2d.6 — gradient (and pattern) fillStyle on text. Route
@@ -1459,7 +1492,11 @@ void SkiaCanvas::stroke_text(const std::string& text, float x, float y,
     // — we only swap the paint's style flag.
     GUARD_CANVAS;
     if (text.empty()) return;
-    SkFont font = make_font(font_family_, font_size_, font_weight_, font_slant_);
+    // pulp #1899 (gap #3) — see fill_text comment. Mirror the edging
+    // policy so stroked glyphs inside an opacity layer track the
+    // greyscale-AA path that fill_text uses.
+    SkFont font = make_font(font_family_, font_size_, font_weight_, font_slant_,
+                            inside_non_opaque_layer());
     if (!font.getTypeface()) return;
 
     auto stroke_paint = make_stroke_paint(stroke_color_, line_width_);
@@ -2794,6 +2831,12 @@ void SkiaCanvas::save_layer(float x, float y, float w, float h,
     }
 
     canvas_->saveLayer(&bounds, &layer_paint);
+
+    // pulp #1899 (gap #3) — record that this layer's destination is
+    // non-opaque so text-paint paths inside it use greyscale AA.
+    if (opacity < 1.0f) {
+        non_opaque_layer_stack_.push_back(canvas_->getSaveCount());
+    }
 }
 
 // pulp #1549 — saveLayer with explicit blend mode. The layer-paint's blend
@@ -2820,6 +2863,12 @@ void SkiaCanvas::save_layer_with_blend(float x, float y, float w, float h,
     }
 
     canvas_->saveLayer(&bounds, &layer_paint);
+
+    // pulp #1899 (gap #3) — mirror save_layer(): track non-opaque layer
+    // so text inside it picks greyscale AA over LCD subpixel AA.
+    if (opacity < 1.0f) {
+        non_opaque_layer_stack_.push_back(canvas_->getSaveCount());
+    }
 }
 
 
@@ -3034,6 +3083,11 @@ void SkiaCanvas::save_layer_with_filters(float x, float y, float w, float h,
     if (opacity < 1.0f) layer_paint.setAlphaf(opacity);
 
     canvas_->saveLayer(&bounds, &layer_paint);
+
+    // pulp #1899 (gap #3) — track non-opaque destination for text-edging.
+    if (opacity < 1.0f) {
+        non_opaque_layer_stack_.push_back(canvas_->getSaveCount());
+    }
 }
 
 void SkiaCanvas::save_backdrop_filter(float x, float y, float w, float h,
@@ -3484,6 +3538,12 @@ void SkiaCanvas::save_layer_with_mask(float x, float y, float w, float h,
     SkPaint outer_paint;
     if (opacity < 1.0f) outer_paint.setAlphaf(opacity);
     canvas_->saveLayer(&bounds, &outer_paint);
+
+    // pulp #1899 (gap #3) — non-opaque text-edging tracking, mirrors
+    // the other save_layer* variants.
+    if (opacity < 1.0f) {
+        non_opaque_layer_stack_.push_back(canvas_->getSaveCount());
+    }
 
     // Always push a PendingMask so restore() pops one entry per
     // save_layer_with_mask call. Null shader means "no mask to apply,

--- a/core/view/js/css-parser.js
+++ b/core/view/js/css-parser.js
@@ -501,14 +501,24 @@ function _resolveVar(str, depth) {
         }
         if (name.indexOf("--") === 0) name = name.slice(2);
 
-        var val = getMotionToken(name);
-        if (val !== 0 && val !== undefined) {
-            out += String(val);
-        } else if (fallback !== undefined) {
-            // Recurse so nested var() in the fallback resolves too.
-            out += _resolveVar(fallback, depth + 1);
+        // pulp #1899 (gap #3) — consult the string-token map first so
+        // font-family-shaped tokens (`--mono: "JetBrains Mono"`)
+        // resolve to the registered string rather than zero. Falls
+        // through to the motion-token (numeric) lookup for legacy
+        // length/spacing tokens.
+        var strVal = (typeof getStringToken === 'function') ? getStringToken(name) : '';
+        if (strVal) {
+            out += String(strVal);
         } else {
-            out += "0";
+            var val = getMotionToken(name);
+            if (val !== 0 && val !== undefined) {
+                out += String(val);
+            } else if (fallback !== undefined) {
+                // Recurse so nested var() in the fallback resolves too.
+                out += _resolveVar(fallback, depth + 1);
+            } else {
+                out += "0";
+            }
         }
         i = j + 1;
     }

--- a/core/view/js/web-compat-style-decl.js
+++ b/core/view/js/web-compat-style-decl.js
@@ -2001,6 +2001,14 @@ CSSStyleDeclaration.prototype.setProperty = function(name, value) {
             if (color) {
                 // Use applyTokenDiff for color tokens
                 applyTokenDiff('{"colors":{"' + tokenName + '":"' + color + '"}}');
+            } else if (typeof setStringToken === 'function') {
+                // pulp #1899 (gap #3) — string-valued custom property
+                // (e.g. `--mono: "JetBrains Mono"`). Store on
+                // theme.strings so resolveVar() on the React side and
+                // getPropertyValue() below can read it back. Without
+                // this, fontFamily-shaped custom properties were
+                // silently dropped at setProperty time.
+                setStringToken(tokenName, String(value));
             }
         }
     } else {
@@ -2013,6 +2021,14 @@ CSSStyleDeclaration.prototype.setProperty = function(name, value) {
 CSSStyleDeclaration.prototype.getPropertyValue = function(name) {
     if (name.indexOf("--") === 0) {
         var tokenName = name.slice(2);
+        // pulp #1899 (gap #3) — prefer the string-token map for
+        // values that weren't parseable as length / color at set time
+        // (e.g. font families). Fall back to the motion-token value
+        // otherwise to preserve legacy numeric token reads.
+        if (typeof getStringToken === 'function') {
+            var s = getStringToken(tokenName);
+            if (s) return s;
+        }
         return String(getMotionToken(tokenName));
     }
     var camel = name.replace(/-([a-z])/g, function(_, c) { return c.toUpperCase(); });

--- a/core/view/js/web-compat-style-decl.js
+++ b/core/view/js/web-compat-style-decl.js
@@ -1992,6 +1992,16 @@ CSSStyleDeclaration.prototype.setProperty = function(name, value) {
     // --custom-property -> set as theme token
     if (name.indexOf("--") === 0) {
         var tokenName = name.slice(2);
+        // pulp #1918 (Codex review) — custom-property storage spans
+        // three theme slots: dimensions (motion), colors, strings.
+        // When a var() is reassigned from one value-type to another
+        // (e.g. `--my-var: "red"` → `--my-var: 12px`) the OLD slot
+        // would otherwise retain a stale token, and the React-side
+        // resolver checks strings BEFORE motion — so the stale string
+        // would shadow the new length. Conservatively clear every
+        // non-active slot up front, then write the new value.
+        if (typeof setStringToken === 'function') setStringToken(tokenName, "");
+        if (typeof setMotionToken === 'function') setMotionToken(tokenName, 0);
         var parsed = parseCSSLength(value);
         if (parsed) {
             setMotionToken(tokenName, parsed.value);

--- a/core/view/js/web-compat.js
+++ b/core/view/js/web-compat.js
@@ -1537,6 +1537,13 @@ CSSStyleDeclaration.prototype.setProperty = function(name, value) {
     // --custom-property -> set as theme token
     if (name.indexOf("--") === 0) {
         var tokenName = name.slice(2);
+        // pulp #1918 (Codex review) — clear every non-active slot
+        // first so a var() reassignment that changes the value type
+        // (string ↔ length ↔ color) doesn't leave a stale token in
+        // one of the other slots. See the matching fix and rationale
+        // in web-compat-style-decl.js.
+        if (typeof setStringToken === 'function') setStringToken(tokenName, "");
+        if (typeof setMotionToken === 'function') setMotionToken(tokenName, 0);
         var parsed = parseCSSLength(value);
         if (parsed) {
             setMotionToken(tokenName, parsed.value);

--- a/core/view/js/web-compat.js
+++ b/core/view/js/web-compat.js
@@ -1546,6 +1546,11 @@ CSSStyleDeclaration.prototype.setProperty = function(name, value) {
             if (color) {
                 // Use applyTokenDiff for color tokens
                 applyTokenDiff('{"colors":{"' + tokenName + '":"' + color + '"}}');
+            } else if (typeof setStringToken === 'function') {
+                // pulp #1899 (gap #3) — string-valued custom property
+                // (font family / arbitrary string). Mirrors
+                // web-compat-style-decl.js.
+                setStringToken(tokenName, String(value));
             }
         }
     } else {
@@ -1558,6 +1563,12 @@ CSSStyleDeclaration.prototype.setProperty = function(name, value) {
 CSSStyleDeclaration.prototype.getPropertyValue = function(name) {
     if (name.indexOf("--") === 0) {
         var tokenName = name.slice(2);
+        // pulp #1899 (gap #3) — string-token round-trip; mirrors
+        // web-compat-style-decl.js.
+        if (typeof getStringToken === 'function') {
+            var s = getStringToken(tokenName);
+            if (s) return s;
+        }
         return String(getMotionToken(tokenName));
     }
     var camel = name.replace(/-([a-z])/g, function(_, c) { return c.toUpperCase(); });

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -1609,6 +1609,36 @@ void WidgetBridge::register_api() {
         return choc::value::createFloat64(d.value_or(0.0f));
     });
 
+    // pulp #1899 (gap #3) — string-valued theme-token lookup.
+    // setStringToken(name, value) / getStringToken(name) parallel the
+    // motion-token / color-token APIs but back onto `theme.strings`
+    // (the same map that already stores design-system font names
+    // imported via Stitch / W3C tokens — see design_import.cpp). The
+    // React-side prop-applier consults this to resolve `var(--mono)`
+    // in `fontFamily` / `color` / `borderColor` etc. before forwarding
+    // to setFontFamily / setTextColor — without this, Skia's font
+    // matcher received the literal string "var(--mono)" as a family
+    // name and fell through to a proportional sans, which is visible
+    // as the Spectr top-bar "faint label" symptom from #1899.
+    engine_.register_function("setStringToken", [this](choc::javascript::ArgumentList args) {
+        auto name = args.get<std::string>(0, "");
+        auto value = args.get<std::string>(1, "");
+        if (name.empty()) return choc::value::Value();
+        auto theme = root_.theme();
+        theme.strings[name] = value;
+        root_.set_theme(theme);
+        return choc::value::Value();
+    });
+
+    // getStringToken(tokenName) -> string. Returns empty string when the
+    // token isn't defined — callers (e.g. prop-applier resolveVar) treat
+    // empty as "miss" and try the next lookup tier.
+    engine_.register_function("getStringToken", [this](choc::javascript::ArgumentList args) {
+        auto name = args.get<std::string>(0, "");
+        auto s = root_.theme().string_token(name);
+        return choc::value::createString(s.value_or(std::string()));
+    });
+
     // setVisible(id, bool)
     engine_.register_function("setVisible", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");

--- a/packages/pulp-react/src/bridge.ts
+++ b/packages/pulp-react/src/bridge.ts
@@ -380,6 +380,12 @@ export function createMockBridge(): MockBridge {
         'createSvgLine', 'setSvgLine',
         // pulp #1148 — generalized overlay-click routing
         'claimOverlay', 'releaseOverlay',
+        // pulp #1899 (gap #3) — string-token bridge fns. setStringToken
+        // writes theme.strings[name]; getStringToken reads it back. The
+        // prop-applier _resolveVar helper consults getStringToken to
+        // resolve var(--mono) etc. in fontFamily / color / borderColor
+        // before forwarding to the bridge.
+        'setStringToken', 'getStringToken',
     ];
     const saved: Record<string, unknown> = {};
     return {

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -113,6 +113,103 @@ function isWheelEvent(eventName: string): boolean {
     return eventName === 'wheel';
 }
 
+// pulp #1899 (gap #3) — resolve `var(--name [, fallback])` references in
+// string-valued style props before forwarding to the bridge.
+//
+// The HTML-shim path (`core/view/js/css-parser.js`) already resolves
+// var() via the same lookup tiers, but the React-prop-applier lane
+// bypasses that — it forwards the raw `style.fontFamily` value straight
+// into `setFontFamily`. The string "var(--mono)" then reached Skia's
+// font matcher as a literal family name, returned no match, and fell
+// through to a proportional sans (visible as the Spectr top-bar "faint
+// label" symptom — labels rendered in the wrong typeface AND in a layer
+// that degraded the LCD AA, compounding the faintness).
+//
+// Resolution tiers (first hit wins):
+//   1. `globalThis.__pulpCssVars[name]` — developer-set runtime
+//       registry. Apps populate this at mount when they have direct
+//       knowledge of which CSS variables map to which strings.
+//   2. `getStringToken(name)` — bridge call into `theme.strings` (the
+//       same map design-import.cpp writes when loading Stitch / W3C
+//       tokens, and the same map `setStringToken` from the CSS shim
+//       writes for string-valued custom properties).
+//   3. `getMotionToken(name)` — bridge call into `theme.dimensions`
+//       (only useful when the var is numeric — fontFamily callers
+//       won't hit this branch, but length-typed callers might).
+//   4. The literal fallback supplied as `var(--name, FALLBACK)`.
+//   5. The original string, returned unchanged so the caller can decide
+//       how to handle the miss.
+//
+// The regex match is conservative: only top-level `^var(...)` is
+// resolved. Embedded `calc(var(...) + 10px)` is out of scope for the
+// React lane — the bridge consumers for `fontFamily` / `color` /
+// `borderColor` etc. don't accept calc-expressions anyway.
+function _resolveVar(value: unknown): unknown {
+    if (typeof value !== 'string') return value;
+    const s = value.trim();
+    if (!s.startsWith('var(') || !s.endsWith(')')) return value;
+
+    // Find the FIRST top-level comma inside var(...) so a nested
+    // `var(--a, var(--b, default))` is split at the right point.
+    const inner = s.slice(4, s.length - 1);
+    let commaPos = -1;
+    let depth = 0;
+    for (let i = 0; i < inner.length; i++) {
+        const c = inner.charAt(i);
+        if (c === '(') depth++;
+        else if (c === ')') depth--;
+        else if (c === ',' && depth === 0) { commaPos = i; break; }
+    }
+
+    let name: string;
+    let fallback: string | undefined;
+    if (commaPos >= 0) {
+        name = inner.slice(0, commaPos).trim();
+        fallback = inner.slice(commaPos + 1).trim();
+    } else {
+        name = inner.trim();
+    }
+    if (name.startsWith('--')) name = name.slice(2);
+    if (!name) return value;
+
+    // Tier 1: runtime developer-set registry.
+    const reg = (globalThis as Record<string, unknown>).__pulpCssVars as
+        | Record<string, string> | undefined;
+    if (reg && typeof reg[name] === 'string' && reg[name]) {
+        return reg[name];
+    }
+
+    // Tier 2: theme.strings via bridge.
+    const getStr = (globalThis as Record<string, unknown>).getStringToken as
+        | ((n: string) => string) | undefined;
+    if (typeof getStr === 'function') {
+        const sv = getStr(name);
+        if (typeof sv === 'string' && sv) return sv;
+    }
+
+    // Tier 3: theme.dimensions via bridge (numeric tokens).
+    const getNum = (globalThis as Record<string, unknown>).getMotionToken as
+        | ((n: string) => number) | undefined;
+    if (typeof getNum === 'function') {
+        const nv = getNum(name);
+        if (typeof nv === 'number' && nv !== 0 && Number.isFinite(nv)) {
+            return String(nv);
+        }
+    }
+
+    // Tier 4: explicit fallback. Recurse so `var(--a, var(--b, 0))`
+    // walks the chain. Cap recursion via the input shrinking strictly
+    // on each step (we strip one var() wrapper per call).
+    if (fallback !== undefined && fallback.length > 0) {
+        return _resolveVar(fallback);
+    }
+
+    // Tier 5: surface the original unresolved string. Better than ""
+    // because downstream Skia / View code can at least log the unknown
+    // token name.
+    return value;
+}
+
 // pulp #1434 (batch 3) — translate CSS / React-Native fontWeight keyword
 // values to numeric weights before reaching the bridge. Mirrors the same
 // logic in the JS CSS shim (`web-compat-style-decl.js`). Numeric values
@@ -756,7 +853,11 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
                 return call('setBackgroundGradient', id, sval);
             }
             if (/^\s*url\s*\(/i.test(sval)) return;
-            return call('setBackground', id, sval);
+            // pulp #1899 (gap #3) — resolve var() for solid-color backgrounds
+            // (`background: var(--panel)`). Gradient strings keep their
+            // raw value because the gradient parser handles var() itself
+            // via the C++ shim.
+            return call('setBackground', id, _resolveVar(sval) as string);
         }
         case 'backgroundGradient': return call('setBackgroundGradient', id, value as string);
         // CSS `background-image` longhand. The C++ `setBackground` bridge fn
@@ -774,7 +875,8 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
             if (/^\s*url\s*\(/i.test(sval)) {
                 return;
             }
-            return call('setBackground', id, sval);
+            // pulp #1899 (gap #3) — mirror `background` above.
+            return call('setBackground', id, _resolveVar(sval) as string);
         }
         // pulp #1517 — background sub-properties. The bridge stores the
         // keyword on the View slot. Paint impact today is partial:
@@ -797,7 +899,7 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         // commitUpdate that touches only one of them preserves the others.
         // Lowering them onto the unified `setBorder(id, color, width, radius)`
         // would clobber the unset slots back to 0/empty.
-        case 'borderColor':  return call('setBorderColor', id, value as string);
+        case 'borderColor':  return call('setBorderColor', id, _resolveVar(value) as string);
         case 'borderWidth':  return call('setBorderWidth', id, value as number);
         // Wave 2 rn — `borderRadius` accepts the RN Fabric elliptical
         // form `{ x, y }`. The Skia paint backend currently takes a
@@ -856,10 +958,10 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         // RN per-side flat props — route to the per-side bridge setters
         // that already preserve the unrelated attribute (see widget_bridge
         // applyBorderSide helper introduced in pulp #1026).
-        case 'borderTopColor':       return call('setBorderTopColor', id, value as string);
-        case 'borderRightColor':     return call('setBorderRightColor', id, value as string);
-        case 'borderBottomColor':    return call('setBorderBottomColor', id, value as string);
-        case 'borderLeftColor':      return call('setBorderLeftColor', id, value as string);
+        case 'borderTopColor':       return call('setBorderTopColor', id, _resolveVar(value) as string);
+        case 'borderRightColor':     return call('setBorderRightColor', id, _resolveVar(value) as string);
+        case 'borderBottomColor':    return call('setBorderBottomColor', id, _resolveVar(value) as string);
+        case 'borderLeftColor':      return call('setBorderLeftColor', id, _resolveVar(value) as string);
         case 'borderTopWidth':       return call('setBorderTopWidth', id, value as number);
         case 'borderRightWidth':     return call('setBorderRightWidth', id, value as number);
         case 'borderBottomWidth':    return call('setBorderBottomWidth', id, value as number);
@@ -876,7 +978,7 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         // own per-attribute bridge fn so a JSX prop diff that touches one
         // outline-* preserves the others. Style keyword set mirrors
         // borderStyle (CSS spec is identical).
-        case 'outlineColor':  return call('setOutlineColor',  id, value as string);
+        case 'outlineColor':  return call('setOutlineColor',  id, _resolveVar(value) as string);
         case 'outlineOffset': return call('setOutlineOffset', id, value as number);
         case 'outlineStyle':  return call('setOutlineStyle',  id, value as string);
         case 'outlineWidth':  return call('setOutlineWidth',  id, value as number);
@@ -1060,7 +1162,7 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         //                     ::set_text_decoration_style.
         case 'verticalAlign':         return call('setVerticalAlign', id, value as string);
         case 'textAlignVertical':     return call('setVerticalAlign', id, value as string);
-        case 'textDecorationColor':   return call('setTextDecorationColor', id, value as string);
+        case 'textDecorationColor':   return call('setTextDecorationColor', id, _resolveVar(value) as string);
         case 'textDecorationStyle':   return call('setTextDecorationStyle', id, value as string);
 
         // pulp #1434 Phase A2-1 — CSS transitions. The bridge parses
@@ -1349,7 +1451,7 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         // before this — bridge has `setTextColor`, the dispatch case was
         // missing the alias.
         case 'color':
-        case 'textColor':       return call('setTextColor', id, value as string);
+        case 'textColor':       return call('setTextColor', id, _resolveVar(value) as string);
         // pulp #1434 — widen to include `'auto'` and `'justify'` (CSS /
         // RN canonical). `'auto'` is writing-direction-relative
         // (LTR-only today, degrades to `'left'`); `'justify'` flows to
@@ -1367,7 +1469,13 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         // registered with Skia fall through to the platform default.
         // Wiring is independent: when #932 lands, no consumer change
         // is needed — the registry just resolves the same name.
-        case 'fontFamily':      return call('setFontFamily', id, value as string);
+        // pulp #1899 (gap #3) — resolve `var(--mono)` before forwarding.
+        // The bridge expects a real family name; the literal "var(--mono)"
+        // gives Skia's font matcher nothing to match against and silently
+        // falls back to a proportional sans (e.g. Spectr top-bar labels
+        // rendered in the wrong typeface AND inside an opacity layer that
+        // degraded the LCD AA — both fixed in this change).
+        case 'fontFamily':      return call('setFontFamily', id, _resolveVar(value) as string);
         case 'fontSize':        return call('setFontSize', id, value as number);
         case 'fontWeight':      return call('setFontWeight', id, _normalizeFontWeight(value));
         case 'fontStyle':       return call('setFontStyle', id, value as string);
@@ -1410,7 +1518,7 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         // branch) every consumer flips on without a JSX-side change.
         // Each per-attribute setter writes ONE slot in isolation so a
         // diff that touches one prop doesn't clobber the others.
-        case 'textShadowColor':  return call('setTextShadowColor',  id, value as string);
+        case 'textShadowColor':  return call('setTextShadowColor',  id, _resolveVar(value) as string);
         case 'textShadowOffset': {
             // RN spec: `{ width, height }` (number / number).
             const o = value as { width?: number; height?: number };
@@ -1430,7 +1538,7 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         // textShadow* fan-out above. Each per-attribute setter writes
         // ONE slot of View::shadow_ in isolation so a JSX diff that
         // touches one prop doesn't clobber the others.
-        case 'shadowColor':   return call('setShadowColor',   id, value as string);
+        case 'shadowColor':   return call('setShadowColor',   id, _resolveVar(value) as string);
         case 'shadowOffset': {
             // RN spec: `{ width, height }` (number / number).
             const o = value as { width?: number; height?: number };

--- a/packages/pulp-react/test/prop-applier-var-resolve.test.ts
+++ b/packages/pulp-react/test/prop-applier-var-resolve.test.ts
@@ -1,0 +1,139 @@
+// pulp #1899 (gap #3) — `var(--name)` references in string-valued
+// style props must be resolved BEFORE the value reaches the bridge.
+// The raw string "var(--mono)" gives Skia's font matcher nothing to
+// match against, so the literal flows through silently and the rendered
+// text falls back to a proportional sans (Spectr top-bar "faint label"
+// symptom, compounded by the opacity-layer LCD AA degradation handled
+// on the C++ side).
+//
+// Resolution tiers (first hit wins): __pulpCssVars registry →
+// getStringToken bridge → getMotionToken bridge → explicit fallback →
+// original string passthrough.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { applyChangedProps } from '../src/prop-applier.js';
+import { createMockBridge, type MockBridge } from '../src/bridge.js';
+import type { PulpInstance } from '../src/types.js';
+
+let bridge: MockBridge;
+
+beforeEach(() => {
+    bridge = createMockBridge();
+    bridge.install();
+});
+afterEach(() => {
+    bridge.uninstall();
+    delete (globalThis as Record<string, unknown>).__pulpCssVars;
+});
+
+function makeInstance(id = 'l', type: string = 'Label'): PulpInstance {
+    return {
+        id,
+        type: type as PulpInstance['type'],
+        props: {},
+        childIds: [],
+        onBridge: true,
+        pendingChildren: [],
+    };
+}
+
+function callsOf(name: string) {
+    return bridge.calls.filter((c) => c.fn === name);
+}
+
+describe('prop-applier var() resolution (pulp #1899 gap #3)', () => {
+    it('fontFamily: var(--mono) resolves via __pulpCssVars registry', () => {
+        (globalThis as Record<string, unknown>).__pulpCssVars = {
+            mono: 'JetBrains Mono',
+        };
+        applyChangedProps(makeInstance(), {}, { fontFamily: 'var(--mono)' });
+        const calls = callsOf('setFontFamily');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].args).toEqual(['l', 'JetBrains Mono']);
+    });
+
+    it('fontFamily: var(--mono) resolves via getStringToken bridge call', () => {
+        // Install a getStringToken stub on globalThis (mirrors what the
+        // C++ bridge installs at runtime).
+        (globalThis as Record<string, unknown>).getStringToken = (
+            name: string,
+        ) => (name === 'mono' ? 'JetBrains Mono' : '');
+        applyChangedProps(makeInstance(), {}, { fontFamily: 'var(--mono)' });
+        const calls = callsOf('setFontFamily');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].args).toEqual(['l', 'JetBrains Mono']);
+        delete (globalThis as Record<string, unknown>).getStringToken;
+    });
+
+    it('color: var(--ink) resolves and dispatches setTextColor', () => {
+        (globalThis as Record<string, unknown>).__pulpCssVars = {
+            ink: '#e8e8e8',
+        };
+        applyChangedProps(makeInstance(), {}, { color: 'var(--ink)' });
+        const calls = callsOf('setTextColor');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].args).toEqual(['l', '#e8e8e8']);
+    });
+
+    it('borderColor: var(--panel-border) resolves through the registry', () => {
+        (globalThis as Record<string, unknown>).__pulpCssVars = {
+            'panel-border': '#333',
+        };
+        applyChangedProps(makeInstance(), {}, { borderColor: 'var(--panel-border)' });
+        const calls = callsOf('setBorderColor');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].args).toEqual(['l', '#333']);
+    });
+
+    it('falls through to explicit fallback when token is missing', () => {
+        // No registry, no bridge stubs — resolver should use the
+        // fallback inside the var() expression.
+        applyChangedProps(makeInstance(), {}, {
+            fontFamily: 'var(--missing, "SF Mono")',
+        });
+        const calls = callsOf('setFontFamily');
+        expect(calls).toHaveLength(1);
+        // The fallback is the literal string after the comma, trimmed.
+        // Quoted strings keep their quotes — Skia's font matcher strips
+        // them (issue-932 commit list test).
+        expect(calls[0].args[1]).toBe('"SF Mono"');
+    });
+
+    it('passes a non-var literal through unchanged', () => {
+        applyChangedProps(makeInstance(), {}, { fontFamily: 'Inter' });
+        const calls = callsOf('setFontFamily');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].args).toEqual(['l', 'Inter']);
+    });
+
+    it('resolves nested var(--a, var(--b, default)) via fallback chain', () => {
+        (globalThis as Record<string, unknown>).__pulpCssVars = {
+            // --a is undefined, --b resolves; the resolver should walk
+            // into the nested fallback and pick --b's value.
+            b: 'JetBrains Mono',
+        };
+        applyChangedProps(makeInstance(), {}, {
+            fontFamily: 'var(--a, var(--b, monospace))',
+        });
+        const calls = callsOf('setFontFamily');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].args).toEqual(['l', 'JetBrains Mono']);
+    });
+
+    it('passes the original string through when no tier resolves', () => {
+        // No registry, no fallback — emit the input so downstream code
+        // can log "unresolved var token". Better than swallowing
+        // silently or substituting "".
+        applyChangedProps(makeInstance(), {}, { fontFamily: 'var(--ghost)' });
+        const calls = callsOf('setFontFamily');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].args).toEqual(['l', 'var(--ghost)']);
+    });
+
+    it('does NOT mangle numeric / object values', () => {
+        applyChangedProps(makeInstance(), {}, { fontSize: 14 });
+        const calls = callsOf('setFontSize');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].args).toEqual(['l', 14]);
+    });
+});

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -3430,3 +3430,175 @@ TEST_CASE("pulp #1806 — begin_path resets between fill+stroke pairs",
     }
     REQUIRE(strokes == 2);
 }
+
+#ifdef PULP_HAS_SKIA
+// pulp #1899 (gap #3) — SkiaCanvas tracks every currently-open
+// save_layer whose layer-paint alpha is < 1. Text paint paths
+// (fill_text / stroke_text) consult `inside_non_opaque_layer()` at
+// paint time and select greyscale AA over LCD subpixel AA, so glyphs
+// stay legible inside CSS-opacity layers (browser parity). This test
+// asserts the stack state transitions across the four save_layer
+// entry points + plain save + restore + restore_to_count.
+TEST_CASE("SkiaCanvas tracks non-opaque layers for text edging "
+          "(pulp #1899 gap #3)", "[canvas][skia][issue-1899]") {
+    SkImageInfo info = SkImageInfo::Make(64, 64, kN32_SkColorType,
+                                         kPremul_SkAlphaType,
+                                         SkColorSpace::MakeSRGB());
+    auto surface = SkSurfaces::Raster(info);
+    REQUIRE(surface != nullptr);
+    auto* sk_canvas = surface->getCanvas();
+    REQUIRE(sk_canvas != nullptr);
+
+    SkiaCanvas canvas(sk_canvas);
+
+    // Baseline: no layer open → not inside non-opaque destination.
+    REQUIRE_FALSE(canvas.inside_non_opaque_layer());
+
+    SECTION("opacity < 1 layer flips the flag; restore clears it") {
+        canvas.save_layer(0, 0, 64, 64, /*opacity=*/0.5f, /*blur=*/0.0f);
+        REQUIRE(canvas.inside_non_opaque_layer());
+        canvas.restore();
+        REQUIRE_FALSE(canvas.inside_non_opaque_layer());
+    }
+
+    SECTION("opacity == 1 layer does NOT flip the flag") {
+        canvas.save_layer(0, 0, 64, 64, /*opacity=*/1.0f, /*blur=*/0.0f);
+        REQUIRE_FALSE(canvas.inside_non_opaque_layer());
+        canvas.restore();
+        REQUIRE_FALSE(canvas.inside_non_opaque_layer());
+    }
+
+    SECTION("plain save() never touches the stack") {
+        canvas.save();
+        REQUIRE_FALSE(canvas.inside_non_opaque_layer());
+        canvas.save_layer(0, 0, 64, 64, 0.25f, 0.0f);
+        REQUIRE(canvas.inside_non_opaque_layer());
+        canvas.restore();   // closes the opacity layer
+        REQUIRE_FALSE(canvas.inside_non_opaque_layer());
+        canvas.restore();   // closes the plain save
+        REQUIRE_FALSE(canvas.inside_non_opaque_layer());
+    }
+
+    SECTION("nested non-opaque layers stay tracked until each restore") {
+        canvas.save_layer(0, 0, 64, 64, 0.8f, 0.0f);
+        REQUIRE(canvas.inside_non_opaque_layer());
+        canvas.save_layer(0, 0, 64, 64, 0.5f, 0.0f);
+        REQUIRE(canvas.inside_non_opaque_layer());
+        canvas.restore();
+        // Outer layer still open and non-opaque.
+        REQUIRE(canvas.inside_non_opaque_layer());
+        canvas.restore();
+        REQUIRE_FALSE(canvas.inside_non_opaque_layer());
+    }
+
+    SECTION("save_layer_with_blend tracks non-opaque destinations too") {
+        canvas.save_layer_with_blend(0, 0, 64, 64, /*opacity=*/0.6f,
+                                     /*blur=*/0.0f,
+                                     Canvas::BlendMode::multiply);
+        REQUIRE(canvas.inside_non_opaque_layer());
+        canvas.restore();
+        REQUIRE_FALSE(canvas.inside_non_opaque_layer());
+    }
+
+    SECTION("restore_to_count drops every non-opaque layer above target") {
+        const int baseline = canvas.save_count();
+        canvas.save_layer(0, 0, 64, 64, 0.5f, 0.0f);
+        canvas.save_layer(0, 0, 64, 64, 0.5f, 0.0f);
+        canvas.save_layer(0, 0, 64, 64, 0.5f, 0.0f);
+        REQUIRE(canvas.inside_non_opaque_layer());
+
+        canvas.restore_to_count(baseline);
+        // All three opacity layers are gone — stack must be empty.
+        REQUIRE_FALSE(canvas.inside_non_opaque_layer());
+    }
+}
+
+// pulp #1899 (gap #3) — end-to-end: render the same glyph twice into
+// the same surface, once inside save_layer(opacity = 0.5) and once
+// outside, and verify the inside-layer pixels show no LCD subpixel
+// pattern. LCD AA produces unequal R / G / B coverage at glyph edges;
+// greyscale AA writes equal R / G / B. Scanning a few rows where the
+// glyph should have an edge and asserting "max channel difference == 0"
+// for the inside-layer block is the simplest cross-platform probe.
+TEST_CASE("SkiaCanvas text inside opacity layer uses greyscale AA "
+          "(pulp #1899 gap #3)", "[canvas][skia][issue-1899]") {
+    // Two side-by-side surfaces — one painted with an opacity layer,
+    // one without — so we can compare per-pixel coverage shapes.
+    auto make_surface = []() {
+        SkImageInfo info = SkImageInfo::Make(96, 32, kN32_SkColorType,
+                                             kPremul_SkAlphaType,
+                                             SkColorSpace::MakeSRGB());
+        return SkSurfaces::Raster(info);
+    };
+    auto opaque_surface = make_surface();
+    auto layer_surface = make_surface();
+    REQUIRE(opaque_surface != nullptr);
+    REQUIRE(layer_surface != nullptr);
+
+    // Opaque-destination text (LCD AA expected — but we don't assert
+    // on that direction; we only assert the layer surface uses uniform
+    // coverage).
+    {
+        auto* sc = opaque_surface->getCanvas();
+        sc->clear(SK_ColorBLACK);
+        SkiaCanvas canvas(sc);
+        canvas.set_font("Inter", 18.0f);
+        canvas.set_fill_color(Color::rgba8(255, 255, 255, 255));
+        canvas.fill_text("Hg", 4.0f, 24.0f);
+    }
+
+    // Inside an opacity layer (greyscale AA expected — verify glyph
+    // edge pixels have equal R / G / B coverage).
+    {
+        auto* sc = layer_surface->getCanvas();
+        sc->clear(SK_ColorBLACK);
+        SkiaCanvas canvas(sc);
+        canvas.save_layer(0, 0, 96, 32, /*opacity=*/0.5f, /*blur=*/0.0f);
+        canvas.set_font("Inter", 18.0f);
+        canvas.set_fill_color(Color::rgba8(255, 255, 255, 255));
+        canvas.fill_text("Hg", 4.0f, 24.0f);
+        canvas.restore();
+    }
+
+    // Read back the layer surface and look for a pixel whose
+    // R / G / B coverage isn't uniform. Greyscale AA writes equal
+    // channels at every glyph edge; LCD AA writes unequal channels
+    // by construction. Allow a 1-LSB tolerance for premultiplied
+    // round-trip noise on layer compositing.
+    SkImageInfo info = SkImageInfo::Make(96, 32, kRGBA_8888_SkColorType,
+                                         kUnpremul_SkAlphaType,
+                                         SkColorSpace::MakeSRGB());
+    std::vector<uint8_t> pixels(96 * 32 * 4, 0);
+    REQUIRE(layer_surface->readPixels(info, pixels.data(), 96 * 4, 0, 0));
+
+    int unequal_channel_pixels = 0;
+    int edge_pixels = 0;
+    for (int y = 0; y < 32; ++y) {
+        for (int x = 0; x < 96; ++x) {
+            const uint8_t r = pixels[(y * 96 + x) * 4 + 0];
+            const uint8_t g = pixels[(y * 96 + x) * 4 + 1];
+            const uint8_t b = pixels[(y * 96 + x) * 4 + 2];
+            const int max_c = std::max({r, g, b});
+            const int min_c = std::min({r, g, b});
+            // Only inspect partial-coverage pixels (genuine glyph
+            // edges) — fully transparent / fully opaque pixels can't
+            // distinguish edging mode.
+            if (max_c > 4 && max_c < 250) {
+                ++edge_pixels;
+                if (max_c - min_c > 1) {
+                    ++unequal_channel_pixels;
+                }
+            }
+        }
+    }
+
+    // Sanity — we should have found SOME glyph-edge pixels at all.
+    // If the font isn't available on the host, the test would yield
+    // zero edge pixels; bail with a Catch2 message instead of a
+    // false-positive pass.
+    REQUIRE(edge_pixels > 0);
+    // Core assertion — inside the opacity layer, the renderer used
+    // greyscale AA, so glyph-edge pixels carry uniform R / G / B.
+    REQUIRE(unequal_channel_pixels == 0);
+}
+#endif // PULP_HAS_SKIA

--- a/test/web-compat/test_web_compat_prelude.cpp
+++ b/test/web-compat/test_web_compat_prelude.cpp
@@ -1375,6 +1375,56 @@ TEST_CASE("WebCompat: setProperty('--name') routes to motion-token bridge (issue
     REQUIRE(roundTrip.getWithDefault<double>(-1.0) == 128.0);
 }
 
+// pulp #1918 (Codex review P2) — when a custom property is reassigned
+// from one value type to another (string ↔ length) the stale slot
+// from the prior assignment must be cleared. The resolver checks
+// theme.strings before theme.dimensions, so without slot-clearing a
+// prior string-typed assignment shadows a later length-typed one.
+//
+// Note: this test exercises the string ↔ length axis specifically.
+// `red` would route to theme.colors via parseCSSColor before the
+// string-token fallback fires; we use a non-color, non-length value
+// (a font-family name) instead so the first assignment definitely
+// lands in the string slot.
+TEST_CASE("WebCompat: setProperty('--name') clears stale slots on type-change reassignment (issue-1918)",
+          "[webcompat][css-var][issue-1918]") {
+    TestEnvironment env;
+
+    // 1. First assignment is a string-typed custom property (font name
+    //    — not parseable as length or color) — lands in theme.strings
+    //    via setStringToken.
+    env.eval(R"JS(
+        var __relEl = document.createElement('div');
+        __relEl.style.setProperty('--my-var', 'JetBrains Mono');
+    )JS");
+    auto stringSlot1 = env.engine.evaluate("getStringToken('my-var')");
+    REQUIRE(std::string(stringSlot1.getWithDefault<std::string_view>("")) == "JetBrains Mono");
+
+    // 2. Reassign to a length value. The motion slot should now hold
+    //    12, and the string slot must be cleared so the resolver
+    //    doesn't return "JetBrains Mono" for var(--my-var).
+    env.eval("__relEl.style.setProperty('--my-var', '12px');");
+
+    auto stringSlot2 = env.engine.evaluate("getStringToken('my-var')");
+    auto motionSlot2 = env.engine.evaluate("getMotionToken('my-var')");
+    REQUIRE(std::string(stringSlot2.getWithDefault<std::string_view>("")).empty());
+    REQUIRE(motionSlot2.getWithDefault<double>(-1.0) == 12.0);
+
+    // 3. Resolver must pick up the new length — not the stale string —
+    //    when asked to resolve var(--my-var).
+    auto resolved = env.engine.evaluate("_resolveVar('var(--my-var)')");
+    REQUIRE(std::string(resolved.getWithDefault<std::string_view>("")) == "12");
+
+    // 4. Reverse direction: reassign back to a string. The motion slot
+    //    must be cleared so getPropertyValue / resolver don't see a
+    //    stale "12" left from the previous length assignment.
+    env.eval("__relEl.style.setProperty('--my-var', 'SF Mono');");
+    auto stringSlot3 = env.engine.evaluate("getStringToken('my-var')");
+    auto motionSlot3 = env.engine.evaluate("getMotionToken('my-var')");
+    REQUIRE(std::string(stringSlot3.getWithDefault<std::string_view>("")) == "SF Mono");
+    REQUIRE(motionSlot3.getWithDefault<double>(-1.0) == 0.0);
+}
+
 TEST_CASE("WebCompat: StyleSheet attach applies rules to existing elements (issue-1551)",
           "[webcompat][stylesheet][issue-1551]") {
     TestEnvironment env;


### PR DESCRIPTION
## Summary

Fixes visual gap #3 of the Spectr import-flow chase (#1899): top-bar
labels render faint AND in the wrong typeface. Two compounding bugs:

### Bug A — LCD subpixel AA degrades inside opacity layers

`View::paint_all` opens `save_layer(opacity_)` for any View with
opacity < 1. Skia's LCD subpixel AA can't antialias correctly into a
partially transparent pixel (documented Skia behavior), so glyphs
render faint. Browsers flip to greyscale AA inside non-opaque layers;
Pulp did not.

**Fix (Option 1)**: track every currently-open `save_layer*` whose
layer-paint alpha is < 1 on a new `non_opaque_layer_stack_`. Text
paint paths consult `inside_non_opaque_layer()` and select
`kAntiAlias` (greyscale) over `kSubpixelAntiAlias`. All four
`save_layer*` variants push; `restore()` / `restore_to_count()` pop.
Plain `save()` and `save_layer(opacity = 1)` don't push.

**Why Option 1 over Option 2 (unconditional kAntiAlias flip):**
Option 2 would shift edging in every existing visual-regression
golden and invalidate 50+ tests. Option 1 isolates the change to
non-opaque destinations exactly, so opaque-text goldens stay
bit-identical. No goldens needed refresh.

### Bug B — `var(--mono)` not resolved in React prop-applier

`fontFamily: 'var(--mono)'` flowed raw through prop-applier into
`setFontFamily`. Skia's font matcher saw the literal "var(--mono)"
as a family name and fell back to a proportional sans.

**Fix**: add `_resolveVar(value)` to `prop-applier.ts` with four
lookup tiers (developer registry `__pulpCssVars` → `getStringToken`
bridge → `getMotionToken` bridge → explicit fallback → passthrough),
call it from every string-valued style prop case that can carry a
CSS var (fontFamily, color/textColor, borderColor + 4 per-side
variants, outlineColor, textDecorationColor, textShadowColor,
shadowColor, background, backgroundImage). Add matching
`setStringToken` / `getStringToken` bridge fns next to
`setMotionToken` / `getMotionToken`. `setProperty('--name', value)`
in `web-compat-style-decl.js` and `web-compat.js` gains a third
tier for string-valued custom properties.

## Tests

- `test/test_canvas.cpp` — 2 Catch2 cases under `[issue-1899]`:
  layer-stack transitions and end-to-end greyscale-AA validation
  (paints glyphs inside `save_layer(opacity = 0.5)` and asserts
  edge-pixel R/G/B coverage is uniform).
- `packages/pulp-react/test/prop-applier-var-resolve.test.ts` —
  9 Vitest cases covering all resolution tiers + non-var passthrough
  + numeric prop non-mangling + nested var() fallback chain.

All 430 pulp-react tests pass. All 50 text + canvas + opacity ctest
targets pass.

## Quickcycle / visual-regression goldens

Screenshot harness on macOS defaults to CoreGraphics (not Skia), and
Spectr's `dom-adapter.tsx` resolves `var(--mono)` via its own
`resolveTokens()` before reaching our applier — so the harness
doesn't exercise either fix's code path. quickcycle score 0.588
(byte-identical to prior runs against this baseline). The fixes
target the live-render path documented in the #1899 triage; the
harness is a coverage gap on this kind of fix, not a refutation.

## Test plan
- [x] `ctest -R "canvas|text|opacity"` (50 pass)
- [x] `npx vitest run` in packages/pulp-react (430 pass)
- [x] `cmake --build build --target pulp-screenshot pulp-test-canvas pulp-test-widget-bridge pulp-test-design-import` (all pass)
- [x] Skill-sync: `engine` SKILL.md updated with three-tier
      `setProperty` resolution gotcha + `_resolveVar` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)