### PR TITLE
feat(import): add Stitch React export parser (Phase 6.6.4)

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -57,6 +57,12 @@ Ask the user or detect from context:
 - C-1 deliberately rejects default v0 surfaces that are outside the supported matrix: Tailwind `className` output, shadcn/Radix components, Next.js wrappers/imports, custom JSX components, non-range inputs, and network/storage/worker APIs. Use inline React `style` objects plus the supported DOM/CSS/API subset.
 - Representative fixtures live under `planning/fixtures/v0-dev/`; the primary one is `audio-control-panel.tsx` (audio control panel + canvas meter). Run `tools/import-validation/v0-roundtrip.sh --parser-only` for the parser/dispatch gate.
 
+**Google Stitch runtime-import parser (Phase 6.6.4)**:
+- The runtime-import lane accepts constrained Stitch React exports through `parse_stitch_react()` and `source: 'stitch'`. Stitch has no reliable standalone file marker, so do not auto-detect arbitrary TSX as Stitch.
+- Accepted input is a single-component React TSX module from Stitch's vanilla/inline-style export path. The default Tailwind export is out of scope until the shared Tailwind-to-inline-style preprocessor exists.
+- C-3 deliberately rejects Tailwind `className`, external CSS imports, Next.js wrappers or `"use client"`, Radix/shadcn components, React Native imports, Stitch MCP JSON node trees, custom JSX components, non-range inputs, and network/storage/worker APIs.
+- Representative fixtures live under `planning/fixtures/stitch/`; the primary one is `transport-bar.tsx` (transport controls + range sliders + canvas VU meter). Run `tools/import-validation/stitch-roundtrip.sh --parser-only` for the parser/dispatch gate.
+
 **Claude Design (manual HTML export — pulp #468)**:
 - Anthropic Labs has no MCP / public API. The user runs Claude Design, exports the canvas as Standalone HTML (or "Send to Local Coding Agent"), and hands you the resulting file.
 - Run `pulp import-design --from claude --file <path>` — the parser delegates to the Stitch HTML pipeline and tags the IR as Claude. **This is the static path** — it sees only the loader-shell HTML wrapping the bundled React app (~9 elements: title, bundler placeholders, inline styles, the `<script>` blob).

--- a/core/view/include/pulp/view/design_import.hpp
+++ b/core/view/include/pulp/view/design_import.hpp
@@ -200,6 +200,14 @@ std::optional<ClaudeBundle> parse_v0_dev_react(const std::string& tsx_or_envelop
 /// Tailwind/Radix/default Figma Make dependencies.
 std::optional<ClaudeBundle> parse_figma_make_react(const std::string& tsx);
 
+/// Normalize a constrained Google Stitch React export into the runtime-import
+/// bundle payload shape. Stitch has no reliable standalone file marker, so
+/// callers should route here only from an explicit `source: "stitch"` manifest
+/// or runtime-import source label. Returns nullopt for Tailwind/default Stitch
+/// exports, external CSS, Next/Radix wrappers, RN imports, MCP JSON, or any
+/// surface outside Pulp's supported runtime-import DOM/CSS/API subset.
+std::optional<ClaudeBundle> parse_stitch_react(const std::string& tsx);
+
 /// Options for the `--execute-bundle` import lane.
 struct ClaudeRuntimeOptions {
     /// Hard cap on bytes of bundled JS to evaluate. Bundles larger than

--- a/core/view/src/design_import.cpp
+++ b/core/view/src/design_import.cpp
@@ -1304,6 +1304,76 @@ std::string figma_build_runtime_js(const std::string& source,
     return js;
 }
 
+std::string stitch_slug_from_component(std::string name) {
+    std::string out = "stitch";
+    for (char c : name) {
+        if (std::isupper(static_cast<unsigned char>(c)) && !out.empty() && out.back() != '-') {
+            out += '-';
+        }
+        if (std::isalnum(static_cast<unsigned char>(c))) {
+            out += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        } else if (c == '-' || c == '_') {
+            if (!out.empty() && out.back() != '-') out += '-';
+        }
+    }
+    while (!out.empty() && out.back() == '-') out.pop_back();
+    return out.empty() ? "stitch-runtime-import" : out;
+}
+
+std::string stitch_extract_root_id(const std::string& source,
+                                   const std::string& component_name) {
+    static const std::regex id_re(R"RX(\bid\s*=\s*(?:"([^"]+)"|'([^']+)'))RX");
+    if (auto m = v0_match_first(source, id_re)) return *m;
+    return stitch_slug_from_component(component_name);
+}
+
+bool stitch_uses_only_supported_surfaces(const std::string& source) {
+    if (source.find("[V0_FILE]") != std::string::npos) return false;
+    if (!v0_uses_only_supported_surfaces(source)) return false;
+
+    const auto lower = v0_lower(source);
+    const char* stitch_reject_markers[] = {
+        "\"use client\"", "'use client'", "figma:asset/", "react-native",
+        "mcp__stitch", "\"mcp_response\"", "\"node_tree\"", "\"screen_id\""
+    };
+    for (const char* marker : stitch_reject_markers) {
+        if (lower.find(marker) != std::string::npos) return false;
+    }
+    return true;
+}
+
+std::string stitch_build_runtime_js(const std::string& source,
+                                    const std::string& file_name,
+                                    const std::string& component_name,
+                                    const std::string& root_id) {
+    auto js = v0_build_runtime_js(source, file_name, component_name, root_id);
+    js = replace_all_copy(
+        std::move(js),
+        "v0.dev runtime import requires host React and ReactDOM",
+        "Stitch runtime import requires host React and ReactDOM");
+    js = replace_all_copy(
+        std::move(js),
+        "v0.dev React runtime import",
+        "Stitch React runtime import");
+    js = replace_all_copy(
+        std::move(js),
+        "'data-pulp-source': 'v0'",
+        "'data-pulp-source': 'stitch'");
+    js = replace_all_copy(
+        std::move(js),
+        "sourceFile.indexOf('/') >= 0 ? 'v0' : 'OUT'",
+        "'ST'");
+    js = replace_all_copy(
+        std::move(js),
+        "var panelStyle = { width: 420, minHeight: 280,",
+        "var panelStyle = { width: 420, height: 340,");
+    js = replace_all_copy(
+        std::move(js),
+        "var buttonStyle = { minWidth: 88, minHeight: 36,",
+        "var buttonStyle = { minWidth: 72, minHeight: 32, display: 'flex', alignItems: 'center', justifyContent: 'center',");
+    return js;
+}
+
 void set_runtime_error(ClaudeRuntimeOptions& opts, const std::string& msg) {
     if (opts.error_out) *opts.error_out = msg;
 }
@@ -1821,6 +1891,34 @@ std::optional<ClaudeBundle> parse_figma_make_react(const std::string& tsx) {
         "<div id=\"root\" data-pulp-source=\"figma\" data-figma-root=\"" +
         v0_html_attr_escape(root_id) +
         "\"></div><script src=\"figma-runtime-app\"></script>";
+    return bundle;
+}
+
+std::optional<ClaudeBundle> parse_stitch_react(const std::string& tsx) {
+    auto source = v0_trim(tsx);
+    if (source.empty()) return std::nullopt;
+    if (source.find("export default") == std::string::npos) return std::nullopt;
+    if (!v0_contains_ci(source, "react")) return std::nullopt;
+    if (!stitch_uses_only_supported_surfaces(source)) return std::nullopt;
+
+    auto component_name = v0_extract_component_name(source);
+    if (component_name == "V0RuntimeImport") component_name = "StitchRuntimeImport";
+    const auto root_id = stitch_extract_root_id(source, component_name);
+    auto runtime_js = stitch_build_runtime_js(
+        source, "TransportBar.tsx", component_name, root_id);
+
+    ClaudeBundleAsset app;
+    app.uuid = "stitch-runtime-app";
+    app.mime = "text/javascript";
+    app.data.assign(runtime_js.begin(), runtime_js.end());
+
+    ClaudeBundle bundle;
+    bundle.assets.push_back(std::move(app));
+    bundle.javascript_indices.push_back(0);
+    bundle.template_html =
+        "<div id=\"root\" data-pulp-source=\"stitch\" data-stitch-root=\"" +
+        v0_html_attr_escape(root_id) +
+        "\"></div><script src=\"stitch-runtime-app\"></script>";
     return bundle;
 }
 

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -1107,6 +1107,13 @@ void WidgetBridge::install_runtime_import_handlers() {
                                 + src_label + "')");
                         return choc::value::Value();
                     }
+                } else if (source_lc == "stitch" || source_lc == "google-stitch") {
+                    bundle = parse_stitch_react(html);
+                    if (!bundle) {
+                        set_err("__pulpRuntimeImport__: unsupported Stitch React export (got '"
+                                + src_label + "')");
+                        return choc::value::Value();
+                    }
                 } else {
                     bundle = parse_claude_bundle(html);
                 }

--- a/test/fixtures/stitch/transport-bar.tsx
+++ b/test/fixtures/stitch/transport-bar.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useRef, useState } from "react";
+
+export default function TransportBar() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [playing, setPlaying] = useState(true);
+  const [position, setPosition] = useState(0.34);
+  const [gain, setGain] = useState(0.62);
+
+  useEffect(() => {
+    let active = true;
+
+    const draw = () => {
+      const canvas = canvasRef.current;
+      if (!canvas) {
+        if (active) requestAnimationFrame(draw);
+        return;
+      }
+
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        if (active) requestAnimationFrame(draw);
+        return;
+      }
+
+      const width = canvas.width;
+      const height = canvas.height;
+      const time = performance.now() / 1000;
+      const level = playing ? 0.38 + Math.sin(time * 2.1) * 0.16 + gain * 0.28 : 0.1;
+      const peak = Math.max(0, Math.min(1, level));
+      const bars = 20;
+      const gap = 3;
+      const barWidth = (width - gap * (bars - 1)) / bars;
+
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = "#101826";
+      ctx.fillRect(0, 0, width, height);
+
+      for (let index = 0; index < bars; index++) {
+        const ratio = (index + 1) / bars;
+        const x = index * (barWidth + gap);
+        const barHeight = Math.max(8, height * ratio * 0.82);
+        const y = height - barHeight;
+        ctx.fillStyle = ratio <= peak ? (ratio > 0.82 ? "#f59e0b" : "#2dd4bf") : "#243244";
+        ctx.fillRect(x, y, barWidth, barHeight);
+      }
+
+      ctx.fillStyle = "#cbd5e1";
+      ctx.font = "12px Inter, sans-serif";
+      ctx.fillText("VU", 8, 18);
+
+      if (active) requestAnimationFrame(draw);
+    };
+
+    draw();
+    return () => {
+      active = false;
+    };
+  }, [gain, playing]);
+
+  const panelStyle = {
+    width: 460,
+    minHeight: 278,
+    display: "flex",
+    flexDirection: "column" as const,
+    gap: 16,
+    padding: 18,
+    backgroundColor: "#111827",
+    color: "#f8fafc",
+    border: "1px solid #334155",
+    borderRadius: 8,
+    fontFamily: "Inter, system-ui, sans-serif",
+  };
+
+  const rowStyle = {
+    display: "flex",
+    flexDirection: "row" as const,
+    gap: 12,
+    alignItems: "center",
+  };
+
+  const controlStyle = {
+    display: "flex",
+    flexDirection: "column" as const,
+    gap: 6,
+    flexGrow: 1,
+  };
+
+  const buttonStyle = {
+    minWidth: 82,
+    minHeight: 36,
+    borderRadius: 6,
+    border: "1px solid #475569",
+    backgroundColor: playing ? "#115e59" : "#1f2937",
+    color: "#f8fafc",
+    cursor: "pointer",
+  };
+
+  return (
+    <div id="stitch-transport-bar" data-stitch-screen="transport-bar" style={panelStyle}>
+      <div style={{ ...rowStyle, justifyContent: "space-between" }}>
+        <div>
+          <h2 style={{ margin: 0, fontSize: 22, lineHeight: 1.1 }}>Transport</h2>
+          <p style={{ margin: "6px 0 0", color: "#94a3b8", fontSize: 13 }}>
+            Level and playback
+          </p>
+        </div>
+        <div style={rowStyle}>
+          <button type="button" style={buttonStyle}>
+            Play
+          </button>
+          <button type="button" style={buttonStyle}>
+            Stop
+          </button>
+        </div>
+      </div>
+
+      <canvas
+        ref={canvasRef}
+        width={420}
+        height={104}
+        style={{
+          width: "100%",
+          height: 104,
+          borderRadius: 6,
+          border: "1px solid #1f2937",
+          backgroundColor: "#101826",
+        }}
+      />
+
+      <div style={rowStyle}>
+        <div style={controlStyle}>
+          <span style={{ color: "#cbd5e1", fontSize: 12 }}>Position</span>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={position}
+            onChange={(event) => setPosition(Number(event.currentTarget.value))}
+          />
+          <span style={{ color: "#94a3b8", fontSize: 12 }}>{Math.round(position * 100)}%</span>
+        </div>
+        <div style={controlStyle}>
+          <span style={{ color: "#cbd5e1", fontSize: 12 }}>Gain</span>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={gain}
+            onChange={(event) => setGain(Number(event.currentTarget.value))}
+          />
+          <span style={{ color: "#94a3b8", fontSize: 12 }}>{Math.round(gain * 100)}%</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -160,6 +160,15 @@ void maybe_write_figma_runtime_script(const std::string& runtime_js) {
     file << minimal_host_react_dom_shim() << "\n" << runtime_js << "\n";
 }
 
+void maybe_write_stitch_runtime_script(const std::string& runtime_js) {
+    const char* out = std::getenv("PULP_STITCH_RUNTIME_JS_OUT");
+    if (out == nullptr || *out == '\0') return;
+
+    std::ofstream file(out, std::ios::binary);
+    REQUIRE(file.good());
+    file << minimal_host_react_dom_shim() << "\n" << runtime_js << "\n";
+}
+
 } // namespace
 
 // ── Design source parsing ───────────────────────────────────────────────
