### PR TITLE
docs+plugin: TLDR install at top of README + agent-integrations doc + Setup hook for missing CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.35.0"
+  "version": "0.36.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/README.md
+++ b/README.md
@@ -1,10 +1,36 @@
 # Pulp
 
+[![SDK](https://img.shields.io/github/v/release/danielraffel/pulp?label=SDK%20%2F%20CLI)](https://github.com/danielraffel/pulp/releases)
+[![Claude plugin](https://img.shields.io/github/v/tag/danielraffel/pulp?filter=plugin-v*&label=Claude%20plugin)](https://github.com/danielraffel/pulp/tags)
 [![Coverage](https://codecov.io/gh/danielraffel/pulp/branch/main/graph/badge.svg)](https://app.codecov.io/gh/danielraffel/pulp)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE.md)
 
 A cross-platform audio plugin and application framework. MIT licensed, C++20 core, Swift on Apple, JS-scripted GPU UIs.
 
-> **What version is Pulp?** The SDK / CLI version is the `project(Pulp VERSION …)` number in `CMakeLists.txt`. The Claude Code plugin has its own version (`.claude-plugin/plugin.json`). Full explanation: [docs/reference/versioning.md](docs/reference/versioning.md).
+## Install
+
+```bash
+curl -fsSL https://www.generouscorp.com/pulp/install.sh | sh
+```
+
+Then:
+
+```bash
+pulp create my-plugin && cd my-plugin && pulp run
+```
+
+Three commands from zero to a working plugin in all formats.
+
+The CLI works great with any AI coding agent (Claude, Codex, Cursor). If you use **Claude Code**, you can additionally install the [Pulp plugin](docs/agent-integrations.md#claude-code-with-the-optional-plugin) for slash-command shortcuts (`/build`, `/test`, `/ship`) and a native MCP server:
+
+```bash
+claude plugin marketplace add danielraffel/pulp && claude plugin install pulp
+```
+
+See [docs/agent-integrations.md](docs/agent-integrations.md) for details on each agent path.
+
+<details>
+<summary><strong>What you get</strong> (click to expand)</summary>
 
 ## Features
 
@@ -74,27 +100,10 @@ A cross-platform audio plugin and application framework. MIT licensed, C++20 cor
 - JSFX — bounded subset support via QuickJS
 - Three.js bridge for 3D rendering in Dawn without a browser
 
-## Quick Start
+</details>
 
-**Install:**
-```bash
-curl -fsSL https://www.generouscorp.com/pulp/install.sh | sh
-```
-
-The public installer installs Pulp CLI artifacts only. It does not install
-Shipyard or GitHub CLI (`gh`); those are optional source-checkout contributor
-tools for PR/CI workflows.
-
-**Create and run your first plugin:**
-```bash
-pulp create my-plugin
-cd my-plugin
-pulp run
-```
-
-Three commands from zero to a working plugin in all formats.
-
-### From Source
+<details>
+<summary><strong>Build from source</strong> (contributors)</summary>
 
 ```bash
 git clone https://github.com/danielraffel/pulp.git
@@ -105,6 +114,8 @@ ctest --test-dir build --output-on-failure    # test
 ```
 
 **Prerequisites:** CMake 3.24+, C++20 compiler (Clang 15+, GCC 13+, MSVC 2022+), git-lfs.
+
+</details>
 
 ## Example
 
@@ -139,30 +150,19 @@ pulp_add_plugin(MyGain
 )
 ```
 
-## Claude Code Plugin
+## Agent integrations
 
-Pulp ships with a Claude Code plugin for the full development lifecycle.
+Pulp's CLI works with any AI coding agent. Skills (`.agents/skills/`) are auto-loaded by Claude Code and Codex; `AGENTS.md` redirects Codex to the same `CLAUDE.md` Claude reads. No agent-specific install is required to use the CLI.
 
-**Install:**
+**Claude Code users** can additionally install the Pulp plugin for slash-command shortcuts and a native MCP server:
+
 ```bash
-claude plugin marketplace add danielraffel/pulp
-claude plugin install pulp
+claude plugin marketplace add danielraffel/pulp && claude plugin install pulp
 ```
 
-The plugin also activates automatically when you open the Pulp repo in Claude Code.
+The plugin extends Claude Code with `/build`, `/test`, `/create`, `/design`, `/ship`, `/import-design`, `/version`, `/upgrade` plus an MCP server exposing build/test/inspect tools (highest value: the live-plugin inspector tools).
 
-Use slash commands directly in your Claude Code session:
-
-- `/build` — configure, build, and test
-- `/test` — run the test suite with filtering
-- `/create` — scaffold a new plugin project
-- `/design` — generate UI from a text prompt
-- `/ship` — sign, package, and notarize
-- `/import-design` — import from Figma, Stitch, or Pencil
-
-Available skills: `ci` (PR creation, local/cloud CI, merge workflow), `import-design` (design tool integration), `aax` (AAX format support), `engine` (audio engine internals), `webview-ui` (web-based UI targets).
-
-See [docs/guides/claude-code-plugin.md](docs/guides/claude-code-plugin.md) for setup.
+Full breakdown of which agent gets what: [docs/agent-integrations.md](docs/agent-integrations.md). Plugin-specific setup details: [docs/guides/claude-code-plugin.md](docs/guides/claude-code-plugin.md).
 
 ## Documentation
 

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -1,0 +1,79 @@
+# Agent integrations
+
+Pulp is designed to work with any AI coding agent. Nothing about the
+SDK or CLI assumes a specific agent. Editor integrations are additive.
+
+## Layers
+
+| Layer | What it is | Who needs it |
+|---|---|---|
+| **Pulp CLI + SDK** | The framework itself: `pulp` binary + libraries | **Everyone.** Universal foundation. |
+| **Skills** (`.agents/skills/`) | Markdown SKILL.md files that document subsystems | Auto-loaded by both Claude Code and Codex |
+| **Slash commands** (`.claude/commands/`) | Claude Code shortcuts like `/build`, `/ship` | Claude Code users only |
+| **MCP server** (`tools/mcp/pulp-mcp`) | Native tools (build/test/inspect) for MCP-aware agents | Currently Claude Code; extensible |
+
+## What each agent gets out of the box
+
+### Bare CLI (no agent, or any agent)
+
+```bash
+curl -fsSL https://www.generouscorp.com/pulp/install.sh | sh
+pulp create my-plugin && cd my-plugin && pulp run
+```
+
+Everything works — `pulp build`, `pulp test`, `pulp ship`, the lot.
+Type-completion and AI assistance are whatever your editor provides.
+
+### Codex
+
+Codex automatically reads `AGENTS.md` (which redirects to `CLAUDE.md`)
+and discovers `.agents/skills/` for subsystem-specific guidance —
+audio formats, view system, CI flow, hosting other plugins. Same
+skills the Claude Code plugin exposes; no separate install.
+
+```bash
+# Same install as bare CLI — Codex picks up the skills automatically
+curl -fsSL https://www.generouscorp.com/pulp/install.sh | sh
+```
+
+### Claude Code (with the optional plugin)
+
+Install Pulp CLI first (above), then add the plugin for slash-command
+shortcuts and the native MCP server:
+
+```bash
+claude plugin marketplace add danielraffel/pulp
+claude plugin install pulp
+```
+
+The plugin extends Claude Code with:
+
+- **Slash commands**: `/build`, `/test`, `/create`, `/design`, `/ship`,
+  `/import-design`, `/version`, `/upgrade` — convenience wrappers over
+  the CLI.
+- **MCP server**: Claude can call build/test/inspect tools as MCP
+  tool calls instead of shell-and-parse. Highest value for the
+  inspector tools (`pulp_inspect_dom`, `pulp_inspect_evaluate`,
+  etc.) which wrap the running-plugin inspector socket protocol.
+- **Setup hook**: when a Claude Code session starts in a project that
+  has the plugin installed but `pulp` is not on PATH, prints a
+  one-time install banner. Informational, never blocks the session.
+
+If `pulp` is missing when a slash command is invoked, the command
+itself also prints the install command before failing. Pulp CLI is
+always the dependency the plugin sits on top of.
+
+## Why the split
+
+The Claude plugin is a **convenience layer**, not the primary install.
+Splitting it from the CLI:
+
+- Means Codex / Cursor / bare-editor users aren't blocked on a
+  Claude-specific install.
+- Lets the CLI ship updates on its own cadence (`pulp upgrade`)
+  independent of the plugin's release cycle (`plugin-vX.Y.Z` tags).
+- Keeps the marketplace listing honest — the plugin is what it says
+  it is (commands + skills + MCP), not a CLI installer in disguise.
+
+If you have feedback on integrations for an agent we haven't covered
+yet, open an issue with the `agent-integration` label.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "Setup": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-pulp-cli.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/hooks/scripts/check-pulp-cli.sh
+++ b/hooks/scripts/check-pulp-cli.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# check-pulp-cli.sh — Setup-hook script wired in hooks/hooks.json.
+#
+# Fires once per Claude Code session. Verifies the Pulp CLI is reachable
+# and prints a friendly install banner if not. Always exits 0 — this
+# hook is informational, never blocking. Most plugin slash commands
+# (/build, /test, /create, /design, /ship, ...) shell out to `pulp`,
+# so without this hook the user sees a confusing "command not found"
+# the first time they invoke any command. With it they see the install
+# command up-front.
+#
+# Output goes to stderr because Claude Code surfaces hook stderr in
+# the session UI without treating it as a tool failure.
+
+set -e
+
+# Three states this hook handles:
+#
+#   1. `pulp` on PATH       → silent success (most common case after
+#                              the user has run the curl|sh installer)
+#   2. `pulp` not on PATH,
+#       but a local source-tree build exists at ./build/pulp or
+#       ./build/tools/cli/pulp-cpp → the user is a Pulp contributor
+#                              working from a checkout. Tell them to
+#                              symlink; do NOT push them at the install
+#                              script (which would clobber their build).
+#   3. nothing at all       → print the curl|sh install command.
+#
+# All three exit 0. Detecting state happens once, no network calls,
+# no recursion into pulp itself.
+
+# Allow tests to override the cwd / candidate paths via env so we can
+# run cases 2 + 3 deterministically without polluting the user's repo.
+PULP_CHECK_CWD="${PULP_CHECK_CWD:-$PWD}"
+
+# Case 1: pulp already on PATH.
+if command -v pulp >/dev/null 2>&1; then
+    exit 0
+fi
+
+# Case 2: source-tree contributor.
+SOURCE_BUILD_RUST="$PULP_CHECK_CWD/build/pulp"
+SOURCE_BUILD_CPP="$PULP_CHECK_CWD/build/tools/cli/pulp-cpp"
+SOURCE_BUILD=""
+if [ -x "$SOURCE_BUILD_RUST" ]; then
+    SOURCE_BUILD="$SOURCE_BUILD_RUST"
+elif [ -x "$SOURCE_BUILD_CPP" ]; then
+    SOURCE_BUILD="$SOURCE_BUILD_CPP"
+fi
+
+if [ -n "$SOURCE_BUILD" ]; then
+    cat >&2 <<EOF
+[pulp plugin] \`pulp\` is not on PATH, but a source-tree build exists at:
+    $SOURCE_BUILD
+
+Symlink it once and the plugin's slash commands (/build, /test, ...)
+will work everywhere:
+
+    sudo ln -s "$SOURCE_BUILD" /usr/local/bin/pulp
+
+Or — if you'd rather use the installed binary that auto-updates:
+
+    curl -fsSL https://www.generouscorp.com/pulp/install.sh | sh
+EOF
+    exit 0
+fi
+
+# Case 3: pulp not installed at all.
+cat >&2 <<EOF
+[pulp plugin] \`pulp\` CLI is not installed. The plugin's slash commands
+(/build, /test, /create, /design, /ship, /version, /upgrade) shell out
+to it, so they will fail until you install it.
+
+One-line install (macOS / Linux):
+
+    curl -fsSL https://www.generouscorp.com/pulp/install.sh | sh
+
+Then restart this Claude Code session.
+EOF
+exit 0

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,6 +97,17 @@ if(UNIX)
     set_tests_properties(pulp-mcp-launcher PROPERTIES TIMEOUT 15)
 endif()
 
+# Setup-hook unit test — verifies hooks/scripts/check-pulp-cli.sh
+# handles the three "is pulp available" states (on PATH / source-tree
+# build / nothing) plus three invariants (always exits 0, banner goes
+# to stderr, stale non-executable build/pulp doesn't false-positive).
+# Hermetic (stages a tempdir layout per case), no real binary required.
+if(UNIX)
+    add_test(NAME check-pulp-cli-hook
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_check_pulp_cli_hook.sh)
+    set_tests_properties(check-pulp-cli-hook PROPERTIES TIMEOUT 15)
+endif()
+
 # Window-only capture invariants (pulp-internal task #81) —
 # spectr-roundtrip.sh must not silently fall back to full-screen
 # screencapture, because terminal / desktop background then poisons

--- a/test/test_check_pulp_cli_hook.sh
+++ b/test/test_check_pulp_cli_hook.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Unit test for hooks/scripts/check-pulp-cli.sh.
+#
+# Mirrors test/test_pulp_mcp_launcher.sh's case-driven shell-test
+# pattern. We scrub PATH per case and stand up a temp PULP_CHECK_CWD
+# pointing at a synthetic build tree, so the hook script's three
+# states (pulp on PATH / source-tree-only / nothing) are exercised
+# deterministically without depending on what the developer has
+# installed on their machine.
+#
+# Usage:
+#   bash test/test_check_pulp_cli_hook.sh
+#
+# CTest registration in test/CMakeLists.txt mirrors the launcher
+# test wiring (~line 90). The hook is informational only — it must
+# always exit 0, so a failure in any case here means we'd start
+# blocking Claude Code session init, which would be a real
+# regression.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$SCRIPT_DIR/hooks/scripts/check-pulp-cli.sh"
+
+if [ ! -x "$HOOK" ]; then
+    echo "FAIL: hook missing or not executable: $HOOK"
+    exit 1
+fi
+
+# Shared per-case scaffold. Each case gets a fresh tempdir; PATH is
+# scrubbed to /usr/bin:/bin so a globally-installed pulp can't pollute
+# results. PULP_CHECK_CWD points the hook at the per-case fake build
+# tree so cases 2 + 3 are independent.
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "ok: $*"; }
+
+# ── Case 1: `pulp` is on PATH → silent exit 0 ───────────────────────────────
+case1=$(mktemp -d)
+mkdir -p "$case1/bin"
+cat > "$case1/bin/pulp" <<'EOF'
+#!/usr/bin/env bash
+echo "stub pulp"
+EOF
+chmod +x "$case1/bin/pulp"
+
+# Empty PULP_CHECK_CWD so source-tree branch can't fire even by accident.
+out=$(PATH="$case1/bin:/usr/bin:/bin" PULP_CHECK_CWD="$case1/empty-cwd" "$HOOK" 2>&1)
+status=$?
+if [ "$status" -ne 0 ]; then
+    fail "case1: hook exited $status (expected 0)"
+fi
+if [ -n "$out" ]; then
+    fail "case1: pulp on PATH should produce no output, got: $out"
+fi
+pass "case1: pulp on PATH → silent success"
+rm -rf "$case1"
+
+# ── Case 2: pulp NOT on PATH but source build exists → contributor message ──
+case2=$(mktemp -d)
+mkdir -p "$case2/build"
+cat > "$case2/build/pulp" <<'EOF'
+#!/usr/bin/env bash
+echo "fake source-tree pulp"
+EOF
+chmod +x "$case2/build/pulp"
+
+out=$(PATH="/usr/bin:/bin" PULP_CHECK_CWD="$case2" "$HOOK" 2>&1)
+status=$?
+if [ "$status" -ne 0 ]; then
+    fail "case2: hook exited $status (expected 0)"
+fi
+if ! grep -q "source-tree build" <<<"$out"; then
+    fail "case2: missing 'source-tree build' phrase in output: $out"
+fi
+if ! grep -q "ln -s" <<<"$out"; then
+    fail "case2: missing 'ln -s' suggestion in output"
+fi
+if ! grep -q "$case2/build/pulp" <<<"$out"; then
+    fail "case2: output should reference the actual found binary path"
+fi
+pass "case2: source-tree build → contributor symlink message"
+rm -rf "$case2"
+
+# ── Case 2b: source build is pulp-cpp (Rust binary missing) → still works ───
+case2b=$(mktemp -d)
+mkdir -p "$case2b/build/tools/cli"
+cat > "$case2b/build/tools/cli/pulp-cpp" <<'EOF'
+#!/usr/bin/env bash
+echo "fake pulp-cpp"
+EOF
+chmod +x "$case2b/build/tools/cli/pulp-cpp"
+
+out=$(PATH="/usr/bin:/bin" PULP_CHECK_CWD="$case2b" "$HOOK" 2>&1)
+status=$?
+if [ "$status" -ne 0 ]; then
+    fail "case2b: hook exited $status (expected 0)"
+fi
+if ! grep -q "$case2b/build/tools/cli/pulp-cpp" <<<"$out"; then
+    fail "case2b: should fall back to pulp-cpp when build/pulp is absent"
+fi
+pass "case2b: pulp-cpp fallback → contributor symlink message"
+rm -rf "$case2b"
+
+# ── Case 3: nothing → install banner ────────────────────────────────────────
+case3=$(mktemp -d)  # empty cwd — no build/, no bin/
+
+out=$(PATH="/usr/bin:/bin" PULP_CHECK_CWD="$case3" "$HOOK" 2>&1)
+status=$?
+if [ "$status" -ne 0 ]; then
+    fail "case3: hook exited $status (expected 0)"
+fi
+if ! grep -q "curl -fsSL" <<<"$out"; then
+    fail "case3: missing curl install command in output: $out"
+fi
+if ! grep -q "generouscorp.com/pulp/install.sh" <<<"$out"; then
+    fail "case3: missing install URL in output"
+fi
+if grep -q "source-tree build" <<<"$out"; then
+    fail "case3: should not show source-tree message when no build/ exists"
+fi
+pass "case3: nothing installed → install banner"
+rm -rf "$case3"
+
+# ── Case 4: invariant — exit code is ALWAYS 0 even on broken cwd ─────────────
+# A non-existent PULP_CHECK_CWD should not crash the hook (hooks must
+# never block Claude session init).
+out=$(PATH="/usr/bin:/bin" PULP_CHECK_CWD="/nonexistent/path/$(date +%s)" "$HOOK" 2>&1) || true
+status=$?
+if [ "$status" -ne 0 ]; then
+    fail "case4: hook exited $status with bad PULP_CHECK_CWD; must always be 0"
+fi
+pass "case4: bad PULP_CHECK_CWD → still exits 0"
+
+# ── Case 5: source-build path that is NOT executable → fall through to case 3 ──
+# A `build/pulp` that exists but lacks +x means the user has stale build
+# artifacts; treating it as a usable binary would be a lie.
+case5=$(mktemp -d)
+mkdir -p "$case5/build"
+echo "not executable" > "$case5/build/pulp"
+chmod -x "$case5/build/pulp"
+
+out=$(PATH="/usr/bin:/bin" PULP_CHECK_CWD="$case5" "$HOOK" 2>&1)
+status=$?
+if [ "$status" -ne 0 ]; then
+    fail "case5: hook exited $status (expected 0)"
+fi
+if grep -q "source-tree build" <<<"$out"; then
+    fail "case5: non-executable build/pulp should NOT trigger contributor branch"
+fi
+if ! grep -q "curl -fsSL" <<<"$out"; then
+    fail "case5: non-executable build/pulp should fall through to install banner"
+fi
+pass "case5: non-executable source build → install banner (no false-positive)"
+rm -rf "$case5"
+
+# ── Case 6: STDOUT vs STDERR — banner must go to stderr ─────────────────────
+# Claude Code surfaces hook STDERR in the session UI without treating it
+# as a tool failure. Sending banner to stdout would either be silenced
+# or misclassified.
+case6=$(mktemp -d)
+stdout_file=$(mktemp)
+stderr_file=$(mktemp)
+
+PATH="/usr/bin:/bin" PULP_CHECK_CWD="$case6" "$HOOK" >"$stdout_file" 2>"$stderr_file"
+if [ -s "$stdout_file" ]; then
+    fail "case6: banner should not appear on stdout (got: $(cat "$stdout_file"))"
+fi
+if [ ! -s "$stderr_file" ]; then
+    fail "case6: banner should appear on stderr (was empty)"
+fi
+if ! grep -q "curl -fsSL" "$stderr_file"; then
+    fail "case6: stderr should contain install banner"
+fi
+pass "case6: install banner on stderr (correct stream for Claude UI)"
+rm -rf "$case6" "$stdout_file" "$stderr_file"
+
+echo ""
+echo "All 7 cases passed."

--- a/test/test_check_pulp_cli_hook.sh
+++ b/test/test_check_pulp_cli_hook.sh
@@ -124,8 +124,14 @@ rm -rf "$case3"
 # ── Case 4: invariant — exit code is ALWAYS 0 even on broken cwd ─────────────
 # A non-existent PULP_CHECK_CWD should not crash the hook (hooks must
 # never block Claude session init).
-out=$(PATH="/usr/bin:/bin" PULP_CHECK_CWD="/nonexistent/path/$(date +%s)" "$HOOK" 2>&1) || true
-status=$?
+#
+# pulp #2000 Codex P2 — capture the hook's exit code into `status`
+# directly via `|| status=$?`, NOT via `out=$(...) || true; status=$?`.
+# The latter pattern always reports 0 because `true` is what `$?` sees,
+# so a regression where the hook started returning non-zero would slip
+# through the gate undetected.
+status=0
+PATH="/usr/bin:/bin" PULP_CHECK_CWD="/nonexistent/path/$(date +%s)" "$HOOK" >/dev/null 2>&1 || status=$?
 if [ "$status" -ne 0 ]; then
     fail "case4: hook exited $status with bad PULP_CHECK_CWD; must always be 0"
 fi


### PR DESCRIPTION
Three threads, one PR — they're all the same "make it obvious how to
install Pulp and what the editor integrations actually do" problem.

== 1. README rewrite ==

The previous top-of-README led with a "What version is Pulp?" prose
block explaining how versioning works (a *concept*, not a value
users want to see). The actual install command was buried under a
~70-line Features section that pushed it below the fold.

Replaced with:
  - Dynamic shields.io badges for SDK/CLI version and Claude plugin
    version (auto-update from GitHub releases + tags — never go
    stale, click through to the release page).
  - One-line install prominently right under the title.
  - The three-command "create your first plugin" right after.
  - A succinct one-paragraph "works with any agent; Claude users
    can also install the plugin" line + link to the new
    agent-integrations doc.
  - Features section collapsed into <details> so it's still
    discoverable but doesn't dominate the front page.
  - Build-from-source moved into <details> as a contributor
    convenience (was previously a top-level Quick Start block).
  - "Claude Code Plugin" section renamed and reframed as part
    of the broader "agent integrations" story; reflects the
    actual layering (CLI is universal, skills work for Claude +
    Codex, slash commands + MCP are Claude conveniences).

== 2. docs/agent-integrations.md (new) ==

Single screen explaining the four layers (CLI / skills / slash
commands / MCP) and which agent gets what. Codex users see the
table and immediately understand they don't need the Claude
plugin — their skills come for free via AGENTS.md → CLAUDE.md.

== 3. Setup hook for missing-CLI banner ==

Slash commands like /build, /test, /create, /design, /ship all
shell out to `pulp`. If `pulp` isn't on PATH, the user sees a
confusing "command not found" inside the slash command instead
of an actionable install hint up-front.

New hook:
  - hooks/scripts/check-pulp-cli.sh — fires once per session via
    the new Setup lifecycle event in hooks/hooks.json. Three
    states: pulp on PATH (silent success), source-tree build
    found (suggest symlinking the local build, do NOT push the
    installer at a contributor), or nothing installed (print
    the curl|sh install command). Always exits 0 — informational,
    never blocks session init. Banner goes to stderr (Claude Code
    surfaces stderr without treating it as a tool failure).

  - test/test_check_pulp_cli_hook.sh — 7 hermetic shell-test
    cases mirroring test/test_pulp_mcp_launcher.sh's pattern.
    Per-case tempdir + scrubbed PATH so global pulp installs
    can't pollute results. Exercises:
      • case 1: pulp on PATH → silent exit 0, no output
      • case 2: source-tree build/pulp → contributor symlink message
      • case 2b: pulp-cpp fallback when build/pulp missing
      • case 3: nothing installed → install banner
      • case 4: invariant — non-existent PULP_CHECK_CWD still exits 0
      • case 5: non-executable build/pulp → falls through to install
        banner (no false-positive on stale build artifacts)
      • case 6: banner on stderr, not stdout (correct stream
        for Claude UI surfacing)

  - test/CMakeLists.txt — register the hook test under CTest
    next to the existing pulp-mcp-launcher test, identical
    UNIX-only guard + 15s timeout pattern.

The Setup hook covers Claude Code session init. The existing
per-command checks in /upgrade and /version stay as
belt-and-suspenders for users who skip the session-init banner.