### PR TITLE
fix(view): reserve Yoga height for multi-line Labels (pulp-internal #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0980"></a>
+## [0.99.0]
+
 ## [0.98.0] - 2026-05-14
 
 - feat(import): add Pencil React export parser (Phase 6.6.6) ([#1964](https://github.com/danielraffel/pulp/pull/1964))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.98.0
+    VERSION 0.99.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -135,7 +135,21 @@ public:
     /// Intrinsic height based on font size and line height.
     /// issue-969: walks the inheritance cascade so an unset font_size
     /// picks up an ancestor View's setInheritableFontSize value.
+    /// pulp-internal #74: returns lh × (newline-count + 1) for
+    /// multi_line labels so Yoga reserves space for every explicit
+    /// `\n`-delimited line. Soft-wrap (multi_line + bounded width) is
+    /// handled by the width-aware `measured_height()` overload below.
     float intrinsic_height() const override;
+
+    /// Width-aware height: shaper-true line count × line-height for a
+    /// multi_line Label given the parent's available content width.
+    /// pulp-internal #74 — invoked by the Yoga measure callback when a
+    /// multi-line Label is laid out in a bounded-width parent (CSS
+    /// `flex: 1`, `width: 100%`, fixed-width section subtitles). Falls
+    /// back to `intrinsic_height()` when `multi_line_` is false or
+    /// `available_width <= 0`, so single-line labels and unbounded
+    /// containers keep the legacy one-line metric.
+    float measured_height(float available_width) const;
 
 private:
     std::string text_;

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -285,6 +285,15 @@ float Label::intrinsic_height() const {
         for (char c : text_) {
             if (c == '\n') ++line_count;
         }
+        // pulp #1969 Codex P2 — don't reserve a phantom line for a trailing
+        // newline. Label::paint()'s `\n`-split loop emits one line per
+        // *non-trailing* `\n` plus the final segment, so `"Title\n"` paints
+        // exactly one visible line. If we keep the naive `\n`-count + 1
+        // here, Yoga reserves extra vertical whitespace that paint never
+        // fills, breaking CSS-style vertical-align centering and shifting
+        // siblings down. Matches the line-box counting CSS uses for
+        // `white-space: pre`.
+        if (text_.back() == '\n') --line_count;
         // Honor line-clamp if explicitly set — paint() will only emit
         // `line_clamp_` lines, so reserving more height is wasteful and
         // confuses CSS vertical-align centering.
@@ -615,11 +624,20 @@ void Label::paint(canvas::Canvas& canvas) {
     // pulp #1737 PR-2 — `source_lines` for the soft-wrap path is the
     // shaped layout's line count (which already accounts for inside-word
     // breaks). For the legacy path it stays count('\n') + 1.
+    //
+    // pulp #1969 Codex P2 — drop a trailing newline before counting in the
+    // legacy path. The split-and-emit loop below stops once `pos ==
+    // display_text.size()`, so a trailing `\n` doesn't actually paint an
+    // extra line — but feeding the inflated count into `text_h` would
+    // mis-position vertical-align: center/bottom. The shaper path doesn't
+    // need a fix here because shaped_layout.line_count is the count the
+    // shaper actually produced.
     int source_lines = multi_line_
         ? (use_shaper_wrap
                ? std::max(1, shaped_layout.line_count)
                : static_cast<int>(std::count(display_text.begin(),
-                                             display_text.end(), '\n')) + 1)
+                                             display_text.end(), '\n')) + 1
+                 - (!display_text.empty() && display_text.back() == '\n' ? 1 : 0))
         : 1;
     int visible_lines = source_lines;
     if (multi_line_ && line_clamp_ > 0 && line_clamp_ < source_lines)

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -262,7 +262,110 @@ float Label::intrinsic_height() const {
     // ~12pt buys 16px of box room for fs=10, fully containing the glyph
     // extent. Larger sizes keep 1.4 — they have plenty of absolute slack.
     const float lh_mult = effective_font_size < 12.0f ? 1.6f : 1.4f;
-    return line_height_ > 0 ? line_height_ : effective_font_size * lh_mult;
+    const float lh = line_height_ > 0 ? line_height_ : effective_font_size * lh_mult;
+
+    // pulp-internal #74 — when the Label is multi_line, the reserved
+    // height must reflect the number of lines paint() will emit, not a
+    // hard-coded one-line metric. Otherwise Yoga reserves only `lh` of
+    // vertical room and the parent (overflow:hidden on the toolbar / row
+    // gap on Settings-modal section subtitles) clips every line after
+    // the first. Spectr's Settings-modal description paragraphs are the
+    // motivating case.
+    //
+    // The \n count is the lower bound here. Soft-wrap (no \n but text
+    // exceeds the available width) needs the width Yoga passes to the
+    // measure callback — see `measured_height(available_width)` below.
+    //
+    // Single-line labels (multi_line_ == false) keep the legacy one-line
+    // return so single-line widths/heights match exactly what paint()
+    // computes for `text_h = effective_font_size` (the contract every
+    // existing test depends on).
+    if (multi_line_ && !text_.empty()) {
+        int line_count = 1;
+        for (char c : text_) {
+            if (c == '\n') ++line_count;
+        }
+        // Honor line-clamp if explicitly set — paint() will only emit
+        // `line_clamp_` lines, so reserving more height is wasteful and
+        // confuses CSS vertical-align centering.
+        if (line_clamp_ > 0 && line_clamp_ < line_count)
+            line_count = line_clamp_;
+        return lh * static_cast<float>(line_count);
+    }
+    return lh;
+}
+
+float Label::measured_height(float available_width) const {
+    // pulp-internal #74 — width-aware height for multi_line Labels with
+    // soft-wrap. The Yoga measure callback receives the available width
+    // during layout, which is the only place we can run the shaper to
+    // figure out how many lines a soft-wrap block will actually produce.
+    // Without this hook, Yoga reserves exactly one line `lh` and any
+    // wrapped line past the first paints into sibling territory and is
+    // visually clipped (Spectr Settings modal section subtitles, any
+    // dropdown label, any flex-row chrome that uses bounded-width
+    // multi-line text).
+    //
+    // Contract:
+    //   • single-line labels                 → intrinsic_height() (legacy).
+    //   • multi-line + zero/unbounded width  → intrinsic_height() (\n only).
+    //   • multi-line + finite width          → shaper line count * lh.
+    //
+    // The shaper itself is the same one paint() uses, so the count we
+    // return here matches what paint() draws — no off-by-one, no
+    // double-shape penalty (TextShaper::prepare() caches per
+    // (text, family, size); paint will hit the same cache entry).
+    if (!multi_line_ || text_.empty() || available_width <= 0.0f)
+        return intrinsic_height();
+
+    float effective_font_size = font_size_;
+    if (!has_own_font_size_) {
+        if (auto inh = inheritable_font_size(); inh.has_value())
+            effective_font_size = inh.value();
+    }
+    // Match intrinsic_height's small-font multiplier (pulp-internal #76)
+    // so the measured line height is consistent with what paint() draws.
+    const float lh_mult = effective_font_size < 12.0f ? 1.6f : 1.4f;
+    const float lh = line_height_ > 0 ? line_height_ : effective_font_size * lh_mult;
+
+    // Mirror paint()'s text-transform — the line count for an
+    // ALL-CAPS-via-text-transform string can differ from the source
+    // string's because uppercase advances are typically wider.
+    std::string display_text = text_;
+    if (text_transform_ == TextTransform::uppercase) {
+        for (auto& ch : display_text)
+            ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+    } else if (text_transform_ == TextTransform::lowercase) {
+        for (auto& ch : display_text)
+            ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+    } else if (text_transform_ == TextTransform::capitalize) {
+        bool cap_next = true;
+        for (auto& ch : display_text) {
+            if (cap_next && std::isalpha(static_cast<unsigned char>(ch))) {
+                ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+                cap_next = false;
+            }
+            if (ch == ' ') cap_next = true;
+        }
+    }
+
+    const std::string& family = font_family_.empty() ? std::string("Inter") : font_family_;
+    auto& shaper = canvas::global_text_shaper();
+    auto prepared = shaper.prepare(display_text, family, effective_font_size);
+
+    // Use the same break_mode pulp paint uses (CSS word-break / overflow-
+    // wrap; Label paint reads `View::word_break()` at draw time, the
+    // measure path mirrors that decision).
+    const std::string wb = word_break();
+    canvas::BreakMode break_mode = canvas::BreakMode::normal;
+    if      (wb == "break-word") break_mode = canvas::BreakMode::break_word;
+    else if (wb == "anywhere")   break_mode = canvas::BreakMode::anywhere;
+    auto layout = shaper.layout(prepared, available_width, lh, /*max_lines=*/0, break_mode);
+
+    int line_count = std::max(1, layout.line_count);
+    if (line_clamp_ > 0 && line_clamp_ < line_count)
+        line_count = line_clamp_;
+    return std::ceil(lh * static_cast<float>(line_count));
 }
 
 float Label::intrinsic_width() const {

--- a/core/view/src/yoga_layout.cpp
+++ b/core/view/src/yoga_layout.cpp
@@ -4,6 +4,7 @@
 #ifdef PULP_HAS_YOGA
 
 #include <pulp/view/view.hpp>
+#include <pulp/view/widgets.hpp>
 #include <yoga/Yoga.h>
 #include <vector>
 #include <algorithm>
@@ -395,6 +396,20 @@ static YGSize yoga_measure(YGNodeConstRef node, float width, YGMeasureMode width
     float w = view->intrinsic_width();
     float h = view->intrinsic_height();
     if (w <= 0) w = width;
+
+    // pulp-internal #74 — Label-specific width-aware height. When a
+    // multi-line Label is laid out in a bounded-width parent, the
+    // intrinsic (\n-counted) height is a lower bound that misses
+    // soft-wrap line additions. `measured_height(width)` consults the
+    // TextShaper to count actual wrapped lines and returns the true
+    // painted block height so Yoga reserves enough room for every line.
+    // For single-line labels (multi_line_ == false), measured_height()
+    // returns the same `intrinsic_height()` value — no behavior change.
+    if (auto* label = dynamic_cast<Label*>(view)) {
+        float wrapped = label->measured_height(w);
+        if (wrapped > h) h = wrapped;
+    }
+
     if (h <= 0) h = height;
     return {w, h};
 }

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -4,6 +4,7 @@
 #include <pulp/view/widgets.hpp>
 #include <pulp/canvas/canvas.hpp>
 
+#include <cmath>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -178,6 +179,146 @@ TEST_CASE("Label intrinsic_width yields zero for multi-line", "[view][widget][is
     Label ml("ZOOMABLE FILTER BANK\nWITH SUBTITLE");
     ml.set_multi_line(true);
     REQUIRE(ml.intrinsic_width() == 0);
+}
+
+TEST_CASE("Label intrinsic_height counts explicit newlines on multi_line labels",
+          "[view][widget][internal-74]") {
+    // pulp-internal #74 — Spectr's Settings modal section subtitles and
+    // any multi-line description text rendered as `<p>foo\nbar</p>` were
+    // having every line past the first clipped because Label always
+    // reported a one-line height regardless of how many `\n`-delimited
+    // lines paint() emitted. Yoga then reserved exactly one line and the
+    // parent's overflow / sibling layout truncated the rest.
+    //
+    // The fix in widgets.cpp counts `\n` and multiplies by `lh` so the
+    // intrinsic height returned to Yoga matches paint()'s line count.
+
+    // Sanity: single-line behavior is unchanged (regression guard).
+    Label single("just one line");
+    single.set_font_size(12.0f);
+    const float lh_single = 12.0f * 1.4f;
+    REQUIRE_THAT(single.intrinsic_height(), WithinAbs(lh_single, 0.01f));
+
+    // Multi-line label with no newlines and no width — still a single
+    // line until a soft-wrap path actually wraps (handled separately by
+    // measured_height(available_width) below).
+    Label ml_short("just one line");
+    ml_short.set_multi_line(true);
+    ml_short.set_font_size(12.0f);
+    REQUIRE_THAT(ml_short.intrinsic_height(), WithinAbs(lh_single, 0.01f));
+
+    // Two explicit lines.
+    Label two("line one\nline two");
+    two.set_multi_line(true);
+    two.set_font_size(12.0f);
+    REQUIRE_THAT(two.intrinsic_height(), WithinAbs(lh_single * 2.0f, 0.01f));
+
+    // Three explicit lines — generalizes to N.
+    Label three("Smooths transitions between filter states.\n"
+                "Reduces clicks and zipper noise during automation.\n"
+                "Adjustable per modulation source.");
+    three.set_multi_line(true);
+    three.set_font_size(13.0f);
+    const float lh_13 = 13.0f * 1.4f;
+    REQUIRE_THAT(three.intrinsic_height(), WithinAbs(lh_13 * 3.0f, 0.01f));
+
+    // Explicit line_height beats font_size * 1.4 default — multi-line
+    // count still multiplies through.
+    Label four("a\nb\nc\nd");
+    four.set_multi_line(true);
+    four.set_font_size(12.0f);
+    four.set_line_height(20.0f);
+    REQUIRE_THAT(four.intrinsic_height(), WithinAbs(20.0f * 4.0f, 0.01f));
+
+    // multi_line=false keeps the legacy one-line height even when the
+    // text contains `\n` (single-line paint draws the whole string in
+    // one fill_text call — the count must reflect that contract).
+    Label single_with_newlines("hidden\nnewlines");
+    single_with_newlines.set_multi_line(false);
+    single_with_newlines.set_font_size(12.0f);
+    REQUIRE_THAT(single_with_newlines.intrinsic_height(), WithinAbs(lh_single, 0.01f));
+}
+
+TEST_CASE("Label intrinsic_height honors line_clamp on multi_line labels",
+          "[view][widget][internal-74][issue-1552]") {
+    // pulp-internal #74 + pulp #1552 — when a clamp is set, paint() only
+    // emits `line_clamp_` lines, so the reserved height must match.
+    // Otherwise Yoga reserves space for lines that will never be drawn
+    // and the surrounding flex layout has dead vertical whitespace.
+    Label clamped("a\nb\nc\nd\ne");
+    clamped.set_multi_line(true);
+    clamped.set_font_size(12.0f);
+    clamped.set_line_clamp(2);
+    const float lh = 12.0f * 1.4f;
+    REQUIRE_THAT(clamped.intrinsic_height(), WithinAbs(lh * 2.0f, 0.01f));
+
+    // line_clamp_ == 0 disables clamping — all source lines counted.
+    Label unclamped("a\nb\nc\nd\ne");
+    unclamped.set_multi_line(true);
+    unclamped.set_font_size(12.0f);
+    unclamped.set_line_clamp(0);
+    REQUIRE_THAT(unclamped.intrinsic_height(), WithinAbs(lh * 5.0f, 0.01f));
+
+    // line_clamp_ >= source line count is effectively no clamp.
+    Label looseclamp("a\nb");
+    looseclamp.set_multi_line(true);
+    looseclamp.set_font_size(12.0f);
+    looseclamp.set_line_clamp(99);
+    REQUIRE_THAT(looseclamp.intrinsic_height(), WithinAbs(lh * 2.0f, 0.01f));
+}
+
+TEST_CASE("Label measured_height counts soft-wrapped lines under a bounded width",
+          "[view][widget][internal-74]") {
+    // pulp-internal #74 — Spectr's Settings-modal subtitle paragraphs
+    // (and the equivalent SNAPSHOT-style chrome) live inside flex parents
+    // with a fixed/computed width. The bridge does NOT inject `\n` into
+    // a description like `"How bands and colors render in the analyzer
+    // panel."` — instead the Label is multi_line, the parent gives it a
+    // width, and paint()'s shaped-wrap loop emits 2–3 lines. Until this
+    // PR, intrinsic_height() returned ONE line, so Yoga clipped lines 2+.
+    //
+    // measured_height(available_width) consults the same shaper paint()
+    // uses, so the line count returned to Yoga matches the line count
+    // actually drawn.
+
+    const std::string long_text =
+        "Smooths transitions between filter states. Reduces clicks "
+        "and zipper noise during automation by interpolating the "
+        "filter coefficients between two snapshots in real time.";
+    Label desc(long_text);
+    desc.set_multi_line(true);
+    desc.set_font_size(13.0f);
+    const float lh = 13.0f * 1.4f;
+
+    // Very wide: the text fits on one line → measured height collapses
+    // to one line (= ceil(lh), since the shaper path ceils to a sub-
+    // pixel-safe integer).
+    REQUIRE_THAT(desc.measured_height(10000.0f), WithinAbs(std::ceil(lh), 0.5f));
+
+    // Bounded narrow width forces wrap to several lines — measured
+    // height must reflect 2+ lines, never just one.
+    float narrow_h = desc.measured_height(220.0f);
+    REQUIRE(narrow_h >= lh * 2.0f);
+    REQUIRE(narrow_h <= lh * 10.0f);  // sanity: bounded above
+
+    // Tighter width → at least as many lines as the wider case.
+    float tighter_h = desc.measured_height(140.0f);
+    REQUIRE(tighter_h >= narrow_h);
+
+    // available_width <= 0 falls back to intrinsic_height() — measure
+    // callback gives 0 when Yoga has no constraint yet, and the caller
+    // would otherwise feed garbage to the shaper.
+    REQUIRE_THAT(desc.measured_height(0.0f),  WithinAbs(lh, 0.01f));
+    REQUIRE_THAT(desc.measured_height(-1.0f), WithinAbs(lh, 0.01f));
+
+    // Single-line label: measured_height matches intrinsic_height
+    // regardless of width — the multi_line gate keeps the shaper path
+    // off so single-line widgets pay no extra cost.
+    Label snap("SNAPSHOT");
+    snap.set_font_size(10.0f);
+    const float snap_lh = 10.0f * 1.4f;
+    REQUIRE_THAT(snap.measured_height(50.0f),    WithinAbs(snap_lh, 0.01f));
+    REQUIRE_THAT(snap.measured_height(10000.0f), WithinAbs(snap_lh, 0.01f));
 }
 
 TEST_CASE("Label intrinsic_width is sane for typical chrome strings",

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -239,6 +239,63 @@ TEST_CASE("Label intrinsic_height counts explicit newlines on multi_line labels"
     REQUIRE_THAT(single_with_newlines.intrinsic_height(), WithinAbs(lh_single, 0.01f));
 }
 
+TEST_CASE("Label intrinsic_height ignores a trailing newline (no phantom line)",
+          "[view][widget][internal-74][issue-1969]") {
+    // PR #1969 Codex P2 — a string ending with `\n` used to count an
+    // extra line in the `\n`-count loop ("Title\n" → 2). But
+    // Label::paint()'s split-and-emit loop stops once `pos ==
+    // display_text.size()`, so it draws exactly one line. Yoga was
+    // reserving phantom whitespace that the paint pass never filled,
+    // breaking vertical centering / sibling layout. Mirrors CSS
+    // `white-space: pre` line-box counting (a trailing `\n` is the end
+    // of a paragraph, not the start of a new empty line).
+    const float fs = 12.0f;
+    const float lh = fs * 1.4f;
+
+    // "Title\n" — counts as ONE line, not two.
+    Label trailing("Title\n");
+    trailing.set_multi_line(true);
+    trailing.set_font_size(fs);
+    REQUIRE_THAT(trailing.intrinsic_height(), WithinAbs(lh, 0.01f));
+
+    // "Title\nSubtitle" — no trailing `\n`, two real lines.
+    Label two_real("Title\nSubtitle");
+    two_real.set_multi_line(true);
+    two_real.set_font_size(fs);
+    REQUIRE_THAT(two_real.intrinsic_height(), WithinAbs(lh * 2.0f, 0.01f));
+
+    // "Title\nSubtitle\n" — two visible lines, trailing `\n` shaves
+    // the phantom third.
+    Label two_with_trailing("Title\nSubtitle\n");
+    two_with_trailing.set_multi_line(true);
+    two_with_trailing.set_font_size(fs);
+    REQUIRE_THAT(two_with_trailing.intrinsic_height(), WithinAbs(lh * 2.0f, 0.01f));
+
+    // Just a single `\n` — empty content, one (empty) line reserved.
+    // We don't try to claim height 0; an empty line still occupies
+    // one line-height of vertical space in CSS block-flow semantics.
+    Label only_newline("\n");
+    only_newline.set_multi_line(true);
+    only_newline.set_font_size(fs);
+    REQUIRE_THAT(only_newline.intrinsic_height(), WithinAbs(lh, 0.01f));
+
+    // "\nFoo" — leading `\n` keeps both lines (the leading newline
+    // is a real empty line; only TRAILING is dropped).
+    Label leading_newline("\nFoo");
+    leading_newline.set_multi_line(true);
+    leading_newline.set_font_size(fs);
+    REQUIRE_THAT(leading_newline.intrinsic_height(), WithinAbs(lh * 2.0f, 0.01f));
+
+    // Trailing-newline shave interacts correctly with line_clamp: the
+    // count is shaved BEFORE clamp comparison, so a clamp of 2 on
+    // "a\nb\n" still gives 2 lines (not clamped from a phantom 3).
+    Label clamped_trailing("a\nb\n");
+    clamped_trailing.set_multi_line(true);
+    clamped_trailing.set_font_size(fs);
+    clamped_trailing.set_line_clamp(2);
+    REQUIRE_THAT(clamped_trailing.intrinsic_height(), WithinAbs(lh * 2.0f, 0.01f));
+}
+
 TEST_CASE("Label intrinsic_height honors line_clamp on multi_line labels",
           "[view][widget][internal-74][issue-1552]") {
     // pulp-internal #74 + pulp #1552 — when a clamp is set, paint() only
@@ -316,7 +373,10 @@ TEST_CASE("Label measured_height counts soft-wrapped lines under a bounded width
     // off so single-line widgets pay no extra cost.
     Label snap("SNAPSHOT");
     snap.set_font_size(10.0f);
-    const float snap_lh = 10.0f * 1.4f;
+    // pulp-internal #76: small fonts (<12pt) use the 1.6 line-height
+    // multiplier so glyphs don't clip in compact toolbars; the measure
+    // path mirrors that to keep Yoga reservation in sync with paint.
+    const float snap_lh = 10.0f * 1.6f;
     REQUIRE_THAT(snap.measured_height(50.0f),    WithinAbs(snap_lh, 0.01f));
     REQUIRE_THAT(snap.measured_height(10000.0f), WithinAbs(snap_lh, 0.01f));
 }


### PR DESCRIPTION
## Summary

`Label::intrinsic_height()` always returned a single line's worth of
height regardless of how many lines paint() would actually draw. Yoga
then reserved exactly one line of vertical room and every line past
the first was clipped by the parent's overflow / sibling layout.

Surfaces in Spectr's Settings modal section subtitles (pulp-internal #74)
and any flex-row chrome that mounts a `<p>`/`<span>` with soft-wrap into
a bounded-width parent.

## Fix layered in two places that mirror how paint() computes line count

1. **`Label::intrinsic_height()`** — count explicit `\n` for multi_line
   labels. Single-line labels keep the legacy one-line return so every
   existing single-line test holds.

2. **`Label::measured_height(available_width)`** — new width-aware
   overload that consults the global TextShaper to count soft-wrapped
   lines when Yoga supplies a finite available width. The Yoga measure
   callback in `yoga_layout.cpp` dispatches to this for any Label node,
   so the shaped line count drives layout.

`line_clamp_` is honored on both paths.

## Tests

`test/test_widgets.cpp` adds three test cases that pin:

- Single-line height contract preserved (regression guard).
- Multi-line + explicit `\n` returns lh × line_count.
- Multi-line + `line_clamp` returns lh × clamp.
- `measured_height(wide width)` collapses to one line.
- `measured_height(narrow width)` returns shaper-true wrapped lines.
- `measured_height(<=0)` falls back to `intrinsic_height()` safely.
- Single-line label `measured_height` matches `intrinsic_height` at any width.

## Out of scope

**pulp-internal #76** (SNAPSHOT inline label clipped at the bottom edge
of Spectr's 56px toolbar) is a separate symptom that this fix does NOT
resolve — SNAPSHOT is a **single-line `<span>` Label** and goes through
the legacy single-line path that this PR intentionally preserves.

Diagnosis for #76 is still open. Most likely root cause: a flex-baseline
or `align-items` interaction in the toolbar row, where SNAPSHOT's bounds
get placed near the bottom of the 56px toolbar instead of centered.
Investigation hit diminishing returns within this PR; tracked as a
separate follow-up.

## Test plan

- [x] `pulp-test-widgets` — all 74 cases pass (3 new for internal-74).
- [x] `pulp-test-view-layout-widgets`, `pulp-test-phase9-widgets` — pass.
- [x] 213 widget/Label/yoga/view ctest cases pass (1 demo target was unbuilt before this run, not a real test).
- [x] Local pulp-screenshot with Skia backend confirms no regression on the rest of Spectr's chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)