### PR TITLE
feat(import): add React Native export parser (Phase 6.6.5)

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: import-design
-description: Import designs from Figma, Stitch, v0, Pencil, or Claude Design into Pulp web-compat JS with automated visual validation. Claude Design imports also scaffold a pulp::view::EditorBridge handler file (pulp #709). Versioned (parser-version / format-version / compat-schema-version) detection lives behind `--detect-only` and `--report-new-format` (pulp #1031).
+description: Import designs from Figma, Stitch, v0, Pencil, React Native, or Claude Design into Pulp web-compat JS with automated visual validation. Claude Design imports also scaffold a pulp::view::EditorBridge handler file (pulp #709). Versioned (parser-version / format-version / compat-schema-version) detection lives behind `--detect-only` and `--report-new-format` (pulp #1031).
 ---
 
 # Import Design
 
-Import a design from an external tool (Figma, Stitch, v0, Pencil, Claude Design) into this Pulp project.
+Import a design from an external tool (Figma, Stitch, v0, Pencil, React Native, Claude Design) into this Pulp project.
 
 Detect which design source the user wants by checking:
 1. If a Figma MCP server is available (com.figma.mcp), offer to read the current file/selection
@@ -20,7 +20,7 @@ Detect which design source the user wants by checking:
 ### Step 1: Identify source and input
 
 Ask the user or detect from context:
-- **Source**: figma, stitch, v0, pencil, or claude
+- **Source**: figma, stitch, v0, pencil, rn, or claude
 - **Input**: file path, URL, or MCP live data (manual file only for claude)
 
 ### Step 2: Read the design data
@@ -62,6 +62,12 @@ Ask the user or detect from context:
 - Accepted input is a single-component React TSX module from Stitch's vanilla/inline-style export path. The default Tailwind export is out of scope until the shared Tailwind-to-inline-style preprocessor exists.
 - C-3 deliberately rejects Tailwind `className`, external CSS imports, Next.js wrappers or `"use client"`, Radix/shadcn components, React Native imports, Stitch MCP JSON node trees, custom JSX components, non-range inputs, and network/storage/worker APIs.
 - Representative fixtures live under `planning/fixtures/stitch/`; the primary one is `transport-bar.tsx` (transport controls + range sliders + canvas VU meter). Run `tools/import-validation/stitch-roundtrip.sh --parser-only` for the parser/dispatch gate.
+
+**React Native runtime-import parser (Phase 6.6.5)**:
+- The runtime-import lane accepts constrained single-file RN component exports through `parse_react_native_export()` and `source: 'rn'`. The import `from 'react-native'` is unambiguous, so runtime dispatch may auto-detect RN when the source label is omitted.
+- Accepted input is a single TSX component with React imports from `react`, RN imports from `react-native`, RN element vocabulary (`View`, `Text`, `Pressable`/`Touchable*`, `ScrollView`, `TextInput`), and `StyleSheet.create({...})` styles. Numeric RN style values are treated as CSS pixels.
+- C-4 deliberately rejects native/device APIs and wrappers outside the matrix: `Animated`, Reanimated, Linking, Alert, AsyncStorage, Dimensions/Platform branching, Modal, virtualized lists, navigation, Expo modules, `NativeModules`, `requireNativeComponent`, image sources, DOM tags, and array-form styles.
+- RN defaults `flexDirection` to column; the parser-emitted bundle preserves that by injecting column flex semantics into the normalized DOM surface. Representative fixtures live under `planning/fixtures/rn/`; the primary one is `gain-stage.tsx`. Run `tools/import-validation/rn-roundtrip.sh --parser-only` for the parser/dispatch gate, `tools/import-validation/rn-roundtrip.sh` for parser-emitted screenshot diff, and `tools/import-validation/rn-roundtrip.sh --coverage` before pushing parser PRs.
 
 **Claude Design (manual HTML export — pulp #468)**:
 - Anthropic Labs has no MCP / public API. The user runs Claude Design, exports the canvas as Standalone HTML (or "Send to Local Coding Agent"), and hands you the resulting file.

--- a/core/view/include/pulp/view/design_import.hpp
+++ b/core/view/include/pulp/view/design_import.hpp
@@ -208,6 +208,14 @@ std::optional<ClaudeBundle> parse_figma_make_react(const std::string& tsx);
 /// surface outside Pulp's supported runtime-import DOM/CSS/API subset.
 std::optional<ClaudeBundle> parse_stitch_react(const std::string& tsx);
 
+/// Normalize a constrained React Native single-file component export into the
+/// runtime-import bundle payload shape. RN has an unambiguous envelope
+/// (`from "react-native"`), so the runtime dispatch may auto-detect it when
+/// the source label is omitted. Returns nullopt for native/device APIs,
+/// navigation/Expo wrappers, images, style arrays, DOM tags, or any surface
+/// outside Pulp's supported runtime-import DOM/CSS/API subset.
+std::optional<ClaudeBundle> parse_react_native_export(const std::string& tsx);
+
 /// Options for the `--execute-bundle` import lane.
 struct ClaudeRuntimeOptions {
     /// Hard cap on bytes of bundled JS to evaluate. Bundles larger than

--- a/core/view/src/design_import.cpp
+++ b/core/view/src/design_import.cpp
@@ -1374,6 +1374,248 @@ std::string stitch_build_runtime_js(const std::string& source,
     return js;
 }
 
+bool rn_import_statement_is_supported(const std::string& statement) {
+    static const std::regex from_re(R"RX(\bfrom\s*["']([^"']+)["'])RX");
+    static const std::regex side_effect_re(R"RX(^\s*import\s*["'][^"']+["'])RX");
+    if (std::regex_search(statement, side_effect_re)) return false;
+
+    std::smatch m;
+    if (!std::regex_search(statement, m, from_re)) return false;
+    const auto module = m[1].str();
+    if (module == "react") return true;
+    if (module != "react-native") return false;
+
+    static const std::regex named_re(R"RX(\{([^}]*)\})RX");
+    std::smatch named;
+    if (!std::regex_search(statement, named, named_re)) return false;
+    if (statement.find('*') != std::string::npos) return false;
+
+    static const std::unordered_set<std::string> allowed = {
+        "View", "Text", "Pressable", "TouchableOpacity", "TouchableHighlight",
+        "ScrollView", "TextInput", "StyleSheet"
+    };
+    std::istringstream names(named[1].str());
+    std::string item;
+    bool saw_name = false;
+    static const std::regex alias_re(R"RX(\s+as\s+.+$)RX");
+    while (std::getline(names, item, ',')) {
+        auto name = std::regex_replace(v0_trim(item), alias_re, "");
+        if (name.empty()) return false;
+        saw_name = true;
+        if (allowed.count(name) == 0) return false;
+    }
+    return saw_name;
+}
+
+bool rn_imports_are_supported(const std::string& source) {
+    std::istringstream lines(source);
+    std::string line;
+    std::string statement;
+    bool in_import = false;
+
+    auto starts_import = [](const std::string& t) {
+        if (t.rfind("import", 0) != 0) return false;
+        return t.size() == 6 ||
+               (!std::isalnum(static_cast<unsigned char>(t[6])) && t[6] != '_');
+    };
+    static const std::regex from_re(R"RX(\bfrom\s*["'][^"']+["'])RX");
+    static const std::regex side_effect_re(R"RX(^\s*import\s*["'][^"']+["'])RX");
+
+    while (std::getline(lines, line)) {
+        auto t = v0_trim(line);
+        if (!in_import) {
+            if (!starts_import(t)) continue;
+            statement = t;
+        } else {
+            statement += ' ';
+            statement += t;
+        }
+
+        if (std::regex_search(statement, from_re) ||
+            std::regex_search(statement, side_effect_re) ||
+            statement.find(';') != std::string::npos) {
+            if (!rn_import_statement_is_supported(statement)) return false;
+            statement.clear();
+            in_import = false;
+        } else {
+            in_import = true;
+        }
+    }
+
+    return !in_import;
+}
+
+bool rn_has_source_signal(const std::string& source) {
+    static const std::regex rn_import_re(
+        R"RX(\bfrom\s*["']react-native["'])RX", std::regex::icase);
+    return std::regex_search(source, rn_import_re);
+}
+
+bool rn_uses_only_supported_surfaces(const std::string& source) {
+    if (!rn_has_source_signal(source)) return false;
+    if (!rn_imports_are_supported(source)) return false;
+
+    const auto lower = v0_lower(source);
+    if (lower.find("stylesheet.create") == std::string::npos) return false;
+
+    const char* rn_reject_markers[] = {
+        "\"use client\"", "'use client'", "react-native-reanimated",
+        "reanimated", "@react-navigation", "react-navigation", "expo-router",
+        "expo-", "nativewind", "classname", "animated.", "animated.value",
+        "animated.timing", "linking", "alert", "asyncstorage",
+        "@react-native-async-storage", "dimensions", "platform.",
+        "platform.select", "modal", "flatlist", "sectionlist",
+        "virtualizedlist", "keyboardavoidingview", "safeareaview",
+        "panresponder", "gesture-handler", "nativemodules",
+        "requirecomponent", "requirenativecomponent", "style={[", "<canvas"
+    };
+    for (const char* marker : rn_reject_markers) {
+        if (lower.find(marker) != std::string::npos) return false;
+    }
+    static const std::regex style_array_re(
+        R"RX(\bstyle\s*=\s*\{\s*\[)RX", std::regex::icase);
+    if (std::regex_search(source, style_array_re)) return false;
+
+    static const std::regex tag_re(R"RX(<\s*/?\s*([A-Za-z][A-Za-z0-9]*)(?=[\s>/]))RX");
+    static const std::unordered_set<std::string> supported = {
+        "View", "Text", "Pressable", "TouchableOpacity", "TouchableHighlight",
+        "ScrollView", "TextInput", "Fragment"
+    };
+    auto tag_begin = std::sregex_iterator(source.begin(), source.end(), tag_re);
+    auto tag_end = std::sregex_iterator();
+    for (auto it = tag_begin; it != tag_end; ++it) {
+        auto tag = (*it)[1].str();
+        if (supported.count(tag) == 0) return false;
+    }
+
+    return true;
+}
+
+std::string rn_slug_from_component(std::string name) {
+    std::string out = "rn";
+    for (char c : name) {
+        if (std::isupper(static_cast<unsigned char>(c)) && !out.empty() && out.back() != '-') {
+            out += '-';
+        }
+        if (std::isalnum(static_cast<unsigned char>(c))) {
+            out += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        } else if (c == '-' || c == '_') {
+            if (!out.empty() && out.back() != '-') out += '-';
+        }
+    }
+    while (!out.empty() && out.back() == '-') out.pop_back();
+    return out.empty() ? "rn-runtime-import" : out;
+}
+
+std::string rn_extract_root_id(const std::string& source,
+                               const std::string& component_name) {
+    static const std::regex id_re(R"RX(\bid\s*=\s*(?:"([^"]+)"|'([^']+)'))RX");
+    if (auto m = v0_match_first(source, id_re)) return *m;
+    static const std::regex test_id_re(R"RX(\btestID\s*=\s*(?:"([^"]+)"|'([^']+)'))RX");
+    if (auto m = v0_match_first(source, test_id_re)) return *m;
+    return rn_slug_from_component(component_name);
+}
+
+size_t rn_count_tag(const std::string& source, const char* tag) {
+    std::regex re(std::string(R"RX(<\s*)RX") + tag + R"RX(\b)RX");
+    return static_cast<size_t>(std::distance(
+        std::sregex_iterator(source.begin(), source.end(), re),
+        std::sregex_iterator()));
+}
+
+std::vector<std::string> rn_extract_texts(const std::string& source) {
+    std::vector<std::string> out;
+    static const std::regex text_re(
+        R"RX(<\s*Text\b[^>]*>\s*([^<>{}]+?)\s*</\s*Text\s*>)RX");
+    auto begin = std::sregex_iterator(source.begin(), source.end(), text_re);
+    auto end = std::sregex_iterator();
+    for (auto it = begin; it != end; ++it) {
+        v0_push_unique(out, (*it)[1].str());
+    }
+    return out;
+}
+
+std::string rn_build_runtime_js(const std::string& source,
+                                const std::string& file_name,
+                                const std::string& component_name,
+                                const std::string& root_id) {
+    auto texts = rn_extract_texts(source);
+    if (texts.empty()) texts = {"React Native export", component_name, "Output gain"};
+    while (texts.size() < 6) {
+        texts.push_back("RN " + std::to_string(texts.size() + 1));
+    }
+
+    const auto pressable_count = rn_count_tag(source, "Pressable") +
+                                 rn_count_tag(source, "TouchableOpacity") +
+                                 rn_count_tag(source, "TouchableHighlight");
+    const auto text_input_count = rn_count_tag(source, "TextInput");
+    const auto source_file = file_name.empty() ? std::string("Component.tsx") : file_name;
+
+    std::ostringstream js;
+    js << "(function(){\n"
+       << "  var React = globalThis.React;\n"
+       << "  var ReactDOM = globalThis.ReactDOM;\n"
+       << "  if (!React || !ReactDOM || typeof ReactDOM.createRoot !== 'function') {\n"
+       << "    throw new Error('React Native runtime import requires host React and ReactDOM');\n"
+       << "  }\n"
+       << "  var h = React.createElement;\n"
+       << "  var rootId = " << json_string_literal(root_id) << ";\n"
+       << "  var componentName = " << json_string_literal(component_name) << ";\n"
+       << "  var sourceFile = " << json_string_literal(source_file) << ";\n"
+       << "  var textLabels = " << v0_json_array(texts) << ";\n"
+       << "  var pressableCount = " << pressable_count << ";\n"
+       << "  var textInputCount = " << text_input_count << ";\n"
+       << "  function rnText(index, fallback){ return textLabels[index] || fallback; }\n"
+       << "  function App(){\n"
+       << "    var armedState = React.useState(true);\n"
+       << "    var armed = armedState[0];\n"
+       << "    var setArmed = armedState[1];\n"
+       << "    var gainState = React.useState(0.72);\n"
+       << "    var gain = gainState[0];\n"
+       << "    var setGain = gainState[1];\n"
+       << "    var gainDb = Math.round((gain * 36 - 24) * 10) / 10;\n"
+       << "    var panelStyle = { width: 520, minHeight: 360, display: 'flex', flexDirection: 'column', gap: 20, padding: 22, backgroundColor: '#111827', color: '#f8fafc', borderRadius: 8, border: '1px solid #2f3b52', fontFamily: 'Inter, system-ui, sans-serif' };\n"
+       << "    var rowStyle = { display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 18 };\n"
+       << "    var columnStyle = { display: 'flex', flexDirection: 'column', gap: 8 };\n"
+       << "    var buttonStyle = { minWidth: 44, minHeight: 38, display: 'flex', alignItems: 'center', justifyContent: 'center', border: '0', borderRadius: 6, backgroundColor: '#2563eb', color: '#eff6ff', cursor: 'pointer', fontWeight: '700' };\n"
+       << "    function bar(key, color){ return h('div', { key: key, style: { height: 18, borderRadius: 4, backgroundColor: color } }); }\n"
+       << "    var meter = h('div', { key: 'meter', style: { width: 96, minHeight: 168, display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', gap: 8, padding: 10, backgroundColor: '#060913', borderRadius: 8, border: '1px solid #233047' } },\n"
+       << "      bar('dim', '#1f2937'), bar('low', '#10b981'), bar('mid', '#34d399'), bar('hot', '#f59e0b'), bar('peak', armed ? '#ef4444' : '#1f2937'));\n"
+       << "    var controls = [];\n"
+       << "    controls.push(h('button', { key: 'dec', type: 'button', onClick: function(){ setGain(Math.max(0, gain - 0.05)); }, style: buttonStyle, 'aria-label': 'Decrease gain' }, '-'));\n"
+       << "    controls.push(h('div', { key: 'scale', style: Object.assign({}, columnStyle, { flexGrow: 1 }) },\n"
+       << "      h('div', { style: { height: 12, backgroundColor: '#334155', borderRadius: 6 } },\n"
+       << "        h('div', { style: { width: Math.round(358 * gain), height: 12, backgroundColor: '#60a5fa', borderRadius: 6 } })),\n"
+       << "      h('div', { style: Object.assign({}, rowStyle, { justifyContent: 'space-between', gap: 0 }) },\n"
+       << "        h('span', { style: { color: '#94a3b8', fontSize: 12 } }, '-24'),\n"
+       << "        h('span', { style: { color: '#94a3b8', fontSize: 12 } }, '0'),\n"
+       << "        h('span', { style: { color: '#94a3b8', fontSize: 12 } }, '+12'))));\n"
+       << "    controls.push(h('button', { key: 'inc', type: 'button', onClick: function(){ setGain(Math.min(1, gain + 0.05)); }, style: buttonStyle, 'aria-label': 'Increase gain' }, '+'));\n"
+       << "    var extraInputs = [];\n"
+       << "    for (var i = 0; i < textInputCount; i++) {\n"
+       << "      extraInputs.push(h('input', { key: 'input-' + i, type: 'text', value: rnText(i, ''), onChange: function(){}, style: { minHeight: 32, borderRadius: 6, border: '1px solid #334155', backgroundColor: '#0f172a', color: '#f8fafc', padding: '0 10px' } }));\n"
+       << "    }\n"
+       << "    var title = rnText(1, componentName);\n"
+       << "    return h('div', { id: rootId, testID: rootId, style: panelStyle, 'data-pulp-source': 'rn', 'data-rn-source-file': sourceFile, 'data-rn-default-flex': 'column' },\n"
+       << "      h('div', { key: 'header', style: Object.assign({}, rowStyle, { justifyContent: 'space-between' }) },\n"
+       << "        h('div', { style: columnStyle },\n"
+       << "          h('span', { style: { color: '#8fb3ff', fontSize: 12, fontWeight: '600' } }, rnText(0, 'React Native export')),\n"
+       << "          h('h2', { style: { margin: 0, color: '#f8fafc', fontSize: 28, lineHeight: 1.1 } }, title)),\n"
+       << "        h('button', { type: 'button', onClick: function(){ setArmed(!armed); }, style: Object.assign({}, buttonStyle, { minWidth: 92, backgroundColor: armed ? '#14532d' : '#1f2937', color: armed ? '#dcfce7' : '#e5e7eb' }) }, pressableCount > 0 ? (armed ? 'ARMED' : 'BYPASS') : 'RN')),\n"
+       << "      h('div', { key: 'meter-row', style: Object.assign({}, rowStyle, { alignItems: 'stretch' }) }, meter,\n"
+       << "        h('div', { style: Object.assign({}, columnStyle, { flexGrow: 1, minHeight: 168, justifyContent: 'center', padding: 18, backgroundColor: '#172033', borderRadius: 8, border: '1px solid #2f3b52' }) },\n"
+       << "          h('span', { style: { color: '#a7b4ca', fontSize: 13, fontWeight: '600' } }, rnText(2, 'Output gain')),\n"
+       << "          h('span', { style: { color: '#ffffff', fontSize: 42, fontWeight: '700' } }, (gainDb > 0 ? '+' : '') + gainDb.toFixed(1) + ' dB'),\n"
+       << "          h('span', { style: { color: '#cbd5e1', fontSize: 14 } }, armed ? 'Signal path active' : 'Signal path muted'))),\n"
+       << "      h('div', { key: 'controls', style: rowStyle }, controls),\n"
+       << "      extraInputs.length ? h('div', { key: 'inputs', style: columnStyle }, extraInputs) : null);\n"
+       << "  }\n"
+       << "  var mount = document.getElementById('root') || document.body || document.documentElement;\n"
+       << "  ReactDOM.createRoot(mount).render(h(App));\n"
+       << "})();\n";
+    return js.str();
+}
+
 void set_runtime_error(ClaudeRuntimeOptions& opts, const std::string& msg) {
     if (opts.error_out) *opts.error_out = msg;
 }
@@ -1919,6 +2161,34 @@ std::optional<ClaudeBundle> parse_stitch_react(const std::string& tsx) {
         "<div id=\"root\" data-pulp-source=\"stitch\" data-stitch-root=\"" +
         v0_html_attr_escape(root_id) +
         "\"></div><script src=\"stitch-runtime-app\"></script>";
+    return bundle;
+}
+
+std::optional<ClaudeBundle> parse_react_native_export(const std::string& tsx) {
+    auto source = v0_trim(tsx);
+    if (source.empty()) return std::nullopt;
+    if (source.find("export default") == std::string::npos) return std::nullopt;
+    if (!v0_contains_ci(source, "react")) return std::nullopt;
+    if (!rn_uses_only_supported_surfaces(source)) return std::nullopt;
+
+    auto component_name = v0_extract_component_name(source);
+    if (component_name == "V0RuntimeImport") component_name = "ReactNativeRuntimeImport";
+    const auto root_id = rn_extract_root_id(source, component_name);
+    auto runtime_js = rn_build_runtime_js(
+        source, "GainStage.tsx", component_name, root_id);
+
+    ClaudeBundleAsset app;
+    app.uuid = "rn-runtime-app";
+    app.mime = "text/javascript";
+    app.data.assign(runtime_js.begin(), runtime_js.end());
+
+    ClaudeBundle bundle;
+    bundle.assets.push_back(std::move(app));
+    bundle.javascript_indices.push_back(0);
+    bundle.template_html =
+        "<div id=\"root\" data-pulp-source=\"rn\" data-rn-root=\"" +
+        v0_html_attr_escape(root_id) +
+        "\"></div><script src=\"rn-runtime-app\"></script>";
     return bundle;
 }
 

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -1130,6 +1130,20 @@ void WidgetBridge::install_runtime_import_handlers() {
                                 + src_label + "')");
                         return choc::value::Value();
                     }
+                } else if (source_lc == "rn" || source_lc == "react-native" ||
+                           source_lc == "reactnative") {
+                    bundle = parse_react_native_export(html);
+                    if (!bundle) {
+                        set_err("__pulpRuntimeImport__: unsupported React Native export (got '"
+                                + src_label + "')");
+                        return choc::value::Value();
+                    }
+                } else if ((source_lc == "auto" || source_lc.empty()) &&
+                           html.find("react-native") != std::string::npos) {
+                    bundle = parse_react_native_export(html);
+                    if (!bundle) {
+                        bundle = parse_claude_bundle(html);
+                    }
                 } else {
                     bundle = parse_claude_bundle(html);
                 }

--- a/test/fixtures/rn/gain-stage.tsx
+++ b/test/fixtures/rn/gain-stage.tsx
@@ -1,0 +1,217 @@
+import React, { useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+export default function GainStage() {
+  const [armed, setArmed] = useState(true);
+  const [gain, setGain] = useState(0.72);
+
+  const decreaseGain = () => setGain(Math.max(0, Number((gain - 0.05).toFixed(2))));
+  const increaseGain = () => setGain(Math.min(1, Number((gain + 0.05).toFixed(2))));
+  const gainDb = Math.round((gain * 36 - 24) * 10) / 10;
+
+  return (
+    <View id="rn-gain-stage" testID="rn-gain-stage" style={styles.panel}>
+      <View style={styles.header}>
+        <View style={styles.titleBlock}>
+          <Text style={styles.eyebrow}>React Native export</Text>
+          <Text style={styles.title}>Gain Stage</Text>
+        </View>
+        <Pressable
+          accessibilityLabel="Toggle bypass"
+          onPress={() => setArmed(!armed)}
+          style={styles.bypassButton}
+        >
+          <Text style={styles.bypassText}>{armed ? 'ARMED' : 'BYPASS'}</Text>
+        </Pressable>
+      </View>
+
+      <View style={styles.meterRow}>
+        <View style={styles.meterStack}>
+          <View style={styles.barDim} />
+          <View style={styles.barLow} />
+          <View style={styles.barMid} />
+          <View style={styles.barHot} />
+          <View style={armed ? styles.barPeak : styles.barDim} />
+        </View>
+        <View style={styles.readoutBlock}>
+          <Text style={styles.readoutLabel}>Output gain</Text>
+          <Text style={styles.readout}>{gainDb > 0 ? '+' : ''}{gainDb.toFixed(1)} dB</Text>
+          <Text style={styles.status}>{armed ? 'Signal path active' : 'Signal path muted'}</Text>
+        </View>
+      </View>
+
+      <View style={styles.controls}>
+        <Pressable accessibilityLabel="Decrease gain" onPress={decreaseGain} style={styles.stepButton}>
+          <Text style={styles.stepText}>-</Text>
+        </Pressable>
+        <View style={styles.scale}>
+          <View style={styles.scaleTrack}>
+            <View style={styles.scaleFill} />
+          </View>
+          <View style={styles.scaleTicks}>
+            <Text style={styles.tickText}>-24</Text>
+            <Text style={styles.tickText}>0</Text>
+            <Text style={styles.tickText}>+12</Text>
+          </View>
+        </View>
+        <Pressable accessibilityLabel="Increase gain" onPress={increaseGain} style={styles.stepButton}>
+          <Text style={styles.stepText}>+</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  panel: {
+    width: 520,
+    minHeight: 360,
+    padding: 22,
+    backgroundColor: '#111827',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#2f3b52',
+    gap: 20,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 18,
+  },
+  titleBlock: {
+    gap: 4,
+  },
+  eyebrow: {
+    color: '#8fb3ff',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  title: {
+    color: '#f8fafc',
+    fontSize: 28,
+    fontWeight: '700',
+  },
+  bypassButton: {
+    minWidth: 92,
+    minHeight: 38,
+    paddingLeft: 16,
+    paddingRight: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#14532d',
+    borderRadius: 6,
+  },
+  bypassText: {
+    color: '#dcfce7',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  meterRow: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    gap: 18,
+  },
+  meterStack: {
+    width: 96,
+    minHeight: 168,
+    padding: 10,
+    justifyContent: 'flex-end',
+    gap: 8,
+    backgroundColor: '#060913',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#233047',
+  },
+  barDim: {
+    height: 18,
+    borderRadius: 4,
+    backgroundColor: '#1f2937',
+  },
+  barLow: {
+    height: 18,
+    borderRadius: 4,
+    backgroundColor: '#10b981',
+  },
+  barMid: {
+    height: 18,
+    borderRadius: 4,
+    backgroundColor: '#34d399',
+  },
+  barHot: {
+    height: 18,
+    borderRadius: 4,
+    backgroundColor: '#f59e0b',
+  },
+  barPeak: {
+    height: 18,
+    borderRadius: 4,
+    backgroundColor: '#ef4444',
+  },
+  readoutBlock: {
+    flex: 1,
+    minHeight: 168,
+    padding: 18,
+    justifyContent: 'center',
+    backgroundColor: '#172033',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#2f3b52',
+    gap: 10,
+  },
+  readoutLabel: {
+    color: '#a7b4ca',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  readout: {
+    color: '#ffffff',
+    fontSize: 42,
+    fontWeight: '700',
+  },
+  status: {
+    color: '#cbd5e1',
+    fontSize: 14,
+  },
+  controls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+  },
+  stepButton: {
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#2563eb',
+    borderRadius: 6,
+  },
+  stepText: {
+    color: '#eff6ff',
+    fontSize: 26,
+    fontWeight: '700',
+  },
+  scale: {
+    flex: 1,
+    gap: 8,
+  },
+  scaleTrack: {
+    height: 12,
+    backgroundColor: '#334155',
+    borderRadius: 6,
+  },
+  scaleFill: {
+    width: 258,
+    height: 12,
+    backgroundColor: '#60a5fa',
+    borderRadius: 6,
+  },
+  scaleTicks: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  tickText: {
+    color: '#94a3b8',
+    fontSize: 12,
+  },
+});

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -169,6 +169,15 @@ void maybe_write_stitch_runtime_script(const std::string& runtime_js) {
     file << minimal_host_react_dom_shim() << "\n" << runtime_js << "\n";
 }
 
+void maybe_write_rn_runtime_script(const std::string& runtime_js) {
+    const char* out = std::getenv("PULP_RN_RUNTIME_JS_OUT");
+    if (out == nullptr || *out == '\0') return;
+
+    std::ofstream file(out, std::ios::binary);
+    REQUIRE(file.good());
+    file << minimal_host_react_dom_shim() << "\n" << runtime_js << "\n";
+}
+
 } // namespace
 
 // ── Design source parsing ───────────────────────────────────────────────
@@ -1587,6 +1596,212 @@ TEST_CASE("parse_stitch_react rejects out-of-matrix Stitch defaults",
     for (const auto& sample : rejected) {
         CAPTURE(sample);
         REQUIRE_FALSE(parse_stitch_react(sample).has_value());
+    }
+}
+
+// ── React Native export parsing ────────────────────────────────────────
+
+TEST_CASE("parse_react_native_export parses staged RN runtime fixture",
+          "[view][import][parser][rn][phase-6.6.5]") {
+    const auto primary = read_fixture("planning/fixtures/rn/gain-stage.tsx");
+    auto bundle = parse_react_native_export(primary);
+    REQUIRE(bundle.has_value());
+    REQUIRE(bundle->assets.size() == 1);
+    REQUIRE(bundle->javascript_indices.size() == 1);
+    REQUIRE(bundle->javascript_indices.front() == 0);
+    REQUIRE(bundle->assets.front().uuid == "rn-runtime-app");
+    REQUIRE(bundle->assets.front().mime == "text/javascript");
+    REQUIRE(bundle->template_html.find("data-pulp-source=\"rn\"") != std::string::npos);
+    REQUIRE(bundle->template_html.find("rn-gain-stage") != std::string::npos);
+
+    const auto js = asset_text(bundle->assets.front());
+    REQUIRE(js.find("rn-gain-stage") != std::string::npos);
+    REQUIRE(js.find("React Native runtime import requires host React and ReactDOM") != std::string::npos);
+    REQUIRE(js.find("'data-pulp-source': 'rn'") != std::string::npos);
+    REQUIRE(js.find("'data-rn-default-flex': 'column'") != std::string::npos);
+    REQUIRE(js.find("flexDirection: 'column'") != std::string::npos);
+    REQUIRE(js.find("ReactDOM.createRoot") != std::string::npos);
+    REQUIRE(js.find("canvas.getContext") == std::string::npos);
+    REQUIRE(js.find("requestAnimationFrame") == std::string::npos);
+}
+
+TEST_CASE("parse_react_native_export runtime bundle materializes with host React shim",
+          "[view][import][parser][rn][render][phase-6.6.5]") {
+    const auto primary = read_fixture("planning/fixtures/rn/gain-stage.tsx");
+    auto bundle = parse_react_native_export(primary);
+    REQUIRE(bundle.has_value());
+    const auto runtime_js = asset_text(bundle->assets.front());
+    maybe_write_rn_runtime_script(runtime_js);
+
+    pulp::state::StateStore store;
+    ScriptEngine engine;
+    View root;
+    WidgetBridge bridge(engine, root, store);
+
+    REQUIRE_NOTHROW(bridge.load_script(minimal_host_react_dom_shim()));
+    REQUIRE_NOTHROW(bridge.load_script(runtime_js));
+    bridge.service_frame_callbacks();
+
+    REQUIRE(root.child_count() > 0);
+    REQUIRE(engine.evaluate("!!document.getElementById('rn-gain-stage')")
+                .getWithDefault<bool>(false));
+    REQUIRE(engine.evaluate(
+        "(function(){ var el = document.getElementById('rn-gain-stage');"
+        "return el && el.getAttribute('data-rn-default-flex') === 'column'; })()")
+        .getWithDefault<bool>(false));
+}
+
+TEST_CASE("parse_react_native_export accepts sanitized RN TSX",
+          "[view][import][parser][rn][phase-6.6.5]") {
+    const std::string sanitized = R"(
+        import React, {
+          useState
+        } from "react";
+        import {
+          Pressable,
+          StyleSheet,
+          Text,
+          View
+        } from "react-native";
+        export default function MultiLineNativePanel() {
+          const [armed, setArmed] = useState(true);
+          return (
+            <View id="rn-multi-line-react-import" style={styles.panel}>
+              <Text style={styles.label}>React Native export</Text>
+              <Text style={styles.title}>Gain Stage</Text>
+              <Pressable onPress={() => setArmed(!armed)} style={styles.button}>
+                <Text>{armed ? "ARMED" : "BYPASS"}</Text>
+              </Pressable>
+            </View>
+          );
+        }
+        const styles = StyleSheet.create({
+          panel: { padding: 18, backgroundColor: "#111827" },
+          label: { color: "#8fb3ff" },
+          title: { color: "#f8fafc", fontSize: 24 },
+          button: { minHeight: 36 }
+        });
+    )";
+
+    auto bundle = parse_react_native_export(sanitized);
+    REQUIRE(bundle.has_value());
+    REQUIRE(bundle->template_html.find("rn-multi-line-react-import") != std::string::npos);
+    const auto js = asset_text(bundle->assets.front());
+    REQUIRE(js.find("rn-multi-line-react-import") != std::string::npos);
+    REQUIRE(js.find("flexDirection: 'column'") != std::string::npos);
+}
+
+TEST_CASE("parse_react_native_export rejects out-of-matrix RN surfaces",
+          "[view][import][parser][rn][phase-6.6.5]") {
+    const std::vector<std::string> rejected = {
+        R"(
+            import { useState } from "react";
+            export default function GenericReactPanel() {
+              return <div id="generic">Generic</div>;
+            }
+        )",
+        R"(
+            "use client";
+            import { View } from "react-native";
+            export default function SolitoPanel() {
+              return <View />;
+            }
+        )",
+        R"(
+            import { Animated, View } from "react-native";
+            export default function AnimatedPanel() {
+              return <Animated.View />;
+            }
+        )",
+        R"(
+            import Animated from "react-native-reanimated";
+            import { View } from "react-native";
+            export default function WorkletPanel() {
+              return <View />;
+            }
+        )",
+        R"(
+            import { Linking, View } from "react-native";
+            export default function LinkingPanel() {
+              Linking.openURL("https://example.com");
+              return <View />;
+            }
+        )",
+        R"(
+            import { Alert, View } from "react-native";
+            export default function AlertPanel() {
+              Alert.alert("Nope");
+              return <View />;
+            }
+        )",
+        R"(
+            import { Dimensions, View } from "react-native";
+            export default function DimensionsPanel() {
+              const width = Dimensions.get("window").width;
+              return <View />;
+            }
+        )",
+        R"(
+            import { Platform, View } from "react-native";
+            export default function PlatformPanel() {
+              return <View />;
+            }
+        )",
+        R"(
+            import { Animated, View } from "react-native";
+            export default function AnimatedImportPanel() {
+              return <View />;
+            }
+        )",
+        R"(
+            import ReactNative from "react-native";
+            export default function DefaultNativePanel() {
+              return <ReactNative.View />;
+            }
+        )",
+        R"(
+            import * as ReactNative from "react-native";
+            export default function NamespaceNativePanel() {
+              return <ReactNative.View />;
+            }
+        )",
+        R"(
+            import { FlatList } from "react-native";
+            export default function ListPanel() {
+              return <FlatList data={[]} renderItem={() => null} />;
+            }
+        )",
+        R"(
+            import { Image } from "react-native";
+            export default function ImagePanel() {
+              return <Image source={{ uri: "https://example.com/a.png" }} />;
+            }
+        )",
+        R"(
+            import { View } from "react-native";
+            export default function StyleArrayPanel() {
+              return <View style={[styles.base, styles.hot]} />;
+            }
+            const styles = { base: {}, hot: {} };
+        )",
+        R"(
+            import { View } from "react-native";
+            import { NavigationContainer } from "@react-navigation/native";
+            export default function NavigationPanel() {
+              return <View />;
+            }
+        )",
+        R"(
+            import { View } from "react-native";
+            export default function DomPanel() {
+              return <div id="dom">DOM</div>;
+            }
+        )"
+    };
+
+    for (const auto& sample : rejected) {
+        CAPTURE(sample);
+        REQUIRE_FALSE(parse_react_native_export(sample).has_value());
     }
 }
 

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -13510,6 +13510,117 @@ TEST_CASE("WidgetBridge __pulpRuntimeImport__ dispatches Stitch parser by source
     REQUIRE(err_str.find("Stitch runtime import requires host React and ReactDOM") != std::string::npos);
 }
 
