### PR TITLE
fix(cli): explicitly link fontconfig after libskia.a in pulp-cli (#1962)

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -130,16 +130,20 @@ jobs:
         #   - tools/scripts/fetch_skia_for_release.py: chrome/m144 zip
         #     arch-subdir layout flatten (#1962).
         #   - core/canvas/CMakeLists.txt: fontconfig propagation from
-        #     pulp-canvas STATIC lib to downstream executables — `PUBLIC`
-        #     instead of `PRIVATE`. Without this, the chrome/m144 Skia
-        #     archive's SkFontMgr_New_FontConfig symbol fails to resolve
-        #     in pulp-cpp's link step (#1962 follow-up).
+        #     pulp-canvas STATIC lib via PkgConfig::FONTCONFIG IMPORTED
+        #     target (#1962 follow-up).
+        #   - tools/cli/CMakeLists.txt: re-link fontconfig in pulp-cli
+        #     so it appears AFTER libskia.a in the GNU ld link line
+        #     (left-to-right archive resolution; the chrome/m144 Skia
+        #     archive references Fc* symbols that ld won't resolve from
+        #     an earlier-positioned -lfontconfig). #1962 follow-up.
         run: |
           set -euo pipefail
           repo='${{ github.repository }}'
           for path in \
               tools/scripts/fetch_skia_for_release.py \
               core/canvas/CMakeLists.txt \
+              tools/cli/CMakeLists.txt \
               ; do
             url="https://raw.githubusercontent.com/${repo}/main/${path}"
             echo "Overlaying ${path} from ${url}"

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -90,6 +90,30 @@ add_executable(pulp-cli
 set_target_properties(pulp-cli PROPERTIES OUTPUT_NAME "pulp-cpp")
 target_compile_features(pulp-cli PRIVATE cxx_std_20)
 target_link_libraries(pulp-cli PRIVATE pulp::runtime pulp::tool-audio pulp::ship pulp::view pulp::format pulp::inspect pulp::host)
+
+# Link-order fix for libskia.a → fontconfig on Linux+GNU ld (#1962).
+#
+# `libskia.a` (pulled in by `pulp::canvas`'s PUBLIC `skia::skia` dep)
+# contains `SkFontMgr_New_FontConfig` which references `FcInit*`,
+# `FcConfig*`, `FcPattern*`, `FcGetVersion`, `FcFontSet*` etc. GNU ld
+# processes static archives left-to-right and only pulls in symbols
+# that are unresolved AT THE TIME the archive is processed; symbols
+# referenced AFTER the archive go unresolved even if a later library
+# would have satisfied them. Adding `fontconfig` again here ensures it
+# appears AFTER `libskia.a` in the final link line. (`PkgConfig::FONTCONFIG`
+# is already wired PUBLIC on `pulp-canvas` per pulp #1962 follow-up, so
+# the include dirs and -L flags are already correct — this just nails
+# the link-line position down for ld.)
+if(UNIX AND NOT APPLE AND NOT ANDROID)
+    find_package(PkgConfig)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(_PULP_CLI_FONTCONFIG IMPORTED_TARGET fontconfig)
+        if(_PULP_CLI_FONTCONFIG_FOUND)
+            target_link_libraries(pulp-cli PRIVATE PkgConfig::_PULP_CLI_FONTCONFIG)
+        endif()
+    endif()
+endif()
+
 target_include_directories(pulp-cli PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
## Summary

Last-mile fix for the v0.95.0..v0.98.0 release backfill matrix. After:

- #1965 — chrome/m144 arch-subdir flatten + workflow_dispatch source_ref + main-overlay
- #1974 — `libfontconfig1-dev` apt dep
- #1979 — `pulp-canvas` links fontconfig PUBLIC
- #1982 — `PkgConfig::FONTCONFIG` IMPORTED target

4 of 5 release-cli matrix legs are green (darwin-arm64, linux-arm64, windows-x64, windows-arm64). **linux-x64 still fails** with `libskia.a → undefined reference to Fc*`.

Root cause: GNU ld processes static archives left-to-right and pulls in only symbols whose references are UNRESOLVED when the archive is processed. The PUBLIC-propagated `-lfontconfig` from pulp-canvas's INTERFACE_LINK_LIBRARIES lands BEFORE `libskia.a` in the final link line, so libskia's `Fc*` references go unresolved.

Fix: directly link `fontconfig` into `pulp-cli` (PRIVATE) so it appears AT THE END of the link line — after all the static libraries.

## Files

- `tools/cli/CMakeLists.txt` — add `pkg_check_modules(_PULP_CLI_FONTCONFIG IMPORTED_TARGET fontconfig)` + `target_link_libraries(pulp-cli PRIVATE PkgConfig::_PULP_CLI_FONTCONFIG)` on Linux.
- `.github/workflows/release-cli.yml` — add `tools/cli/CMakeLists.txt` to the workflow_dispatch backfill overlay list so the v0.95.0..v0.98.0 backfills pick this up without tag-tree edits.

## Test plan

- [x] `actionlint -shellcheck= -pyflakes= .github/workflows/release-cli.yml` exit 0
- [x] `skill_sync_check.py --mode=report` green (Skill-Update: skip trailers)
- [x] `version_bump_check.py --require-bump-for-fix-feat ...` green (Version-Bump: skip trailer)
- [ ] CI matrix passes on this PR (Linux build should succeed where it didn't before)
- [ ] Post-merge: v0.97.0 backfill linux-x64 Build succeeds → release publishes

Closes #1962 when watchdog confirms SDK assets land for v0.95.0..v0.98.0.