### PR TITLE
fix(plugin): bump marketplace plugins[0].version + relative .mcp.json path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.8.0",
+      "version": "0.35.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.34.0"
+  "version": "0.35.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,8 @@
 {
+  "_comment": "Project-local MCP server for Pulp source-tree work. Path is RELATIVE because Claude Code launches MCP servers from the project root for project-local .mcp.json — ${CLAUDE_PLUGIN_ROOT} is only set for marketplace-installed plugins, not for project-local configs. The pulp-mcp-launcher itself locates the binary via $BASH_SOURCE so this still works regardless of cwd if Claude Code follows the MCP spec.",
   "mcpServers": {
     "pulp": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/tools/mcp/pulp-mcp-launcher",
+      "command": "./tools/mcp/pulp-mcp-launcher",
       "env": {}
     }
   }

--- a/docs/guides/claude-code-plugin.md
+++ b/docs/guides/claude-code-plugin.md
@@ -83,6 +83,57 @@ The plugin includes two hooks that run automatically:
 - **docs-reminder** — When you modify files in `core/`, `examples/`, or `tools/cli/`, reminds you to update documentation manifests
 - **cli-plugin-sync** — When you modify the CLI or MCP server, reminds you to check if the plugin commands and skills need matching updates
 
+### MCP server
+
+The plugin ships an MCP (Model Context Protocol) server — `pulp-mcp` — that
+exposes 18 Pulp operations as callable tools, so Claude Code (and other MCP
+clients) can drive them in one turn instead of multiple shell calls.
+
+| Category | Tools |
+|---|---|
+| Build / test / status | `pulp_build`, `pulp_test`, `pulp_status`, `pulp_validate`, `pulp_create`, `pulp_docs_check`, `pulp_docs_search` |
+| UI rendering + interaction | `pulp_screenshot` (render JS UI to PNG), `pulp_simulate_click`, `pulp_get_view_tree` |
+| Live plugin inspection (inspector protocol) | `pulp_inspect_dom`, `pulp_inspect_params`, `pulp_inspect_screenshot`, `pulp_inspect_evaluate` (JS expr), `pulp_inspect_performance`, `pulp_inspect_audio` |
+| Audio model / WAV-first excerpt-find | `pulp_audio_model_list`, `pulp_audio_model_status`, `pulp_audio_model_activate`, `pulp_audio_excerpt_find`, `pulp_audio_read_bundle` |
+
+#### Setup
+
+`tools/mcp/pulp-mcp-launcher` is a thin shell shim. It looks for the binary
+in this order:
+
+1. `<repo>/build/tools/mcp/pulp-mcp` (source-tree build) — typical Pulp
+   contributor workflow.
+2. `pulp-mcp` on `$PATH` (installed binary).
+
+If neither exists, the launcher prints a readable diagnostic on stderr and
+exits 127 so Claude Code surfaces the failure rather than silently no-oping
+(`pulp #1821`).
+
+To wire it up from a Pulp checkout:
+
+```bash
+cmake --build build --target pulp-mcp
+# Then in Claude Code: "Reconnect" the pulp MCP server.
+```
+
+#### `.mcp.json` and `${CLAUDE_PLUGIN_ROOT}` (gotcha)
+
+The Pulp repo's project-local `.mcp.json` uses a path **relative to the
+project root** — `./tools/mcp/pulp-mcp-launcher` — not
+`${CLAUDE_PLUGIN_ROOT}/...`. Reason: `${CLAUDE_PLUGIN_ROOT}` is set by
+Claude Code only when launching a marketplace-installed plugin's MCP
+server. Project-local `.mcp.json` files (loaded by Claude Code from
+the working-directory project, not from a plugin install) get an empty
+`${CLAUDE_PLUGIN_ROOT}`, which makes the command resolve to the literal
+`/tools/mcp/pulp-mcp-launcher` — fails with `No such file or directory`,
+exit 127, and Claude Code shows the server as `✘ failed`.
+
+Until the Pulp plugin ships a separate marketplace-bundled `.mcp.json`
+under `.claude-plugin/`, only project-local source-tree usage is
+supported. That's intentional — `pulp-mcp` requires the binary to be
+built (or installed on `$PATH`) regardless of how it's wired in, so
+non-checkout users don't gain anything from the marketplace path.
+
 ## Plugin Structure
 
 ```

--- a/tools/scripts/test_version_bump_check_extra.py
+++ b/tools/scripts/test_version_bump_check_extra.py
@@ -52,6 +52,71 @@ class VersionFileIoTests(unittest.TestCase):
             self.assertFalse(vbc.write_version(repo, vbc.VersionFile("missing", "json_field", "version"), "1.0.0"))
             self.assertIsNone(vbc.read_version(repo, vbc.VersionFile("missing", "json_field", "version")))
 
+    def test_json_path_kind_walks_nested_arrays_and_objects(self) -> None:
+        # pulp #1962-followup — marketplace.json has both a top-level
+        # `.version` and a nested `.plugins[0].version`. The Claude Code
+        # marketplace reads the nested one, so plugin bumps must update
+        # both. Cover read + write + the missing-segment fallthrough that
+        # keeps the gate advisory rather than crashing on shape drift.
+        with tempfile.TemporaryDirectory() as td:
+            repo = pathlib.Path(td)
+            (repo / "marketplace.json").write_text(
+                '{"version": "1.2.3", "plugins": [{"version": "0.1.0"}]}\n',
+                encoding="utf-8")
+
+            top = vbc.VersionFile("marketplace.json", "json_field", "version")
+            nested = vbc.VersionFile("marketplace.json", "json_path", "plugins.0.version")
+
+            self.assertEqual(vbc.read_version(repo, top), "1.2.3")
+            self.assertEqual(vbc.read_version(repo, nested), "0.1.0")
+
+            # Bump both; nested write should not clobber sibling fields.
+            self.assertTrue(vbc.write_version(repo, top, "2.0.0"))
+            self.assertTrue(vbc.write_version(repo, nested, "2.0.0"))
+            self.assertEqual(vbc.read_version(repo, top), "2.0.0")
+            self.assertEqual(vbc.read_version(repo, nested), "2.0.0")
+
+            # Missing nested segment returns None and write returns False —
+            # neither crashes the gate. Models the case where someone
+            # restructures marketplace.json.
+            missing = vbc.VersionFile("marketplace.json", "json_path", "plugins.99.version")
+            self.assertIsNone(vbc.read_version(repo, missing))
+            self.assertFalse(vbc.write_version(repo, missing, "9.9.9"))
+
+            empty = vbc.VersionFile("marketplace.json", "json_path", "")
+            self.assertIsNone(vbc.read_version(repo, empty))
+            self.assertFalse(vbc.write_version(repo, empty, "9.9.9"))
+
+    def test_marketplace_plugins_version_stays_in_sync_with_top_level(self) -> None:
+        # pulp #1962-followup — assert versioning.json registers BOTH the
+        # top-level marketplace.json `.version` AND the nested
+        # `.plugins[0].version` for the plugin surface. If a future
+        # refactor drops the nested entry, Claude Code's marketplace
+        # silently ships a stale plugin version and we never notice.
+        repo = pathlib.Path(vbc.__file__).resolve().parents[2]
+        cfg_path = repo / "tools/scripts/versioning.json"
+        cfg = json.loads(cfg_path.read_text())
+        plugin = cfg["surfaces"]["plugin"]
+        marketplace_entries = [vf for vf in plugin["version_files"]
+                               if vf["path"] == ".claude-plugin/marketplace.json"]
+        kinds = sorted({vf["kind"] for vf in marketplace_entries})
+        self.assertIn("json_field", kinds,
+                      "top-level .version on marketplace.json must be bumped")
+        self.assertIn("json_path", kinds,
+                      "plugins[0].version on marketplace.json must be bumped — "
+                      "it's what Claude Code marketplace reads")
+        nested = [vf for vf in marketplace_entries if vf["kind"] == "json_path"]
+        self.assertEqual(nested[0]["field"], "plugins.0.version")
+
+        # And the on-disk values had better match — or the marketplace
+        # is shipping the wrong version right now.
+        market = json.loads((repo / ".claude-plugin/marketplace.json").read_text())
+        self.assertEqual(
+            market["version"],
+            market["plugins"][0]["version"],
+            "marketplace.json top-level version and plugins[0].version drifted; "
+            "Claude Code installs from plugins[0].version.")
+
     def test_json_decode_and_unknown_version_kinds_are_tolerated(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             repo = pathlib.Path(td)

--- a/tools/scripts/version_bump_check.py
+++ b/tools/scripts/version_bump_check.py
@@ -284,6 +284,12 @@ def read_version(repo: Path, vf: VersionFile) -> str | None:
         except json.JSONDecodeError:
             return None
         return data.get(vf.field)
+    if vf.kind == "json_path":
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            return None
+        return _json_walk_get(data, vf.field or "")
     if vf.kind == "pyproject_version":
         m = re.search(r'^\s*version\s*=\s*"([^"]+)"', text, re.MULTILINE)
         return m.group(1) if m else None
@@ -294,6 +300,65 @@ def read_version(repo: Path, vf: VersionFile) -> str | None:
         m = re.search(vf.pattern, text)
         return m.group(1) if m else None
     return None
+
+
+def _json_walk_get(data, dotted_path: str):
+    # Walk `plugins.0.version`-style paths. Numeric segments index into
+    # arrays; string segments index into objects. Returns None on any
+    # miss rather than raising, so the gate stays advisory-style on
+    # shape drift.
+    if not dotted_path:
+        return None
+    cur = data
+    for seg in dotted_path.split("."):
+        if seg == "":
+            return None
+        if isinstance(cur, list):
+            try:
+                cur = cur[int(seg)]
+            except (ValueError, IndexError):
+                return None
+        elif isinstance(cur, dict):
+            if seg not in cur:
+                return None
+            cur = cur[seg]
+        else:
+            return None
+    return cur
+
+
+def _json_walk_set(data, dotted_path: str, value) -> bool:
+    # Mirror of _json_walk_get for write_version. Returns True iff the
+    # walk reached a settable leaf.
+    if not dotted_path:
+        return False
+    parts = dotted_path.split(".")
+    if any(p == "" for p in parts):
+        return False
+    cur = data
+    for seg in parts[:-1]:
+        if isinstance(cur, list):
+            try:
+                cur = cur[int(seg)]
+            except (ValueError, IndexError):
+                return False
+        elif isinstance(cur, dict):
+            if seg not in cur:
+                return False
+            cur = cur[seg]
+        else:
+            return False
+    last = parts[-1]
+    if isinstance(cur, list):
+        try:
+            cur[int(last)] = value
+        except (ValueError, IndexError):
+            return False
+        return True
+    if isinstance(cur, dict):
+        cur[last] = value
+        return True
+    return False
 
 
 def write_version(repo: Path, vf: VersionFile, new: str) -> bool:
@@ -313,6 +378,15 @@ def write_version(repo: Path, vf: VersionFile, new: str) -> bool:
             return False
         data[vf.field] = new
         # Preserve trailing newline if original had one.
+        end = "\n" if text.endswith("\n") else ""
+        new_text = json.dumps(data, indent=2) + end
+    elif vf.kind == "json_path":
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            return False
+        if not _json_walk_set(data, vf.field or "", new):
+            return False
         end = "\n" if text.endswith("\n") else ""
         new_text = json.dumps(data, indent=2) + end
     elif vf.kind == "pyproject_version":
@@ -579,6 +653,11 @@ def _extract_version_from_text(text: str, vf: VersionFile) -> str | None:
     if vf.kind == "json_field":
         try:
             return json.loads(text).get(vf.field)
+        except json.JSONDecodeError:
+            return None
+    if vf.kind == "json_path":
+        try:
+            return _json_walk_get(json.loads(text), vf.field or "")
         except json.JSONDecodeError:
             return None
     if vf.kind == "pyproject_version":

--- a/tools/scripts/versioning.json
+++ b/tools/scripts/versioning.json
@@ -42,7 +42,8 @@
       "label": "Claude Code plugin",
       "version_files": [
         { "path": ".claude-plugin/plugin.json", "kind": "json_field", "field": "version" },
-        { "path": ".claude-plugin/marketplace.json", "kind": "json_field", "field": "version" }
+        { "path": ".claude-plugin/marketplace.json", "kind": "json_field", "field": "version" },
+        { "path": ".claude-plugin/marketplace.json", "kind": "json_path",  "field": "plugins.0.version" }
       ],
       "trigger_paths": [
         ".claude-plugin/**",

--- a/tools/scripts/versioning.schema.json
+++ b/tools/scripts/versioning.schema.json
@@ -31,7 +31,7 @@
                 "path": { "type": "string" },
                 "kind": {
                   "type": "string",
-                  "enum": ["cmake_project_version", "json_field", "python_dunder_version", "pyproject_version", "regex"]
+                  "enum": ["cmake_project_version", "json_field", "json_path", "python_dunder_version", "pyproject_version", "regex"]
                 },
                 "field": { "type": "string" },
                 "pattern": { "type": "string" }
@@ -39,6 +39,10 @@
               "allOf": [
                 {
                   "if": { "properties": { "kind": { "const": "json_field" } } },
+                  "then": { "required": ["field"] }
+                },
+                {
+                  "if": { "properties": { "kind": { "const": "json_path" } } },
                   "then": { "required": ["field"] }
                 },
                 {


### PR DESCRIPTION
Two related plugin-distribution bugs that compounded into "users see
nothing useful from the Pulp Claude plugin":

== 1. marketplace.json plugins[0].version drift ==

Claude Code's marketplace reads `plugins[0].version` from
.claude-plugin/marketplace.json to decide what plugin version to
install. version_bump_check.py only knew how to bump the top-level
.version field, so plugins[0].version drifted and got stuck at
0.8.0 while plugin.json marched up to 0.34.0 over the last several
months. Every Claude Code user who installed Pulp from the
marketplace saw it as v0.8.0, missing every command/skill/hook
update we shipped since plugin-v0.9.0.

Fix:
  - Add a `json_path` kind to version_bump_check.py that walks
    dotted paths like `plugins.0.version`. Mirror of `json_field`
    for nested locations; arrays are indexed by stringified
    integer. Returns None / False on shape drift rather than
    raising, so the gate stays advisory-style.
  - Register a SECOND marketplace.json entry on the `plugin` surface
    in versioning.json with `json_path` field `plugins.0.version`.
    Future plugin bumps keep both fields in lockstep automatically;
    future restructures of marketplace.json that drop or rename
    plugins[0] fail loudly via the new test.
  - Bump plugin surface 0.34.0 → 0.35.0 across all three locations
    (plugin.json .version, marketplace.json .version, marketplace.json
    plugins[0].version) so the lockstep invariant holds on this PR.
  - Extend versioning.schema.json to accept "json_path" alongside
    the existing kinds.
  - Two regression tests:
      • test_json_path_kind_walks_nested_arrays_and_objects exercises
        read + write + missing-segment fallthrough.
      • test_marketplace_plugins_version_stays_in_sync_with_top_level
        asserts on-disk values match — future drift fails CI loudly
        rather than silently shipping the wrong version.

== 2. .mcp.json `${CLAUDE_PLUGIN_ROOT}` only set for marketplace path ==

The repo-root .mcp.json used `${CLAUDE_PLUGIN_ROOT}/tools/mcp/pulp-mcp-launcher`,
which works ONLY when Claude Code launches a marketplace-installed
plugin's MCP server. Project-local .mcp.json (loaded by Claude Code
from the working-directory project) gets an empty `${CLAUDE_PLUGIN_ROOT}`,
so the command resolves to literal `/tools/mcp/pulp-mcp-launcher`
→ "No such file" → exit 127 → Claude Code shows the server as
✘ failed.

The pulp-mcp launcher itself is fine — it uses $BASH_SOURCE to
self-locate, then probes either `<repo>/build/tools/mcp/pulp-mcp`
(source-tree build) or `pulp-mcp` on $PATH. The bug is just in the
.mcp.json's path expansion.

Fix: change the .mcp.json command to a project-relative path
(`./tools/mcp/pulp-mcp-launcher`). Claude Code launches MCP servers
with cwd = project root for project-local .mcp.json, so the relative
path works without depending on any Claude-set variable.

== Documentation ==

Added a new "MCP server" section to docs/guides/claude-code-plugin.md:
  - Lists the 18 tools pulp-mcp exposes (build/test, UI rendering,
    live plugin inspection, audio model / excerpt-find).
  - Documents the source-tree-build-required setup
    (`cmake --build build --target pulp-mcp`).
  - Documents the `${CLAUDE_PLUGIN_ROOT}` gotcha so future maintainers
    don't reintroduce the variable for the project-local path.

Out of scope (filed as follow-ups):
  - The 4 plugin-v* git tags (plugin-v0.32.0..0.34.0) have NO GitHub
    Releases. Doesn't break Claude Code's marketplace (it reads HEAD's
    marketplace.json) but indicates a missing plugin-tag-triggered
    release workflow.
  - PR #1988 has 2 unaddressed Codex P2 findings on already-merged
    code: codecov.yml top-level `ignore` removes files from ALL
    Codecov processing (not just patch comments); test_codecov_config.py
    only checks one direction of sync.

Skill-Update: skip skill=cli-maintenance reason="No CLI command surface change. The fix is internal to version_bump_check.py + versioning.json + .mcp.json + a docs/ addition; the cli-maintenance skill documents user-facing CLI commands only."