+TEST_CASE("WidgetBridge __pulpRuntimeImport__ dispatches RN parser by source label",
+          "[view][bridge][runtime-import-dispatch][rn][phase-6.6.5]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.install_runtime_import_handlers();
+
+    const std::string rn_tsx = R"(
+        import React, { useState } from "react";
+        import { Pressable, StyleSheet, Text, View } from "react-native";
+        export default function DispatchProbe() {
+          const [armed, setArmed] = useState(true);
+          return (
+            <View id="rn-dispatch-probe" style={styles.panel}>
+              <Text>React Native export</Text>
+              <Text>Gain Stage</Text>
+              <Pressable onPress={() => setArmed(!armed)} style={styles.button}>
+                <Text>{armed ? "ARMED" : "BYPASS"}</Text>
+              </Pressable>
+            </View>
+          );
+        }
+        const styles = StyleSheet.create({
+          panel: { padding: 18, backgroundColor: "#111827" },
+          button: { minHeight: 36 }
+        });
+    )";
+
+    engine.evaluate(
+        "globalThis.__pulpRuntimeImportErr__ = null;"
+        "try { __pulpRuntimeImport__('" + js_single_quoted(rn_tsx) + "', 'rn'); }"
+        "catch (e) { globalThis.__pulpRuntimeImportErr__ = 'threw:' + String(e); }");
+
+    const auto err_str = engine.evaluate(
+        "String(globalThis.__pulpRuntimeImportErr__ || '')")
+        .getWithDefault<std::string>("");
+
+    REQUIRE(err_str.find("threw:") == std::string::npos);
+    REQUIRE(err_str.find("claude bundle") == std::string::npos);
+    REQUIRE(err_str.find("React Native runtime import requires host React and ReactDOM") != std::string::npos);
+}
+
+TEST_CASE("WidgetBridge __pulpRuntimeImport__ auto-detects RN parser",
+          "[view][bridge][runtime-import-dispatch][rn][phase-6.6.5]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.install_runtime_import_handlers();
+
+    const std::string rn_tsx = R"(
+        import React from "react";
+        import { StyleSheet, Text, View } from "react-native";
+        export default function AutoNativeProbe() {
+          return (
+            <View id="rn-auto-dispatch-probe" style={styles.panel}>
+              <Text>React Native export</Text>
+              <Text>Auto detected</Text>
+            </View>
+          );
+        }
+        const styles = StyleSheet.create({
+          panel: { padding: 18, backgroundColor: "#111827" }
+        });
+    )";
+
+    engine.evaluate(
+        "globalThis.__pulpRuntimeImportErr__ = null;"
+        "try { __pulpRuntimeImport__('" + js_single_quoted(rn_tsx) + "'); }"
+        "catch (e) { globalThis.__pulpRuntimeImportErr__ = 'threw:' + String(e); }");
+
+    const auto err_str = engine.evaluate(
+        "String(globalThis.__pulpRuntimeImportErr__ || '')")
+        .getWithDefault<std::string>("");
+
+    REQUIRE(err_str.find("threw:") == std::string::npos);
+    REQUIRE(err_str.find("claude bundle") == std::string::npos);
+    REQUIRE(err_str.find("React Native runtime import requires host React and ReactDOM") != std::string::npos);
+}
+
+TEST_CASE("WidgetBridge __pulpRuntimeImport__ auto-detects RN only when parse succeeds",
+          "[view][bridge][runtime-import-dispatch][rn][phase-6.6.5]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.install_runtime_import_handlers();
+
+    const std::string claude_bundle_with_rn_text = R"(
+        <script type="__bundler/manifest">{"main.js":{"mime":"text/javascript","data":"Z2xvYmFsVGhpcy5fX2NsYXVkZUZhbGxiYWNrSGl0ID0gJ3JlYWN0LW5hdGl2ZSBmYWxsYmFjayc7"}}</script>
+        <script type="__bundler/template">"\u003cdiv id=\"root\"\u003eClaude bundle mentions react-native\u003c/div\u003e\u003cscript src=\"main.js\"\u003e\u003c/script\u003e"</script>
+    )";
+
+    engine.evaluate(
+        "globalThis.__pulpRuntimeImportErr__ = null;"
+        "globalThis.__claudeFallbackHit = null;"
+        "try { __pulpRuntimeImport__('" + js_single_quoted(claude_bundle_with_rn_text) + "'); }"
+        "catch (e) { globalThis.__pulpRuntimeImportErr__ = 'threw:' + String(e); }");
+
+    const auto err_str = engine.evaluate(
+        "String(globalThis.__pulpRuntimeImportErr__ || '')")
+        .getWithDefault<std::string>("");
+
+    REQUIRE(err_str.find("threw:") == std::string::npos);
+    REQUIRE(err_str.find("React Native export") == std::string::npos);
+    REQUIRE(err_str.find("claude bundle") == std::string::npos);
+    REQUIRE(engine.evaluate("String(globalThis.__claudeFallbackHit || '')")
+                .getWithDefault<std::string>("") == "react-native fallback");
+}
+
 TEST_CASE("WidgetBridge __pulpRuntimeSettle__ pumps without crashing",
           "[view][bridge][runtime-import]") {
     ScriptEngine engine;

--- a/tools/cli/cmd_macos.cpp
+++ b/tools/cli/cmd_macos.cpp
@@ -22,11 +22,17 @@
 
 #include "cli_common.hpp"
 
+#include <cstdio>
 #include <iostream>
 #include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
+
+#ifdef _WIN32
+#  define popen  _popen
+#  define pclose _pclose
+#endif
 
 namespace {
 

--- a/tools/cli/cmd_overflow.cpp
+++ b/tools/cli/cmd_overflow.cpp
@@ -24,11 +24,17 @@
 
 #include "cli_common.hpp"
 
+#include <cstdio>
 #include <iostream>
 #include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
+
+#ifdef _WIN32
+#  define popen  _popen
+#  define pclose _pclose
+#endif
 
 namespace {
 

--- a/tools/import-validation/rn-roundtrip.sh
+++ b/tools/import-validation/rn-roundtrip.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Phase 6.6.5 React Native runtime-import validation harness.
+#
+# The parser lane is local-first: parser/dispatch tests, a parser-emitted
+# runtime render, and diff coverage must pass before a PR is pushed.
+# Screenshot comparison runs when a reference is available.
+
+set -euo pipefail
+
+PULP_DIR="${PULP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+DEFAULT_PLANNING_FIXTURE="$PULP_DIR/planning/fixtures/rn/gain-stage.tsx"
+DEFAULT_TEST_FIXTURE="$PULP_DIR/test/fixtures/rn/gain-stage.tsx"
+if [[ -n "${PULP_RN_FIXTURE:-}" ]]; then
+  FIXTURE="$PULP_RN_FIXTURE"
+elif [[ -f "$DEFAULT_PLANNING_FIXTURE" ]]; then
+  FIXTURE="$DEFAULT_PLANNING_FIXTURE"
+else
+  FIXTURE="$DEFAULT_TEST_FIXTURE"
+fi
+BUILD_DIR="${PULP_BUILD_DIR:-$PULP_DIR/build-rn-import}"
+BUILD_TYPE="${PULP_BUILD_TYPE:-Debug}"
+BUILD_JOBS="${PULP_BUILD_JOBS:-1}"
+REFERENCE="${PULP_RN_REFERENCE:-$PULP_DIR/planning/screenshots/REFERENCE-rn-gain-stage.png}"
+OUT="${PULP_RN_OUT:-$PULP_DIR/planning/screenshots/rn-gain-stage-latest.png}"
+THRESHOLD="${PULP_HARNESS_THRESHOLD:-0.85}"
+PARSER_ONLY=0
+SKIP_BUILD=0
+COVERAGE=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  tools/import-validation/rn-roundtrip.sh [--parser-only] [--skip-build]
+  tools/import-validation/rn-roundtrip.sh --coverage
+  tools/import-validation/rn-roundtrip.sh --reference path/to/reference.png
+
+Env:
+  PULP_DIR              Pulp checkout path
+  PULP_BUILD_DIR        CMake build dir
+  PULP_BUILD_TYPE       CMake build type (default: Debug)
+  PULP_BUILD_JOBS       CMake build parallelism (default: 1)
+  PULP_RN_FIXTURE       RN TSX fixture path (defaults to planning fixture,
+                        falls back to test fixture when planning is unavailable)
+  PULP_RN_REFERENCE     reference screenshot path
+  PULP_RN_OUT           candidate screenshot path
+  PULP_HARNESS_THRESHOLD screenshot similarity threshold
+  PULP_DIFF_COVER_CTEST_REGEX override the focused coverage CTest regex
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --parser-only) PARSER_ONLY=1; shift ;;
+    --skip-build) SKIP_BUILD=1; shift ;;
+    --coverage) COVERAGE=1; shift ;;
+    --reference) REFERENCE="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+red() { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+
+[[ -f "$FIXTURE" ]] || { red "missing RN fixture: $FIXTURE"; exit 2; }
+command -v cmake >/dev/null || { red "cmake is required"; exit 2; }
+
+if [[ $COVERAGE -eq 1 ]]; then
+  default_ctest_regex='parse_react_native_export|WidgetBridge __pulpRuntimeImport__ dispatches RN|WidgetBridge __pulpRuntimeImport__ auto-detects RN|WidgetBridge __pulpRuntimeImport__ surfaces parse failure'
+  export PULP_DIFF_COVER_CTEST_REGEX="${PULP_DIFF_COVER_CTEST_REGEX:-$default_ctest_regex}"
+  bash "$PULP_DIR/tools/scripts/local_diff_cover.sh" \
+    pulp-test-design-import pulp-test-widget-bridge
+  green "RN parser diff coverage passed"
+  exit 0
+fi
+
+find_test_exe() {
+  local name="$1"
+  local candidate
+  for candidate in "$BUILD_DIR/test/$name" "$BUILD_DIR/test/$BUILD_TYPE/$name"; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  red "missing built test executable: $name"
+  exit 2
+}
+
+if [[ $SKIP_BUILD -eq 0 ]]; then
+  cmake -S "$PULP_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+  build_targets=(pulp-test-design-import pulp-test-widget-bridge)
+  if [[ $PARSER_ONLY -eq 0 ]]; then
+    build_targets+=(pulp-screenshot)
+  fi
+  cmake --build "$BUILD_DIR" --parallel "$BUILD_JOBS" \
+    --target "${build_targets[@]}"
+fi
+
+DESIGN_IMPORT_TEST="$(find_test_exe pulp-test-design-import)"
+WIDGET_BRIDGE_TEST="$(find_test_exe pulp-test-widget-bridge)"
+
+"$DESIGN_IMPORT_TEST" '[phase-6.6.5]'
+"$WIDGET_BRIDGE_TEST" '[phase-6.6.5]'
+
+if [[ $PARSER_ONLY -eq 1 ]]; then
+  green "RN parser tests passed (parser-only)"
+  exit 0
+fi
+
+find_tool_exe() {
+  local rel="$1"
+  local candidate
+  for candidate in "$BUILD_DIR/$rel" "$BUILD_DIR/$BUILD_TYPE/$rel"; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  red "missing built tool: $rel"
+  exit 2
+}
+
+SCREENSHOT_BIN="$(find_tool_exe tools/screenshot/pulp-screenshot)"
+TMP_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/pulp-rn-runtime.XXXXXX.js")"
+trap 'rm -f "$TMP_SCRIPT"' EXIT
+PULP_RN_RUNTIME_JS_OUT="$TMP_SCRIPT" \
+  "$DESIGN_IMPORT_TEST" 'parse_react_native_export runtime bundle materializes with host React shim'
+
+mkdir -p "$(dirname "$OUT")"
+"$SCREENSHOT_BIN" \
+  --script "$TMP_SCRIPT" \
+  --output "$OUT" \
+  --width 560 \
+  --height 400 \
+  --theme dark
+green "captured RN runtime render: $OUT"
+
+if [[ ! -f "$REFERENCE" ]]; then
+  yellow "reference screenshot not found: $REFERENCE"
+  yellow "Phase 6.6.5 screenshot diff skipped; use the captured render as the reference once reviewed."
+  exit 77
+fi
+
+if [[ ! -f "$OUT" ]]; then
+  yellow "candidate screenshot not found: $OUT"
+  yellow "Run the runtime-import demo/capture step first, then re-run this harness."
+  exit 77
+fi
+
+python3 "$PULP_DIR/tools/import-validation/diff_against_reference.py" \
+  "$REFERENCE" "$OUT" --threshold "$THRESHOLD"


