### PR TITLE
fix(view+cmake): port viewport_reconcile to core/view; LOUD perf-regression guard when Skia not linked

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,43 @@ if(PULP_ENABLE_GPU)
     endif()
 endif()
 
+# pulp-internal #62 — LOUD perf-regression guard. PULP_ENABLE_GPU=ON
+# but no Skia found silently falls back to CoreGraphics CPU rendering.
+# That fallback is ~5-10× slower than Skia/Dawn for live JS-driven UIs
+# (Spectr's editor.js drag went from 7% CPU on Skia to 100% CPU on CG
+# fallback — 2026-05-13 regression). The fallback is the right
+# behavior for offline tooling and CI bot builds that don't render
+# windows, but for ANY local interactive developer session it produces
+# a UX that looks broken with no obvious build-output explanation.
+#
+# Print a screaming WARNING banner whenever GPU is requested but
+# Skia is not linked, with concrete instructions on how to recover.
+# The release path keeps the hard FATAL_ERROR below
+# (PULP_REQUIRE_GPU_FOR_SDK); local dev gets the loud warning instead
+# so an incremental rebuild without skia-build still works.
+if(PULP_ENABLE_GPU AND NOT PULP_HAS_SKIA)
+    message(WARNING
+        "\n"
+        "  ╔══════════════════════════════════════════════════════════════════════╗\n"
+        "  ║  PERF REGRESSION RISK — Skia is NOT linked into this build           ║\n"
+        "  ║                                                                      ║\n"
+        "  ║  PULP_ENABLE_GPU=ON but FindSkia.cmake could not locate libskia.a    ║\n"
+        "  ║  at the configured SKIA_DIR ('${SKIA_DIR}').                          \n"
+        "  ║                                                                      ║\n"
+        "  ║  Live windows (pulp-design-tool, pulp-ui-preview, pulp-screenshot    ║\n"
+        "  ║  with use_gpu=true) will silently fall back to CoreGraphics CPU      ║\n"
+        "  ║  rendering — ~5-10× slower for animated / JS-driven UIs.             ║\n"
+        "  ║                                                                      ║\n"
+        "  ║  Recover:                                                            ║\n"
+        "  ║    1. Run tools/build-skia.sh (or fetch the pinned tarball) to       ║\n"
+        "  ║       populate external/skia-build/build/<platform>-gpu/lib/Release/ ║\n"
+        "  ║    2. Or pass -DSKIA_DIR=/abs/path/to/external/skia-builder when     ║\n"
+        "  ║       the libs live at external/skia-builder/build/<plat>-gpu/...    ║\n"
+        "  ║    3. Or pass -DPULP_ENABLE_GPU=OFF if you genuinely want a          ║\n"
+        "  ║       CoreGraphics-only build (offline tooling, CI bots).            ║\n"
+        "  ╚══════════════════════════════════════════════════════════════════════╝")
+endif()
+
 # SDK-release safety net for pulp #1817. The release workflow turns this
 # option ON via -DPULP_REQUIRE_GPU_FOR_SDK=ON so a missing Skia tarball
 # is a hard configure error instead of a silent CG-only build that ships

--- a/core/view/include/pulp/view/viewport_reconcile.hpp
+++ b/core/view/include/pulp/view/viewport_reconcile.hpp
@@ -1,14 +1,14 @@
 // pulp #1899 — viewport reconciliation for runtime-imported content.
 //
-// Extracted into a header so unit tests can exercise the recursive
-// clamp without linking the screenshot CLI binary. Intentionally
-// header-only — the logic is small, pure (no I/O beyond an env-gated
-// diagnostic), and all of its dependencies (pulp::view::View) are
-// already in the include path of any consumer that wants it.
+// Header-only helper for clamping oversize absolute-positioned
+// descendants to fit a viewport. Generic enough to live in core/view
+// because both the headless screenshot tool and the live host (and
+// any future live host running runtime-imported React trees) need
+// the same reconciliation.
 //
 // Background: imports (Spectr, v0.dev, Stitch, Figma exports) routinely
 // ship a top-level container with literal-CSS hardcoded dimensions that
-// exceed the screenshot viewport. Canonical Spectr case
+// exceed the runtime viewport. Canonical Spectr case
 // (`spectr-editor-extracted.js:4140`, originating in
 // `dom-adapter.tsx:440-441` as a workaround for what dom-adapter
 // perceived as a Yoga absolute-pin bug):
@@ -27,7 +27,7 @@
 // main axis to fit the body's content box.
 //
 // This helper emulates that flex-shrink behaviour for runtime-import
-// captures. For any descendant of root_ with
+// hosts. For any descendant of root_ with
 // `position:absolute|fixed` AND a `preferred_width|height` exceeding
 // the viewport AND no opposite-edge anchor (`right` for width,
 // `bottom` for height — i.e. the source told us a concrete size, not
@@ -35,7 +35,7 @@
 // the viewport size on that axis. Descendants anchored at `bottom:0`
 // / `right:0` then anchor to the visible edge instead of falling off.
 //
