### PR TITLE
feat(ci): pulp overflow CLI for macOS-runner overflow routing

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -225,6 +225,35 @@ When this is the right tool vs. `shipyard rescue`:
 | Move one PR's macOS to a different pool without disturbing Linux/Windows | `pulp macos retarget` |
 | Move multiple PRs' workflow_runs to a different provider (cancel + redispatch the WHOLE workflow) | `shipyard rescue` |
 
+## `pulp overflow` — macOS overflow routing
+
+`tools/cli/cmd_overflow.cpp`. Wraps three repo variables that
+`.github/workflows/build.yml`'s resolve-provider reads:
+
+| Var | Purpose |
+|-----|---------|
+| `PULP_LOCAL_MACOS_RUNS_ON_JSON` | Selector when local has capacity |
+| `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON` | Selector when local is saturated (overflow target; despite the historical name, this is the generic overflow var) |
+| `PULP_LOCAL_MAC_OVERFLOW_THRESHOLD` | BUSY count that trips overflow |
+
+Surfaces:
+
+- `pulp overflow status` — show current state, including which runner
+  the local target points at, the overflow target, threshold value, and
+  registered self-hosted runners (if the default token can list them).
+- `pulp overflow enable [--to <selector>]` — set the overflow target.
+  Default `--to "macos-15"` for free GH-hosted; pass
+  `--to '"namespace-profile-generouscorp-macos"'` for paid Namespace.
+- `pulp overflow disable` — delete the overflow var. Note this only
+  changes future dispatches; in-flight cloud runs keep running.
+- `pulp overflow threshold [N]` — get (no arg) or set the BUSY count.
+
+The variable is named `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON` for
+historical reasons (Plan B in `planning/2026-05-13-namespace-overflow-
+implementation.md` originally targeted Namespace exclusively). It now
+holds the overflow target regardless of provider — rename tracked as a
+future cleanup.
+
 ## `pulp upgrade --check-only`
 
 The sandbox E2E harness runs this command with

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -195,6 +195,33 @@ gh run view <run-id> --log --repo danielraffel/pulp | grep "macOS route"
 
 **Manual overflow / rescue** is still available via `shipyard rescue <PR>` and remains useful for in-flight PRs that queued before the overflow logic kicked in. With Plan B in place, manual rescue should be needed much less frequently.
 
+### `pulp overflow` — operator surface
+
+`tools/cli/cmd_overflow.cpp` wraps the three repo variables behind a discoverable CLI:
+
+```bash
+# Show current routing state (local target, overflow target, threshold,
+# plus self-hosted runner registration if visible to the default token):
+pulp overflow status
+
+# Turn overflow on (defaults to free GH-hosted "macos-15"):
+pulp overflow enable
+pulp overflow enable --to '"namespace-profile-generouscorp-macos"'   # paid Namespace
+
+# Turn overflow off — every macOS leg goes to the local target.
+# In-flight cloud jobs continue to completion; only new dispatches change.
+pulp overflow disable
+
+# Read / set the BUSY threshold (default 2; set to 1 for single-runner setups):
+pulp overflow threshold
+pulp overflow threshold 1
+```
+
+`pulp overflow disable` does not cancel in-flight cloud runs — it's a
+config-change only. To force a currently-routed-to-cloud PR back to local,
+use `pulp macos retarget --pr N --to local` (see "Per-PR macOS retargeting"
+below).
+
 ## Per-PR macOS retargeting (`pulp macos`)
 
 For the case where automatic overflow picked the "wrong" pool — e.g. you want to push a specific PR to Namespace for paid-fast turnaround, or pull a queued GH-hosted job back to the local Mac because local just freed up — use the **`build-macos.yml`** workflow + the **`pulp macos`** CLI:

