### PR TITLE
ci(build): macOS overflow routing to Namespace when local Mac is busy

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -239,6 +239,58 @@ shipyard run --targets windows --resume-from test   # ~2 min vs 15 min
 shipyard run --resume-from build
 ```
 
+### macOS overflow routing (Plan B)
+
+`.github/workflows/build.yml`'s `resolve-provider` job auto-routes the
+macOS leg to Namespace when the local self-hosted Mac runner is busy.
+With one local runner serving ~15 open PRs serially, this is the
+difference between "PR merges in 20 min" and "PR queues for 5 hours."
+
+**Trigger condition** (all three must hold):
+
+- Local runner BUSY count >= `PULP_LOCAL_MAC_OVERFLOW_THRESHOLD` (default `2`)
+- `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON` is set on the repo
+- Event is `pull_request` (manual `workflow_dispatch` honors the operator's explicit `macos_runner_selector_json`)
+
+When triggered, the macOS matrix leg dispatches to the Namespace
+runner profile (e.g. `namespace-profile-generouscorp-macos`) instead
+of the local `["self-hosted","sanitizer"]` pool. The stable `macos`
+wrapper job (branch-protection's required check) doesn't change — it
+gates on the matrix leg's conclusion regardless of which runner pool
+served it.
+
+**When this kicks in vs. doesn't:**
+
+```
+push to PR  →  resolve-provider runs
+            →  count busy local "sanitizer" runners
+            →  BUSY >= 2 AND Namespace configured?
+                  ├── yes  →  macOS = namespace-profile-...
+                  └── no   →  macOS = self-hosted,sanitizer (local)
+```
+
+**Inspect the decision:**
+
+```bash
+gh run view <run-id> --log --repo danielraffel/pulp | grep "macOS route"
+# → resolve-provider: macOS route = overflow (BUSY=2 >= 2); selector = "namespace-profile-generouscorp-macos"
+```
+
+**`shipyard rescue <PR>` still works** as a manual override for PRs
+that queued before Plan B was in place, or when overflow conditions
+don't match (e.g., only 1 busy runner) but you want cloud anyway.
+With Plan B routing automatic, rescue is a less common tool.
+
+**Disable temporarily** (revert all PRs to local-only):
+
+```bash
+gh variable delete PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON --repo danielraffel/pulp
+```
+
+Plan source: `planning/2026-05-13-namespace-overflow-implementation.md`
+(reviewed by `/codex` 2026-05-13). Full operator docs:
+`docs/guides/local-ci.md` § "macOS overflow routing".
+
 ### Path-scoped validation profile: `parser`
 
 `.shipyard/config.toml` defines a `[validation.parser]` lane (pulp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,15 +55,37 @@ jobs:
           REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.PULP_DEFAULT_RUNNER_PROVIDER || 'namespace' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
           EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON: ${{ inputs.windows_runner_selector_json || '' }}
-          # Falls back to the PULP_LOCAL_MACOS_RUNS_ON_JSON repo var so the
-          # macOS leg routes to the local self-hosted runner (label `sanitizer`)
-          # without a workflow_dispatch input on auto pull_request triggers.
-          # Mirrors Shipyard's local-mac runner pattern; allows Linux + Windows
-          # to fall through to GitHub-hosted defaults via PULP_DEFAULT_RUNNER_PROVIDER='github-hosted'.
-          EXPLICIT_MACOS_RUNNER_SELECTOR_JSON: ${{ inputs.macos_runner_selector_json || vars.PULP_LOCAL_MACOS_RUNS_ON_JSON || '' }}
+          # macOS routing has three layers, evaluated in order (highest
+          # precedence first). The Python block below composes
+          # `EXPLICIT_MACOS_RUNNER_SELECTOR_JSON` from these inputs so the
+          # downstream resolver still sees a single explicit env.
+          #
+          # 1. Operator override (workflow_dispatch input). Always wins.
+          # 2. Namespace overflow (Plan B, pulp planning/2026-05-13-
+          #    namespace-overflow-implementation.md). Activates when the
+          #    local self-hosted Mac runner has at least
+          #    LOCAL_MAC_OVERFLOW_THRESHOLD busy workers AND Namespace is
+          #    configured (NAMESPACE_MACOS_RUNS_ON_JSON non-empty).
+          # 3. Local default (PULP_LOCAL_MACOS_RUNS_ON_JSON). The
+          #    operator's "macOS local runner: primary required gate"
+          #    policy when local is idle.
+          WORKFLOW_DISPATCH_MACOS_SELECTOR: ${{ inputs.macos_runner_selector_json || '' }}
+          LOCAL_MACOS_RUNS_ON_JSON: ${{ vars.PULP_LOCAL_MACOS_RUNS_ON_JSON || '' }}
+          # BUSY threshold for macOS overflow. With one local runner,
+          # BUSY >= 1 would overflow as soon as any job is in flight —
+          # Codex flagged that as too aggressive (planning doc Step 2).
+          # Default 2 means "local is fully saturated AND new work is
+          # coming"; when Plan A's 2nd local runner is added, bump to
+          # match the new capacity.
+          LOCAL_MAC_OVERFLOW_THRESHOLD: ${{ vars.PULP_LOCAL_MAC_OVERFLOW_THRESHOLD || '2' }}
+          # The runner label the overflow logic queries for `busy`. Must
+          # match the label PULP_LOCAL_MACOS_RUNS_ON_JSON targets.
+          LOCAL_MAC_RUNNER_LABEL: ${{ vars.PULP_LOCAL_MAC_RUNNER_LABEL || 'sanitizer' }}
           NAMESPACE_LINUX_RUNS_ON_JSON: ${{ vars.PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON }}
           NAMESPACE_WINDOWS_RUNS_ON_JSON: ${{ vars.PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON }}
           NAMESPACE_MACOS_RUNS_ON_JSON: ${{ vars.PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON }}
+          # gh CLI auth for the overflow-busy-count probe.
+          GH_TOKEN: ${{ github.token }}
         # Uses the shared resolver at tools/scripts/resolve_runs_on.py so the
         # same precedence (explicit input → repo var → provider fallback) is
         # reused by sanitizers.yml and any future workflow. See that script's
@@ -81,6 +103,7 @@ jobs:
           REQUESTED = (os.environ.get("REQUESTED_PROVIDER") or "github-hosted").strip()
           EVENT_NAME = (os.environ.get("GITHUB_EVENT_NAME") or "").strip()
           RESOLVER = ["python3", "tools/scripts/resolve_runs_on.py"]
+          REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "")
 
           def run(args):
               result = subprocess.run(
@@ -94,6 +117,79 @@ jobs:
                   sys.stderr.write(result.stderr)
                   sys.exit(result.returncode)
               return result.stdout
+
+          # ─── macOS overflow routing (Plan B, pulp #1916 follow-up) ────────
+          # When the local self-hosted Mac runner is saturated and Namespace
+          # is configured, route the macOS leg to Namespace cloud instead
+          # of waiting in the local queue. Precedence is "operator wins,
+          # then overflow, then local default" — see the env-block comment
+          # above for the layer ordering. Failures of the busy probe fall
+          # back to local (the safer choice — overflow is an optimization,
+          # not a correctness requirement).
+          def _count_busy_local_mac_runners() -> int:
+              label = (os.environ.get("LOCAL_MAC_RUNNER_LABEL") or "").strip()
+              if not label or not REPOSITORY:
+                  return 0
+              try:
+                  result = subprocess.run(
+                      [
+                          "gh", "api",
+                          f"repos/{REPOSITORY}/actions/runners",
+                          "--jq",
+                          f'[.runners[] | select(.busy and (.labels[].name == "{label}"))] | length',
+                      ],
+                      check=True,
+                      capture_output=True,
+                      text=True,
+                      timeout=15,
+                  )
+                  return int((result.stdout or "0").strip() or "0")
+              except (subprocess.SubprocessError, ValueError) as exc:
+                  sys.stderr.write(
+                      f"resolve-provider: local-busy probe failed; "
+                      f"falling back to BUSY=0. ({exc})\n"
+                  )
+                  return 0
+
+          workflow_dispatch_selector = (
+              os.environ.get("WORKFLOW_DISPATCH_MACOS_SELECTOR") or ""
+          ).strip()
+          namespace_macos_selector = (
+              os.environ.get("NAMESPACE_MACOS_RUNS_ON_JSON") or ""
+          ).strip()
+          local_macos_selector = (
+              os.environ.get("LOCAL_MACOS_RUNS_ON_JSON") or ""
+          ).strip()
+          try:
+              overflow_threshold = int(
+                  (os.environ.get("LOCAL_MAC_OVERFLOW_THRESHOLD") or "2").strip()
+              )
+          except ValueError:
+              overflow_threshold = 2
+
+          if workflow_dispatch_selector:
+              macos_route = "operator-override"
+              chosen_macos_selector = workflow_dispatch_selector
+          elif namespace_macos_selector and EVENT_NAME == "pull_request":
+              busy = _count_busy_local_mac_runners()
+              if busy >= overflow_threshold:
+                  macos_route = f"overflow (BUSY={busy} >= {overflow_threshold})"
+                  chosen_macos_selector = namespace_macos_selector
+              else:
+                  macos_route = f"local (BUSY={busy} < {overflow_threshold})"
+                  chosen_macos_selector = local_macos_selector
+          else:
+              # workflow_dispatch without an explicit override, or
+              # Namespace not configured. Stay local.
+              macos_route = "local (default)"
+              chosen_macos_selector = local_macos_selector
+
+          os.environ["EXPLICIT_MACOS_RUNNER_SELECTOR_JSON"] = chosen_macos_selector
+          print(
+              f"resolve-provider: macOS route = {macos_route}; "
+              f"selector = {chosen_macos_selector or '(empty → falls through to provider mode)'}",
+              file=sys.stderr,
+          )
 
           linux_runs_on = run([
               "--target-name", "Linux (x64)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -874,12 +874,19 @@ advisory unless explicitly required by branch protection.
 
 #### Runner priority (hard rule)
 
-Namespace is decommissioned for Pulp CI. Do not use `--mode namespace` or set
-`*_NAMESPACE_*_RUNS_ON_JSON` repo variables.
+Pulp's macOS leg is local-first with Namespace overflow (Plan B,
+`planning/2026-05-13-namespace-overflow-implementation.md`). The
+`resolve-provider` job in `build.yml` routes the macOS matrix leg to
+Namespace when the local self-hosted Mac runner has >= 2 busy workers
+AND `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON` is set. Otherwise it
+stays local. Linux and Windows continue to route via the existing
+provider machinery (default `github-hosted`). The `macos` wrapper job
+that branch protection requires is unchanged.
 
-1. **macOS local runner**: primary required gate.
-2. **GitHub-hosted Linux/Windows**: advisory cross-platform signal.
-3. **SSH Ubuntu/Windows**: use only when a human explicitly asks for those local hosts.
+1. **macOS local runner**: primary required gate when local has capacity.
+2. **Namespace macOS cloud**: automatic overflow when local is saturated. See `docs/guides/local-ci.md` § "macOS overflow routing".
+3. **GitHub-hosted Linux/Windows**: advisory cross-platform signal.
+4. **SSH Ubuntu/Windows**: use only when a human explicitly asks for those local hosts.
 
 If Shipyard tries to probe SSH Ubuntu or Windows for a macOS-focused PR where
 those hosts are not in scope, use `--skip-target ubuntu --skip-target windows`

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -156,6 +156,45 @@ broad validation.
 
 To opt out for an individual run, pass `--pipeline default` explicitly.
 
+## macOS overflow routing (Plan B)
+
+When the local self-hosted Mac runner is saturated, `build.yml`'s
+`resolve-provider` job routes new macOS legs to a Namespace cloud
+runner instead of queueing on local. Snap-back is automatic — once
+local clears, fresh dispatches return to local. Source of truth:
+`planning/2026-05-13-namespace-overflow-implementation.md` (Plan B,
+reviewed by `/codex` 2026-05-13).
+
+**Precedence** (highest first, resolved per dispatch):
+
+1. **Operator override** — `gh workflow run build.yml --field macos_runner_selector_json='"<label>"'`. Always wins.
+2. **Overflow** — `BUSY >= PULP_LOCAL_MAC_OVERFLOW_THRESHOLD` (default `2`) AND `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON` is set AND the trigger is `pull_request`. Routes to `namespace-profile-generouscorp-macos`.
+3. **Local default** — `PULP_LOCAL_MACOS_RUNS_ON_JSON` (currently `["self-hosted","sanitizer"]`).
+
+**Tuning knobs** (repo variables):
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `PULP_LOCAL_MAC_OVERFLOW_THRESHOLD` | `2` | BUSY count that triggers overflow. Raise when Plan A's 2nd local runner lands. |
+| `PULP_LOCAL_MAC_RUNNER_LABEL` | `sanitizer` | Label the busy probe filters runners by. Must match `PULP_LOCAL_MACOS_RUNS_ON_JSON`'s target label. |
+| `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON` | (unset) | Namespace selector JSON, e.g. `"namespace-profile-generouscorp-macos"`. When empty, overflow is disabled — everything stays local. |
+
+**Disabling overflow** (revert to local-only):
+
+```bash
+gh variable delete PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON --repo danielraffel/pulp
+```
+
+The next PR's `resolve-provider` falls through to local since condition #2 fails.
+
+**Inspecting routing decisions:** `resolve-provider`'s stderr prints a one-line summary, e.g. `resolve-provider: macOS route = overflow (BUSY=2 >= 2); selector = "namespace-profile-generouscorp-macos"`. Find it via the GitHub Actions UI under the `resolve-provider` job's log, or:
+
+```bash
+gh run view <run-id> --log --repo danielraffel/pulp | grep "macOS route"
+```
+
+**Manual overflow / rescue** is still available via `shipyard rescue <PR>` and remains useful for in-flight PRs that queued before the overflow logic kicked in. With Plan B in place, manual rescue should be needed much less frequently.
+
 ## Required Merge Process (All Agents)
 
 Every change to `main` must go through this workflow — no exceptions:


### PR DESCRIPTION
Plan B from planning/2026-05-13-namespace-overflow-implementation.md
(reviewed by /codex 2026-05-13). The local self-hosted Mac runner
serves Pulp PRs serially; when 15+ PRs queue, wall-time-to-merge runs
into hours. This wires automatic overflow to a Namespace cloud runner
when local is saturated, while keeping local-first for idle state.

Changes:

- `.github/workflows/build.yml` `resolve-provider` job grows a three-
  layer macOS routing decision before the existing per-target
  resolver invocation:
    1. workflow_dispatch `macos_runner_selector_json` — operator wins
    2. Overflow: BUSY local "sanitizer" runners >= threshold (default
       2) AND `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON` is set AND
       event is `pull_request` → route to Namespace
    3. Local default: `PULP_LOCAL_MACOS_RUNS_ON_JSON`
  The chosen selector is written back into
  `EXPLICIT_MACOS_RUNNER_SELECTOR_JSON` so the downstream resolver
  picks it up unchanged. Decision is printed on stderr for log-grep
  visibility.
- Busy probe via `gh api .../actions/runners`. Probe failure (timeout,
  auth, rate limit) falls back to BUSY=0 — overflow is an
  optimization, not a correctness gate.
- `PULP_LOCAL_MAC_OVERFLOW_THRESHOLD` + `PULP_LOCAL_MAC_RUNNER_LABEL`
  repo vars expose the tuning surface (defaults `2` / `sanitizer`).
- Existing `macos` wrapper job (branch-protection's required check) is
  unchanged: it still gates on the matrix leg's conclusion regardless
  of which runner pool served.

Companion doc + skill updates:

- `docs/guides/local-ci.md` — new "macOS overflow routing" section
  with the precedence ladder, tuning knobs, decision-inspection
  recipe, and disable instructions.
- `.agents/skills/ci/SKILL.md` — agent-facing summary of the routing
  decision and how to inspect it.
- `CLAUDE.md` — replaces the stale "Namespace is decommissioned" note
  with the local-first + overflow policy.

V1 acceptance (per plan): Namespace runner profile
`namespace-profile-generouscorp-macos` is already registered to the
Pulp tenant (shape: macOS arm64, 6 vCPU, 14 GB) and has been used by
Pulp before (last instance 2026-05-06 ran the Coverage workflow
successfully on this profile, see `nsc instance history`). The
operator confirmed re-enabling Namespace and asked to skip a fresh
trial since the runner profile is unchanged.

V2 acceptance: Shipyard's `src/reconcile.rs:300-330` matches checks by
NAME (`check_name(check)`) not runner label, so the existing `macos`
wrapper-job pattern composes with overflow routing unchanged. No
Shipyard config changes needed.

Skill-Update: skip skill=import-design reason="overflow routing is CI infra; no import-design code or runtime behaviour changes"