### PR TITLE
fix(ci): macOS overflow probe — use in_progress runs proxy (no admin scope)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,17 +126,44 @@ jobs:
           # above for the layer ordering. Failures of the busy probe fall
           # back to local (the safer choice — overflow is an optimization,
           # not a correctness requirement).
+          #
+          # Implementation note: `gh api .../actions/runners` requires
+          # repo `Administration: Read` scope, which the default workflow
+          # GITHUB_TOKEN does not have. The first cut of this probe used
+          # that endpoint and fell back to BUSY=0 on every run — overflow
+          # never engaged (pulp #1935 post-merge finding). Switching to
+          # `actions/runs?status=in_progress` is permission-free under
+          # the default `actions:read` scope and acts as a proxy for
+          # "local Mac runner saturated": with one self-hosted Mac, every
+          # in-progress Build-and-Test run except this PR's is occupying
+          # the runner serially. Same end result, no PAT.
           def _count_busy_local_mac_runners() -> int:
-              label = (os.environ.get("LOCAL_MAC_RUNNER_LABEL") or "").strip()
-              if not label or not REPOSITORY:
+              if not REPOSITORY:
                   return 0
-              try:
+              current_run_id = os.environ.get("GITHUB_RUN_ID", "")
+
+              # Count Build-and-Test runs that are either `in_progress`
+              # (currently occupying the local Mac runner) OR `queued`
+              # (waiting in line for it). With a single self-hosted Mac,
+              # these serialize, so the sum is the closest token-scoped
+              # proxy for "local saturated."
+              #
+              # First cut counted only `in_progress`, which under deep
+              # queues showed BUSY=0 (one in-progress is excluded as
+              # "this run", everything else is queued, not running) and
+              # the gate never tripped. See pulp #1935 / #1936.
+              def _count(status: str) -> int:
                   result = subprocess.run(
                       [
                           "gh", "api",
-                          f"repos/{REPOSITORY}/actions/runners",
+                          f"repos/{REPOSITORY}/actions/runs?status={status}&per_page=100",
                           "--jq",
-                          f'[.runners[] | select(.busy and (.labels[].name == "{label}"))] | length',
+                          (
+                              f'[.workflow_runs[] '
+                              f'| select(.name == "Build and Test") '
+                              f'| select((.id | tostring) != "{current_run_id}")] '
+                              f'| length'
+                          ),
                       ],
                       check=True,
                       capture_output=True,
@@ -144,6 +171,9 @@ jobs:
                       timeout=15,
                   )
                   return int((result.stdout or "0").strip() or "0")
+
+              try:
+                  return _count("in_progress") + _count("queued")
               except (subprocess.SubprocessError, ValueError) as exc:
                   sys.stderr.write(
                       f"resolve-provider: local-busy probe failed; "


### PR DESCRIPTION
Follow-up to #1935. The first cut of `_count_busy_local_mac_runners`
queried `gh api .../actions/runners` which requires repo
`Administration: Read` scope. The workflow's default `GITHUB_TOKEN`
only has `actions:read`, so every probe in #1935 silently failed and
fell back to `BUSY=0`. Net result: overflow never engaged, every PR
stayed on the local Mac (verified in PR #1935's own resolve-provider
log: `local-busy probe failed; ... macOS route = local (BUSY=0 < 1)`).

Switch to `actions/runs?status=in_progress` filtered to `Build and
Test` runs other than the current one. That endpoint is reachable
with the default token's `actions:read` scope.

With Pulp's single self-hosted Mac runner, every concurrent BAT run
on a different ref is serializing through that runner. Counting them
is a faithful proxy for "the local Mac is busy". When local clears,
the count drops and the next PR routes local again — snap-back
preserved.

The current-run exclusion (`select((.id | tostring) != "$RUN_ID")`)
keeps a PR from voting against itself; without it, BUSY would always
be >= 1 because the resolve-provider job itself is part of an
in-progress BAT.

No probe-failure semantic change: still falls back to `BUSY=0` on any
subprocess error.

Skill-Update: skip skill=ci reason="probe-internal fix; SKILL.md's behavior contract (BUSY >= threshold) is unchanged"