### PR TITLE
ci(import-validation): gate source-contract registry

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -56,10 +56,14 @@ in `tools/shipyard.toml`). It:
 2. Calls `tools/scripts/version_bump_check.py --mode=apply` to bump SDK,
    Claude plugin, and marketplace versions consistently, honoring any
    `Version-Bump:` trailers.
-3. Commits the bump (if any) as `chore: bump <surfaces>`.
-4. Pushes the branch, creates the PR, and records Shipyard tracking state.
-5. Runs cross-platform validate + merge on green.
-6. Auto-release workflow (`.github/workflows/auto-release.yml`) tags and
+3. Runs the no-build source-contract registry gate:
+   `tools/import-validation/check-source-contracts.py --strict` plus
+   `tools/import-validation/test_source_contracts.py`. This mirrors the
+   GitHub `Versioning & Skill-Sync` workflow and the local pre-push hook.
+4. Commits the bump (if any) as `chore: bump <surfaces>`.
+5. Pushes the branch, creates the PR, and records Shipyard tracking state.
+6. Runs cross-platform validate + merge on green.
+7. Auto-release workflow (`.github/workflows/auto-release.yml`) tags and
    publishes binaries on merge.
 
 Never run `gh pr create` + `shipyard ship` separately for a normal ship

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Pulp pre-push hook (agent-agnostic).
 #
-# Runs the versioning + skill-sync + compat-sync + deps-audit + diff-coverage
-# gates against origin/main before pushing. **Enforcing by default** as of
+# Runs the versioning + skill-sync + compat-sync + source-contract +
+# deps-audit + diff-coverage gates against origin/main before pushing.
+# **Enforcing by default** as of
 # pulp #1144 — gate failures block the push locally so contributors don't
 # burn 20-min CI roundtrips on the same problem.
 #
@@ -10,7 +11,7 @@
 #   git config core.hooksPath .githooks
 #
 # Bypass knobs (use sparingly — CI runs the same gates):
-#   PULP_DISABLE_PREPUSH_GATES=1   # demote ALL gates to advisory (skill/version/compat/deps)
+#   PULP_DISABLE_PREPUSH_GATES=1   # demote ALL gates to advisory (skill/version/compat/source-contract/deps)
 #   PULP_DISABLE_PREPUSH_DIFF_COVER=1  # demote diff-cover gate only
 #   PULP_SKIP_PREPUSH=1            # skip ALL gates entirely (true emergencies)
 #
@@ -64,8 +65,8 @@ unset _drift_origin _drift_branch _drift_sha _drift_ts
 if [ "${SHIPYARD_PR_RUNNING:-0}" != "1" ] && [ "${PULP_VIA_SHIPYARD:-0}" != "1" ]; then
     echo "" >&2
     echo "⚠ Direct push detected (not via 'shipyard pr')." >&2
-    echo "   Local validation gates (skill-sync, version-bump, diff-cover, build/test on" >&2
-    echo "   macOS+Ubuntu+Windows VMs) get skipped, so CI becomes the discovery channel." >&2
+    echo "   Local validation gates (skill-sync, version-bump, source-contract, diff-cover," >&2
+    echo "   build/test on macOS+Ubuntu+Windows VMs) get skipped, so CI becomes the discovery channel." >&2
     echo "" >&2
     echo "   Acceptable temporary fallbacks:" >&2
     echo "   - GraphQL rate limit (run: gh api rate_limit --jq .resources.graphql)" >&2
@@ -82,6 +83,8 @@ PYTHON="${PYTHON:-python3}"
 VBC="$ROOT/tools/scripts/version_bump_check.py"
 SSC="$ROOT/tools/scripts/skill_sync_check.py"
 CSC="$ROOT/tools/scripts/compat_sync_check.py"
+SCC="$ROOT/tools/import-validation/check-source-contracts.py"
+SCT="$ROOT/tools/import-validation/test_source_contracts.py"
 CFG="$ROOT/tools/scripts/versioning.json"
 COMPAT_MAP="$ROOT/tools/scripts/compat_path_map.json"
 
@@ -132,6 +135,26 @@ if [ -f "$CSC" ] && [ -f "$COMPAT_MAP" ]; then
         0) ;;
         1) fail=1 ;;
         *) echo "[pre-push] compat_sync_check: internal error" >&2 ;;
+    esac
+fi
+
+# Import source-contract registry (#1434 follow-up). The checker is no-build
+# and `--strict` only fails warning/error findings; optional planning-submodule
+# paths remain informational so normal worktree checkouts can run it.
+if [ -f "$SCC" ]; then
+    "$PYTHON" "$SCC" --strict
+    case $? in
+        0) ;;
+        1) fail=1 ;;
+        *) echo "[pre-push] check-source-contracts: internal error" >&2 ;;
+    esac
+fi
+if [ -f "$SCT" ]; then
+    "$PYTHON" "$SCT"
+    case $? in
+        0) ;;
+        1) fail=1 ;;
+        *) echo "[pre-push] test_source_contracts: internal error" >&2 ;;
     esac
 fi
 

--- a/.github/workflows/version-skill-check.yml
+++ b/.github/workflows/version-skill-check.yml
@@ -115,6 +115,15 @@ jobs:
               --base "${{ steps.base.outputs.ref }}" \
               --mode=report --enforce
 
+      - name: Source-contract registry check
+        # Lightweight import-provider contract gate. The registry linter is
+        # intentionally no-build and treats optional planning-submodule paths
+        # as informational, so it can run on ordinary PR checkouts without
+        # initializing the private planning submodule.
+        run: |
+          python3 tools/import-validation/check-source-contracts.py --strict
+          python3 tools/import-validation/test_source_contracts.py
+
       - name: Gate-script fixture tests
         run: |
           python3 tools/scripts/test_gates.py

--- a/.shipyard/config.toml
+++ b/.shipyard/config.toml
@@ -96,7 +96,7 @@ test      = "ctest --test-dir build -C Release --output-on-failure --exclude-reg
 # errors; the Python scripts inspect the same env var for parity.
 # See docs/guides/versioning.md for the full three-layer design.
 stages = ["setup"]
-setup = "PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report && PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/version_bump_check.py --base origin/main --mode=report"
+setup = "PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report && PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/version_bump_check.py --base origin/main --mode=report && python3 tools/import-validation/check-source-contracts.py --strict && python3 tools/import-validation/test_source_contracts.py"
 
 [validation.parser]
 # Path-scoped lane for runtime-import parser PRs (pulp #1916).


### PR DESCRIPTION
Run the no-build source-contract linter and seeded-drift tests in the GitHub gate, Shipyard gates pipeline, and local pre-push hook. This branch is staged on top of #1980 because the strict gate requires the warning-free registry backfill.