@@ -1441,6 +1450,143 @@ TEST_CASE("parse_figma_make_react rejects out-of-matrix Figma defaults",
     for (const auto& sample : rejected) {
         CAPTURE(sample);
         REQUIRE_FALSE(parse_figma_make_react(sample).has_value());
+    }
+}
+
+// ── Google Stitch React parsing ────────────────────────────────────────
+
+TEST_CASE("parse_stitch_react parses staged Stitch runtime fixture",
+          "[view][import][parser][stitch][phase-6.6.4]") {
+    const auto primary = read_fixture("planning/fixtures/stitch/transport-bar.tsx");
+    auto bundle = parse_stitch_react(primary);
+    REQUIRE(bundle.has_value());
+    REQUIRE(bundle->assets.size() == 1);
+    REQUIRE(bundle->javascript_indices.size() == 1);
+    REQUIRE(bundle->javascript_indices.front() == 0);
+    REQUIRE(bundle->assets.front().uuid == "stitch-runtime-app");
+    REQUIRE(bundle->assets.front().mime == "text/javascript");
+    REQUIRE(bundle->template_html.find("data-pulp-source=\"stitch\"") != std::string::npos);
+    REQUIRE(bundle->template_html.find("stitch-transport-bar") != std::string::npos);
+
+    const auto js = asset_text(bundle->assets.front());
+    REQUIRE(js.find("stitch-transport-bar") != std::string::npos);
+    REQUIRE(js.find("Stitch runtime import requires host React and ReactDOM") != std::string::npos);
+    REQUIRE(js.find("'data-pulp-source': 'stitch'") != std::string::npos);
+    REQUIRE(js.find("ReactDOM.createRoot") != std::string::npos);
+    REQUIRE(js.find("requestAnimationFrame") != std::string::npos);
+    REQUIRE(js.find("performance.now") != std::string::npos);
+    REQUIRE(js.find("canvas.getContext('2d')") != std::string::npos);
+    REQUIRE(js.find("type: 'range'") != std::string::npos);
+}
+
+TEST_CASE("parse_stitch_react runtime bundle materializes with host React shim",
+          "[view][import][parser][stitch][render][phase-6.6.4]") {
+    const auto primary = read_fixture("planning/fixtures/stitch/transport-bar.tsx");
+    auto bundle = parse_stitch_react(primary);
+    REQUIRE(bundle.has_value());
+    const auto runtime_js = asset_text(bundle->assets.front());
+    maybe_write_stitch_runtime_script(runtime_js);
+
+    pulp::state::StateStore store;
+    ScriptEngine engine;
+    View root;
+    WidgetBridge bridge(engine, root, store);
+
+    REQUIRE_NOTHROW(bridge.load_script(minimal_host_react_dom_shim()));
+    REQUIRE_NOTHROW(bridge.load_script(runtime_js));
+    bridge.service_frame_callbacks();
+
+    REQUIRE(root.child_count() > 0);
+    REQUIRE(engine.evaluate("!!document.getElementById('stitch-transport-bar')")
+                .getWithDefault<bool>(false));
+    REQUIRE_FALSE(engine.evaluate(
+        "(function(){ var el = document.getElementById('stitch-transport-bar');"
+        "return el ? String(el._id || '') : ''; })()").toString().empty());
+}
+
+TEST_CASE("parse_stitch_react accepts sanitized Stitch TSX",
+          "[view][import][parser][stitch][phase-6.6.4]") {
+    const std::string sanitized = R"(
+        import {
+          useState
+        } from "react";
+        export default function MultiLineStitchPanel() {
+          const [level, setLevel] = useState(0.5);
+          return (
+            <div id="stitch-multi-line-react-import" data-stitch-screen="level" style={{ display: "flex", flexDirection: "column" }}>
+              <span>Level</span>
+              <input type="range" value={level} onChange={(event) => setLevel(Number(event.currentTarget.value))} />
+            </div>
+          );
+        }
+    )";
+
+    auto bundle = parse_stitch_react(sanitized);
+    REQUIRE(bundle.has_value());
+    REQUIRE(bundle->template_html.find("stitch-multi-line-react-import") != std::string::npos);
+    REQUIRE(asset_text(bundle->assets.front()).find("stitch-multi-line-react-import") != std::string::npos);
+}
+
+TEST_CASE("parse_stitch_react rejects out-of-matrix Stitch defaults",
+          "[view][import][parser][stitch][phase-6.6.4]") {
+    const std::vector<std::string> rejected = {
+        R"(
+            "use client";
+            import { useState } from "react";
+            export default function NextStitchPanel() {
+              return <div id="stitch-next-panel">Next path</div>;
+            }
+        )",
+        R"(
+            import { useState } from "react";
+            export default function TailwindPanel() {
+              return <div className="flex rounded-lg">Tailwind</div>;
+            }
+        )",
+        R"(
+            import "./transport.css";
+            import { useState } from "react";
+            export default function ExternalCssPanel() {
+              return <div id="stitch-css-panel">CSS</div>;
+            }
+        )",
+        R"(
+            import { Dialog } from "@radix-ui/react-dialog";
+            export default function RadixPanel() {
+              return <div id="stitch-radix-panel">Radix</div>;
+            }
+        )",
+        R"(
+            import Link from "next/link";
+            export default function NextImportPanel() {
+              return <Link href="/">Next</Link>;
+            }
+        )",
+        R"(
+            import { View } from "react-native";
+            export default function NativePanel() {
+              return <View />;
+            }
+        )",
+        R"({"screen_id":"transport-bar","nodes":[]})",
+        R"(
+            import { useState } from "react";
+            export default function TextInputPanel() {
+              const [value, setValue] = useState("");
+              return <input type="text" value={value} onChange={(event) => setValue(event.currentTarget.value)} />;
+            }
+        )",
+        R"(
+            import { useState } from "react";
+            export default function CustomComponentPanel() {
+              return <TransportSlider value={0.5} />;
+            }
+        )"
+    };
+
+    for (const auto& sample : rejected) {
+        CAPTURE(sample);
+        REQUIRE_FALSE(parse_stitch_react(sample).has_value());
     }
 }
 

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -12708,6 +12708,48 @@ TEST_CASE("WidgetBridge __pulpRuntimeImport__ dispatches Figma parser by source 
     REQUIRE(err_str.find("Figma Make runtime import requires host React and ReactDOM") != std::string::npos);
 }
 
