### PR TITLE
fix(view): bump line-height multiplier to 1.6 for small font Labels (pulp-internal #76)

### DIFF
--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -252,7 +252,17 @@ float Label::intrinsic_height() const {
         if (auto inh = inheritable_font_size(); inh.has_value())
             effective_font_size = inh.value();
     }
-    return line_height_ > 0 ? line_height_ : effective_font_size * 1.4f;
+    // pulp-internal #76 — small font sizes need a larger line-height
+    // multiplier than the standard 1.4. At fs=10 (Spectr's
+    // `<span fontSize=10>SNAPSHOT</span>` in the bottom toolbar), Inter's
+    // typographic ascent + descent is ~13px, leaving only ~1px of slack
+    // in a 14px box (10 * 1.4); the GPU clip-rect on the View bounds
+    // then shaved the descender-side slack off in practice and the label
+    // visibly clipped from the bottom. Bumping to 1.6 for sizes below
+    // ~12pt buys 16px of box room for fs=10, fully containing the glyph
+    // extent. Larger sizes keep 1.4 — they have plenty of absolute slack.
+    const float lh_mult = effective_font_size < 12.0f ? 1.6f : 1.4f;
+    return line_height_ > 0 ? line_height_ : effective_font_size * lh_mult;
 }
 
 float Label::intrinsic_width() const {
@@ -287,7 +297,9 @@ float Label::intrinsic_width() const {
     bool vertical = (text_direction_ == canvas::TextDirection::top_to_bottom ||
                      text_direction_ == canvas::TextDirection::bottom_to_top);
     if (vertical) {
-        return std::ceil(line_height_ > 0 ? line_height_ : effective_font_size * 1.4f);
+        // pulp-internal #76 — same small-font-size bump as intrinsic_height.
+        const float lh_mult = effective_font_size < 12.0f ? 1.6f : 1.4f;
+        return std::ceil(line_height_ > 0 ? line_height_ : effective_font_size * lh_mult);
     }
 
     // Mirror paint()'s text-transform — measurement must match what's
@@ -447,7 +459,13 @@ void Label::paint(canvas::Canvas& canvas) {
     }
 
     // Vertical alignment
-    float lh = line_height_ > 0 ? line_height_ : effective_font_size * 1.4f;
+    // pulp-internal #76 — match intrinsic_height's small-font-size bump so
+    // multi-line / shaper-wrapped layout uses the same line-box height
+    // that Yoga reserved. Without matching here, an fs=10 multi-line
+    // label would size to 16px boxes but paint at 14px line height and
+    // siblings would not align.
+    const float lh_mult = effective_font_size < 12.0f ? 1.6f : 1.4f;
+    float lh = line_height_ > 0 ? line_height_ : effective_font_size * lh_mult;
 
     // pulp #1737 PR-2 / #1924 — CSS `white-space` / `overflow-wrap` /
     // `word-break` soft-wrap path. Route any multi-line, bounded-width

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/view/widgets.hpp>
 #include <pulp/canvas/canvas.hpp>
@@ -90,6 +91,51 @@ TEST_CASE("Label intrinsic_width scales with font size", "[view][widget][issue-9
     large.set_font_size(36.0f);
 
     REQUIRE(large.intrinsic_width() > small.intrinsic_width());
+}
+
+TEST_CASE("Label intrinsic_height bumps line-height multiplier for small fonts (#76)",
+          "[view][widget][issue-pulp-internal-76]") {
+    // pulp-internal #76 — Spectr's `<span fontSize=10>SNAPSHOT</span>` in
+    // the bottom toolbar was vertically clipped because Yoga reserved
+    // 10 * 1.4 = 14px for the Label, but Inter's typographic ascent +
+    // descent at 10pt is ~13px and the GPU clip-rect on the View bounds
+    // shaved descender slack off in practice. intrinsic_height now uses
+    // a 1.6 multiplier for small font sizes (< 12pt) to ensure the full
+    // glyph extent fits inside the reserved box.
+    //
+    // Larger sizes keep the historical 1.4 multiplier — they have plenty
+    // of absolute slack and downstream visual tests / golden-files
+    // depend on the exact numbers.
+
+    // Below the threshold — bumped multiplier.
+    Label tiny("snapshot");
+    tiny.set_font_size(10.0f);
+    REQUIRE(tiny.intrinsic_height() == Catch::Approx(10.0f * 1.6f));
+
+    Label small("ok");
+    small.set_font_size(11.5f);
+    REQUIRE(small.intrinsic_height() == Catch::Approx(11.5f * 1.6f));
+
+    // At/above the threshold — original multiplier.
+    Label normal("hello");
+    normal.set_font_size(12.0f);
+    REQUIRE(normal.intrinsic_height() == Catch::Approx(12.0f * 1.4f));
+
+    Label big("HEADING");
+    big.set_font_size(24.0f);
+    REQUIRE(big.intrinsic_height() == Catch::Approx(24.0f * 1.4f));
+
+    // Explicit line_height ALWAYS wins (multiplier ignored on either side
+    // of the threshold) — preserves the existing escape hatch.
+    Label explicit_tiny("snapshot");
+    explicit_tiny.set_font_size(10.0f);
+    explicit_tiny.set_line_height(20.0f);
+    REQUIRE(explicit_tiny.intrinsic_height() == Catch::Approx(20.0f));
+
+    Label explicit_big("HEADING");
+    explicit_big.set_font_size(24.0f);
+    explicit_big.set_line_height(20.0f);
+    REQUIRE(explicit_big.intrinsic_height() == Catch::Approx(20.0f));
 }
 
 TEST_CASE("Label intrinsic_width respects text-transform", "[view][widget][issue-928]") {


### PR DESCRIPTION
## Summary

Fixes #76 — Spectr's `<span style={{fontSize:10}}>SNAPSHOT</span>` in the bottom toolbar painted with the bottom ~50% of glyphs visibly clipped.

## Root cause

`Label::intrinsic_height` defaults its line-height to `font_size * 1.4`. At fs=10 that gives Yoga only 14px to reserve for the Label, but Inter's typographic ascent + descent at 10pt is ~13px — leaving roughly 1px of slack. The View bounds get clipped against the GPU surface, that 1px of slack disappears in practice, and the descender side of glyphs gets cut.

## Before / After

- Before: bottom-half of `SNAPSHOT` letters clipped — see `/tmp/snapshot-bug/snapshot-only.png`
- After: full glyphs visible, properly centred — see `/tmp/snapshot-bug/final-bright.png`

## Fix

Bump the multiplier to `1.6` for font sizes below 12pt. Larger sizes keep `1.4` (they have plenty of absolute slack and downstream visual / golden tests depend on the existing numbers).

Three callsites updated together so paint and Yoga agree:
- `Label::intrinsic_height`
- `Label::intrinsic_width` (vertical-text branch)
- `Label::paint` (multi-line text_h math)

## Test coverage

6 new Catch2 assertions under `[issue-pulp-internal-76]`:
- Below 12pt → 1.6 multiplier (fs=10 → 16, fs=11.5 → 18.4)
- At/above 12pt → 1.4 multiplier (fs=12 → 16.8, fs=24 → 33.6)
- Explicit `set_line_height` wins on either side of the threshold

Full `pulp-test-widgets` suite green: 289 assertions in 72 test cases.

## Test plan

- [x] `ctest -R \"\\[issue-pulp-internal-76\\]\"` → 6/6 pass locally
- [x] `pulp-test-widgets` full suite → 289/289 pass locally
- [x] Visual regression: rendered Spectr's editor.js at 1320×860 design size, SNAPSHOT label fully visible
- [ ] CI green (Linux/Windows/macOS, sanitizers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)