### PR TITLE
fix(canvas,ci): propagate fontconfig from pulp-canvas + extend backfill overlay

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -116,16 +116,36 @@ jobs:
       # up the fix regardless of when the tag was cut. This is a no-op
       # for tag-push triggers (the dispatched source_ref is empty so we
       # skip).
-      - name: Overlay latest fetch-skia script (workflow_dispatch backfill)
+      - name: Overlay latest release-pipeline files (workflow_dispatch backfill)
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.source_ref != '' }}
         shell: bash
+        # Pull the current `main` copies of files that gate release-cli's
+        # success but live in the source tree rather than the workflow
+        # itself. Without this, a backfill against a tag created BEFORE
+        # the fix landed runs the broken script / broken CMake. Add new
+        # files to the list when a backfill surfaces another fix that
+        # the tag's tree doesn't have.
+        #
+        # Current overlay set:
+        #   - tools/scripts/fetch_skia_for_release.py: chrome/m144 zip
+        #     arch-subdir layout flatten (#1962).
+        #   - core/canvas/CMakeLists.txt: fontconfig propagation from
+        #     pulp-canvas STATIC lib to downstream executables — `PUBLIC`
+        #     instead of `PRIVATE`. Without this, the chrome/m144 Skia
+        #     archive's SkFontMgr_New_FontConfig symbol fails to resolve
+        #     in pulp-cpp's link step (#1962 follow-up).
         run: |
           set -euo pipefail
           repo='${{ github.repository }}'
-          url="https://raw.githubusercontent.com/${repo}/main/tools/scripts/fetch_skia_for_release.py"
-          echo "Overlaying tools/scripts/fetch_skia_for_release.py from ${url}"
-          curl -fsSL "$url" -o tools/scripts/fetch_skia_for_release.py
-          python3 -c "import pathlib; print(pathlib.Path('tools/scripts/fetch_skia_for_release.py').stat().st_size, 'bytes')"
+          for path in \
+              tools/scripts/fetch_skia_for_release.py \
+              core/canvas/CMakeLists.txt \
+              ; do
+            url="https://raw.githubusercontent.com/${repo}/main/${path}"
+            echo "Overlaying ${path} from ${url}"
+            curl -fsSL "$url" -o "$path"
+            wc -c "$path"
+          done
 
       - name: Fetch Skia binaries
         run: python3 tools/scripts/fetch_skia_for_release.py ${{ matrix.platform }}

--- a/core/canvas/CMakeLists.txt
+++ b/core/canvas/CMakeLists.txt
@@ -102,7 +102,16 @@ if(PULP_HAS_SKIA)
             pkg_check_modules(FONTCONFIG fontconfig)
             if(FONTCONFIG_FOUND)
                 target_include_directories(pulp-canvas PRIVATE ${FONTCONFIG_INCLUDE_DIRS})
-                target_link_libraries(pulp-canvas PRIVATE ${FONTCONFIG_LIBRARIES})
+                # Use PUBLIC so the fontconfig dependency propagates to
+                # downstream executables (e.g. `pulp-cpp` in
+                # release-cli.yml). pulp-canvas is a STATIC library, so
+                # CMake does NOT automatically inherit PRIVATE link deps
+                # — the executable's link line wouldn't include
+                # `-lfontconfig` and the chrome/m144 Skia archive's
+                # `SkFontMgr_New_FontConfig` symbol fails to resolve.
+                # Closes the linux-x64 Build leg of release-cli's
+                # backfill matrix (#1962, #1970 follow-up).
+                target_link_libraries(pulp-canvas PUBLIC ${FONTCONFIG_LIBRARIES})
             endif()
         endif()
     # Android: Skia bundles FreeType + HarfBuzz, no system fontconfig needed


### PR DESCRIPTION
## Summary

Final unblocker for the v0.95.0..v0.98.0 release backfills.

After #1974 added `libfontconfig1-dev` to the apt install step, `pkg_check_modules(FONTCONFIG fontconfig)` in `core/canvas/CMakeLists.txt` did find fontconfig 2.15.0 — but `pulp-canvas` is a STATIC library and the fontconfig dep was wired `PRIVATE`. CMake does not propagate `PRIVATE` deps of a static library to downstream consumers' link line, so when `release-cli.yml` links the `pulp-cpp` executable against `pulp-canvas`, the chrome/m144 Skia archive's `SkFontMgr_New_FontConfig` (referencing `FcInitLoadConfigAndFonts`, `FcConfigGetSysRoot`, `FcConfigGetFonts`, `FcPatternGetString`, `FcConfigDestroy`, `FcGetVersion`) fails to resolve.

Symptom: v0.97.0 backfill run [25883828847](https://github.com/danielraffel/pulp/actions/runs/25883828847) — linux-x64 Build failed with undefined references to `Fc*` symbols despite fontconfig being installed AND found by CMake.

## Changes

- `core/canvas/CMakeLists.txt` — `target_link_libraries(pulp-canvas PUBLIC ${FONTCONFIG_LIBRARIES})` instead of `PRIVATE`. `PUBLIC` includes the dep in `INTERFACE_LINK_LIBRARIES`, which is what downstream consumers consult during their own link step.
- `.github/workflows/release-cli.yml` — the `Overlay latest …` step now overlays a LIST of files from main rather than a single hardcoded path. Adds `core/canvas/CMakeLists.txt` to the overlay set so the v0.95.0..v0.98.0 backfills pick up the PUBLIC fix even though their source trees still have PRIVATE.

## After merge: re-dispatch the backfills

```bash
for v in v0.95.0 v0.95.1 v0.96.0 v0.97.0 v0.98.0; do
  gh workflow run release-cli.yml --ref main -f version=$v -f source_ref=$v
  # wait for prior to start before dispatching next — concurrency
  # group cancels older pending runs
done
```

## Test plan

- [x] `actionlint -shellcheck= -pyflakes= .github/workflows/release-cli.yml` exit 0
- [x] `skill_sync_check.py --mode=report` green (Skill-Update: skip trailers)
- [x] `version_bump_check.py --require-bump-for-fix-feat ...` green (Version-Bump: skip trailer)
- [ ] CI matrix passes on this PR
- [ ] Post-merge: v0.97.0 backfill linux-x64 Build step succeeds → release publishes
- [ ] release-cli-watchdog.yml auto-closes #1962, #1866, #1939, #1948

Closes #1962 once the watchdog confirms SDK assets land.