### PR TITLE
fix(deps): pin Highway to 1.2.0 release SHA to stop FetchContent flake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,13 @@ set(PULP_HAS_YOGA TRUE)
 message(STATUS "Pulp: Yoga layout engine enabled")
 
 # Google Highway (Apache 2.0) — portable SIMD abstraction (SSE/NEON/AVX)
+# Pinned to the exact SHA of the 1.2.0 release (verified via
+# `git ls-remote https://github.com/google/highway.git refs/tags/1.2.0`).
+# Pinning the SHA instead of the tag avoids intermittent
+# `fatal: invalid reference: 1.2.0` failures when GIT_SHALLOW combines
+# with tag-name resolution under load (Pulp #1930). SHA pins are also
+# more cache-friendly: FetchContent's UPDATE_DISCONNECTED check sees a
+# stable ref and skips the re-fetch on every reconfigure.
 set(HWY_ENABLE_EXAMPLES OFF CACHE BOOL "" FORCE)
 set(HWY_ENABLE_TESTS OFF CACHE BOOL "" FORCE)
 set(HWY_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
@@ -415,8 +422,8 @@ pulp_register_fetchcontent_source(highway REF 1.2.0)
 FetchContent_Declare(
     highway
     GIT_REPOSITORY https://github.com/google/highway.git
-    GIT_TAG 1.2.0
-    GIT_SHALLOW TRUE
+    # 1.2.0 release commit
+    GIT_TAG 457c891775a7397bdb0376bb1031e6e027af1c48
 )
 FetchContent_MakeAvailable(highway)
 set(PULP_HAS_HIGHWAY TRUE)

--- a/tools/deps/manifest.json
+++ b/tools/deps/manifest.json
@@ -152,6 +152,7 @@
       "upstream": { "kind": "git-tag", "ref": "1.2.0" },
       "documented_in_dependencies_md": true,
       "documented_in_notice_md": true,
+      "notes": "CMake pins the exact 1.2.0 release SHA (457c891775a7397bdb0376bb1031e6e027af1c48) instead of the tag name to avoid intermittent `fatal: invalid reference: 1.2.0` shallow-clone failures hit by tools/scripts/local_diff_cover.sh (Pulp #1930). Upstream drift is still tracked against the 1.2.0 tag.",
       "source_files": [
         "CMakeLists.txt",
         "core/runtime/CMakeLists.txt",


### PR DESCRIPTION
`tools/scripts/local_diff_cover.sh` (and `shipyard pr` when it runs the
diff-cover gate) intermittently fails its fresh-build cmake configure with:

    fatal: invalid reference: 1.2.0
    CMake Error: ... FetchContent_Populate(highway) ...

The tag exists upstream (`457c891775a7397bdb0376bb1031e6e027af1c48`), so
this is a transient resolution failure: `GIT_SHALLOW TRUE` combined with
tag-name lookup races under load on github's smart-http negotiation.
Re-running cmake usually succeeds, which is why it hadn't been root-caused.

Pin the exact 1.2.0 release commit instead. SHA pins are deterministic
(no negotiation step) and more cache-friendly — FetchContent's
UPDATE_DISCONNECTED check sees a stable ref and short-circuits the
re-fetch on every reconfigure. Drop `GIT_SHALLOW TRUE` since it isn't
guaranteed for SHA fetches; the resulting clone is still small.

Upstream-drift tracking continues to use `kind: git-tag, ref: 1.2.0` in
the manifest so `tools/deps/audit.py --check-upstream` keeps surfacing
new Highway releases.

Closes the Highway portion of #1930.

Version-Bump: skip reason="tooling-only fix to FetchContent pin; no SDK/CLI/plugin surface change"
Skill-Update: skip skill=packages reason="manifest entry for an existing dep had a notes field added; no new dep added/removed and no install/audit workflow change"