### PR TITLE
fix(design-tool): install runtime-import handlers + deferred settle pump for React imports

### DIFF
--- a/examples/design-tool/main.cpp
+++ b/examples/design-tool/main.cpp
@@ -240,6 +240,8 @@ int main(int argc, char* argv[]) {
         bridge->set_ai_cli_command(*ai_cli);
     }
 
+    bridge->install_runtime_import_handlers();
+
     // Load library scripts first (oklch.js)
     auto js_dir = js_path.parent_path();
     auto load_library_scripts = [&](WidgetBridge& target) {
@@ -309,6 +311,7 @@ int main(int argc, char* argv[]) {
             StateStore probe_store;
             auto probe_engine = make_engine("reload:");
             auto probe_bridge = std::make_unique<WidgetBridge>(*probe_engine, probe_root, probe_store);
+            probe_bridge->install_runtime_import_handlers();
             load_library_scripts(*probe_bridge);
             probe_bridge->load_script(new_code);
 
@@ -324,6 +327,7 @@ int main(int argc, char* argv[]) {
             } else if (auto ai_cli = pulp::runtime::get_env("PULP_AI_CLI")) {
                 next_bridge->set_ai_cli_command(*ai_cli);
             }
+            next_bridge->install_runtime_import_handlers();
             load_library_scripts(*next_bridge);
             next_bridge->load_script(new_code);
             next_bridge->restore_values(saved);
@@ -361,6 +365,22 @@ int main(int argc, char* argv[]) {
         }
     });
     dispatch_resume(reload_timer);
+
+    {
+        auto* bridge_slot = &bridge;
+        auto* window_ptr = window.get();
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 200 * NSEC_PER_MSEC),
+                       dispatch_get_main_queue(), ^{
+            if (*bridge_slot) {
+                try {
+                    (*bridge_slot)->load_script(
+                        "if (typeof __pulpRuntimeSettle__ === 'function') __pulpRuntimeSettle__(4);");
+                } catch (...) {
+                }
+                if (window_ptr) window_ptr->repaint();
+            }
+        });
+    }
 
     int automation_exit_code = 0;
     if (automation.enabled) {


### PR DESCRIPTION
Live pulp-design-tool window mounting Spectr's editor.js was showing
only the top chrome (SPECTR / ZOOMABLE FILTER BANK / IIR-FFT-HYBRID) —
spectrum chart, dB scale, and bottom toolbar all blank — while the
headless pulp-screenshot tool rendered them correctly with the same
script. Diff was the runtime-import surface: pulp-screenshot installs
runtime-import handlers and pumps __pulpRuntimeSettle__ after script
load; pulp-design-tool did neither, so React's useEffect /
requestAnimationFrame / setTimeout callbacks (where Spectr's
drawSpectrum, drawRulers, and bottom-toolbar paint live) never ran.

Two changes:

1. Install runtime-import handlers right after WidgetBridge creation
   so React-imported subtrees can register & drain useEffect / RAF /
   timer callbacks via the same path pulp-screenshot uses.

2. Schedule one low-count __pulpRuntimeSettle__(4) pump via
   dispatch_after(200ms) AFTER the window is open. Cannot be
   synchronous before WindowHost::create() because RAF callbacks
   self-re-arm and a synchronous (64) pump never returns — the
   process hangs with no window. The deferred low-count pump lets
   the live run loop own subsequent ticks.

Verified locally with /Users/danielraffel/Code/spectr/native-react/
dist/editor.js: window opens, chart + spectrum bands + dB scale +
top chrome all render. Zoom and bar-drawing interactions work.

Follow-ups tracked separately:
- Bottom toolbar requires window resize to lay out (needs
  reconcile_oversize_absolute_subtree port from screenshot tool).
- Sluggish interaction (likely RAF re-arm or 100ms poll timer).
- Keyboard shortcuts not reaching JS.
- Icons/logo missing.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>