### PR TITLE
fix(view/auto_ui): centered wrapping grid layout (closes #97)

### DIFF
--- a/core/view/src/auto_ui.cpp
+++ b/core/view/src/auto_ui.cpp
@@ -4,30 +4,96 @@
 
 namespace pulp::view {
 
+// pulp #97 — make AutoUi look intentional at any param count.
+//
+// AutoUi is the default editor for Processors that don't supply a
+// custom create_view() (and aren't using a scripted UI). That's the
+// majority of in-tree examples and the natural starting point for
+// `pulp create my-plugin`. Previously, the layout was a single
+// `flex-start`-aligned non-wrapping row, so a 4-knob plugin in the
+// stock 400x300 editor window rendered the cluster in the top-left
+// with ~70% of the window empty — looked like a layout bug.
+//
+// New layout (Codex-consult on 2026-05-14):
+//
+//   root: column, padding 14, gap 12
+//   ├── title: "Parameters" 16pt
+//   └── body: column, flex_grow=1, justify=center, align_items=center
+//        └── grid: row, flex_wrap=wrap, justify=center, align_items=center,
+//                  align_content=center, max_width=760
+//             └── tile per param (column, fixed 82x96, no shrink)
+//                  └── Knob 64x64  OR  Toggle 54x30
+//
+// Properties of the new shape:
+//   - 1 param → centered single tile
+//   - 4 params → centered cluster, 4 across in a stock 400x300 window
+//   - 16 params → wraps to multiple rows, still centered
+//   - 32+ params → wraps but exceeds visible area in stock window;
+//                  proper fix is scroll/paging via a future SDK
+//                  capability, NOT a static-layout trick
+//
+// Caveat: editor_size() is intentionally NOT auto-overridden by AutoUi.
+// That virtual is processor-owned and has no StateStore input. Layout
+// must look correct at the host's chosen size; an AutoUi-aware size
+// hint is a separate feature if Pulp wants smarter defaults later.
+
 std::unique_ptr<View> AutoUi::build(state::StateStore& store) {
+    auto format_value = [](const state::ParamInfo& param, float norm) {
+        float val = param.range.denormalize(norm);
+        std::ostringstream ss;
+        if (std::abs(val) >= 100) ss << std::fixed << std::setprecision(0);
+        else if (std::abs(val) >= 10) ss << std::fixed << std::setprecision(1);
+        else                          ss << std::fixed << std::setprecision(2);
+        ss << val;
+        if (!param.unit.empty()) ss << " " << param.unit;
+        return ss.str();
+    };
+
     auto root = std::make_unique<View>();
     root->flex().direction = FlexDirection::column;
-    root->flex().padding = 12;
-    root->flex().gap = 8;
+    root->flex().padding = 14;
+    root->flex().gap = 12;
 
-    // Title
+    // Title — kept as a stable anchor; small enough to leave room for
+    // params, large enough to not feel buried.
     auto title = std::make_unique<Label>("Parameters");
-    title->set_font_size(18.0f);
+    title->set_font_size(16.0f);
     title->flex().preferred_height = 24;
     root->add_child(std::move(title));
 
-    // Create a row container for controls
-    auto row = std::make_unique<View>();
-    row->flex().direction = FlexDirection::row;
-    row->flex().gap = 16;
-    row->flex().flex_grow = 1;
+    // Body fills remaining vertical space and centers its single child
+    // (the param grid) in both axes — that's what gives "1 knob in a
+    // 400x300 window" the same intentional look as "16 knobs in a
+    // 800x600 window."
+    auto body = std::make_unique<View>();
+    body->flex().direction = FlexDirection::column;
+    body->flex().flex_grow = 1;
+    body->flex().justify_content = FlexJustify::center;
+    body->flex().align_items = FlexAlign::center;
+
+    // Grid: wrapping flex row of fixed-size tiles, centered along all
+    // three axes (main, cross, and cross-when-wrapped). max_width caps
+    // the row so the grid stays readable on very wide editor windows
+    // and pushes wrapping into a denser block.
+    auto grid = std::make_unique<View>();
+    grid->flex().direction = FlexDirection::row;
+    grid->flex().flex_wrap = FlexWrap::wrap;
+    grid->flex().gap = 14;
+    grid->flex().justify_content = FlexJustify::center;
+    grid->flex().align_items = FlexAlign::center;
+    grid->flex().align_content = FlexAlign::center;
+    grid->flex().max_width = 760;
 
     auto params = store.all_params();
     for (auto& param : params) {
-        auto col = std::make_unique<View>();
-        col->flex().direction = FlexDirection::column;
-        col->flex().gap = 4;
-        col->flex().preferred_width = 64;
+        auto tile = std::make_unique<View>();
+        tile->flex().direction = FlexDirection::column;
+        tile->flex().align_items = FlexAlign::center;
+        tile->flex().justify_content = FlexJustify::center;
+        tile->flex().gap = 6;
+        tile->flex().preferred_width = 82;
+        tile->flex().preferred_height = 96;
+        tile->flex().flex_shrink = 0;
 
         // Determine widget type based on parameter range
         bool is_toggle = (param.range.min == 0.0f && param.range.max == 1.0f &&
@@ -38,37 +104,29 @@ std::unique_ptr<View> AutoUi::build(state::StateStore& store) {
             toggle->set_id(param.name);
             toggle->set_label(param.name);
             toggle->set_on(store.get_normalized(param.id) > 0.5f);
-            toggle->flex().preferred_height = 28;
-            toggle->flex().preferred_width = 50;
-            col->add_child(std::move(toggle));
+            toggle->flex().preferred_height = 30;
+            toggle->flex().preferred_width = 54;
+            tile->add_child(std::move(toggle));
         } else {
             auto knob = std::make_unique<Knob>();
             knob->set_id(param.name);
             knob->set_label(param.name);
             knob->set_value(store.get_normalized(param.id));
-
-            // Format function showing value with unit
-            auto unit = param.unit;
-            auto range = param.range;
-            knob->set_format([unit, range](float norm_val) {
-                float val = range.denormalize(norm_val);
-                std::ostringstream ss;
-                if (std::abs(val) >= 100) ss << std::fixed << std::setprecision(0) << val;
-                else if (std::abs(val) >= 10) ss << std::fixed << std::setprecision(1) << val;
-                else ss << std::fixed << std::setprecision(2) << val;
-                if (!unit.empty()) ss << " " << unit;
-                return ss.str();
+            // Capture the per-param formatter by value so each knob owns
+            // its own closure (params is a temporary).
+            knob->set_format([param, format_value](float norm) {
+                return format_value(param, norm);
             });
-
             knob->flex().preferred_height = 64;
             knob->flex().preferred_width = 64;
-            col->add_child(std::move(knob));
+            tile->add_child(std::move(knob));
         }
 
-        row->add_child(std::move(col));
+        grid->add_child(std::move(tile));
     }
 
-    root->add_child(std::move(row));
+    body->add_child(std::move(grid));
+    root->add_child(std::move(body));
     return root;
 }
 

--- a/test/test_auto_ui.cpp
+++ b/test/test_auto_ui.cpp
@@ -15,8 +15,119 @@ TEST_CASE("AutoUi builds from parameter store", "[view][auto_ui]") {
     auto root = AutoUi::build(store);
     REQUIRE(root != nullptr);
 
-    // Should have title label + row with 3 params
+    // pulp #97 — new shape: root has [title, body], body has [grid],
+    // grid has one tile per param.
     REQUIRE(root->child_count() == 2);
+    auto* body = root->child_at(1);
+    REQUIRE(body->child_count() == 1);
+    auto* grid = body->child_at(0);
+    REQUIRE(grid->child_count() == 3);  // Gain + Mix + Bypass
+}
+
+// ── pulp #97 — layout invariants for the centered-wrapping-grid design ──
+//
+// These assertions encode the design contract the visual fix relies on
+// at the Yoga-flex level. A regression that flips justify_content back
+// to start, or removes flex_wrap, would surface here BEFORE the user
+// sees a knob cluster stranded in the top-left of their editor.
+
+TEST_CASE("AutoUi root: column layout with title + body",
+          "[view][auto_ui][issue-97]") {
+    StateStore store;
+    store.add_parameter({1, "G", "dB", {-60.0f, 12.0f, 0.0f}});
+
+    auto root = AutoUi::build(store);
+    REQUIRE(root != nullptr);
+    REQUIRE(root->flex().direction == FlexDirection::column);
+    REQUIRE(root->child_count() == 2);
+
+    // Child 0: title Label "Parameters"
+    auto* title = dynamic_cast<Label*>(root->child_at(0));
+    REQUIRE(title != nullptr);
+    REQUIRE(title->text() == "Parameters");
+
+    // Child 1: body (column, flex_grow=1, centered both axes).
+    auto* body = root->child_at(1);
+    REQUIRE(body != nullptr);
+    REQUIRE(body->flex().direction == FlexDirection::column);
+    REQUIRE(body->flex().flex_grow == 1.0f);
+    REQUIRE(body->flex().justify_content == FlexJustify::center);
+    REQUIRE(body->flex().align_items == FlexAlign::center);
+}
+
+TEST_CASE("AutoUi grid: wrapping flex row, centered all three axes",
+          "[view][auto_ui][issue-97]") {
+    StateStore store;
+    store.add_parameter({1, "A", "", {0.0f, 1.0f, 0.5f}});
+
+    auto root = AutoUi::build(store);
+    REQUIRE(root != nullptr);
+    auto* body = root->child_at(1);
+    REQUIRE(body->child_count() == 1);
+    auto* grid = body->child_at(0);
+    REQUIRE(grid != nullptr);
+
+    // The crux of the fix: row + wrap + center across all three axes
+    // (justify_content for the main axis, align_items for the cross
+    // axis within a single line, align_content for cross when wrapped).
+    REQUIRE(grid->flex().direction == FlexDirection::row);
+    REQUIRE(grid->flex().flex_wrap == FlexWrap::wrap);
+    REQUIRE(grid->flex().justify_content == FlexJustify::center);
+    REQUIRE(grid->flex().align_items == FlexAlign::center);
+    REQUIRE(grid->flex().align_content == FlexAlign::center);
+    // max_width caps the row on very wide editors so the cluster stays
+    // dense rather than spreading edge-to-edge.
+    REQUIRE(grid->flex().max_width > 0);
+}
+
+TEST_CASE("AutoUi tiles: fixed size, no shrink, knob/toggle inside",
+          "[view][auto_ui][issue-97]") {
+    StateStore store;
+    store.add_parameter({1, "Knob",   "Hz", {20.0f, 20000.0f, 1000.0f}});
+    store.add_parameter({2, "Switch", "",   {0.0f, 1.0f, 0.0f, 1.0f}});
+
+    auto root = AutoUi::build(store);
+    auto* grid = root->child_at(1)->child_at(0);
+    REQUIRE(grid->child_count() == 2);
+
+    // Tile 0 → Knob
+    auto* tile_knob = grid->child_at(0);
+    REQUIRE(tile_knob->flex().preferred_width == 82);
+    REQUIRE(tile_knob->flex().preferred_height == 96);
+    REQUIRE(tile_knob->flex().flex_shrink == 0);  // tiles never shrink
+    REQUIRE(tile_knob->child_count() == 1);
+    REQUIRE(dynamic_cast<Knob*>(tile_knob->child_at(0)) != nullptr);
+
+    // Tile 1 → Toggle (Switch range [0,1] step 1 → toggle path)
+    auto* tile_toggle = grid->child_at(1);
+    REQUIRE(tile_toggle->child_count() == 1);
+    REQUIRE(dynamic_cast<Toggle*>(tile_toggle->child_at(0)) != nullptr);
+}
+
+TEST_CASE("AutoUi scales from 1 param up to 16 without losing structure",
+          "[view][auto_ui][issue-97]") {
+    // Sanity at the extremes: 1, 4, 16 params all produce the same
+    // root → body → grid → tiles shape. The wrap/center invariants
+    // hold regardless of count, which is what makes the editor look
+    // intentional whether the developer defined 1 knob or 16.
+    for (size_t n : {1, 4, 16}) {
+        StateStore store;
+        for (size_t i = 1; i <= n; ++i) {
+            store.add_parameter({static_cast<uint32_t>(i),
+                                 "P" + std::to_string(i), "",
+                                 {0.0f, 1.0f, 0.5f}});
+        }
+
+        auto root = AutoUi::build(store);
+        REQUIRE(root != nullptr);
+        REQUIRE(root->child_count() == 2);
+        auto* grid = root->child_at(1)->child_at(0);
+        REQUIRE(grid->child_count() == n);
+        // Wrap + center invariants survive at every count.
+        REQUIRE(grid->flex().flex_wrap == FlexWrap::wrap);
+        REQUIRE(grid->flex().justify_content == FlexJustify::center);
+        REQUIRE(grid->flex().align_content == FlexAlign::center);
+    }
 }
 
 TEST_CASE("AutoUi sync updates widgets", "[view][auto_ui]") {


### PR DESCRIPTION
AutoUi is the default editor for Processors that don't supply a
custom create_view() — the natural starting point for `pulp create
my-plugin` and the surface ~25 of 30 in-tree examples present.

Previously, layout was a single flex-start non-wrapping row. A
4-knob plugin in the stock 400x300 editor window rendered the
cluster in the top-left corner with ~70% of the window empty,
which read as "layout bug" rather than "default editor."

New layout (Codex-consult on the design, 2026-05-14):

  root: column, padding 14, gap 12
  ├── title: "Parameters" (16pt anchor)
  └── body: column, flex_grow=1, justify+align_items center
       └── grid: row, flex_wrap=wrap, justify+align_items+
                 align_content all center, max_width=760
            └── tile per param (column, fixed 82x96, no shrink)
                 └── Knob 64x64  OR  Toggle 54x30

The wrap+center invariants give "1 knob in a 400x300 window" and
"16 knobs in an 800x600 window" the same intentional look. 32+
params still exceed the visible area in the stock window — proper
fix is scroll/paging via a future SDK capability, not a static-
layout trick.

editor_size() is intentionally NOT auto-overridden by AutoUi.
That virtual is processor-owned and has no StateStore input;
auto-sizing is a separate feature if Pulp wants smarter defaults.

Tests cover the layout invariants directly at the Yoga-flex level
so a regression that flips justify_content back to start, or
removes flex_wrap, surfaces in CI before the user sees it. New
[issue-97] cases:
  - root structure: column, [title, body], body centered
  - grid wrap+center: the crux contract (3 axes + max_width cap)
  - tile dimensions + widget dispatch (Knob vs Toggle)
  - scale invariants at 1, 4, 16 params

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>