+TEST_CASE("WidgetBridge __pulpRuntimeImport__ dispatches Stitch parser by source label",
+          "[view][bridge][runtime-import-dispatch][stitch][phase-6.6.4]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.install_runtime_import_handlers();
+
+    const std::string stitch_tsx = R"(
+        import { useState } from "react";
+        export default function DispatchProbe() {
+          const [level, setLevel] = useState(0.5);
+          return (
+            <div id="stitch-dispatch-probe" data-stitch-screen="probe" style={{ display: "flex", flexDirection: "column" }}>
+              <span>Level</span>
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.01}
+                value={level}
+                onChange={(event) => setLevel(Number(event.currentTarget.value))}
+              />
+            </div>
+          );
+        }
+    )";
+
+    engine.evaluate(
+        "globalThis.__pulpRuntimeImportErr__ = null;"
+        "try { __pulpRuntimeImport__('" + js_single_quoted(stitch_tsx) + "', 'stitch'); }"
+        "catch (e) { globalThis.__pulpRuntimeImportErr__ = 'threw:' + String(e); }");
+
+    const auto err_str = engine.evaluate(
+        "String(globalThis.__pulpRuntimeImportErr__ || '')")
+        .getWithDefault<std::string>("");
+
+    REQUIRE(err_str.find("threw:") == std::string::npos);
+    REQUIRE(err_str.find("claude bundle") == std::string::npos);
+    REQUIRE(err_str.find("Stitch runtime import requires host React and ReactDOM") != std::string::npos);
+}
+
 TEST_CASE("WidgetBridge __pulpRuntimeSettle__ pumps without crashing",
           "[view][bridge][runtime-import]") {
     ScriptEngine engine;

--- a/tools/import-validation/stitch-roundtrip.sh
+++ b/tools/import-validation/stitch-roundtrip.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Phase 6.6.4 Google Stitch runtime-import validation harness.
+#
+# The parser lane is local-first: parser/dispatch tests, a parser-emitted
+# runtime render, and diff coverage must pass before a PR is pushed.
+# Screenshot comparison runs when a reference is available.
+
+set -euo pipefail
+
+PULP_DIR="${PULP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+FIXTURE="${PULP_STITCH_FIXTURE:-$PULP_DIR/planning/fixtures/stitch/transport-bar.tsx}"
+BUILD_DIR="${PULP_BUILD_DIR:-$PULP_DIR/build-stitch-import}"
+BUILD_TYPE="${PULP_BUILD_TYPE:-Debug}"
+BUILD_JOBS="${PULP_BUILD_JOBS:-1}"
+REFERENCE="${PULP_STITCH_REFERENCE:-$PULP_DIR/planning/screenshots/REFERENCE-stitch-transport-bar.png}"
+OUT="${PULP_STITCH_OUT:-$PULP_DIR/planning/screenshots/stitch-transport-bar-latest.png}"
+THRESHOLD="${PULP_HARNESS_THRESHOLD:-0.85}"
+PARSER_ONLY=0
+SKIP_BUILD=0
+COVERAGE=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  tools/import-validation/stitch-roundtrip.sh [--parser-only] [--skip-build]
+  tools/import-validation/stitch-roundtrip.sh --coverage
+  tools/import-validation/stitch-roundtrip.sh --reference path/to/reference.png
+
+Env:
+  PULP_DIR              Pulp checkout path
+  PULP_BUILD_DIR        CMake build dir
+  PULP_BUILD_TYPE       CMake build type (default: Debug)
+  PULP_BUILD_JOBS       CMake build parallelism (default: 1)
+  PULP_STITCH_FIXTURE   Stitch TSX fixture path
+  PULP_STITCH_REFERENCE reference screenshot path
+  PULP_STITCH_OUT       candidate screenshot path
+  PULP_HARNESS_THRESHOLD screenshot similarity threshold
+  PULP_DIFF_COVER_CTEST_REGEX override the focused coverage CTest regex
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --parser-only) PARSER_ONLY=1; shift ;;
+    --skip-build) SKIP_BUILD=1; shift ;;
+    --coverage) COVERAGE=1; shift ;;
+    --reference) REFERENCE="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+red() { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+
+[[ -f "$FIXTURE" ]] || { red "missing Stitch fixture: $FIXTURE"; exit 2; }
+command -v cmake >/dev/null || { red "cmake is required"; exit 2; }
+
+if [[ $COVERAGE -eq 1 ]]; then
+  default_ctest_regex='parse_stitch_react|WidgetBridge __pulpRuntimeImport__ dispatches Stitch|WidgetBridge __pulpRuntimeImport__ surfaces parse failure'
+  export PULP_DIFF_COVER_CTEST_REGEX="${PULP_DIFF_COVER_CTEST_REGEX:-$default_ctest_regex}"
+  bash "$PULP_DIR/tools/scripts/local_diff_cover.sh" \
+    pulp-test-design-import pulp-test-widget-bridge
+  green "Stitch parser diff coverage passed"
+  exit 0
+fi
+
+find_test_exe() {
+  local name="$1"
+  local candidate
+  for candidate in "$BUILD_DIR/test/$name" "$BUILD_DIR/test/$BUILD_TYPE/$name"; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  red "missing built test executable: $name"
+  exit 2
+}
+
+if [[ $SKIP_BUILD -eq 0 ]]; then
+  cmake -S "$PULP_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+  build_targets=(pulp-test-design-import pulp-test-widget-bridge)
+  if [[ $PARSER_ONLY -eq 0 ]]; then
+    build_targets+=(pulp-screenshot)
+  fi
+  cmake --build "$BUILD_DIR" --parallel "$BUILD_JOBS" \
+    --target "${build_targets[@]}"
+fi
+
+DESIGN_IMPORT_TEST="$(find_test_exe pulp-test-design-import)"
+WIDGET_BRIDGE_TEST="$(find_test_exe pulp-test-widget-bridge)"
+
+"$DESIGN_IMPORT_TEST" '[phase-6.6.4]'
+"$WIDGET_BRIDGE_TEST" '[phase-6.6.4]'
+
+if [[ $PARSER_ONLY -eq 1 ]]; then
+  green "Stitch parser tests passed (parser-only)"
+  exit 0
+fi
+
+find_tool_exe() {
+  local rel="$1"
+  local candidate
+  for candidate in "$BUILD_DIR/$rel" "$BUILD_DIR/$BUILD_TYPE/$rel"; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  red "missing built tool: $rel"
+  exit 2
+}
+
+SCREENSHOT_BIN="$(find_tool_exe tools/screenshot/pulp-screenshot)"
+TMP_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/pulp-stitch-runtime.XXXXXX.js")"
+trap 'rm -f "$TMP_SCRIPT"' EXIT
+PULP_STITCH_RUNTIME_JS_OUT="$TMP_SCRIPT" \
+  "$DESIGN_IMPORT_TEST" 'parse_stitch_react runtime bundle materializes with host React shim'
+
+mkdir -p "$(dirname "$OUT")"
+"$SCREENSHOT_BIN" \
+  --script "$TMP_SCRIPT" \
+  --output "$OUT" \
+  --width 540 \
+  --height 360 \
+  --theme dark
+green "captured Stitch runtime render: $OUT"
+
+if [[ ! -f "$REFERENCE" ]]; then
+  yellow "reference screenshot not found: $REFERENCE"
+  yellow "Phase 6.6.4 screenshot diff skipped; use the captured render as the reference once reviewed."
+  exit 77
+fi
+
+if [[ ! -f "$OUT" ]]; then
+  yellow "candidate screenshot not found: $OUT"
+  yellow "Run the runtime-import demo/capture step first, then re-run this harness."
+  exit 77
+fi
+
+python3 "$PULP_DIR/tools/import-validation/diff_against_reference.py" \
+  "$REFERENCE" "$OUT" --threshold "$THRESHOLD"
+


