### PR TITLE
ci(release): add release-path PR gate + draft-stuck watchdog (#1962 prevention)

### DIFF
--- a/.github/workflows/release-draft-stuck-check.yml
+++ b/.github/workflows/release-draft-stuck-check.yml
@@ -1,0 +1,258 @@
+name: Release draft stuck check
+
+# Layer-3 watchdog for the "release tag exists but the GitHub Release
+# is still draft" invariant. Sibling to release-cadence-check.yml
+# (which catches "tag missing after VERSION bump"). Together they
+# cover the two ways a release can silently rot:
+#
+#   - bump landed, tag missing      → release-cadence-check.yml
+#   - tag exists, release == draft  → THIS FILE
+#
+# Motivated by pulp #1962 (2026-05-12..2026-05-14): five tags
+# (v0.95.0..v0.98.0) sat as draft GitHub Releases for 48+ hours
+# with only `appcast.xml` attached because release-cli.yml's
+# linux-x64 leg failed each time and the `release` job (which
+# flips `draft: false` and uploads the SDK assets) was gated on
+# the full matrix being green. Nothing watched for the symptom —
+# only auto-release-watchdog.yml fires on auto-release.yml
+# completion, and only release-cadence-check.yml fires on missing
+# tags. Result: every consumer of the v0.95.0..v0.98.0 SDK was
+# broken for 3 days, and the only visible signal was
+# https://github.com/danielraffel/pulp/releases showing "Draft"
+# next to several rows — which nobody was reading.
+#
+# Cadence: every 30 minutes (matches release-cadence-check). The
+# grace window defaults to 60 minutes (release-cli.yml runs the
+# full SDK matrix and can take 30-45 min on cold caches; 60 leaves
+# slack).
+#
+# Output: a single tracking issue ("Release stuck as draft …")
+# that lists every offending tag. The issue is reopened when new
+# stuck drafts appear and auto-closes on the next sweep when
+# every recent tag is published.
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+    inputs:
+      lookback_days:
+        description: 'Days of release history to scan'
+        required: false
+        default: '14'
+      grace_minutes:
+        description: 'Minutes a release can stay draft before flagging'
+        required: false
+        default: '60'
+      dry_run:
+        description: 'Log findings but do not touch the tracking issue'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: release-draft-stuck-check
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: Check tag-vs-published-release invariant
+
+    env:
+      LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days || '14' }}
+      GRACE_MINUTES: ${{ github.event.inputs.grace_minutes || '60' }}
+      DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+      TRACKING_TITLE: 'Release pipeline: tag exists but GitHub Release is draft'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags explicitly
+        run: git fetch --tags --force
+
+      - name: Scan stuck drafts
+        id: scan
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          lookback="${LOOKBACK_DAYS}"
+          grace="${GRACE_MINUTES}"
+          repo='${{ github.repository }}'
+
+          grace_cutoff=$(date -u -d "${grace} minutes ago" +%s 2>/dev/null \
+              || python3 -c "import datetime; print(int((datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=${grace})).timestamp()))")
+          window_cutoff=$(date -u -d "${lookback} days ago" +%s 2>/dev/null \
+              || python3 -c "import datetime; print(int((datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=${lookback})).timestamp()))")
+
+          # List recent releases. Pagination capped at 100 — a 14-day
+          # window at Pulp's release cadence is well under that.
+          gh api "repos/${repo}/releases?per_page=100" > releases.json
+
+          findings='[]'
+
+          # Process each release. We care about those whose tag exists
+          # in git AND draft == true AND age > grace AND landed inside
+          # the lookback window.
+          mapfile -t release_lines < <(
+              python3 - <<'PY'
+          import json, sys
+          rels = json.load(open('releases.json'))
+          for r in rels:
+              tag = r.get('tag_name') or ''
+              draft = bool(r.get('draft'))
+              created = r.get('created_at') or ''
+              if not tag:
+                  continue
+              # Emit one TSV row per release for downstream awk.
+              print('\t'.join([tag, str(draft).lower(), created]))
+          PY
+          )
+
+          for line in "${release_lines[@]}"; do
+              tag=$(echo "$line" | cut -f1)
+              draft=$(echo "$line" | cut -f2)
+              created=$(echo "$line" | cut -f3)
+
+              if [ "$draft" != "true" ]; then continue; fi
+
+              # Tag must exist in git — drafts on deleted tags are
+              # someone-else's-problem (likely a deletion in flight).
+              if ! git rev-parse --verify --quiet "refs/tags/${tag}" > /dev/null; then
+                  echo "  skip ${tag} — draft but tag absent from git"
+                  continue
+              fi
+
+              created_ts=$(python3 -c "import datetime; print(int(datetime.datetime.fromisoformat('${created}'.replace('Z','+00:00')).timestamp()))")
+
+              if [ "$created_ts" -lt "$window_cutoff" ]; then
+                  echo "  skip ${tag} — outside lookback window"
+                  continue
+              fi
+              if [ "$created_ts" -gt "$grace_cutoff" ]; then
+                  echo "  skip ${tag} — within grace window (${grace} min)"
+                  continue
+              fi
+
+              age_min=$(( ($(date -u +%s) - created_ts) / 60 ))
+              echo "  STUCK ${tag} draft=true age=${age_min}min"
+
+              findings=$(echo "$findings" | python3 -c "
+          import json, sys
+          arr = json.load(sys.stdin)
+          arr.append({
+              'tag': '${tag}',
+              'created_at': '${created}',
+              'age_minutes': ${age_min},
+          })
+          print(json.dumps(arr))
+          ")
+          done
+
+          echo "$findings" > findings.json
+          count=$(python3 -c "import json; print(len(json.load(open('findings.json'))))")
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+          echo "Stuck-draft count: ${count}"
+
+      - name: Render issue body
+        if: env.DRY_RUN != 'true' && steps.scan.outputs.count != '0'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' > body.md
+          import json, datetime
+          findings = json.load(open('findings.json'))
+          now = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M UTC')
+          lines = []
+          lines.append(f"_Auto-generated by `.github/workflows/release-draft-stuck-check.yml` on {now}._")
+          lines.append("")
+          lines.append("**Invariant violated:** one or more git tags have a corresponding "
+                       "GitHub Release that is still `draft: true` past the grace window. "
+                       "Anyone consuming the SDK at those versions sees no published artifacts.")
+          lines.append("")
+          lines.append("Likely root causes:")
+          lines.append("- `release-cli.yml` matrix leg failed (Linux/macOS/Windows build), "
+                       "so the `release` job that flips `draft: false` was skipped")
+          lines.append("- `sign-and-release.yml` created the draft but a downstream uploader "
+                       "(SDK tarball, plugin .pkg, appcast) did not attach assets")
+          lines.append("- Manual draft from a previous experiment that should have been deleted")
+          lines.append("")
+          lines.append("### Stuck draft releases")
+          lines.append("")
+          for f in findings:
+              lines.append(f"- **`{f['tag']}`** — drafted {f['created_at']} "
+                           f"({f['age_minutes']} min ago), still `draft: true`")
+          lines.append("")
+          lines.append("**Resolution path** (one of):")
+          lines.append("1. Re-fire the failed `release-cli.yml` run via `workflow_dispatch` "
+                       "with the offending tag once the underlying breakage is fixed; "
+                       "the `release` job will attach SDK assets and flip `draft: false`.")
+          lines.append("2. If the tag was abandoned, delete both the tag and the draft "
+                       "Release manually so this tracker auto-closes.")
+          lines.append("3. If `draft: true` was intentional (rare), file a follow-up issue "
+                       "explaining why and re-trigger this check with `dry_run=true` "
+                       "until the grace window is widened to fit.")
+          lines.append("")
+          lines.append("This tracker closes automatically on the next sweep when every "
+                       "recent tag has a published Release.")
+          print('\n'.join(lines))
+          PY
+
+      - name: Maintain tracking issue
+        if: env.DRY_RUN != 'true'
+        shell: bash
+        env:
+          COUNT: ${{ steps.scan.outputs.count }}
+        run: |
+          set -euo pipefail
+          repo='${{ github.repository }}'
+          title="${TRACKING_TITLE}"
+
+          existing_json=$(
+              gh issue list \
+                  --repo "$repo" \
+                  --state all \
+                  --search "in:title \"${title}\"" \
+                  --json number,title,state \
+                  --jq "[.[] | select(.title == \"${title}\")] | first // {}"
+          )
+          existing=$(echo "$existing_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('number','') or '')")
+          existing_state=$(echo "$existing_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('state','') or '')")
+
+          if [ "$COUNT" -eq 0 ]; then
+              if [ -n "${existing:-}" ] && [ "$existing_state" = "OPEN" ]; then
+                  echo "Stuck-draft invariant restored — closing #${existing}."
+                  gh issue comment "$existing" --repo "$repo" \
+                      --body "Sweep on $(date -u +%Y-%m-%d\ %H:%M) found no stuck draft Releases. Closing."
+                  gh issue close "$existing" --repo "$repo" --reason completed
+              else
+                  echo "No findings and no open tracker — nothing to do."
+              fi
+              exit 0
+          fi
+
+          if [ -z "${existing:-}" ]; then
+              echo "Creating tracking issue."
+              gh issue create --repo "$repo" --title "$title" --body-file body.md --label ci,blocks-release 2>&1 || \
+                  gh issue create --repo "$repo" --title "$title" --body-file body.md
+          else
+              echo "Updating tracking issue #${existing}."
+              gh issue edit "$existing" --repo "$repo" --body-file body.md
+              gh issue reopen "$existing" --repo "$repo" 2>/dev/null || true
+          fi
+
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-draft-stuck-findings
+          path: findings.json
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.github/workflows/release-path-pr-gate.yml
+++ b/.github/workflows/release-path-pr-gate.yml
@@ -1,0 +1,137 @@
+name: Release-path PR gate
+
+# PR-time pre-tag check that runs the actual release-cli.yml build
+# steps for the platforms most likely to surface
+# Skia/dependency/link-order regressions. Catches the class of breakage
+# that would otherwise only fire post-tag (when the ship has sailed).
+#
+# Motivated by pulp #1962 (2026-05-12..2026-05-14): Skia chrome/m144
+# fontconfig + SkUnicode-split breakage sailed through every PR's CI
+# because PR `build.yml` builds from source via FetchContent and never
+# touches `fetch_skia_for_release.py` or the prebuilt-Skia link path.
+# Five tags drafted then rotted as drafts because release-cli.yml was
+# the only thing that exercised the prebuilt path, and it only runs
+# post-tag.
+#
+# Scope: only triggers on PRs touching files that can affect the
+# release path. Most PRs (view / canvas / docs / examples) skip this
+# gate entirely. Linux-x64 is the canonical leg — it's where:
+#   - GNU ld surfaces archive-link-order bugs first (fontconfig, skunicode)
+#   - the "no PULP_REQUIRE_GPU_FOR_SDK" gate trips silently on bad pins
+#   - the WebView=OFF split path runs (issue #720)
+#
+# darwin-arm64 is included as a cross-platform sanity check so we
+# don't ship a Linux-only release-path gate that misses macOS-only
+# regressions (e.g. metal framework drift).
+
+on:
+  pull_request:
+    paths:
+      - 'tools/scripts/fetch_skia_for_release.py'
+      - 'tools/deps/manifest.json'
+      - 'tools/cmake/Find*.cmake'
+      - 'tools/cmake/Pulp*.cmake'
+      - 'tools/cli/CMakeLists.txt'
+      - 'tools/scripts/package_cli.py'
+      - 'core/canvas/CMakeLists.txt'
+      - 'core/render/CMakeLists.txt'
+      - 'core/view/CMakeLists.txt'
+      - 'CMakeLists.txt'
+      - '.github/workflows/release-cli.yml'
+      - '.github/workflows/release-path-pr-gate.yml'
+  workflow_dispatch:
+
+# Multiple PRs touching the same release-path files can stack up;
+# cancel older in-flight runs of THIS workflow when a new commit
+# lands. Does not cancel release-cli.yml itself (different concurrency
+# group), only this PR-time gate.
+concurrency:
+  group: release-path-pr-gate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    name: Release-path build (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: linux-x64
+          - os: macos-15
+            platform: darwin-arm64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      # Mirror release-cli.yml's Linux deps step verbatim. If this list
+      # ever drifts from release-cli.yml, the gate is lying — keep them
+      # in sync (or pull both from a shared composite action).
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libasound2-dev libdbus-1-dev libdrm-dev libegl1-mesa-dev \
+            libgbm-dev libgl1-mesa-dev libx11-dev libxext-dev libxfixes-dev \
+            libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev \
+            libxrender-dev libxss-dev libxtst-dev libwayland-dev \
+            libgtk-3-dev libwebkit2gtk-4.1-dev wayland-protocols \
+            libfontconfig1-dev
+
+      - name: Bootstrap dependencies
+        run: ./setup.sh --ci --deps-only
+        shell: bash
+
+      # The whole point — exercise the prebuilt-Skia path that
+      # release-cli.yml uses. PR build.yml does NOT do this, which is
+      # exactly why fontconfig + skunicode breakage went undetected
+      # at PR time (#1962).
+      - name: Fetch Skia binaries (release path)
+        run: python3 tools/scripts/fetch_skia_for_release.py ${{ matrix.platform }}
+        shell: bash
+
+      # Mirror release-cli.yml's CLI configure exactly so this gate
+      # surfaces the same flag combinations that get exercised at
+      # release time (PULP_REQUIRE_GPU_FOR_SDK=ON, WebView=OFF on
+      # Linux to keep the CLI portable).
+      - name: Configure (CLI, no WebView on Linux, GPU required)
+        run: |
+          REQUIRE_GPU="-DPULP_REQUIRE_GPU_FOR_SDK=OFF"
+          case "${{ matrix.platform }}" in
+            darwin-arm64|linux-x64)
+              REQUIRE_GPU="-DPULP_REQUIRE_GPU_FOR_SDK=ON"
+              ;;
+          esac
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPULP_BUILD_TESTS=OFF \
+            $REQUIRE_GPU \
+            ${{ runner.os == 'Linux' && '-DPULP_BUILD_WEBVIEW=OFF' || '-DPULP_BUILD_WEBVIEW=ON' }}
+        shell: bash
+
+      # Build the same target release-cli.yml builds. The link step
+      # is where the SkUnicode core/icu order bug surfaces (and where
+      # the fontconfig undefineds surfaced in the previous Skia bump).
+      - name: Build pulp-cli (release path)
+        run: |
+          jobs=$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+          cmake --build build --config Release --target pulp-cli -j"$jobs"
+        shell: bash
+
+      # Sanity: the binary actually runs. release-cli.yml has a
+      # smoke-cli matrix that does this on a separate clean runner —
+      # we do a lightweight `--version` here to catch the dynamic
+      # loader failures that linker bugs hide (e.g. missing rpath /
+      # missing dependency symbol resolution).
+      - name: Smoke pulp-cpp --version
+        run: |
+          ./build/tools/cli/pulp-cpp --version || ./build/tools/cli/pulp-cpp version
+        shell: bash

--- a/docs/guides/release-watchdog.md
+++ b/docs/guides/release-watchdog.md
@@ -1,10 +1,11 @@
 # Release Watchdog
 
-Three layers of protection against silent release failures (plus a
-PR-time prevention layer added for issue #1009). All use only standard,
-agent-agnostic tooling (GitHub Actions, `gh` CLI, `yamllint`,
-`actionlint`, Python) — any contributor or automation (Claude, Codex,
-a human) can understand and invoke them.
+Three layers of protection against silent release failures (plus two
+PR-time prevention layers — `fix/feat-needs-bump` for #1009 and the
+release-path PR gate for #1962). All use only standard, agent-agnostic
+tooling (GitHub Actions, `gh` CLI, `yamllint`, `actionlint`, Python) —
+any contributor or automation (Claude, Codex, a human) can understand
+and invoke them.
 
 ## Why three layers
 
@@ -21,10 +22,12 @@ Each layer catches a different failure mode:
 
 | Layer | Trigger | Failure mode caught | Median detection |
 |---|---|---|---|
+| 0. release-path PR gate | PR touching release-path files | prebuilt-Skia / link-order / CMake breakage at PR time (#1962) | 5-15 min (pre-merge) |
 | 1. Workflow lint | PR review | bad YAML / bad `uses:` / bad shell | seconds (pre-merge) |
 | 2. Auto-release watchdog | `workflow_run` completion | runtime failure (any cause) | 1-2 minutes |
 | 2b. Release-CLI watchdog | `workflow_run` completion | per-tag missing SDK/CLI assets (#1375) | 1-2 minutes |
 | 3. Cadence check | `schedule` every 30 min | any outcome drift — even unknown-unknowns | ≤45 min |
+| 3b. Draft-stuck check | `schedule` every 30 min | tag exists, Release stuck as draft (#1962) | ≤90 min |
 
 ## Layer 1 — Workflow lint (pre-merge)
 
@@ -123,6 +126,85 @@ YAML bug (Layer 1 would catch), a runtime job failure (Layer 2 would
 catch), a missing secret (neither of the above might catch), a
 forgotten manual step, or a GitHub outage — the invariant fires because
 the *symptom* (missing release) appears.
+
+## Layer 3b — Release draft stuck check (invariant, sibling to Layer 3)
+
+**File:** `.github/workflows/release-draft-stuck-check.yml`
+
+Runs every 30 minutes (plus `workflow_dispatch`). Sibling to Layer 3:
+where Layer 3 catches "VERSION bump landed, no tag", Layer 3b catches
+"tag exists, GitHub Release still `draft: true`". Both are
+cause-agnostic, both watch the symptom rather than the cause.
+
+For each Release returned by `gh api releases?per_page=100` that is
+within the lookback window (default 14 days), checks:
+
+1. Is the corresponding git tag present?
+2. Is the Release flagged `draft: true`?
+3. Has the Release been drafted longer than the grace window
+   (default 60 min — release-cli + sign-and-release together can take
+   30–45 min cold-cache; 60 leaves slack)?
+
+If yes-yes-yes → add to findings and open/update a tracking issue
+titled `Release pipeline: tag exists but GitHub Release is draft`.
+Auto-closes on the next sweep when every recent tag is published.
+
+**Motivating incident (#1962, 2026-05-12..2026-05-14):** Five tags
+(v0.95.0..v0.98.0) were drafted by `sign-and-release.yml` (which
+creates `draft: true`) but never promoted to published because
+`release-cli.yml`'s linux-x64 leg failed for 5 consecutive runs on a
+Skia chrome/m144 link-order bug. The `release` job that flips
+`draft: false` and uploads the SDK assets is gated on the matrix
+being green, so it skipped each time. Existing layers were quiet:
+`auto-release.yml` and the cadence check both saw "tag exists" and
+moved on; the per-tag release-cli watchdog (Layer 2b) opened
+trackers but those got buried in the issue list and the actual user-
+visible signal — `https://github.com/danielraffel/pulp/releases`
+showing 5 "Draft" rows — wasn't surfaced anywhere actionable.
+
+## release-path PR gate (pre-tag prevention, issue #1962)
+
+**File:** `.github/workflows/release-path-pr-gate.yml`
+
+Sibling to fix/feat-needs-bump. fix/feat-needs-bump catches "user-
+facing change merged without a bump"; the release-path PR gate
+catches the bigger structural gap that #1962 surfaced: **the
+release-build path is never tested at PR time.**
+
+PR `build.yml` builds Pulp from source via FetchContent — it never
+runs `tools/scripts/fetch_skia_for_release.py`, never builds the SDK
+tarball, never links the prebuilt Skia archives. So every breakage
+to the prebuilt-Skia path (chrome/m144 fontconfig undefineds,
+SkUnicode core/icu link-order, future Skia bumps that change asset
+layout) sails through PR green and only detonates post-tag, when
+release-cli.yml is the only workflow exercising that code path.
+
+The PR gate runs the exact `release-cli.yml` build steps —
+`fetch_skia_for_release.py`, the `PULP_REQUIRE_GPU_FOR_SDK=ON`
+configure, `cmake --build … --target pulp-cli`, and a
+`pulp-cpp --version` smoke — for the two platforms that surface
+release-path regressions first:
+
+- `linux-x64` — GNU ld is the strictest static-link environment.
+  fontconfig undefineds, SkUnicode core/icu order bugs, anything
+  involving missing `--start-group`/`--end-group` shows up here
+  before macOS or Windows even notice.
+- `darwin-arm64` — sanity check that we don't ship a Linux-only
+  gate that misses macOS-only regressions (Metal framework drift,
+  AppKit symbol changes, etc.).
+
+Triggered only when a PR touches files in the release-path scope:
+`tools/scripts/fetch_skia_for_release.py`, `tools/deps/manifest.json`,
+`tools/cmake/Find*.cmake`, `tools/cmake/Pulp*.cmake`,
+`tools/cli/CMakeLists.txt`, `core/{canvas,render,view}/CMakeLists.txt`,
+`CMakeLists.txt`, `release-cli.yml`. Most PRs (view / docs / examples /
+plugin) skip this gate entirely so iteration speed is unaffected.
+
+If `release-cli.yml`'s job structure ever drifts from this gate, the
+gate is lying. Mirror any structural change to release-cli.yml here
+(or refactor both into a shared composite action). The "Mirror
+release-cli.yml's Linux deps step verbatim" comment in the workflow
+calls this out.
 
 ## fix/feat-needs-bump (PR-time prevention, issue #1009)
 


### PR DESCRIPTION
Closes the two structural gaps that let pulp #1962 silently rot 5 SDK
release tags (v0.95.0..v0.98.0) for 48+ hours:

1. **release-path PR gate** (`release-path-pr-gate.yml`) — runs the
   exact `release-cli.yml` build steps (fetch_skia_for_release.py,
   PULP_REQUIRE_GPU_FOR_SDK=ON configure, pulp-cli link, smoke
   `pulp-cpp --version`) on linux-x64 + darwin-arm64 whenever a PR
   touches the release-path scope:

     tools/scripts/fetch_skia_for_release.py
     tools/deps/manifest.json
     tools/cmake/Find*.cmake
     tools/cmake/Pulp*.cmake
     tools/cli/CMakeLists.txt
     core/{canvas,render,view}/CMakeLists.txt
     CMakeLists.txt
     .github/workflows/release-cli.yml

   PR `build.yml` builds Pulp from source via FetchContent — it never
   touches the prebuilt-Skia path, which is why both the chrome/m144
   fontconfig undefineds and the SkUnicode core/icu link-order bug
   sailed through PR green. linux-x64 surfaces archive-link-order
   bugs first because GNU ld is the strictest static-link
   environment; darwin-arm64 catches the macOS-only failure modes.

   Most PRs (view / docs / examples / plugins) skip this gate
   entirely so iteration speed is unaffected.

2. **release-draft-stuck watchdog** (`release-draft-stuck-check.yml`)
   — sibling to release-cadence-check.yml. Cadence catches "VERSION
   bump landed, no tag"; this catches "tag exists, GitHub Release
   still draft: true" past a 60-min grace window. Cause-agnostic:
   triggers on the symptom (GitHub Releases page shows "Draft"
   rows) regardless of whether release-cli.yml failed silently, a
   sign-and-release uploader broke, or a draft was abandoned.

   Auto-opens / auto-closes a single tracking issue
   ("Release pipeline: tag exists but GitHub Release is draft")
   matching the close-path pattern of release-cadence-check.

The third recommendation from the #1962 post-mortem
(make release-cli.yml's `release` job `if: always()` and publish
whatever assets succeeded) needs an upstream behavior change to
release-cli.yml itself — keeping that as a follow-up since it
changes user-facing release behavior beyond pure detection.

The fourth recommendation (replace file(GLOB *.a) in FindSkia.cmake
with an explicit ordered library list) is partially addressed by
PR #1991's --start-group/--end-group wrapping — that's the robust
fix for cross-archive symbol resolution. Listing every Skia
sub-archive by name is a separate hardening pass we can take when
the next Skia bump lands and we know the full split layout.

docs/guides/release-watchdog.md updated with Layer 0 (PR gate) and
Layer 3b (draft-stuck) entries in the layers summary, plus full
sections covering the motivating incident and the rationale for
each gate's path filter / grace window.

Version-Bump: skip reason="CI / docs only — no SDK header / ABI / runtime change."
Skill-Update: skip skill=ci reason="Two new release-watchdog workflows + a docs/ update; no change to the canonical ci skill flow (shipyard pr remains the entry point) and no change to the runner / ssh / Shipyard interfaces the skill documents."