### PR TITLE
test(import-validation): backfill source-contract verification

### DIFF
--- a/tools/import-validation/source-contracts.json
+++ b/tools/import-validation/source-contracts.json
@@ -347,7 +347,8 @@
       "display_name": "Figma Make",
       "kind": "screen-export",
       "trust": "official",
-      "last_verified": "unverified",
+      "last_verified": "2026-05-14",
+      "recheck_interval_days": 90,
       "compat": {
         "mode": "foreign-key",
         "source": "figma",
@@ -369,6 +370,27 @@
           "url": "https://developers.figma.com/docs/code",
           "kind": "docs",
           "proves": "Figma Code / Make React project model.",
+          "last_verified": "2026-05-14",
+          "recheck_interval_days": 90
+        },
+        {
+          "url": "https://developers.figma.com/docs/code/working-with-react",
+          "kind": "docs",
+          "proves": "Figma Make and Figma Sites use React, JSX, import/export, and App.tsx-style TSX project files.",
+          "last_verified": "2026-05-14",
+          "recheck_interval_days": 90
+        },
+        {
+          "url": "https://developers.figma.com/docs/code-connect/react/",
+          "kind": "docs",
+          "proves": "Code Connect React files are code-context glue, not executed runtime exports; Pulp intentionally rejects them in the runtime-import parser.",
+          "last_verified": "2026-05-14",
+          "recheck_interval_days": 90
+        },
+        {
+          "url": "https://developers.figma.com/docs/figma-mcp-server/",
+          "kind": "docs",
+          "proves": "Figma MCP provides design context to AI agents; Pulp models it as input acquisition, not raw runtime parser input.",
           "last_verified": "2026-05-14",
           "recheck_interval_days": 90
         }
@@ -419,7 +441,8 @@
       "display_name": "v0.dev",
       "kind": "screen-export",
       "trust": "official",
-      "last_verified": "unverified",
+      "last_verified": "2026-05-14",
+      "recheck_interval_days": 90,
       "compat": {
         "mode": "foreign-key",
         "source": "v0",
@@ -448,6 +471,13 @@
           "url": "https://ui.shadcn.com/docs/registry",
           "kind": "docs",
           "proves": "shadcn registry shape that Pulp's v0 parser deliberately rejects in PR1.",
+          "last_verified": "2026-05-14",
+          "recheck_interval_days": 90
+        },
+        {
+          "url": "https://v0.app/docs/api/platform/mcp",
+          "kind": "docs",
+          "proves": "v0 MCP server access lets IDE agents create and inspect v0 chats; Pulp models this as acquisition before the constrained TSX parser.",
           "last_verified": "2026-05-14",
           "recheck_interval_days": 90
         }
@@ -498,7 +528,8 @@
       "display_name": "React Native",
       "kind": "screen-export",
       "trust": "official",
-      "last_verified": "unverified",
+      "last_verified": "2026-05-14",
+      "recheck_interval_days": 180,
       "compat": {
         "mode": "not-applicable",
         "source": null,
@@ -527,6 +558,13 @@
           "url": "https://reactnative.dev/docs/flexbox",
           "kind": "docs",
           "proves": "React Native Flexbox defaults including column direction.",
+          "last_verified": "2026-05-14",
+          "recheck_interval_days": 180
+        },
+        {
+          "url": "https://reactnative.dev/docs/stylesheet.html",
+          "kind": "docs",
+          "proves": "StyleSheet.create is the canonical React Native static style surface that Pulp normalizes for runtime import.",
           "last_verified": "2026-05-14",
           "recheck_interval_days": 180
         }

--- a/tools/import-validation/test_source_contracts.py
+++ b/tools/import-validation/test_source_contracts.py
@@ -66,21 +66,14 @@ class SourceContractsTest(unittest.TestCase):
             findings = _findings(registry, Path(td))
         self.assertIn(code, _codes(findings), [str(f) for f in findings])
 
-    def test_real_registry_false_positive_budget_is_known(self) -> None:
+    def test_real_registry_has_no_warning_or_error_findings(self) -> None:
         findings = checker.compute_findings(root=ROOT, registry_path=REGISTRY_PATH, today=TODAY)
         warning_pairs = {
             (finding.source, finding.code)
             for finding in findings
             if finding.severity in {"warning", "error"}
         }
-        self.assertEqual(
-            warning_pairs,
-            {
-                ("figma", "unverified-source"),
-                ("v0", "unverified-source"),
-                ("rn", "unverified-source"),
-            },
-        )
+        self.assertEqual(warning_pairs, set(), [str(f) for f in findings])
 
     def test_schema_version_is_required(self) -> None:
         registry = _load_registry()
@@ -139,6 +132,12 @@ class SourceContractsTest(unittest.TestCase):
         entry["recheck_interval_days"] = 1
         self.assert_has_code(registry, "stale-source-contract")
 
+    def test_unverified_source_contract_warns(self) -> None:
+        registry, entry = self.mutate("figma")
+        entry["last_verified"] = "unverified"
+        entry.pop("recheck_interval_days", None)
+        self.assert_has_code(registry, "unverified-source")
+
     def test_compat_source_and_format_foreign_keys_are_checked(self) -> None:
         registry, entry = self.mutate("stitch")
         entry["compat"]["source"] = "missing-source"
@@ -181,6 +180,7 @@ class SourceContractsTest(unittest.TestCase):
 
     def test_strict_flips_exit_code_only_on_warnings(self) -> None:
         registry = _load_registry()
+        _contract(registry, "figma")["last_verified"] = "unverified"
         with tempfile.TemporaryDirectory() as td:
             registry_path = _write_registry(Path(td), registry)
             base_cmd = [
@@ -195,6 +195,19 @@ class SourceContractsTest(unittest.TestCase):
             strict = subprocess.run(base_cmd + ["--strict"], check=False, capture_output=True, text=True)
         self.assertEqual(non_strict.returncode, 0, non_strict.stdout + non_strict.stderr)
         self.assertEqual(strict.returncode, 1, strict.stdout + strict.stderr)
+
+    def test_strict_real_registry_has_clean_exit(self) -> None:
+        cmd = [
+            sys.executable,
+            str(CHECKER_PATH),
+            "--root",
+            str(ROOT),
+            "--registry",
+            str(REGISTRY_PATH),
+            "--strict",
+        ]
+        result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Mark the figma, v0, and rn source-contract rows as verified against current official upstream anchors and keep the linter's unverified-source behavior covered through seeded drift tests.

Skill-Update: skip skill=import-design reason="source-contract evidence/test update; import workflow unchanged"