### PR DESCRIPTION
Adds an explicit Google Stitch runtime-import parser for constrained React TSX exports, with strict out-of-matrix rejects and a source-labeled runtime dispatch path.

Includes mirrored Stitch fixtures, a screenshot/reference roundtrip harness, parser/dispatch/render-smoke tests, and the import-design skill + planning submodule updates.

Version-Bump: skip reason="Phase 6.6.4 source parser is pre-staged behind the C-2 merge gate and does not require a release bump"
Version-Bump: sdk=skip reason="runtime-import parser, fixtures, tests, and harness do not change the public SDK/API contract"
Version-Bump: plugin=skip reason="import-design skill text documents an in-repo workflow; no Claude plugin package release needed"
Compat-Update: skip prefix=canvas2d reason="Stitch parser reuses the existing runtime-import canvas subset; no canvas2d compat surface changed"
Compat-Update: skip prefix=css reason="Stitch parser accepts inline styles within the existing supported CSS subset; no CSS compat matrix change"
Compat-Update: skip prefix=html reason="Stitch parser routes existing supported DOM tags only; no HTML compat surface changed"
Compat-Update: skip prefix=imports reason="Stitch parser rejects unsupported imports and adds no new module-loading capability"
Compat-Update: skip prefix=react reason="Stitch parser reuses the existing host React runtime-import evaluator; no React compat surface changed"
Compat-Update: skip prefix=rn reason="Stitch parser explicitly rejects React Native imports; RN parser remains deferred"
Compat-Update: skip prefix=yoga reason="Stitch parser emits the existing flex-style runtime preview; no Yoga layout capability changed"