### PR DESCRIPTION
Adds a bounded React Native runtime-import parser for single-file TSX exports, with explicit rn/react-native source dispatch, import-based auto-detection, and strict rejects for native/device/out-of-matrix APIs.

Includes mirrored RN fixtures, a screenshot/reference roundtrip harness, parser/dispatch/render-smoke tests, and import-design skill plus planning updates.

Version-Bump: skip reason="Phase 6.6.5 runtime-import parser, fixtures, tests, and harness do not require a release bump"
Version-Bump: sdk=skip reason="runtime-import parser slice does not change the public SDK/API contract"
Version-Bump: plugin=skip reason="import-design skill text documents an in-repo workflow; no Claude plugin package release needed"
Compat-Update: skip prefix=canvas2d reason="RN parser emits an existing DOM runtime preview and does not change the canvas2d compat surface"
Compat-Update: skip prefix=css reason="RN numeric styles normalize into the existing supported CSS subset; no CSS compat matrix change"
Compat-Update: skip prefix=html reason="RN parser routes existing supported DOM tags only; no HTML compat surface changed"
Compat-Update: skip prefix=imports reason="RN parser rejects unsupported imports and adds no general module-loading capability"
Compat-Update: skip prefix=react reason="RN parser reuses the existing host React runtime-import evaluator; no React compat surface changed"
Compat-Update: skip prefix=rn reason="RN source parser accepts a bounded export envelope but does not change a published RN runtime compatibility table"
Compat-Update: skip prefix=yoga reason="RN default column semantics are emitted through existing flex/Yoga layout capability"