### PR TITLE
test(cli+import): cover #1984 helpers (looks_like_bundler_entry, delegate)

### DIFF
--- a/test/test_cli_import_design.cpp
+++ b/test/test_cli_import_design.cpp
@@ -318,6 +318,61 @@ TEST_CASE("looks_like_bundler_entry on empty / pathological input",
     REQUIRE_FALSE(looks_like_bundler_entry("<!doctype html><html></html>"));
 }
 
+// Coverage for the OR-arms of the heuristic that the original four
+// tests don't separately exercise: Vue / Svelte mount points
+// (id="app"), the data-reactroot dev-mode marker, and ES-module inline
+// imports (the `import('./...')` flavour). These keep the heuristic
+// honest if any single needle is removed.
+TEST_CASE("looks_like_bundler_entry matches Vue/Svelte id=\"app\" + script", "[cli][import-design][friction-3]") {
+    const std::string html = R"HTML(
+        <html><body><div id="app"></div>
+        <script type="module" src="./entry.mjs"></script></body></html>
+    )HTML";
+    REQUIRE(looks_like_bundler_entry(html));
+}
+
+TEST_CASE("looks_like_bundler_entry matches data-reactroot SSR marker", "[cli][import-design][friction-3]") {
+    // Server-rendered React markup carries data-reactroot; no explicit
+    // mount placeholder needed for the heuristic to fire.
+    const std::string html = R"HTML(
+        <html><body><div data-reactroot=""><h1>Hi</h1></div></body></html>
+    )HTML";
+    REQUIRE(looks_like_bundler_entry(html));
+}
+
+TEST_CASE("looks_like_bundler_entry matches inline ES-module dynamic import",
+          "[cli][import-design][friction-3]") {
+    // Some bundler shells (esbuild + Bun in particular) inline a tiny
+    // `import('./bundle.js')` instead of a <script src=...>. Both single-
+    // and double-quoted forms are accepted.
+    const std::string html_dq = R"HTML(
+        <html><body><div id="root"></div>
+        <script type="module">import("./bundle.js");</script></body></html>
+    )HTML";
+    REQUIRE(looks_like_bundler_entry(html_dq));
+
+    const std::string html_sq = R"HTML(
+        <html><body><div id='root'></div>
+        <script type="module">import('./bundle.js');</script></body></html>
+    )HTML";
+    REQUIRE(looks_like_bundler_entry(html_sq));
+}
+
+// The heuristic explicitly does not fire on hand-authored Claude
+// Design pages even when they contain <script> tags — those pages
+// always lack a known mount-point id.
+TEST_CASE("looks_like_bundler_entry skips inline-script pages with no mount root",
+          "[cli][import-design][friction-3]") {
+    const std::string html = R"HTML(
+        <html><body>
+          <h1>Sliders</h1>
+          <p>Hand-authored — no mount root.</p>
+          <script>console.log('inline analytics');</script>
+        </body></html>
+    )HTML";
+    REQUIRE_FALSE(looks_like_bundler_entry(html));
+}
+
 TEST_CASE("pulp import-design --from claude emits native-react hint on bundler entry",
           "[cli][import-design][friction-3][shellout]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }

--- a/test/test_cli_project_command.cpp
+++ b/test/test_cli_project_command.cpp
@@ -928,6 +928,120 @@ TEST_CASE("cli common delegates fail cleanly before shelling out",
         // the delegate began resolving from argv[0] before the project
         // root. Match against the stable "helper not found" prefix.
         REQUIRE(capture.err.str().find("helper not found") != std::string::npos);
+        // The PR also added a "Looked in:" listing so users can see
+        // every candidate path that was probed before the failure.
+        REQUIRE(capture.err.str().find("Looked in:") != std::string::npos);
+        // And a "cmake --build" hint pointing at the missing target.
+        REQUIRE(capture.err.str().find("cmake --build build --target missing-tool")
+                != std::string::npos);
+    }
+}
+
+// pulp #-friction-1+#-friction-2 — delegate_to_build_binary must succeed
+// outside a Pulp project (e.g. when the installed `pulp` CLI is invoked
+// from /tmp or a user's project dir). Before #1984 the delegate hard-
+// failed with "not in a Pulp project directory"; after #1984 the lookup
+// resolves from argv[0] + $PULP_BUILD_DIR and only falls back to
+// project-root paths when one exists.
+TEST_CASE("delegate_to_build_binary tolerates running outside a Pulp project",
+          "[cli][common][issue-1984]") {
+    TempDir tmp;  // tmp.path is NOT inside any Pulp checkout
+
+    {
+        ScopedCwd cwd(tmp.path);
+        // Clear PULP_BUILD_DIR so the test sees the no-build-dir-hint
+        // branch of the error message.
+        ScopedEnv build_dir("PULP_BUILD_DIR", "");
+        CapturedStreams capture;
+        REQUIRE(delegate_to_build_binary("tools/missing-tool", {"--flag"}, "") == 1);
+        const auto err = capture.err.str();
+        // The standard helper-not-found prefix still fires.
+        REQUIRE(err.find("helper not found") != std::string::npos);
+        // And the no-project-dir hint kicks in (this is the new branch
+        // added in #1984 — calling out that PULP_BUILD_DIR is the user's
+        // escape hatch when they're not in a checkout).
+        REQUIRE(err.find("cwd is not inside a Pulp project") != std::string::npos);
+        REQUIRE(err.find("PULP_BUILD_DIR") != std::string::npos);
+    }
+}
+
+// pulp #-friction-1+#-friction-2 — $PULP_BUILD_DIR with an absolute path
+// must add the binary at <build>/<relative> to the candidate list, even
+// when the user is outside a Pulp project. Verified by reading back the
+// "Looked in:" listing from the error message: a precise candidate path
+// shows up before the lookup fails (no binary actually exists).
+TEST_CASE("delegate_to_build_binary honors PULP_BUILD_DIR when run outside a project",
+          "[cli][common][issue-1984]") {
+    TempDir tmp;
+    auto build_dir = tmp.path / "custom-build";
+    fs::create_directories(build_dir);
+
+    {
+        ScopedCwd cwd(tmp.path);
+        ScopedEnv build_env("PULP_BUILD_DIR", build_dir.string());
+        CapturedStreams capture;
+        REQUIRE(delegate_to_build_binary("tools/missing-tool", {}, "") == 1);
+        const auto err = capture.err.str();
+        REQUIRE(err.find("helper not found") != std::string::npos);
+        // The absolute-path PULP_BUILD_DIR candidate shows up verbatim
+        // in the "Looked in:" listing.
+        const auto expected_candidate = (build_dir / "tools" / "missing-tool").string();
+        INFO("stderr: " << err);
+        REQUIRE(err.find(expected_candidate) != std::string::npos);
+    }
+}
+
+// pulp #-friction-1+#-friction-2 — $PULP_BUILD_DIR with a RELATIVE path
+// is meaningful only when a project root exists (relative joins against
+// the project root). Outside a project, the relative path is silently
+// dropped so we don't accumulate ambiguous candidates like
+// "relative-build/tools/foo" without a stable root.
+TEST_CASE("delegate_to_build_binary drops relative PULP_BUILD_DIR outside a project",
+          "[cli][common][issue-1984]") {
+    TempDir tmp;
+
+    {
+        ScopedCwd cwd(tmp.path);
+        ScopedEnv build_env("PULP_BUILD_DIR", "relative-build");
+        CapturedStreams capture;
+        REQUIRE(delegate_to_build_binary("tools/missing-tool", {}, "") == 1);
+        const auto err = capture.err.str();
+        REQUIRE(err.find("helper not found") != std::string::npos);
+        // The relative path is not anchored — must NOT appear in the
+        // candidate listing. Looking for "relative-build" is enough; if
+        // the code ever starts CWD-anchoring relative paths, this test
+        // tightens the contract.
+        INFO("stderr: " << err);
+        REQUIRE(err.find("relative-build") == std::string::npos);
+    }
+}
+
+// pulp #-friction-1+#-friction-2 — when both a project root AND
+// $PULP_BUILD_DIR (relative) are present, the relative build dir joins
+// against the project root rather than the cwd. Verified by reading the
+// candidate path back from "Looked in:".
+TEST_CASE("delegate_to_build_binary resolves relative PULP_BUILD_DIR against project root",
+          "[cli][common][issue-1984]") {
+    TempDir tmp;
+    auto repo = tmp.path / "repo";
+    fs::create_directories(repo / "core");
+    write_file(repo / "CMakeLists.txt", "cmake_minimum_required(VERSION 3.20)\n");
+
+    {
+        ScopedCwd cwd(repo);
+        ScopedEnv build_env("PULP_BUILD_DIR", "build-custom");
+        CapturedStreams capture;
+        REQUIRE(delegate_to_build_binary("tools/missing-tool", {}, "") == 1);
+        const auto err = capture.err.str();
+        REQUIRE(err.find("helper not found") != std::string::npos);
+        // The relative PULP_BUILD_DIR is rooted at the discovered
+        // project, so the candidate path must reflect the repo root.
+        const auto expected = (repo / "build-custom" / "tools" / "missing-tool").string();
+        INFO("stderr: " << err);
+        REQUIRE(err.find(expected) != std::string::npos);
+        // And the no-project-dir hint is NOT printed (because we found
+        // a project).
+        REQUIRE(err.find("cwd is not inside a Pulp project") == std::string::npos);
     }
 }
 


