### PR TITLE
feat(view+web-compat): route <rect> <line> <circle> SVG primitives + attribute replay (closes #1926)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
 - fix(css): nested var() fallback + var-in-calc resolution via balanced-paren walker (closes coverage-gap css/__var) ([#1855](https://github.com/danielraffel/pulp/pull/1855))
 
 <a id="v0950"></a>
+## [0.96.0]
+
 ## [0.95.0] - 2026-05-12
 
 - feat(view): SDK C++ runtime-import API — install_runtime_import_handlers ([#1856](https://github.com/danielraffel/pulp/pull/1856))

--- a/core/view/js/web-compat-dom-ops.js
+++ b/core/view/js/web-compat-dom-ops.js
@@ -56,6 +56,19 @@ if (!Element.prototype.appendChild ||
         if (typeof __replayAriaAttributes__ === "function") {
             __replayAriaAttributes__(child);
         }
+        // pulp #1926 — rect / line / circle SVG primitives. React/JSX
+        // commits setAttribute() before appendChild(), so geometry and
+        // fill/stroke land on _attributes before the bridge sees the
+        // native id. Flush them now that the native widget exists.
+        if (typeof __replaySvgRectAttributes__ === "function") {
+            __replaySvgRectAttributes__(child);
+        }
+        if (typeof __replaySvgLineAttributes__ === "function") {
+            __replaySvgLineAttributes__(child);
+        }
+        if (typeof __replaySvgCircleAttributes__ === "function") {
+            __replaySvgCircleAttributes__(child);
+        }
         child.style._flushAll();
         child._reapplyStylesheets();
         // pulp #1323 — `<style>` elements receive CSS via either direct
@@ -118,6 +131,16 @@ if (!Element.prototype.appendChild ||
         }
         if (typeof __replayAriaAttributes__ === "function") {
             __replayAriaAttributes__(newChild);
+        }
+        // pulp #1926 — see appendChild for rationale.
+        if (typeof __replaySvgRectAttributes__ === "function") {
+            __replaySvgRectAttributes__(newChild);
+        }
+        if (typeof __replaySvgLineAttributes__ === "function") {
+            __replaySvgLineAttributes__(newChild);
+        }
+        if (typeof __replaySvgCircleAttributes__ === "function") {
+            __replaySvgCircleAttributes__(newChild);
         }
         newChild.style._flushAll();
         newChild._reapplyStylesheets();

--- a/core/view/js/web-compat-element.js
+++ b/core/view/js/web-compat-element.js
@@ -314,8 +314,18 @@ function __replaySvgLineAttributes__(el) {
             setSvgLine(el._id, x1, y1, x2, y2);
         }
     }
-    if (a.stroke !== undefined && typeof setSvgStroke === "function") {
-        setSvgStroke(el._id, String(a.stroke));
+    if (typeof setSvgStroke === "function") {
+        // SvgLineWidget's C++ default is has_stroke_=true (opaque
+        // black, 1px), but SVG spec says <line> defaults to
+        // stroke="none". Without explicit clearing, a JSX <line> that
+        // omits `stroke` would paint an unwanted opaque-black stroke.
+        // Explicitly drive the widget to the spec default when the
+        // attribute is absent or empty (#1928 review).
+        if (a.stroke !== undefined && String(a.stroke).length > 0) {
+            setSvgStroke(el._id, String(a.stroke));
+        } else {
+            setSvgStroke(el._id, "none");
+        }
     }
     var sw = a["stroke-width"];
     if (sw === undefined) sw = a.strokeWidth;

--- a/core/view/js/web-compat-element.js
+++ b/core/view/js/web-compat-element.js
@@ -74,6 +74,34 @@ Element.prototype._ensureNative = function() {
         // sibling text paints over a blank gutter. Width/height attribute
         // replay happens in the shared block below.
         createCol(id, "");
+    } else if (tag === "rect") {
+        // pulp #1926 — SVG <rect> primitive. Spectr emits these for
+        // toggle-pill backgrounds and segmented-control fills.
+        // Geometry (x/y/width/height) + fill/stroke replayed below
+        // through __replaySvgRectAttributes__.
+        if (typeof createSvgRect === "function") {
+            createSvgRect(id, "");
+        } else {
+            createCol(id, "");
+        }
+    } else if (tag === "line") {
+        // pulp #1926 — SVG <line> primitive. Spectr uses these for
+        // analyzer-line indicators next to PEAK/AVG/BOTH/OFF and as
+        // ruler ticks. Endpoints (x1/y1/x2/y2) + stroke replayed below.
+        if (typeof createSvgLine === "function") {
+            createSvgLine(id, "");
+        } else {
+            createCol(id, "");
+        }
+    } else if (tag === "circle") {
+        // pulp #1926 — SVG <circle> → SvgPath with synthesized `d`
+        // path. The path is computed in __replaySvgCircleAttributes__
+        // from cx/cy/r attributes after mount.
+        if (typeof createSvgPath === "function") {
+            createSvgPath(id, "");
+        } else {
+            createCol(id, "");
+        }
     } else if (tag === "h1") {
         createLabel(id, "", "");
         setFontSize(id, 32); setFontWeight(id, 700);
@@ -155,6 +183,21 @@ Element.prototype._ensureNative = function() {
     if (typeof __replayAriaAttributes__ === "function") {
         __replayAriaAttributes__(this);
     }
+    // pulp #1926 — replay rect / line / circle SVG attributes captured
+    // pre-mount. React/JSX commits attributes before appendChild
+    // materializes the node, so by the time setAttribute('x', ...) /
+    // ('x1', ...) / ('cx', ...) lands the bridge has no native id yet.
+    // The replay functions flush geometry + fill / stroke / stroke-width
+    // from _attributes once `_nativeCreated` flips true.
+    if (typeof __replaySvgRectAttributes__ === "function") {
+        __replaySvgRectAttributes__(this);
+    }
+    if (typeof __replaySvgLineAttributes__ === "function") {
+        __replaySvgLineAttributes__(this);
+    }
+    if (typeof __replaySvgCircleAttributes__ === "function") {
+        __replaySvgCircleAttributes__(this);
+    }
 };
 
 // pulp #1147 — shared helper that maps presentational HTML attributes
@@ -218,6 +261,103 @@ function __replayAriaAttributes__(el) {
                 setAccessibilityState(el._id, states[si], String(val));
             }
         }
+    }
+}
+
+// pulp #1926 — replay <rect> SVG attributes through the SvgRectWidget
+// bridge. Mirrors the pre-mount-replay pattern used for ARIA + media:
+// React/JSX commits setAttribute() before appendChild materializes the
+// node, so the bridge has no native id when the attributes land. We
+// stash them in _attributes (the existing path) and flush them once
+// _nativeCreated flips true. Idempotent — safe to call from
+// _ensureNative AND from the appendChild fast path.
+function __replaySvgRectAttributes__(el) {
+    if (!el || !el._nativeCreated || !el._attributes) return;
+    if (el.tagName !== "RECT") return;
+    var a = el._attributes;
+    if (typeof setSvgRect === "function") {
+        var x  = parseFloat(a.x  || "0");
+        var y  = parseFloat(a.y  || "0");
+        var w  = parseFloat(a.width  || "0");
+        var h  = parseFloat(a.height || "0");
+        if (x === x && y === y && w === w && h === h) {
+            setSvgRect(el._id, x, y, w, h);
+        }
+    }
+    if (a.fill !== undefined && typeof setSvgFill === "function") {
+        setSvgFill(el._id, String(a.fill));
+    }
+    if (a.stroke !== undefined && typeof setSvgStroke === "function") {
+        setSvgStroke(el._id, String(a.stroke));
+    }
+    var sw = a["stroke-width"];
+    if (sw === undefined) sw = a.strokeWidth;
+    if (sw !== undefined && typeof setSvgStrokeWidth === "function") {
+        var psw = parseFloat(sw);
+        if (psw === psw) setSvgStrokeWidth(el._id, psw);
+    }
+}
+
+// pulp #1926 — replay <line> SVG attributes through the SvgLineWidget
+// bridge. SvgLineWidget has no fill semantics — only stroke /
+// stroke-width matter alongside the (x1,y1,x2,y2) endpoints.
+function __replaySvgLineAttributes__(el) {
+    if (!el || !el._nativeCreated || !el._attributes) return;
+    if (el.tagName !== "LINE") return;
+    var a = el._attributes;
+    if (typeof setSvgLine === "function") {
+        var x1 = parseFloat(a.x1 || "0");
+        var y1 = parseFloat(a.y1 || "0");
+        var x2 = parseFloat(a.x2 || "0");
+        var y2 = parseFloat(a.y2 || "0");
+        if (x1 === x1 && y1 === y1 && x2 === x2 && y2 === y2) {
+            setSvgLine(el._id, x1, y1, x2, y2);
+        }
+    }
+    if (a.stroke !== undefined && typeof setSvgStroke === "function") {
+        setSvgStroke(el._id, String(a.stroke));
+    }
+    var sw = a["stroke-width"];
+    if (sw === undefined) sw = a.strokeWidth;
+    if (sw !== undefined && typeof setSvgStrokeWidth === "function") {
+        var psw = parseFloat(sw);
+        if (psw === psw) setSvgStrokeWidth(el._id, psw);
+    }
+}
+
+// pulp #1926 — replay <circle> attributes by synthesizing a `d` path
+// from cx/cy/r and feeding through the SvgPathWidget bridge. Two SVG
+// arc commands (each a half-circle, sweep flag = 0) draw the full
+// circumference and Z closes the loop:
+//   M (cx-r) cy
+//   a r r 0 1 0 ( 2r) 0
+//   a r r 0 1 0 (-2r) 0
+//   Z
+function __replaySvgCircleAttributes__(el) {
+    if (!el || !el._nativeCreated || !el._attributes) return;
+    if (el.tagName !== "CIRCLE") return;
+    var a = el._attributes;
+    var cx = parseFloat(a.cx || "0");
+    var cy = parseFloat(a.cy || "0");
+    var r  = parseFloat(a.r  || "0");
+    if (cx !== cx || cy !== cy || r !== r || r <= 0) return;
+    if (typeof setSvgPath === "function") {
+        var d = "M " + (cx - r) + " " + cy +
+                " a " + r + " " + r + " 0 1 0 " + (2 * r) + " 0" +
+                " a " + r + " " + r + " 0 1 0 " + (-2 * r) + " 0 Z";
+        setSvgPath(el._id, d);
+    }
+    if (a.fill !== undefined && typeof setSvgFill === "function") {
+        setSvgFill(el._id, String(a.fill));
+    }
+    if (a.stroke !== undefined && typeof setSvgStroke === "function") {
+        setSvgStroke(el._id, String(a.stroke));
+    }
+    var sw = a["stroke-width"];
+    if (sw === undefined) sw = a.strokeWidth;
+    if (sw !== undefined && typeof setSvgStrokeWidth === "function") {
+        var psw = parseFloat(sw);
+        if (psw === psw) setSvgStrokeWidth(el._id, psw);
     }
 }
 

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -2685,6 +2685,26 @@ void WidgetBridge::register_api() {
                 return this->describe_native_canvas_frame(childId);
             });
             child = std::move(canvas);
+        } else if (tag == "rect") {
+            // pulp #1926 — SVG primitives other than <path>. Spectr's
+            // bottom-toolbar mini-icons (segmented mode toggles, analyzer
+            // pills) emit lowercase <rect> / <line> / <circle> inside the
+            // parent <svg>. Without this routing they fall through to the
+            // unknown-tag default and paint nothing.
+            auto r = std::make_unique<SvgRectWidget>();
+            r->set_id(childId);
+            child = std::move(r);
+        } else if (tag == "line") {
+            auto l = std::make_unique<SvgLineWidget>();
+            l->set_id(childId);
+            child = std::move(l);
+        } else if (tag == "circle") {
+            // pulp #1926 — no dedicated SvgCircleWidget; map to SvgPath
+            // and synthesize a `d` arc in JS (web-compat-element.js
+            // __replaySvgCircleAttributes__) from cx/cy/r.
+            auto svg = std::make_unique<SvgPathWidget>();
+            svg->set_id(childId);
+            child = std::move(svg);
         } else {
             auto v = std::make_unique<View>();
             v->set_id(childId);

--- a/test/web-compat/CMakeLists.txt
+++ b/test/web-compat/CMakeLists.txt
@@ -171,3 +171,21 @@ elseif(UNIX)
     target_link_options(pulp-test-popover-row-template-1147 PRIVATE -Wl,-z,stacksize=16777216)
 endif()
 catch_discover_tests(pulp-test-popover-row-template-1147)
+
+# pulp #1926 — SVG primitives other than <path> (rect / line / circle)
+# routing via the web-compat shim + __domAppend fast path + attribute
+# replay. Exercises document.createElement('rect'|'line'|'circle')
+# round-trips through the bridge — same DOM-shim stack-depth profile as
+# the rest of the web-compat suite, so match the 16 MB stack.
+add_executable(pulp-test-svg-primitives-1926 test_svg_primitives_1926.cpp)
+target_link_libraries(pulp-test-svg-primitives-1926 PRIVATE pulp::view Catch2::Catch2WithMain)
+target_include_directories(pulp-test-svg-primitives-1926 PRIVATE ${WEBCOMPAT_INCLUDE_DIR})
+target_compile_definitions(pulp-test-svg-primitives-1926 PRIVATE
+    PULP_TEST_SOURCE_DIR="${CMAKE_SOURCE_DIR}/test"
+)
+if(APPLE)
+    target_link_options(pulp-test-svg-primitives-1926 PRIVATE -Wl,-stack_size,0x2000000)
+elseif(UNIX)
+    target_link_options(pulp-test-svg-primitives-1926 PRIVATE -Wl,-z,stacksize=16777216)
+endif()
+catch_discover_tests(pulp-test-svg-primitives-1926)

--- a/test/web-compat/test_svg_primitives_1926.cpp
+++ b/test/web-compat/test_svg_primitives_1926.cpp
@@ -1,0 +1,242 @@
+// pulp #1926 — runtime-import gap: SVG primitives other than <path>
+//
+// Spectr (and any imported design) emits inline SVGs that use multiple
+// primitive elements, not just <path>. Examples from the live import:
+//   • 7× <rect>   — toggle-pill backgrounds, segmented control fills
+//   • 1× <line>   — analyzer ruler ticks / mode indicators
+//   • 1× <circle> — knob caps, focus dots
+//
+// PR #1917 wired <path> → SvgPathWidget via the web-compat shim and the
+// C++ __domAppend fast path. The other primitives still fell into the
+// unknown-tag default (plain View → empty box) so the icons rendered
+// blank. This test pins:
+//
+//   1. <rect x y width height fill stroke> routes to SvgRectWidget
+//      with geometry replayed via setSvgRect(...) and fill applied.
+//   2. <line x1 y1 x2 y2 stroke> routes to SvgLineWidget with
+//      endpoints replayed via setSvgLine(...).
+//   3. <circle cx cy r fill> routes to SvgPathWidget with a `d`
+//      string synthesized from the cx / cy / r attributes (two SVG
+//      arc commands closed with Z).
+//
+// React/JSX commits setAttribute() BEFORE appendChild() materializes
+// the native widget, so each primitive's `_attributes` arrive on a
+// node with no native id yet. The replay functions
+// (__replaySvgRectAttributes__ / __replaySvgLineAttributes__ /
+// __replaySvgCircleAttributes__) flush those values once the bridge
+// has an id; the test pre-mounts attributes the same way React would
+// to exercise that path.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include "test_helpers.hpp"
+#include <pulp/view/svg_path_widget.hpp>
+#include <pulp/view/widgets/svg_rect.hpp>
+#include <pulp/view/widgets/svg_line.hpp>
+
+using namespace pulp::test;
+using namespace pulp::view;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+inline std::string js_id(TestEnvironment& env, const std::string& js_var) {
+    return std::string(env.engine.evaluate(js_var + "._id")
+                            .getWithDefault<std::string_view>(""));
+}
+
+inline View* resolve(TestEnvironment& env, const std::string& js_var) {
+    auto id = js_id(env, js_var);
+    REQUIRE_FALSE(id.empty());
+    auto* w = env.widget(id);
+    REQUIRE(w != nullptr);
+    return w;
+}
+
+} // namespace
+
+// ─────────────────────────────────────────────────────────────────────────────
+// <rect> — SvgRectWidget with geometry + fill
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("svg-1926: <svg><rect>...</rect></svg> creates an SvgRectWidget",
+          "[svg][import][spectr][issue-1926]") {
+    TestEnvironment env(400, 200);
+    env.eval(R"JS(
+        var __svg = document.createElement('svg');
+        __svg.setAttribute('viewBox', '0 0 20 20');
+        __svg.setAttribute('width', '20');
+        __svg.setAttribute('height', '20');
+
+        var __rect = document.createElement('rect');
+        __rect.setAttribute('x', '5');
+        __rect.setAttribute('y', '5');
+        __rect.setAttribute('width', '10');
+        __rect.setAttribute('height', '10');
+        __rect.setAttribute('fill', '#ffffff');
+
+        __svg.appendChild(__rect);
+        document.body.appendChild(__svg);
+    )JS");
+    env.root.layout_children();
+
+    auto* rect = resolve(env, "__rect");
+    auto* rect_widget = dynamic_cast<SvgRectWidget*>(rect);
+    REQUIRE(rect_widget != nullptr);                       // routed, not createCol
+    REQUIRE_THAT(rect_widget->rect_x(),      WithinAbs(5.0f,  0.001f));
+    REQUIRE_THAT(rect_widget->rect_y(),      WithinAbs(5.0f,  0.001f));
+    REQUIRE_THAT(rect_widget->rect_width(),  WithinAbs(10.0f, 0.001f));
+    REQUIRE_THAT(rect_widget->rect_height(), WithinAbs(10.0f, 0.001f));
+    REQUIRE(rect_widget->has_fill());                      // fill="#ffffff" applied
+}
+
+TEST_CASE("svg-1926: <rect> with fill='none' clears the fill",
+          "[svg][import][spectr][issue-1926]") {
+    // SVG `fill="none"` is the standard way to draw an outlined rect.
+    // The shim should pipe the literal string through and the widget
+    // should drop has_fill_ to false.
+    TestEnvironment env(400, 200);
+    env.eval(R"JS(
+        var __svg = document.createElement('svg');
+        var __rect = document.createElement('rect');
+        __rect.setAttribute('x', '0');
+        __rect.setAttribute('y', '0');
+        __rect.setAttribute('width', '8');
+        __rect.setAttribute('height', '8');
+        __rect.setAttribute('fill', 'none');
+        __rect.setAttribute('stroke', '#000000');
+        __rect.setAttribute('stroke-width', '2');
+        __svg.appendChild(__rect);
+        document.body.appendChild(__svg);
+    )JS");
+    env.root.layout_children();
+
+    auto* widget = dynamic_cast<SvgRectWidget*>(resolve(env, "__rect"));
+    REQUIRE(widget != nullptr);
+    REQUIRE_FALSE(widget->has_fill());
+    REQUIRE(widget->has_stroke());
+    REQUIRE_THAT(widget->stroke_width(), WithinAbs(2.0f, 0.001f));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// <line> — SvgLineWidget with endpoints + stroke
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("svg-1926: <svg><line>...</line></svg> creates an SvgLineWidget",
+          "[svg][import][spectr][issue-1926]") {
+    TestEnvironment env(400, 200);
+    env.eval(R"JS(
+        var __svg = document.createElement('svg');
+        __svg.setAttribute('viewBox', '0 0 20 20');
+
+        var __line = document.createElement('line');
+        __line.setAttribute('x1', '0');
+        __line.setAttribute('y1', '0');
+        __line.setAttribute('x2', '20');
+        __line.setAttribute('y2', '20');
+        __line.setAttribute('stroke', '#000000');
+
+        __svg.appendChild(__line);
+        document.body.appendChild(__svg);
+    )JS");
+    env.root.layout_children();
+
+    auto* line = resolve(env, "__line");
+    auto* line_widget = dynamic_cast<SvgLineWidget*>(line);
+    REQUIRE(line_widget != nullptr);                       // routed, not createCol
+    REQUIRE_THAT(line_widget->x1(), WithinAbs(0.0f,  0.001f));
+    REQUIRE_THAT(line_widget->y1(), WithinAbs(0.0f,  0.001f));
+    REQUIRE_THAT(line_widget->x2(), WithinAbs(20.0f, 0.001f));
+    REQUIRE_THAT(line_widget->y2(), WithinAbs(20.0f, 0.001f));
+    REQUIRE(line_widget->has_stroke());                    // stroke="#000000" applied
+}
+
+TEST_CASE("svg-1926: <line> camelCase strokeWidth also routes",
+          "[svg][import][spectr][issue-1926]") {
+    // JSX historically passes `strokeWidth` rather than the HTML
+    // `stroke-width`. The replay must accept either spelling so raw
+    // React imports (no build-time prop-applier) still work.
+    TestEnvironment env(400, 200);
+    env.eval(R"JS(
+        var __svg = document.createElement('svg');
+        var __line = document.createElement('line');
+        __line.setAttribute('x1', '1');
+        __line.setAttribute('y1', '2');
+        __line.setAttribute('x2', '3');
+        __line.setAttribute('y2', '4');
+        __line.setAttribute('stroke', '#ff0000');
+        __line.setAttribute('strokeWidth', '4');
+        __svg.appendChild(__line);
+        document.body.appendChild(__svg);
+    )JS");
+    env.root.layout_children();
+
+    auto* widget = dynamic_cast<SvgLineWidget*>(resolve(env, "__line"));
+    REQUIRE(widget != nullptr);
+    REQUIRE_THAT(widget->stroke_width(), WithinAbs(4.0f, 0.001f));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// <circle> — SvgPathWidget with synthesized `d` arc path
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("svg-1926: <svg><circle>...</circle></svg> creates an SvgPathWidget",
+          "[svg][import][spectr][issue-1926]") {
+    // The circle shim synthesizes a `d` path of two SVG arc commands
+    // (each a half-circle, sweep flag = 0) closed with Z. For
+    // cx=8 cy=8 r=6 we expect the path to start at (cx-r, cy) = (2, 8)
+    // and contain two arc commands. The exact string is not pinned —
+    // tolerate floating-point representation drift — but the prefix
+    // and the cx/cy/r values must be present.
+    TestEnvironment env(400, 200);
+    env.eval(R"JS(
+        var __svg = document.createElement('svg');
+        __svg.setAttribute('viewBox', '0 0 16 16');
+
+        var __circle = document.createElement('circle');
+        __circle.setAttribute('cx', '8');
+        __circle.setAttribute('cy', '8');
+        __circle.setAttribute('r', '6');
+        __circle.setAttribute('fill', '#ffffff');
+
+        __svg.appendChild(__circle);
+        document.body.appendChild(__svg);
+    )JS");
+    env.root.layout_children();
+
+    auto* circle = resolve(env, "__circle");
+    auto* path_widget = dynamic_cast<SvgPathWidget*>(circle);
+    REQUIRE(path_widget != nullptr);                       // routed via createSvgPath
+
+    // Synthesized d must mention the two arc commands. The exact
+    // floating-point formatting depends on QuickJS Number->String, so
+    // assert structural fragments rather than the full literal.
+    const auto& d = path_widget->path_data();
+    REQUIRE_FALSE(d.empty());
+    REQUIRE(d.find("M ") == 0);     // starts with a Move-to
+    REQUIRE(d.find(" a ") != std::string::npos);  // contains arc command
+    REQUIRE(d.find("Z") != std::string::npos);    // closed
+    REQUIRE(path_widget->has_fill());              // fill="#ffffff" applied
+}
+
+TEST_CASE("svg-1926: <circle> with r<=0 is a no-op (skips path synthesis)",
+          "[svg][import][spectr][issue-1926]") {
+    // Degenerate radii (missing, zero, negative) should not generate a
+    // bogus `d` — leave the widget empty so it's clearly absent rather
+    // than a 1-pixel speck near (cx, cy).
+    TestEnvironment env(400, 200);
+    env.eval(R"JS(
+        var __svg = document.createElement('svg');
+        var __circle = document.createElement('circle');
+        __circle.setAttribute('cx', '4');
+        __circle.setAttribute('cy', '4');
+        __circle.setAttribute('r', '0');
+        __svg.appendChild(__circle);
+        document.body.appendChild(__svg);
+    )JS");
+    env.root.layout_children();
+
+    auto* widget = dynamic_cast<SvgPathWidget*>(resolve(env, "__circle"));
+    REQUIRE(widget != nullptr);
+    REQUIRE(widget->path_data().empty());
+}


### PR DESCRIPTION
Spectr's imported design emits inline SVG icons using primitives other
than <path> (7x <rect>, 1x <line>, 1x <circle>). PR #1917 routes <path>
to SvgPathWidget, but the other primitives still fall through the
unknown-tag default to a plain View, painting empty boxes where icons
should be.

This change mirrors the <path> routing pattern across the three other
primitives Spectr emits, in all three layers where the routing must
agree:

  1. C++ __domAppend fast path (widget_bridge.cpp) — adds branches for
     `tag == "rect"` -> SvgRectWidget, `tag == "line"` -> SvgLineWidget,
     `tag == "circle"` -> SvgPathWidget (d-path synthesized in JS).
  2. JS shim _ensureNative (web-compat-element.js) — mirrors the same
     routing through createSvgRect / createSvgLine / createSvgPath.
  3. Attribute replay (web-compat-element.js + web-compat-dom-ops.js) —
     new __replaySvgRectAttributes__ / __replaySvgLineAttributes__ /
     __replaySvgCircleAttributes__ flush x/y/width/height + fill/stroke
     (rect), x1/y1/x2/y2 + stroke (line), and a `d` path synthesized
     from cx/cy/r as two SVG arc commands (circle), once the bridge
     has a native id. Hooked into both _ensureNative's post-mount block
     AND appendChild / insertBefore in dom-ops where the existing
     SvgPath replay already fires.

Tests (test/web-compat/test_svg_primitives_1926.cpp, tag [issue-1926]):
  - <rect x=5 y=5 width=10 height=10 fill=#fff> -> SvgRectWidget with
    set_rect(5,5,10,10) and fill applied.
  - <rect fill=none stroke=#000 stroke-width=2> clears fill, applies
    stroke + stroke-width.
  - <line x1=0 y1=0 x2=20 y2=20 stroke=#000> -> SvgLineWidget endpoints
    set, stroke applied.
  - <line strokeWidth=4> (camelCase JSX form) also routes through.
  - <circle cx=8 cy=8 r=6 fill=#fff> -> SvgPathWidget with synthesized
    `d` containing M + two arc commands + Z, fill applied.
  - <circle r=0> is a no-op (no bogus 1-pixel path).

All 38 assertions across 6 test cases pass; existing prelude (111
cases) and popover (3 cases) regressions stay green.

Version-Bump: sdk=patch reason="JS shim + bridge routing for additional SVG primitives"

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Skill-Update: skip skill=engine reason="Additive SVG-primitive routing in the JS shim (rect/line/circle mirror existing path routing); no new engine-tier gotcha or convention to record."