--- a/docs/reference/compat/css.md
+++ b/docs/reference/compat/css.md
@@ -744,13 +744,6 @@ function is **not registered**, so the value is silently dropped.
    yields `50`, clamped to `1`. Visually fine, semantically wrong.
 8. `css/alignItems: baseline` / `css/alignSelf: baseline` — wired via
    `FlexAlign::baseline` → `YGAlignBaseline` (pulp #1434 rn batch B).
-<<<<<<< HEAD
    `first baseline` aliases to plain `baseline` (Tier 1 PR-B,
    2026-05-12); `last baseline` is intentionally unsupported because
    it requires baseline-set tracking that Yoga does not implement.
-=======
-   `first baseline` and `last baseline` alias to plain `baseline`
-   (Tier 1 PR-B, 2026-05-12) — the baseline-set distinction only
-   matters for grid + block flow, neither of which Pulp's Yoga-only
-   layout pipeline implements.
->>>>>>> 7c1f373d8 (docs(compat/css): document Tier 1 PR-B align/justify alias additions)

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(pulp-cli
     cmd_coverage.cpp
     cmd_create.cpp
     cmd_macos.cpp
+    cmd_overflow.cpp
     cmd_design.cpp
     cmd_doctor.cpp
     cmd_docs.cpp

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -292,3 +292,4 @@ int cmd_project(const std::vector<std::string>& args);
 int cmd_config(const std::vector<std::string>& args);
 int cmd_coverage(const std::vector<std::string>& args);
 int cmd_macos(const std::vector<std::string>& args);
+int cmd_overflow(const std::vector<std::string>& args);

--- a/tools/cli/cmd_overflow.cpp
+++ b/tools/cli/cmd_overflow.cpp
@@ -1,0 +1,216 @@
+// cmd_overflow.cpp — `pulp overflow` subcommand.
+//
+// Operator surface for the macOS-overflow routing repo variables that
+// `.github/workflows/build.yml`'s resolve-provider job reads:
+//
+//   PULP_LOCAL_MACOS_RUNS_ON_JSON          — selector when local has capacity
+//   PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON — selector when local is saturated
+//                                            (despite the historical name,
+//                                            this is the generic overflow
+//                                            target, not Namespace-specific)
+//   PULP_LOCAL_MAC_OVERFLOW_THRESHOLD      — BUSY count that trips overflow
+//
+// Why this lives in `pulp` (not Shipyard): the variable names + semantics are
+// Pulp-workflow-specific. Shipyard stays a generic CI orchestrator; per-repo
+// CI knobs belong in each repo's own CLI.
+//
+// Subcommands:
+//   pulp overflow status                 — show current routing state
+//   pulp overflow enable [--to <sel>]   — set the overflow target var
+//   pulp overflow disable                — delete the overflow target var
+//   pulp overflow threshold [<N>]        — get or set the BUSY threshold
+//
+// All commands are thin gh CLI shells. Source of truth = GitHub repo vars.
+
+#include "cli_common.hpp"
+
+#include <iostream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+const std::string kRepo = "danielraffel/pulp";
+const std::string kVarLocal = "PULP_LOCAL_MACOS_RUNS_ON_JSON";
+const std::string kVarOverflow = "PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON";
+const std::string kVarThreshold = "PULP_LOCAL_MAC_OVERFLOW_THRESHOLD";
+
+void print_overflow_usage() {
+    std::cout << "pulp overflow — macOS-runner overflow routing\n\n";
+    std::cout << "Usage: pulp overflow <subcommand> [options]\n\n";
+    std::cout << "Subcommands:\n";
+    std::cout << "  status              Show current routing (local target, overflow target,\n";
+    std::cout << "                      threshold, plus runner-registration state).\n\n";
+    std::cout << "  enable [--to JSON]  Set the overflow target. With no --to, defaults to\n";
+    std::cout << "                      \"macos-15\" (free GH-hosted). For Namespace, pass\n";
+    std::cout << "                      --to '\"namespace-profile-generouscorp-macos\"'.\n\n";
+    std::cout << "  disable             Delete the overflow target var. All macOS jobs go\n";
+    std::cout << "                      to the local target. In-flight cloud jobs are NOT\n";
+    std::cout << "                      cancelled — only new dispatches change.\n\n";
+    std::cout << "  threshold [N]       Get (no arg) or set the BUSY count that trips\n";
+    std::cout << "                      overflow. Default 2; set to 1 for single-runner\n";
+    std::cout << "                      setups so any local job in flight triggers overflow.\n\n";
+    std::cout << "Backing repo variables on " << kRepo << ":\n";
+    std::cout << "  " << kVarLocal << "\n";
+    std::cout << "  " << kVarOverflow << "\n";
+    std::cout << "  " << kVarThreshold << "\n";
+}
+
+std::string capture(const std::string& cmd) {
+    std::string out;
+    FILE* p = popen(cmd.c_str(), "r");
+    if (!p) return out;
+    char buf[1024];
+    while (fgets(buf, sizeof(buf), p)) out += buf;
+    pclose(p);
+    while (!out.empty() && (out.back() == '\n' || out.back() == ' ' || out.back() == '\t')) {
+        out.pop_back();
+    }
+    return out;
+}
+
+std::string read_var(const std::string& name) {
+    std::string cmd = "gh api repos/" + kRepo + "/actions/variables/" + name +
+                      " --jq .value 2>/dev/null";
+    return capture(cmd);
+}
+
+int set_var(const std::string& name, const std::string& value) {
+    std::string cmd = "gh variable set " + name +
+                      " --repo " + kRepo +
+                      " --body " + shell_quote(value);
+    return run(cmd);
+}
+
+int delete_var(const std::string& name) {
+    std::string cmd = "gh variable delete " + name +
+                      " --repo " + kRepo + " 2>/dev/null";
+    return run(cmd);
+}
+
+int run_status(const std::vector<std::string>&) {
+    auto local = read_var(kVarLocal);
+    auto overflow = read_var(kVarOverflow);
+    auto threshold = read_var(kVarThreshold);
+
+    std::cout << "macOS routing for " << kRepo << ":\n\n";
+
+    std::cout << "  Local target (idle path):\n";
+    std::cout << "    " << kVarLocal << " = "
+              << (local.empty() ? "(unset → falls back to GH-hosted macos-15)" : local) << "\n\n";
+
+    std::cout << "  Overflow target (saturated path):\n";
+    if (overflow.empty()) {
+        std::cout << "    " << kVarOverflow << " = (unset → overflow DISABLED)\n";
+        std::cout << "    Every macOS leg goes to the local target above.\n";
+    } else {
+        std::cout << "    " << kVarOverflow << " = " << overflow << "\n";
+    }
+    std::cout << "\n";
+
+    std::cout << "  Overflow threshold:\n";
+    std::cout << "    " << kVarThreshold << " = "
+              << (threshold.empty() ? "2 (default)" : threshold) << "\n";
+    std::cout << "    (BUSY count = number of queued+in_progress 'Build and Test' runs\n";
+    std::cout << "     excluding the current one; overflow trips when BUSY >= threshold.)\n\n";
+
+    std::cout << "  Self-hosted Mac runner state:\n";
+    auto runners = capture(
+        "gh api repos/" + kRepo + "/actions/runners "
+        "--jq '.runners[] | select(.labels[].name == \"sanitizer\") "
+        "| \"    \" + .name + \" (status=\" + .status + (if .busy then \", busy\" else \", idle\" end) + \")\"' "
+        "2>/dev/null");
+    if (runners.empty()) {
+        std::cout << "    (no self-hosted runners with `sanitizer` label registered, OR\n";
+        std::cout << "     the default token lacks Administration:Read scope)\n";
+    } else {
+        std::cout << runners << "\n";
+    }
+
+    return 0;
+}
+
+int run_enable(const std::vector<std::string>& args) {
+    std::string selector = "\"macos-15\"";
+    for (size_t i = 0; i < args.size(); ++i) {
+        if (args[i] == "--to" && i + 1 < args.size()) {
+            selector = args[++i];
+        } else {
+            std::cerr << "pulp overflow enable: unknown arg '" << args[i] << "'\n";
+            return 1;
+        }
+    }
+    std::cout << "Setting " << kVarOverflow << " = " << selector << "\n";
+    int rc = set_var(kVarOverflow, selector);
+    if (rc != 0) {
+        std::cerr << "pulp overflow enable: failed to set variable\n";
+        return rc;
+    }
+    std::cout << "Overflow enabled. New PR dispatches will route macOS to "
+              << selector << " when local is saturated.\n";
+    std::cout << "(In-flight workflow_runs keep their original dispatch.)\n";
+    return 0;
+}
+
+int run_disable(const std::vector<std::string>&) {
+    auto current = read_var(kVarOverflow);
+    if (current.empty()) {
+        std::cout << "Overflow is already disabled (" << kVarOverflow << " not set).\n";
+        return 0;
+    }
+    std::cout << "Deleting " << kVarOverflow << " (was: " << current << ")\n";
+    int rc = delete_var(kVarOverflow);
+    if (rc != 0) {
+        std::cerr << "pulp overflow disable: failed to delete variable\n";
+        return rc;
+    }
+    std::cout << "Overflow disabled. New PR dispatches stay on the local target.\n";
+    std::cout << "In-flight cloud jobs continue and complete normally.\n";
+    return 0;
+}
+
+int run_threshold(const std::vector<std::string>& args) {
+    if (args.empty()) {
+        auto value = read_var(kVarThreshold);
+        std::cout << kVarThreshold << " = "
+                  << (value.empty() ? "2 (default)" : value) << "\n";
+        return 0;
+    }
+    if (args.size() > 1) {
+        std::cerr << "pulp overflow threshold: too many args\n";
+        return 1;
+    }
+    // Validate integer.
+    try {
+        int n = std::stoi(args[0]);
+        if (n < 0) {
+            std::cerr << "pulp overflow threshold: must be >= 0\n";
+            return 1;
+        }
+        std::cout << "Setting " << kVarThreshold << " = " << n << "\n";
+        return set_var(kVarThreshold, std::to_string(n));
+    } catch (...) {
+        std::cerr << "pulp overflow threshold: '" << args[0] << "' is not a number\n";
+        return 1;
+    }
+}
+
+}  // namespace
+
+int cmd_overflow(const std::vector<std::string>& args) {
+    if (args.empty() || args[0] == "--help" || args[0] == "-h" || args[0] == "help") {
+        print_overflow_usage();
+        return 0;
+    }
+    const std::string& sub = args[0];
+    std::vector<std::string> rest(args.begin() + 1, args.end());
+    if (sub == "status") return run_status(rest);
+    if (sub == "enable") return run_enable(rest);
+    if (sub == "disable") return run_disable(rest);
+    if (sub == "threshold") return run_threshold(rest);
+    std::cerr << "pulp overflow: unknown subcommand '" << sub << "'\n\n";
+    print_overflow_usage();
+    return 1;
+}

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -62,6 +62,7 @@ static const Command commands[] = {
     {"config",   "Read or write ~/.pulp/config.toml settings", cmd_config},
     {"coverage", "Local coverage tooling (diff-cover gate mirror)", cmd_coverage},
     {"macos",    "Per-PR macOS-runner retargeting (local/namespace/github-hosted)", cmd_macos},
+    {"overflow", "Configure macOS-runner overflow routing (status/enable/disable/threshold)", cmd_overflow},
 };
 
 static constexpr int command_count = sizeof(commands) / sizeof(commands[0]);


### PR DESCRIPTION
The macOS overflow routing introduced by pulp #1935 + #1936 is driven
by three repo variables: PULP_LOCAL_MACOS_RUNS_ON_JSON,
PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON, and
PULP_LOCAL_MAC_OVERFLOW_THRESHOLD. Until now, configuring them
required raw `gh variable set/delete/api` calls — discoverable only
to operators who know to look in the docs.

This adds `pulp overflow` as a thin, discoverable CLI wrapper:

  pulp overflow status              — show current routing state
  pulp overflow enable [--to JSON]  — set the overflow target var
                                       (default: "macos-15", free GH-hosted)
  pulp overflow disable             — delete the overflow target var
                                       (config-change only; in-flight
                                        cloud jobs keep running)
  pulp overflow threshold [N]       — get/set the BUSY count threshold

The variable name `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON` is a
misnomer at this point (it now holds the overflow target regardless of
whether it points at Namespace or macos-15). A rename is tracked as a
follow-up; the CLI hides the naming awkwardness behind clean verbs.

Wired into the dispatcher table in pulp_cli.cpp; declared in
cli_common.hpp; built as part of pulp-cli via tools/cli/CMakeLists.txt.

Docs + skill updates:
- docs/guides/local-ci.md gains a "`pulp overflow` — operator surface"
  subsection under the existing macOS overflow routing section.
- .agents/skills/cli-maintenance/SKILL.md documents the new command,
  the three repo variables it reads/writes, and the in-flight-jobs
  semantic of `disable`.