### PR DESCRIPTION
## Summary

Lifts coverage on the easily-testable additions from PR #1984 that landed without dedicated tests for every branch. Branches off `feature/window-design-viewport-fit` so the coverage bump lands inside that PR's diff and the codecov/patch number rises before #1984 merges.

- `delegate_to_build_binary` — 4 new tests for the argv[0]-relative + project-root-tolerant rewrite (#-friction-1, #-friction-2):
  - Outside-project case prints the cwd-not-in-project hint + PULP_BUILD_DIR escape-hatch line.
  - Absolute `PULP_BUILD_DIR` shows up in the "Looked in:" listing even with no project root.
  - Relative `PULP_BUILD_DIR` is dropped (not anchored to cwd) when no project root exists.
  - Relative `PULP_BUILD_DIR` joins against the project root when one is found.
- `looks_like_bundler_entry` — 4 edge cases the original 4 tests didn't separately exercise:
  - `id="app"` (Vue/Svelte) + script entry.
  - `data-reactroot` SSR marker (no mount needed).
  - Inline ES-module `import("./...")` / `import('./...')` (double- and single-quoted).
  - Hand-authored page with inline `<script>` but no mount root that must NOT match.

Test-only change — no source files touched, no skill or version bump needed.

## Test plan

- [x] `pulp-test-cli-project-command [issue-1984]` — 16 assertions in 4 cases pass
- [x] `pulp-test-cli-import-design [friction-3]` — 11 assertions in 9 cases pass
- [x] Full `pulp-test-cli-project-command` regression — 540 assertions in 39 cases pass
- [x] Full `pulp-test-cli-import-design ~[shellout]` — 33 assertions in 15 cases pass
- [ ] Codecov report shows uplift on `tools/cli/cli_common.cpp` (the `delegate_to_build_binary` block) once the PR runs

## Followups

- Issue #2001 tracks the structural gap for `core/view/platform/mac/window_host_mac.mm` (the 91-line Obj-C++ section that genuinely can't be unit-tested without an NSWindow + CAMetalLayer headless harness). Phase B of this fast-follow is a separate PR.

Related: #1984, #2001

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>