-// Scoped strictly to oversize-content + screenshot-tool usage; never
+// Scoped strictly to oversize-content + runtime-import usage; never
 // fires when content already fits, never modifies anchored content.
 
 #pragma once
@@ -45,7 +45,7 @@
 #include <cstdio>
 #include <cstdlib>
 
-namespace pulp::screenshot {
+namespace pulp::view {
 
 inline void clamp_oversize_absolute_view(pulp::view::View& view,
                                           float vw, float vh,
@@ -74,8 +74,6 @@ inline void clamp_oversize_absolute_view(pulp::view::View& view,
     // unset (`auto`). Any explicit value — including 0 — is the
     // source declaring edge-anchoring intent, which Yoga will honour
     // via the inset → size derivation; defer to that.
-    // TODO: pin in #1906 test — Yoga-level fixture with
-    // position:absolute + width:1320 + right:0 must NOT clamp width.
     const bool size_x_is_explicit = cw > 0 && !view.has_right();
     const bool size_y_is_explicit = ch > 0 && !view.has_bottom();
     bool clamped = false;
@@ -138,4 +136,4 @@ inline void reconcile_oversize_absolute_subtree(pulp::view::View& root,
     }
 }
 
-} // namespace pulp::screenshot
+} // namespace pulp::view

--- a/examples/design-tool/main.cpp
+++ b/examples/design-tool/main.cpp
@@ -345,6 +345,19 @@ int main(int argc, char* argv[]) {
             bridge->set_repaint_callback([&window] {
                 if (window) window->repaint();
             });
+            // Codex P2 — re-run viewport reconciliation against the
+            // freshly-rebuilt tree using the CURRENT window size, not
+            // the initial opts.* values (the user may have resized
+            // since launch). Without this, a hot-reloaded script with
+            // oversize absolute roots regresses to the same off-screen
+            // layout that the cold-start reconcile call (line ~295)
+            // exists to prevent.
+            if (window) {
+                const auto sz = window->get_content_size();
+                if (sz.width > 0 && sz.height > 0) {
+                    pulp::view::reconcile_oversize_absolute_subtree(root, sz.width, sz.height);
+                }
+            }
             window->repaint();
         } catch (const std::exception& e) {
             std::cerr << "Hot reload failed: " << e.what() << "\n";

--- a/examples/design-tool/main.cpp
+++ b/examples/design-tool/main.cpp
@@ -9,6 +9,7 @@
 #include <pulp/view/widget_bridge.hpp>
 #include <pulp/view/window_host.hpp>
 #include <pulp/view/hot_reload.hpp>
+#include <pulp/view/viewport_reconcile.hpp>
 #include <pulp/state/store.hpp>
 #include <pulp/runtime/system.hpp>
 #include <filesystem>
@@ -291,6 +292,14 @@ int main(int argc, char* argv[]) {
     opts.resizable = true;
     opts.use_gpu = true;
 
+    // pulp #1899 — clamp any oversize absolute-positioned descendants
+    // to the initial window viewport before first layout, so
+    // runtime-imported trees with hardcoded oversize roots (e.g.
+    // Spectr's 1320x860 abs-positioned wrap) don't lay their
+    // bottom-anchored children off-screen until a manual window
+    // resize triggers re-layout.
+    pulp::view::reconcile_oversize_absolute_subtree(root, opts.width, opts.height);
+
     auto window = WindowHost::create(root, opts);
     bridge->set_repaint_callback([&window] {
         if (window) window->repaint();
@@ -345,6 +354,12 @@ int main(int argc, char* argv[]) {
     });
 
     // Poll hot-reload and async bridge results on a GCD timer (main thread).
+    // poll_async_results() drains BOTH the async_exec_results_ queue
+    // (setTimeout / IO / async-fn callbacks — required for React state
+    // commits to land during drag) AND the pending_frame_ids queue
+    // (RAF). CVDisplayLink alone doesn't drain the async-results
+    // queue, so removing this call breaks drag-driven setState (drawing
+    // filter bands silently stops mid-drag).
     auto* reload_timer = dispatch_source_create(
         DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
     dispatch_source_set_timer(reload_timer,

--- a/test/web-compat/test_layout_position.cpp
+++ b/test/web-compat/test_layout_position.cpp
@@ -439,7 +439,7 @@ TEST_CASE("Yoga: absolute child does not consume flex-line space from siblings",
 // left+right) stays untouched.
 // ═══════════════════════════════════════════════════════════════════════════════
 
-#include "../../tools/screenshot/viewport_reconcile.hpp"
+#include <pulp/view/viewport_reconcile.hpp>
 
 TEST_CASE("Viewport reconcile: 3-level oversize chain clamps every depth",
           "[layout][viewport-reconcile][screenshot][issue-1899]") {
@@ -478,7 +478,7 @@ TEST_CASE("Viewport reconcile: 3-level oversize chain clamps every depth",
     app->add_child(std::move(wrap));
     root.add_child(std::move(app));
 
-    pulp::screenshot::reconcile_oversize_absolute_subtree(root, 1280, 800);
+    pulp::view::reconcile_oversize_absolute_subtree(root, 1280, 800);
 
     // Every depth gets clamped — not just the direct child of root_.
     REQUIRE(appPtr->flex().preferred_width == 1280.0f);
@@ -508,7 +508,7 @@ TEST_CASE("Viewport reconcile: non-anchored explicit oversize is clamped",
     auto* childPtr = child.get();
     root.add_child(std::move(child));
 
-    pulp::screenshot::reconcile_oversize_absolute_subtree(root, 1280, 800);
+    pulp::view::reconcile_oversize_absolute_subtree(root, 1280, 800);
 
     REQUIRE(childPtr->flex().preferred_width == 1280.0f);
     REQUIRE(childPtr->flex().preferred_height == 800.0f);
@@ -530,7 +530,7 @@ TEST_CASE("Viewport reconcile: non-absolute descendants are not clamped",
     auto* flowPtr = flow.get();
     root.add_child(std::move(flow));
 
-    pulp::screenshot::reconcile_oversize_absolute_subtree(root, 1280, 800);
+    pulp::view::reconcile_oversize_absolute_subtree(root, 1280, 800);
 
     REQUIRE(flowPtr->flex().preferred_width == 1320.0f);
     REQUIRE(flowPtr->flex().preferred_height == 860.0f);
@@ -551,7 +551,7 @@ TEST_CASE("Viewport reconcile: content already inside viewport is untouched",
     auto* childPtr = child.get();
     root.add_child(std::move(child));
 
-    pulp::screenshot::reconcile_oversize_absolute_subtree(root, 1280, 800);
+    pulp::view::reconcile_oversize_absolute_subtree(root, 1280, 800);
 
     REQUIRE(childPtr->flex().preferred_width == 1000.0f);
     REQUIRE(childPtr->flex().preferred_height == 600.0f);
@@ -579,7 +579,7 @@ TEST_CASE("Viewport reconcile: explicit right:0 / bottom:0 is edge-anchored, not
     auto* childPtr = child.get();
     root.add_child(std::move(child));
 
-    pulp::screenshot::reconcile_oversize_absolute_subtree(root, 1280, 800);
+    pulp::view::reconcile_oversize_absolute_subtree(root, 1280, 800);
 
     // preferred_width/height must be untouched — explicit right/bottom
     // means "anchor to opposite edge", not "auto".

--- a/tools/screenshot/pulp_screenshot.cpp
+++ b/tools/screenshot/pulp_screenshot.cpp
@@ -8,7 +8,7 @@
 #include <pulp/view/widget_bridge.hpp>
 #include <pulp/view/screenshot.hpp>
 #include <pulp/state/store.hpp>
-#include "viewport_reconcile.hpp"
+#include <pulp/view/viewport_reconcile.hpp>
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -244,7 +244,7 @@ int main(int argc, char* argv[]) {
         // root_, because runtime-import adapters (Spectr's dom-adapter
         // at tsx:440-441) propagate the hardcoded oversize through
         // multiple intermediate wrappers.
-        pulp::screenshot::reconcile_oversize_absolute_subtree(root, width, height);
+        pulp::view::reconcile_oversize_absolute_subtree(root, width, height);
     }
 
     // pulp #1899 — drain React's useEffect callbacks, requestAnimationFrame


### PR DESCRIPTION
Stacked on #1956. After #1956 merges, this rebases onto main automatically.

## Why

Real regression bisect — live pulp-design-tool was at 99% CPU at idle, 100% during drag, with Spectr's editor.js. Cause wasn't QuickJS or the bridge — Skia static libs were at `external/skia-builder/build/mac-gpu/lib/Release/` but `FindSkia.cmake` defaulted `SKIA_DIR=external/skia-build/` (empty). `SKIA_FOUND=FALSE` silently → CoreGraphics CPU fallback, ~5-10× slower.

After pointing `SKIA_DIR` at the real libs: binary 4.5MB → 32MB, idle CPU 99% → 18%, drag CPU 95-100% → 7-13%. Engine kept as QuickJS (no JSC swap needed).

## What lands

**1. LOUD build-time guard for silent-CG-fallback** (CMakeLists.txt) — `PULP_ENABLE_GPU=ON` + Skia not found used to log only `STATUS`. Now emits a screaming banner with concrete recovery steps. `PULP_REQUIRE_GPU_FOR_SDK` keeps its FATAL_ERROR for release. Verified: fires on broken build/, silent on fixed build-release/.

**2. Port reconcile_oversize_absolute_subtree to core/view** — Move `tools/screenshot/viewport_reconcile.hpp` → `core/view/include/pulp/view/viewport_reconcile.hpp`. Namespace `pulp::screenshot` → `pulp::view`. Helper isn't screenshot-specific — any live host running runtime-imported trees with hardcoded oversize roots needs the same clamp. Call sites updated in pulp_screenshot.cpp, test_layout_position.cpp, examples/design-tool/main.cpp.

## Test plan
- All 5 Viewport reconcile Catch2 cases pass under new header path
- Banner fires on broken build, silent when Skia linked
- Live design-tool render with Spectr — chart + bottom toolbar + chrome render at first paint
- CPU: 99%→18% idle, 95-100%→7-13% drag

🤖 Generated with [Claude Code](https://claude.com/claude-code)