### PR TITLE
fix(codecov): align bot ignore list with Pulp diff-cover gate exclusions

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -101,6 +101,27 @@ ignore:
   # with scripts/run_coverage.sh IGNORE and
   # tools/scripts/run_python_coverage.py omit_globs.
   - "tools/sandbox-e2e/**"
+  # ── Aligned with tools/scripts/coverage_config.json `diff_cover_excludes` ──
+  # The Pulp gate (`Diff coverage required` in coverage.yml) excludes these
+  # files because they're either thin dispatchers exercised end-to-end via
+  # shell-out tests (so direct line coverage doesn't propagate cleanly), or
+  # platform-specific renderer code that the cross-platform coverage matrix
+  # can't instrument uniformly. Without aligning the Codecov bot's ignore
+  # list to the same set, the bot's `codecov/patch` check fires red on PRs
+  # whose diff is mostly in these files (e.g. PR #1984's viewport-fit lived
+  # almost entirely in window_host_mac.mm — Pulp gate silent, bot screamed
+  # 8.64% patch coverage). Both sides MUST count the same set.
+  #
+  # Drift between this list and coverage_config.json is detected by
+  # tools/scripts/test_codecov_config_sync.py — keep them in sync.
+  - "**/cmd_loop.cpp"
+  - "**/pulp_import_design.cpp"
+  - "**/cg_canvas.mm"
+  - "**/window_host_mac.mm"
+  - "**/scanner_clap.cpp"
+  - "**/cmd_projects.cpp"
+  - "**/canvas.hpp"
+  - "**/skia_canvas.cpp"
 
 # PR comment. Focused on reach + diff + flags + tree so contributors
 # see "how many lines of THIS PR are covered by THIS PR's tests"

--- a/tools/scripts/test_codecov_config.py
+++ b/tools/scripts/test_codecov_config.py
@@ -370,6 +370,33 @@ class CodecovYamlStructure(unittest.TestCase):
         self.assertEqual(comment["behavior"], "default")
         self.assertIs(comment["require_changes"], True)
 
+    def test_ignore_aligned_with_diff_cover_excludes(self):
+        """Codecov bot's `ignore` MUST mirror coverage_config.json's
+        `diff_cover_excludes`. Drift causes the `codecov/patch` check to
+        scream below-threshold on PRs whose diff is mostly in files the
+        Pulp gate (`Diff coverage required`) silently excludes — which is
+        what happened on PR #1984 (8.64% bot vs Pulp gate happy). Both
+        sides MUST count the same set of files.
+        """
+        import json
+
+        repo_root = pathlib.Path(__file__).resolve().parent.parent.parent
+        gate_config = json.loads(
+            (repo_root / "tools/scripts/coverage_config.json").read_text()
+        )
+        gate_excludes = set(gate_config["diff_cover_excludes"])
+        bot_ignore = set(self.doc["ignore"])
+
+        missing = gate_excludes - bot_ignore
+        self.assertFalse(
+            missing,
+            f"codecov.yml `ignore:` is missing entries from "
+            f"coverage_config.json `diff_cover_excludes`: {sorted(missing)}\n"
+            f"Add them to codecov.yml's ignore list (under the "
+            f"'Aligned with...' comment) or both gates will count the "
+            f"same lines differently.",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Workflow-hygiene fix to stop `codecov/patch` bot nag on PRs whose diff sits in files the **Pulp** `Diff coverage required` gate already excludes.

## Why

`tools/scripts/coverage_config.json` (Pulp gate) and `codecov.yml` (Codecov bot) had **drifted** apart on their exclusion lists:

| List | Excludes `window_host_mac.mm`, `pulp_import_design.cpp`, `cmd_loop.cpp`, etc.? |
|---|---|
| `coverage_config.json` `diff_cover_excludes` (Pulp gate) | ✅ yes |
| `codecov.yml` `ignore` (bot) | ❌ no |

So PRs whose diff was mostly in those excluded files (e.g. **PR #1984's viewport-fit work, ~95% in `window_host_mac.mm`**) got:

- Pulp gate: silent (correct)
- Codecov bot: red `codecov/patch` 8.64% (noise)

Devs then either ignored the bot ("noise"), bypassed the local diff-cover hook with `PULP_DISABLE_PREPUSH_DIFF_COVER=1` (so the local mirror stopped catching real coverage gaps), or burned cycles writing tests for files that had been deliberately classified as exercised end-to-end elsewhere.

## What changed

- `codecov.yml` — added the 8 `diff_cover_excludes` entries from `coverage_config.json` to the top-level `ignore:` list, with a comment pointing at the source-of-truth file.
- `tools/scripts/test_codecov_config.py` — new `test_ignore_aligned_with_diff_cover_excludes` asserts `diff_cover_excludes ⊆ codecov.yml ignore`. Drift fails CI fast.

Both gates now count the same files. `codecov/patch` should stop firing red on PRs whose diff is concentrated in already-excluded files.

## Test plan

- [x] `python3 tools/scripts/test_codecov_config.py` → 14/14 pass (13 existing + 1 new sync test)
- [x] Manually verified the new test catches drift by adding/removing entries and re-running

## Notes

- Doesn't retroactively fix the bot comments already posted on #1984 / #1969 — but the *next* PR you ship that touches excluded files won't get nagged.
- `codecov/patch` is informational only (not in branch protection per `codecov.yml` line 64) so this PR doesn't change which checks are required to merge.
- Separate follow-up needed for the local `tools/scripts/local_diff_cover.sh` clean-build hitting `FetchContent highway 1.2.0 — invalid reference` (drop `GIT_SHALLOW` or pin to commit SHA). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)