### PR TITLE
ci: add path-scoped parser validation profile (closes #1916)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -239,6 +239,42 @@ shipyard run --targets windows --resume-from test   # ~2 min vs 15 min
 shipyard run --resume-from build
 ```
 
+### Path-scoped validation profile: `parser`
+
+`.shipyard/config.toml` defines a `[validation.parser]` lane (pulp
+#1916) for PRs that only touch runtime-import parser code — the
+standalone `tools/import-design` tool, the `tools/import-validation`
+scripts, the `packages/pulp-import-ir` package, parser fixtures, the
+parser test files, and the `core/view/.../design_import*` family.
+
+The lane configures with `PULP_BUILD_EXAMPLES=OFF` and runs ctest with
+`--label-include parser-import`, so plugin validators (auval /
+pluginval / clap-validator, registered under `examples/pulp-*/`) and
+the broader format-adapter smoke surface stay out of the loop. The
+motivating failure was pulp #1910, where pluginval-PulpGain-VST3
+segfaulted on a Figma Make parser PR that had no business touching the
+VST3 adapter.
+
+```bash
+# Auto-select against origin/main and run the matching lane:
+shipyard run --pipeline "$(python3 tools/scripts/validation_profile_select.py)"
+
+# Inspect what the classifier decided + which paths drove it:
+python3 tools/scripts/validation_profile_select.py --json
+
+# Force the broad lane (useful when the parser scope is technically
+# unchanged but you suspect cross-subsystem fallout):
+shipyard run --pipeline default
+```
+
+The selector returns `parser` only when every changed path lives
+inside the scope; any unrelated edit forces `default`. The bias is
+toward broad validation.
+
+`shipyard pr` does not yet auto-route to the parser lane — for a final
+merge gate, let it default through `[validation.default]`. The
+parser lane is for fast iteration before that final gate.
+
 ### Iterating on a single-platform failure
 
 When CI goes red on exactly one of Pulp's platforms — e.g. only the

--- a/.shipyard/config.toml
+++ b/.shipyard/config.toml
@@ -98,6 +98,36 @@ test      = "ctest --test-dir build -C Release --output-on-failure --exclude-reg
 stages = ["setup"]
 setup = "PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report && PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/version_bump_check.py --base origin/main --mode=report"
 
+[validation.parser]
+# Path-scoped lane for runtime-import parser PRs (pulp #1916).
+#
+# Triggered when a diff only touches the parser-import scope defined in
+# tools/scripts/validation_profile_select.py — the standalone
+# import-design tool, the import-validation scripts, the pulp-import-ir
+# package, parser fixtures, and the parser-specific test surface. Run
+# it explicitly with `shipyard run --pipeline parser`; the selector
+# script prints `parser` or `default` so wrappers can pick the matching
+# lane without rolling their own classifier.
+#
+# Configure step disables PULP_BUILD_EXAMPLES, which keeps the plugin
+# validator CTest entries (auval / pluginval / clap-validator,
+# registered in examples/pulp-*/CMakeLists.txt) out of the test
+# discovery list entirely — those failures motivated #1916 in the first
+# place. The test step filters by the `parser-import` CTest label
+# (test/CMakeLists.txt) so even if a non-example validator slips in,
+# it stays out of the lane. `slow` is excluded for symmetry with
+# [validation.default].
+stages = ["setup", "configure", "build", "test"]
+setup     = "./setup.sh --ci --deps-only"
+configure = "cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=OFF"
+build     = "cmake --build build --parallel"
+test      = "ctest --test-dir build --output-on-failure --label-include parser-import --exclude-regex AudioWorkgroup --label-exclude slow"
+
+[validation.parser.overrides.windows]
+configure = "cmake -S . -B build -G \"Visual Studio 17 2022\" -A x64 -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=OFF"
+build     = "cmake --build build --config Release --parallel"
+test      = "ctest --test-dir build -C Release --output-on-failure --label-include parser-import --exclude-regex \"AudioWorkgroup|Toolbar add items\" --label-exclude slow"
+
 [validation.smoke]
 # Lighter validation for quick sanity checks. Builds without tests +
 # GPU + examples; the smoke pipeline (SDK install + downstream

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -112,6 +112,50 @@ between the remote HEAD and the target SHA. Typical cycles drop from
 full bundle automatically when the delta would be larger than the full
 pack.
 
+## Validation Profiles
+
+Shipyard validates from a profile (`shipyard run --pipeline <name>`).
+Pulp's `.shipyard/config.toml` defines three:
+
+| Profile | When to use | What it runs |
+|---------|-------------|--------------|
+| `default` | Most PRs. The lane every cross-platform target gates on. | Full `setup → configure → build → test`. Examples ON. Excludes the `slow` ctest label. |
+| `parser` | PRs that only touch runtime-import parser code. | Same stages with `PULP_BUILD_EXAMPLES=OFF`; tests filter to `--label-include parser-import`. Skips plugin validators (auval / pluginval / clap-validator) and the broader format-adapter smoke surface. |
+| `smoke` | Quick downstream-scaffold check after dependency or install-layout edits. | Configure + build only; runs the SDK-smoke export against a downstream scaffold. |
+| `gates` | Version-bump / skill-sync gate scripts. | `tools/scripts/skill_sync_check.py` + `tools/scripts/version_bump_check.py` in report mode. |
+
+`shipyard config profiles` lists what is installed locally and which one is active.
+
+### Auto-selecting the parser profile
+
+`tools/scripts/validation_profile_select.py` classifies the current diff
+and prints `parser` or `default`:
+
+```bash
+# Default: diff HEAD against origin/main
+shipyard run --pipeline "$(python3 tools/scripts/validation_profile_select.py)"
+
+# Explicit diff base
+shipyard run --pipeline "$(python3 tools/scripts/validation_profile_select.py --base origin/develop)"
+
+# Operate on a literal file list (e.g. piped from gh pr diff)
+gh pr diff <PR> --name-only \
+  | python3 tools/scripts/validation_profile_select.py --paths-from -
+
+# JSON envelope (profile + matched + unmatched)
+python3 tools/scripts/validation_profile_select.py --json
+```
+
+The script returns `parser` only when every changed path falls inside
+the explicit parser-only scope (the standalone `tools/import-design`
+tool, `tools/import-validation` scripts, the `packages/pulp-import-ir`
+package, `test/fixtures/imports/**`, the parser test files in `test/`,
+the `core/view/.../design_import*` family, and the import-runtime JS).
+Any path outside that set forces `default` — the safety bias is toward
+broad validation.
+
+To opt out for an individual run, pass `--pipeline default` explicitly.
+
 ## Required Merge Process (All Agents)
 
 Every change to `main` must go through this workflow — no exceptions:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -106,7 +106,8 @@ if(UNIX)
     add_test(NAME spectr-roundtrip-window-only-capture
         COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_spectr_roundtrip_window_only_capture.sh)
     set_tests_properties(spectr-roundtrip-window-only-capture
-        PROPERTIES TIMEOUT 10)
+        PROPERTIES TIMEOUT 10
+        LABELS "parser-import")
 endif()
 
 # Debug-SDK perf-killer guard smoke (pulp-internal task #35).
@@ -167,7 +168,8 @@ add_executable(pulp-test-cli-design-binding test_cli_design_binding.cpp
 )
 target_include_directories(pulp-test-cli-design-binding PRIVATE ${CMAKE_SOURCE_DIR})
 target_link_libraries(pulp-test-cli-design-binding PRIVATE Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-cli-design-binding)
+catch_discover_tests(pulp-test-cli-design-binding
+    PROPERTIES LABELS "parser-import")
 
 # CLI create target selection tests
 add_executable(pulp-test-cli-create-targets test_cli_create_targets.cpp
@@ -430,7 +432,8 @@ target_link_libraries(pulp-test-cli-import-detect PRIVATE
 # tests from the repo root so the discovery works regardless of build
 # directory shape.
 catch_discover_tests(pulp-test-cli-import-detect
-    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    PROPERTIES LABELS "parser-import")
 
 # CLI tool registry (#643): local-only coverage for registry parsing,
 # managed binary / Python wrapper discovery, deterministic install exits,
@@ -1750,13 +1753,15 @@ catch_discover_tests(pulp-test-modal)
 # Design export tests
 add_executable(pulp-test-design-export test_design_export.cpp)
 target_link_libraries(pulp-test-design-export PRIVATE pulp::view Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-design-export)
+catch_discover_tests(pulp-test-design-export
+    PROPERTIES LABELS "parser-import")
 
 # Design import tests (Figma/Stitch/v0/Pencil → Pulp, W3C tokens)
 add_executable(pulp-test-design-import test_design_import.cpp)
 target_link_libraries(pulp-test-design-import PRIVATE pulp::view Catch2::Catch2WithMain)
 target_compile_definitions(pulp-test-design-import PRIVATE PULP_REPO_ROOT="${CMAKE_SOURCE_DIR}")
-catch_discover_tests(pulp-test-design-import)
+catch_discover_tests(pulp-test-design-import
+    PROPERTIES LABELS "parser-import")
 
 # Post-parse widget promotion: <div onClick> / role=button / cursor:pointer
 # → button. Closure of pulp-internal task #84 / follow-up on #1814.
@@ -1770,7 +1775,8 @@ target_include_directories(pulp-test-widget-promotion PRIVATE
 target_link_libraries(pulp-test-widget-promotion PRIVATE
     pulp::view
     Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-widget-promotion)
+catch_discover_tests(pulp-test-widget-promotion
+    PROPERTIES LABELS "parser-import")
 
 # pulp #468 — web-compat preludes shipped for bundled-React imports
 # (nodeType / nodeName, observer no-ops, scheduler shims). Uses
@@ -1792,7 +1798,8 @@ catch_discover_tests(pulp-test-web-compat-react-shims
 add_executable(pulp-test-design-import-claude-bundle test_design_import_claude_bundle.cpp)
 target_link_libraries(pulp-test-design-import-claude-bundle
     PRIVATE pulp::view pulp::runtime Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-design-import-claude-bundle)
+catch_discover_tests(pulp-test-design-import-claude-bundle
+    PROPERTIES LABELS "parser-import")
 
 # pulp #1035 — `pulp import-design --from claude` classnames.json
 # emission. Combines library-level fixture coverage (no binary
@@ -1806,7 +1813,9 @@ if(TARGET pulp-cli)
     add_dependencies(pulp-test-cli-import-design pulp-cli)
 endif()
 catch_discover_tests(pulp-test-cli-import-design
-    PROPERTIES ENVIRONMENT "PULP_REPO_ROOT=${CMAKE_SOURCE_DIR}")
+    PROPERTIES
+        ENVIRONMENT "PULP_REPO_ROOT=${CMAKE_SOURCE_DIR}"
+        LABELS "parser-import")
 
 # Direct shell-out coverage for the standalone import-design tool
 # executable. These tests hit tools/import-design/pulp_import_design.cpp
@@ -1817,7 +1826,8 @@ target_link_libraries(pulp-test-import-design-tool
 target_compile_definitions(pulp-test-import-design-tool PRIVATE
     PULP_IMPORT_DESIGN_TOOL_PATH="$<TARGET_FILE:pulp-import-design>")
 add_dependencies(pulp-test-import-design-tool pulp-import-design)
-catch_discover_tests(pulp-test-import-design-tool)
+catch_discover_tests(pulp-test-import-design-tool
+    PROPERTIES LABELS "parser-import")
 
 # pulp #468 — `--execute-bundle` harness end-to-end. Boots the
 # ScriptEngine + WidgetBridge, builds a synthetic React-like bundle on
@@ -1827,7 +1837,8 @@ catch_discover_tests(pulp-test-import-design-tool)
 add_executable(pulp-test-design-import-claude-runtime test_design_import_claude_runtime.cpp)
 target_link_libraries(pulp-test-design-import-claude-runtime
     PRIVATE pulp::view pulp::runtime Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-design-import-claude-runtime)
+catch_discover_tests(pulp-test-design-import-claude-runtime
+    PROPERTIES LABELS "parser-import")
 
 # pulp #758 — inline `<script>` evaluation in the `--execute-bundle`
 # harness. Asserts that inline `text/javascript`, inline `text/babel`
@@ -1839,13 +1850,15 @@ catch_discover_tests(pulp-test-design-import-claude-runtime)
 add_executable(pulp-test-design-import-inline-babel test_design_import_inline_babel.cpp)
 target_link_libraries(pulp-test-design-import-inline-babel
     PRIVATE pulp::view pulp::runtime Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-design-import-inline-babel)
+catch_discover_tests(pulp-test-design-import-inline-babel
+    PROPERTIES LABELS "parser-import")
 
 # Screenshot comparison tests (visual diff for design import validation)
 if(APPLE)
     add_executable(pulp-test-screenshot-compare test_screenshot_compare.cpp)
     target_link_libraries(pulp-test-screenshot-compare PRIVATE pulp::view Catch2::Catch2WithMain)
-    catch_discover_tests(pulp-test-screenshot-compare)
+    catch_discover_tests(pulp-test-screenshot-compare
+        PROPERTIES LABELS "parser-import")
 endif()
 
 # Parameter attachment tests

--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -70,8 +70,11 @@
         "ci/**",
         "tools/local-ci/**",
         "tools/shipyard.toml",
+        ".shipyard/config.toml",
         "tools/install-shipyard.sh",
         "tools/scripts/install-githooks.sh",
+        "tools/scripts/validation_profile_select.py",
+        "tools/scripts/test_validation_profile_select.py",
         ".githooks/**"
       ]
     },

--- a/tools/scripts/test_validation_profile_select.py
+++ b/tools/scripts/test_validation_profile_select.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Unit tests for validation_profile_select.
+
+Run with:
+    python3 tools/scripts/test_validation_profile_select.py
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import validation_profile_select as vps  # noqa: E402
+
+
+class PathMatchingTests(unittest.TestCase):
+    def test_import_design_tool_paths_match(self):
+        self.assertTrue(vps.is_parser_only_path("tools/import-design/pulp_import_design.cpp"))
+        self.assertTrue(vps.is_parser_only_path("tools/import-design/catalogs/yoga.tsv"))
+
+    def test_import_validation_scripts_match(self):
+        self.assertTrue(vps.is_parser_only_path("tools/import-validation/spectr-roundtrip.sh"))
+        self.assertTrue(vps.is_parser_only_path("tools/import-validation/check_label_coverage.sh"))
+
+    def test_import_ir_package_matches(self):
+        self.assertTrue(vps.is_parser_only_path("packages/pulp-import-ir/src/diff.ts"))
+        self.assertTrue(vps.is_parser_only_path("packages/pulp-import-ir/test/anchors.test.ts"))
+
+    def test_parser_test_files_match(self):
+        self.assertTrue(vps.is_parser_only_path("test/test_design_import.cpp"))
+        self.assertTrue(vps.is_parser_only_path("test/test_design_import_claude_bundle.cpp"))
+        self.assertTrue(vps.is_parser_only_path("test/test_cli_import_design.cpp"))
+        self.assertTrue(vps.is_parser_only_path("test/test_widget_promotion.cpp"))
+
+    def test_core_view_design_import_paths_match(self):
+        self.assertTrue(vps.is_parser_only_path("core/view/src/design_import.cpp"))
+        self.assertTrue(vps.is_parser_only_path("core/view/include/pulp/view/design_import.hpp"))
+        self.assertTrue(vps.is_parser_only_path("core/view/js/import-runtime.js"))
+
+    def test_unrelated_paths_do_not_match(self):
+        self.assertFalse(vps.is_parser_only_path("core/format/src/vst3_adapter.cpp"))
+        self.assertFalse(vps.is_parser_only_path("core/audio/src/buffer_view.cpp"))
+        self.assertFalse(vps.is_parser_only_path("examples/pulp-gain/CMakeLists.txt"))
+        self.assertFalse(vps.is_parser_only_path(".github/workflows/build.yml"))
+        # CMakeLists at repo root is broad — always falls back to default.
+        self.assertFalse(vps.is_parser_only_path("CMakeLists.txt"))
+
+    def test_unrelated_core_view_paths_do_not_match(self):
+        # The parser-only scope covers `design_import*` and the import
+        # runtime JS — generic view code is broader.
+        self.assertFalse(vps.is_parser_only_path("core/view/src/widget.cpp"))
+        self.assertFalse(vps.is_parser_only_path("core/view/include/pulp/view/widget.hpp"))
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_all_parser_only_returns_parser(self):
+        result = vps.classify([
+            "tools/import-design/pulp_import_design.cpp",
+            "test/test_design_import.cpp",
+            "test/fixtures/imports/stitch/example.html",
+        ])
+        self.assertEqual(result.profile, "parser")
+        self.assertEqual(len(result.unmatched), 0)
+
+    def test_any_unrelated_path_returns_default(self):
+        result = vps.classify([
+            "tools/import-design/pulp_import_design.cpp",
+            "core/format/src/vst3_adapter.cpp",
+        ])
+        self.assertEqual(result.profile, "default")
+        self.assertEqual(len(result.unmatched), 1)
+        self.assertIn("core/format/src/vst3_adapter.cpp", result.unmatched)
+
+    def test_empty_diff_defaults_to_default(self):
+        result = vps.classify([])
+        self.assertEqual(result.profile, "default")
+
+    def test_whitespace_lines_are_ignored(self):
+        result = vps.classify([
+            "  ",
+            "tools/import-design/pulp_import_design.cpp",
+            "",
+        ])
+        self.assertEqual(result.profile, "parser")
+        self.assertEqual(result.matched, ("tools/import-design/pulp_import_design.cpp",))
+
+
+class CliTests(unittest.TestCase):
+    def test_paths_from_stdin_plain_output(self):
+        stdin = io.StringIO("tools/import-design/foo.cpp\ntest/test_design_import.cpp\n")
+        buf = io.StringIO()
+        old_stdin, sys.stdin = sys.stdin, stdin
+        try:
+            with redirect_stdout(buf):
+                rc = vps.main(["--paths-from", "-"])
+        finally:
+            sys.stdin = old_stdin
+        self.assertEqual(rc, 0)
+        self.assertEqual(buf.getvalue().strip(), "parser")
+
+    def test_paths_from_stdin_json_output(self):
+        stdin = io.StringIO("core/format/src/vst3_adapter.cpp\n")
+        buf = io.StringIO()
+        old_stdin, sys.stdin = sys.stdin, stdin
+        try:
+            with redirect_stdout(buf):
+                rc = vps.main(["--paths-from", "-", "--json"])
+        finally:
+            sys.stdin = old_stdin
+        self.assertEqual(rc, 0)
+        payload = json.loads(buf.getvalue())
+        self.assertEqual(payload["profile"], "default")
+        self.assertEqual(payload["unmatched"], ["core/format/src/vst3_adapter.cpp"])
+        self.assertEqual(payload["matched"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/validation_profile_select.py
+++ b/tools/scripts/validation_profile_select.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Select Shipyard validation profile based on diff scope.
+
+A PR that only touches runtime-import parser code — the standalone
+import-design tool, the import-validation scripts, the pulp-import-ir
+package, parser fixtures, and the parser test surface — does not need
+to pay for plugin-validator runs (auval / pluginval / clap-validator),
+example builds, or the broader format-adapter smoke suite. This script
+classifies a diff and prints the validation profile name that matches:
+
+    parser   → narrow lane defined in .shipyard/config.toml
+               ([validation.parser]) — parser unit tests, source
+               roundtrip scripts, screenshot fixture rendering.
+
+    default  → broad lane ([validation.default]) — full build matrix,
+               examples, plugin validators.
+
+The path set is intentionally small. Adding a new path is a deliberate
+decision — if the change can reasonably affect non-parser surfaces,
+keep it on the default lane.
+
+Usage:
+
+    # Compare HEAD against the merge base with origin/main:
+    python3 tools/scripts/validation_profile_select.py
+
+    # Different base (e.g. develop branch):
+    python3 tools/scripts/validation_profile_select.py --base origin/develop
+
+    # Operate on a literal file list (one path per line, '-' for stdin):
+    python3 tools/scripts/validation_profile_select.py --paths-from -
+
+    # JSON envelope (profile + classification + matched/unmatched paths):
+    python3 tools/scripts/validation_profile_select.py --json
+
+Exit code is always 0 when classification succeeds. A non-zero exit
+means the git query failed (no base reachable, not a git repo, etc.) —
+in that case the caller should fall back to the default lane.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+# Glob patterns that delimit the parser-only scope. fnmatch is used in
+# the classifier; `**` is normalized to multi-segment match by walking
+# each path segment. Keep this list in sync with
+# docs/guides/validation-profiles.md.
+PARSER_ONLY_PATTERNS: tuple[str, ...] = (
+    # Standalone import-design CLI tool + catalogs
+    "tools/import-design/**",
+    # Import-validation scripts (label coverage, spectr-roundtrip,
+    # diff_against_reference, etc.)
+    "tools/import-validation/**",
+    # JS/TS IR package and its tests
+    "packages/pulp-import-ir/**",
+    # Import fixtures consumed by parser tests
+    "test/fixtures/imports/**",
+    # Parser-specific C++ tests in the test/ directory
+    "test/test_design_import.cpp",
+    "test/test_design_import_*.cpp",
+    "test/test_design_export.cpp",
+    "test/test_cli_import_design.cpp",
+    "test/test_cli_import_detect.cpp",
+    "test/test_import_design_tool.cpp",
+    "test/test_widget_promotion.cpp",
+    "test/test_screenshot_compare.cpp",
+    "test/test_cli_design_binding.cpp",
+    "test/test_spectr_roundtrip_window_only_capture.sh",
+    # Parser-side core/view code (matches the import-design skill's
+    # tracked paths so the two stay aligned).
+    "core/view/src/design_import*",
+    "core/view/include/pulp/view/design_import.hpp",
+    "core/view/include/pulp/view/design_import*",
+    "core/view/js/import-runtime.js",
+    # Public docs scoped to imports
+    "docs/reference/imports/**",
+    # Tracked skill for the import-design subsystem
+    ".agents/skills/import-design/**",
+)
+
+
+@dataclass(frozen=True)
+class Classification:
+    profile: str
+    matched: tuple[str, ...]
+    unmatched: tuple[str, ...]
+
+
+# ── Path matching ──────────────────────────────────────────────────
+
+
+def _segments(pattern_or_path: str) -> list[str]:
+    return [seg for seg in pattern_or_path.split("/") if seg]
+
+
+def _match_recursive(pattern: str, path: str) -> bool:
+    """fnmatch-style matcher that interprets `**` as multi-segment."""
+
+    pat_parts = _segments(pattern)
+    path_parts = _segments(path)
+    return _match_parts(pat_parts, path_parts)
+
+
+def _match_parts(pat_parts: Sequence[str], path_parts: Sequence[str]) -> bool:
+    if not pat_parts:
+        return not path_parts
+    head, *rest = pat_parts
+    if head == "**":
+        # Match zero or more path segments.
+        for i in range(len(path_parts) + 1):
+            if _match_parts(rest, path_parts[i:]):
+                return True
+        return False
+    if not path_parts:
+        return False
+    if not fnmatch.fnmatchcase(path_parts[0], head):
+        return False
+    return _match_parts(rest, path_parts[1:])
+
+
+def is_parser_only_path(path: str) -> bool:
+    """Return True iff `path` falls inside the parser-only scope."""
+
+    for pattern in PARSER_ONLY_PATTERNS:
+        if _match_recursive(pattern, path):
+            return True
+    return False
+
+
+def classify(paths: Iterable[str]) -> Classification:
+    matched: list[str] = []
+    unmatched: list[str] = []
+    for raw in paths:
+        path = raw.strip()
+        if not path:
+            continue
+        (matched if is_parser_only_path(path) else unmatched).append(path)
+    # An empty diff still defaults to the broad lane — a no-op PR has
+    # no meaningful scope to narrow, so fall through to safety.
+    profile = "parser" if matched and not unmatched else "default"
+    return Classification(
+        profile=profile,
+        matched=tuple(matched),
+        unmatched=tuple(unmatched),
+    )
+
+
+# ── Diff source helpers ────────────────────────────────────────────
+
+
+def _run_git(args: Sequence[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def changed_paths_from_git(base: str) -> list[str]:
+    """Return paths changed between `base` and HEAD.
+
+    Uses `git diff --name-only <base>...HEAD` so the merge-base is the
+    comparison anchor — matches how Shipyard / CI inspect a PR diff.
+    """
+
+    out = _run_git(["diff", "--name-only", f"{base}...HEAD"])
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def paths_from_file(source: str) -> list[str]:
+    if source == "-":
+        return [line for line in sys.stdin.read().splitlines() if line.strip()]
+    text = Path(source).read_text()
+    return [line for line in text.splitlines() if line.strip()]
+
+
+# ── CLI ────────────────────────────────────────────────────────────
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Print the Shipyard validation profile for the current diff.",
+    )
+    p.add_argument(
+        "--base",
+        default="origin/main",
+        help="Git ref to diff HEAD against (default: origin/main).",
+    )
+    p.add_argument(
+        "--paths-from",
+        metavar="FILE",
+        help="Read changed paths from FILE (or '-' for stdin) instead of git diff.",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a JSON envelope (profile + matched + unmatched).",
+    )
+    return p
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+
+    try:
+        if args.paths_from:
+            paths = paths_from_file(args.paths_from)
+        else:
+            paths = changed_paths_from_git(args.base)
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(
+            f"validation_profile_select: git query failed ({exc.returncode}): "
+            f"{exc.stderr.strip()}\n"
+        )
+        return 2
+    except FileNotFoundError as exc:
+        sys.stderr.write(f"validation_profile_select: {exc}\n")
+        return 2
+
+    result = classify(paths)
+
+    if args.json:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "profile": result.profile,
+                    "matched": list(result.matched),
+                    "unmatched": list(result.unmatched),
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+    else:
+        sys.stdout.write(result.profile + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Defines a `[validation.parser]` Shipyard lane in `.shipyard/config.toml`
that configures with `PULP_BUILD_EXAMPLES=OFF` and runs ctest with
`--label-include parser-import`. This keeps plugin validators (auval,
pluginval, clap-validator) and the broader format-adapter smoke surface
out of parser-only PRs — the failure mode that bit #1910 when
pluginval-PulpGain-VST3 segfaulted on a Figma Make parser change.

Test definitions in `test/CMakeLists.txt` for the parser surface
(design-import / design-export / cli-import-design / import-detect /
import-design-tool / widget-promotion / claude-bundle /
claude-runtime / inline-babel / screenshot-compare / design-binding /
spectr-roundtrip-window-only-capture) are tagged with
`LABELS "parser-import"` so the parser lane picks them up.

`tools/scripts/validation_profile_select.py` classifies a diff and
prints `parser` or `default`. The parser-only scope is narrow on
purpose — any path outside the tracked set falls back to default. The
script is wired into `docs/guides/local-ci.md` and the `ci` skill so
agents and humans can run `shipyard run --pipeline "$(... select.py)"`
for fast iteration ahead of the final `shipyard pr` merge gate.

`shipyard pr` still defaults through `[validation.default]`; the
parser lane is for the pre-merge iteration loop, not the final gate.

Skill-Update: skip skill=import-design reason="no import-design code or runtime behaviour changes — this PR only adds CTest labels and a CI profile selector around the existing parser surface"