### PR TITLE
fix(view): Label wraps with CSS default white-space:normal (closes #1924)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
+## [0.95.1]
+
 <a id="v0950"></a>
 ## [0.95.0] - 2026-05-12
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.95.0
+    VERSION 0.95.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -449,12 +449,21 @@ void Label::paint(canvas::Canvas& canvas) {
     // Vertical alignment
     float lh = line_height_ > 0 ? line_height_ : effective_font_size * 1.4f;
 
-    // pulp #1737 PR-2 — CSS `overflow-wrap` / `word-break` soft-wrap path.
-    // When `View::word_break_` opts into break-word or anywhere AND the
-    // Label is multi_line AND we have a bounded width, route the layout
-    // through TextShaper so over-wide words split inside instead of
-    // overflowing. Default (`normal` or empty) keeps the legacy `\n`-only
-    // split below — zero behavior change for existing consumers.
+    // pulp #1737 PR-2 / #1924 — CSS `white-space` / `overflow-wrap` /
+    // `word-break` soft-wrap path. Route any multi-line, bounded-width
+    // Label through TextShaper so CSS default `white-space: normal`
+    // soft-wraps at word boundaries (whitespace), and `break-word` /
+    // `anywhere` additionally split inside over-wide words.
+    //
+    // Pre-#1924 this gate also required `break_mode != normal`, which
+    // meant the default mode skipped the shaper and never soft-wrapped —
+    // dropdown labels (and any other multi_line Label without an
+    // explicit word-break) overflowed their container instead of
+    // wrapping. TextShaper's `BreakMode::normal` already preserves the
+    // legacy "whole-word overflow for a single unbroken word" behavior
+    // (see test_text_shaper.cpp [issue-1737]), so removing the gate
+    // brings Label in line with the CSS spec without regressing the
+    // single-long-word case.
     //
     // The shaped layout is computed ONCE here and reused both for the
     // vertical-align metrics (source_lines / text_h) and the rendering
@@ -466,7 +475,6 @@ void Label::paint(canvas::Canvas& canvas) {
     else if (wb == "anywhere")   break_mode = canvas::BreakMode::anywhere;
     const bool use_shaper_wrap =
         multi_line_ &&
-        break_mode != canvas::BreakMode::normal &&
         bounds().width > 0.0f;
 
     canvas::ShapedLayout shaped_layout;
@@ -611,9 +619,9 @@ void Label::paint(canvas::Canvas& canvas) {
             }
         } else {
             // Legacy `\n`-only split path — bit-identical to pre-#1737.
-            // Used when word_break is "normal" (the default) OR when
-            // bounds().width is 0 / unbounded. Existing consumers see
-            // exactly the previous behavior.
+            // Used when bounds().width is 0 / unbounded (the shaper has
+            // no max_width to break against). Existing consumers see
+            // exactly the previous behavior in that case.
             size_t pos = 0;
             while (pos < display_text.size()) {
                 if (emitted >= visible_lines) break;

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -1450,8 +1450,8 @@ TEST_CASE("Label soft-wrap: word_break='break-word' splits long unbroken word",
     REQUIRE(reconstructed == "Antidisestablishmentarianism");
 }
 
-TEST_CASE("Label soft-wrap: word_break='normal' falls through to legacy \\n-split",
-          "[view][widget][issue-1737]") {
+TEST_CASE("Label soft-wrap: word_break='normal' on a single unbroken word keeps whole-word overflow",
+          "[view][widget][issue-1737][issue-1924]") {
     Label label("Antidisestablishmentarianism");
     label.set_bounds({0, 0, 60, 100});
     label.set_multi_line(true);
@@ -1460,12 +1460,59 @@ TEST_CASE("Label soft-wrap: word_break='normal' falls through to legacy \\n-spli
     RecordingCanvas canvas;
     label.paint(canvas);
 
-    // Legacy path emits exactly one fill_text per `\n`-delimited line.
-    // No newlines in input → exactly 1 fill_text (overflowing — same
-    // behavior as pre-#1737 for `normal`).
+    // pulp #1924: the default (`normal`) path now also routes through
+    // TextShaper for bounded multi_line labels, but TextShaper's
+    // BreakMode::normal preserves the "whole-word overflow for a single
+    // unbroken word" CSS contract (see test_text_shaper.cpp
+    // "BreakMode::normal preserves legacy whole-word overflow"). So an
+    // input with no whitespace still emits exactly one fill_text — the
+    // observable output for this probe is unchanged from pre-#1924.
     auto text_cmds = commands_of(canvas, DrawCommand::Type::fill_text);
     REQUIRE(text_cmds.size() == 1);
     REQUIRE(text_cmds[0].text == "Antidisestablishmentarianism");
+}
+
+// ── pulp #1924 — Label soft-wraps under CSS default `white-space: normal` ──
+// Pre-#1924 the wrap gate required `word_break != normal` before the shaper
+// fired, so default Labels (no explicit word-break) overflowed their bounds
+// instead of soft-wrapping at whitespace. CSS `white-space: normal` is the
+// default and MUST soft-wrap at word boundaries. Hit on Spectr's dropdowns
+// (Settings / Preset Manager) — text overflowed the parent SChips /
+// PatternRow container.
+
+TEST_CASE("Label default word_break: text with whitespace soft-wraps at word boundaries (#1924)",
+          "[view][widget][issue-1924]") {
+    // Several short words separated by spaces. With bounds().width
+    // narrower than the full string the shaper must break at whitespace,
+    // emitting more than one line. NO explicit word_break is set — this
+    // is the CSS default (`white-space: normal`) path that was broken
+    // pre-#1924 (single overflowing line).
+    Label label("Settings Preset Manager Dropdown");
+    label.set_bounds({0, 0, 60, 200});
+    label.set_multi_line(true);
+    // NOTE: no set_word_break — defaults to "normal" / empty.
+
+    RecordingCanvas canvas;
+    label.paint(canvas);
+
+    auto text_cmds = commands_of(canvas, DrawCommand::Type::fill_text);
+    // Expect >1 fill_text — soft-wrap at whitespace inside the bounded
+    // container. Pre-#1924 this would have been exactly 1 (the legacy
+    // `\n`-only path with no newlines in the input).
+    REQUIRE(text_cmds.size() >= 2);
+
+    // Reconstruction across all emitted lines must contain every
+    // non-whitespace character from the original (whitespace at line
+    // boundaries is collapsed under CSS `white-space: normal` — the
+    // exact preservation contract is shaper-defined, but no characters
+    // beyond inter-word spaces should be dropped).
+    std::string concatenated;
+    for (const auto& cmd : text_cmds) concatenated += cmd.text;
+    // Each individual word must still appear in the emitted output.
+    for (const char* word : {"Settings", "Preset", "Manager", "Dropdown"}) {
+        INFO("Expecting word " << word << " in '" << concatenated << "'");
+        REQUIRE(concatenated.find(word) != std::string::npos);
+    }
 }
 
 TEST_CASE("Label soft-wrap: word_break='anywhere' also splits, same as break-word for over-wide single word",


### PR DESCRIPTION
The wrap gate required break_mode != normal before shaper-wrap fires,
but per CSS spec white-space:normal is the default and SHOULD soft-wrap.
Dropping the gate clause lets dropdown labels (and any other Label with
default break-mode) wrap text inside their container instead of
overflowing.

Hit on Spectr's dropdowns (Settings/Preset Manager) — text overflowed
the parent SChips/PatternRow container instead of wrapping.

TextShaper::layout_with_lines with BreakMode::normal already preserves
the legacy "whole-word overflow for a single unbroken word" CSS contract
(see test_text_shaper.cpp [issue-1737]), so removing the gate brings
Label in line with the CSS spec without regressing the single-long-word
case.

Tests: extend existing [issue-1737] coverage with a new [issue-1924]
case that pins default soft-wrap at whitespace; update the prior
"falls through to legacy" test name + comment since the default path
now goes through the shaper but produces the same observable output
for an input with no whitespace.