### PR TITLE
fix(canvas): use pkg-config IMPORTED_TARGET for fontconfig transitive propagation

### DIFF
--- a/core/canvas/CMakeLists.txt
+++ b/core/canvas/CMakeLists.txt
@@ -99,19 +99,21 @@ if(PULP_HAS_SKIA)
     elseif(UNIX AND NOT APPLE AND NOT ANDROID)
         find_package(PkgConfig)
         if(PkgConfig_FOUND)
-            pkg_check_modules(FONTCONFIG fontconfig)
+            # IMPORTED_TARGET makes pkg-config build a proper INTERFACE
+            # `PkgConfig::FONTCONFIG` target that CMake transitively
+            # propagates through INTERFACE_LINK_LIBRARIES — including
+            # the actual `-lfontconfig` flag and link directories.
+            # Without this, the bare `FONTCONFIG_LIBRARIES=fontconfig`
+            # string can fall through CMake's static-lib transitive
+            # propagation without producing a `-lfontconfig` on the
+            # consumer's final ld line, and the chrome/m144 Skia
+            # archive's `SkFontMgr_New_FontConfig` (FcInit*, FcConfig*,
+            # FcPattern*, FcGetVersion, FcFontSet*) fails to resolve at
+            # pulp-cpp link time. Closes the linux-x64 leg of release-cli's
+            # backfill matrix (#1962, #1970 follow-up).
+            pkg_check_modules(FONTCONFIG IMPORTED_TARGET fontconfig)
             if(FONTCONFIG_FOUND)
-                target_include_directories(pulp-canvas PRIVATE ${FONTCONFIG_INCLUDE_DIRS})
-                # Use PUBLIC so the fontconfig dependency propagates to
-                # downstream executables (e.g. `pulp-cpp` in
-                # release-cli.yml). pulp-canvas is a STATIC library, so
-                # CMake does NOT automatically inherit PRIVATE link deps
-                # — the executable's link line wouldn't include
-                # `-lfontconfig` and the chrome/m144 Skia archive's
-                # `SkFontMgr_New_FontConfig` symbol fails to resolve.
-                # Closes the linux-x64 Build leg of release-cli's
-                # backfill matrix (#1962, #1970 follow-up).
-                target_link_libraries(pulp-canvas PUBLIC ${FONTCONFIG_LIBRARIES})
+                target_link_libraries(pulp-canvas PUBLIC PkgConfig::FONTCONFIG)
             endif()
         endif()
     # Android: Skia bundles FreeType + HarfBuzz, no system fontconfig needed


### PR DESCRIPTION
## Summary

#1979 wired fontconfig as `target_link_libraries(pulp-canvas PUBLIC \${FONTCONFIG_LIBRARIES})`. In theory this should propagate through `pulp-canvas → pulp-view → pulp-cli` so the executable link line gets `-lfontconfig`. In practice (v0.97.0 backfill run [25887074941](https://github.com/danielraffel/pulp/actions/runs/25887074941)), the linux-x64 `pulp-cpp` link still failed on `Fc*` undefined references.

Root cause: `pkg_check_modules(FONTCONFIG fontconfig)` sets `FONTCONFIG_LIBRARIES` to bare library NAMES (`fontconfig`), not full paths or `-l` flags. Through STATIC lib INTERFACE propagation chains, CMake can drop these strings (especially if no associated link directories are added), leaving the final ld line without `-lfontconfig`.

The idiomatic fix is `pkg_check_modules(IMPORTED_TARGET …)` + linking the resulting `PkgConfig::FONTCONFIG` INTERFACE target — CMake then carries both library names AND `-L`/`-rpath` entries through `INTERFACE_LINK_LIBRARIES` cleanly.

## After merge

The release-cli.yml workflow's `Overlay latest …` step already pulls `core/canvas/CMakeLists.txt` from main on workflow_dispatch backfills, so the v0.97.0..v0.98.0 re-dispatches will pick up this fix automatically.

```bash
for v in v0.95.0 v0.95.1 v0.96.0 v0.97.0 v0.98.0; do
  gh workflow run release-cli.yml --ref main -f version=\$v -f source_ref=\$v
  # one at a time — concurrency group cancels older pending
done
```

## Test plan

- [x] `skill_sync_check.py --mode=report` green
- [x] `version_bump_check.py --require-bump-for-fix-feat ...` green (Version-Bump: skip trailer)
- [ ] CI matrix passes on this PR
- [ ] Post-merge: v0.97.0 backfill linux-x64 Build now succeeds → release publishes

Refs #1962.