### PR TITLE
test(view): mac platform-test harness scaffold + back-buffer capture seam (#2001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0990"></a>
+## [0.100.0]
+
 ## [0.99.0] - 2026-05-14
 
 - fix(plugin): bump marketplace plugins[0].version + relative .mcp.json path ([#1996](https://github.com/danielraffel/pulp/pull/1996))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.99.0
+    VERSION 0.100.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/window_host.hpp
+++ b/core/view/include/pulp/view/window_host.hpp
@@ -127,7 +127,28 @@ public:
     virtual void detach_native_child_view(void* child_view) { (void) child_view; }
 
     // Capture the current visible content as a PNG image.
+    //
+    // Semantics: "whatever the compositor sees" — on macOS this prefers
+    // `screencapture` and the content-view cache before falling back to a
+    // direct GPU-backbuffer readback. Suitable for live screenshots of a
+    // visible window.
     virtual std::vector<uint8_t> capture_png() { return {}; }
+
+    // Capture the host's own back-buffer as a PNG image (issue #2001).
+    //
+    // Semantics: "host-managed pixels, deterministically." Implementations
+    // MUST NOT call show()/makeKeyAndOrderFront/etc., and MUST bypass any
+    // compositor-side capture path (`screencapture`, content-view caching).
+    // For GPU-backed hosts, this reads the actual rendered back-buffer; for
+    // non-GPU hosts, it can fall back to the rasterized content view.
+    //
+    // Default delegates to capture_png() so non-overriding hosts keep their
+    // current behavior. Test harnesses (`test/mac_window_harness.{hpp,mm}`)
+    // depend on the override existing on macOS GPU hosts so hidden-window
+    // tests get reproducible bytes.
+    virtual std::vector<uint8_t> capture_back_buffer_png() {
+        return capture_png();
+    }
 
     // Clear any cached host-side input targets before the view tree is rebuilt.
     virtual void invalidate_input_state() {}

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -1625,6 +1625,14 @@ public:
         auto live = capture_window_screencapture_png(window_);
         return !live.empty() ? live : capture_window_content_png(window_, view_);
     }
+
+    // issue #2001 — host-managed pixels only. CG-backed host has no GPU
+    // back-buffer, so the deterministic surface is the rasterized content
+    // view. Skips screencapture so hidden windows still produce bytes.
+    std::vector<uint8_t> capture_back_buffer_png() override {
+        return capture_window_content_png(window_, view_);
+    }
+
     void invalidate_input_state() override { [view_ clearInteractionState]; }
     void request_close() override { request_app_close(window_); }
 
@@ -1832,6 +1840,27 @@ public:
         if (!live.empty()) return live;
 
         return capture_window_content_png(window_, metal_view_);
+    }
+
+    // issue #2001 — deterministic GPU back-buffer readback for hidden /
+    // headless test windows. Bypasses screencapture (which fails on hidden
+    // windows) and the content-view cache, going straight through the
+    // existing render_frame(...) path that already powers the
+    // capture_png() fallback. Returns {} on failure (no exceptions).
+    std::vector<uint8_t> capture_back_buffer_png() override {
+        if (!gpu_surface_ || !skia_surface_) return {};
+
+        needs_repaint_.store(true, std::memory_order_relaxed);
+
+        std::vector<uint8_t> pixels;
+        uint32_t pixel_w = 0;
+        uint32_t pixel_h = 0;
+        if (!render_frame(&pixels, &pixel_w, &pixel_h)) return {};
+
+        return encode_rgba_to_png(pixels.data(),
+                                  pixel_w,
+                                  pixel_h,
+                                  static_cast<size_t>(pixel_w) * 4u);
     }
 
     void invalidate_input_state() override {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2295,3 +2295,32 @@ if(PULP_BENCHMARK AND TARGET pulp-render)
         catch_discover_tests(pulp-test-bench-integration)
     endif()
 endif()
+
+# ── Mac platform-test harness (issue #2001) ────────────────────────────────
+#
+# Catch2 fixture that brings up a hidden NSWindow + CAMetalLayer host
+# WITHOUT calling makeKeyAndOrderFront / activateIgnoringOtherApps, so
+# tests can exercise window_host_mac.mm code paths (set_design_viewport,
+# paint_scene, mouse-coordinate inverse mapping, resize → contentsScale)
+# that today are structurally untestable from plain Catch2.
+#
+# Phase B-1 (this PR): ships the harness scaffold + a smoke test proving
+#   the hidden window / capture_back_buffer_png contract.
+# Phase B-2 (next PR): migrates one PR-#1984 invariant as the first real
+#   consumer, and adds simulate_mouse exercise.
+#
+# Plan: planning/2026-05-14-mac-platform-test-harness.md (planning sub).
+if(APPLE AND NOT PULP_IOS AND PULP_HAS_SKIA)
+    add_executable(pulp-test-mac-platform-harness
+        test_mac_platform_harness.cpp
+        mac_window_harness.mm
+    )
+    target_link_libraries(pulp-test-mac-platform-harness PRIVATE
+        pulp::view
+        Catch2::Catch2WithMain
+        "-framework AppKit"
+        "-framework Metal"
+        "-framework QuartzCore"
+    )
+    catch_discover_tests(pulp-test-mac-platform-harness)
+endif()

--- a/test/mac_window_harness.hpp
+++ b/test/mac_window_harness.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+/// @file mac_window_harness.hpp
+/// Mac-only Catch2 test harness — headless NSWindow + CAMetalLayer fixture
+/// (issue #2001).
+///
+/// The harness reuses the production `WindowHost` GPU path and exposes a
+/// minimal API so tests can:
+///
+///   1. construct a hidden GPU window without orderFront / activation,
+///   2. synthesize AppKit mouse events against its real content view,
+///   3. read deterministic back-buffer PNG bytes.
+///
+/// The harness lives in `test/` only — never installed into the SDK. The
+/// production seam it depends on (`WindowHost::capture_back_buffer_png`)
+/// is the only public API addition.
+///
+/// First customer (Phase B-1, this PR): a smoke test that proves the
+/// harness can construct a hidden GPU window and the back-buffer capture
+/// path returns non-empty bytes. Phase B-2 will migrate one PR-#1984
+/// invariant (e.g. set_design_viewport overlay-inside-transform) to the
+/// harness as the first "real" consumer.
+///
+/// Plan: planning/2026-05-14-mac-platform-test-harness.md (planning
+/// submodule).
+
+#include <pulp/view/input_events.hpp>
+#include <pulp/view/window_host.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace pulp::view { class View; }
+
+namespace pulp::test::mac {
+
+/// One synthetic mouse event. Coordinates use Pulp logical pixels with
+/// top-left origin (matching `View::on_mouse_event` semantics). The
+/// harness handles the Cocoa bottom-left conversion internally.
+struct SimulatedMouse {
+    enum class Phase { down, up, move, drag, scroll };
+
+    Phase phase = Phase::move;
+    float x = 0.0f;
+    float y = 0.0f;
+    pulp::view::MouseButton button = pulp::view::MouseButton::left;
+    uint16_t modifiers = 0;
+    int click_count = 1;
+    float scroll_delta_x = 0.0f;
+    float scroll_delta_y = 0.0f;
+};
+
+/// Construct a hidden GPU-backed NSWindow + CAMetalLayer host suitable for
+/// unit tests. Forces `options.use_gpu = true` and
+/// `options.initially_hidden = true` so callers cannot accidentally pop a
+/// real window during a test run.
+///
+/// Returns nullptr on any failure (host construction, native handles
+/// missing, gpu_surface unavailable). Never throws.
+///
+/// Ownership: the caller owns the returned host. The `root` view must
+/// outlive the host, matching `WindowHost::create()` semantics.
+std::unique_ptr<pulp::view::WindowHost>
+make_test_window(pulp::view::View& root,
+                 pulp::view::WindowOptions options = {});
+
+/// Synthesize a single AppKit mouse event against the host's content view
+/// and drain the main run-loop once so deferred click handlers (which
+/// `PulpView::mouseUp:` posts via `dispatch_async`) settle before the
+/// caller asserts or captures.
+///
+/// Returns false on null handles, zero content size, or unsupported
+/// phase. Never throws.
+bool simulate_mouse(pulp::view::WindowHost& host, const SimulatedMouse& event);
+
+/// Wrapper over `WindowHost::capture_back_buffer_png` that drains the
+/// main queue once first so any pending render / deferred state mutations
+/// are ordered before the readback. Returns the host's PNG bytes (may be
+/// empty on capture failure — the harness does not raise).
+std::vector<uint8_t> capture_back_buffer_png(pulp::view::WindowHost& host);
+
+} // namespace pulp::test::mac

--- a/test/mac_window_harness.mm
+++ b/test/mac_window_harness.mm
@@ -1,0 +1,165 @@
+// Mac-only Catch2 test harness — implementation. See header for the contract.
+//
+// issue #2001 — provides a hidden NSWindow + CAMetalLayer fixture that
+// reuses the production WindowHost path. The "trick" is twofold:
+//
+//   1. WindowOptions{ initially_hidden=true, use_gpu=true } gets the host
+//      to construct a real NSWindow + CAMetalLayer + render::GpuSurface
+//      without ever calling makeKeyAndOrderFront / activateIgnoringOtherApps
+//      (those only fire from `run_event_loop()`, which the harness never
+//      invokes — construction alone is sufficient).
+//
+//   2. PulpView::mouseUp: defers the click handler via dispatch_async to
+//      the main queue, so the harness MUST drain the main run loop after
+//      every synthetic event or click-driven state changes will appear
+//      "missing" relative to a subsequent capture / assertion.
+
+#import "mac_window_harness.hpp"
+
+#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+#import <pulp/view/view.hpp>
+#import <pulp/view/window_host.hpp>
+
+namespace {
+
+// Drain the main run loop so any pending dispatch_async work (notably
+// PulpView's deferred click handler) settles before the caller asserts.
+// Spins the run loop briefly with a near-zero deadline rather than
+// sleeping; this is the lightest-weight reliable settle on AppKit.
+void drain_main_queue_once() {
+    @autoreleasepool {
+        [[NSRunLoop currentRunLoop]
+            runMode:NSDefaultRunLoopMode
+            beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.0]];
+    }
+}
+
+// Build an NSEvent for the given simulated mouse event. Coordinates are
+// converted from Pulp top-left logical coords to Cocoa bottom-left
+// window coords using the host's content size.
+NSEvent* build_event(NSWindow* window,
+                     pulp::view::WindowHost::ContentSize content,
+                     const pulp::test::mac::SimulatedMouse& ev) {
+    if (!window || content.width == 0 || content.height == 0) return nil;
+
+    NSPoint location = NSMakePoint(
+        static_cast<CGFloat>(ev.x),
+        // top-left → bottom-left flip
+        static_cast<CGFloat>(static_cast<float>(content.height) - ev.y));
+
+    NSEventType type;
+    switch (ev.phase) {
+        case pulp::test::mac::SimulatedMouse::Phase::down:    type = NSEventTypeLeftMouseDown;    break;
+        case pulp::test::mac::SimulatedMouse::Phase::up:      type = NSEventTypeLeftMouseUp;      break;
+        case pulp::test::mac::SimulatedMouse::Phase::move:    type = NSEventTypeMouseMoved;       break;
+        case pulp::test::mac::SimulatedMouse::Phase::drag:    type = NSEventTypeLeftMouseDragged; break;
+        case pulp::test::mac::SimulatedMouse::Phase::scroll:  type = NSEventTypeScrollWheel;      break;
+    }
+
+    if (ev.button == pulp::view::MouseButton::right) {
+        if (type == NSEventTypeLeftMouseDown)    type = NSEventTypeRightMouseDown;
+        if (type == NSEventTypeLeftMouseUp)      type = NSEventTypeRightMouseUp;
+        if (type == NSEventTypeLeftMouseDragged) type = NSEventTypeRightMouseDragged;
+    } else if (ev.button == pulp::view::MouseButton::middle) {
+        if (type == NSEventTypeLeftMouseDown)    type = NSEventTypeOtherMouseDown;
+        if (type == NSEventTypeLeftMouseUp)      type = NSEventTypeOtherMouseUp;
+        if (type == NSEventTypeLeftMouseDragged) type = NSEventTypeOtherMouseDragged;
+    }
+
+    if (type == NSEventTypeScrollWheel) {
+        // ScrollWheel events use a different constructor.
+        return [NSEvent
+            mouseEventWithType:type
+                      location:location
+                 modifierFlags:0
+                     timestamp:[[NSProcessInfo processInfo] systemUptime]
+                  windowNumber:[window windowNumber]
+                       context:nil
+                   eventNumber:0
+                    clickCount:0
+                      pressure:0.0f];
+    }
+
+    return [NSEvent
+        mouseEventWithType:type
+                  location:location
+             modifierFlags:0
+                 timestamp:[[NSProcessInfo processInfo] systemUptime]
+              windowNumber:[window windowNumber]
+                   context:nil
+               eventNumber:0
+                clickCount:ev.click_count
+                  pressure:(ev.phase == pulp::test::mac::SimulatedMouse::Phase::down ? 1.0f : 0.0f)];
+}
+
+} // namespace
+
+namespace pulp::test::mac {
+
+std::unique_ptr<pulp::view::WindowHost>
+make_test_window(pulp::view::View& root, pulp::view::WindowOptions options) {
+    @autoreleasepool {
+        // Ensure NSApplication exists so NSWindow construction has a
+        // running app to attach to. Safe to call repeatedly.
+        (void)[NSApplication sharedApplication];
+
+        // Force the harness contract: GPU host, never visible.
+        options.use_gpu = true;
+        options.initially_hidden = true;
+        if (options.width <= 0)  options.width  = 320;
+        if (options.height <= 0) options.height = 240;
+
+        auto host = pulp::view::WindowHost::create(root, options);
+        if (!host)                                return nullptr;
+        if (!host->native_window_handle())        return nullptr;
+        if (!host->native_content_view_handle())  return nullptr;
+        if (!host->gpu_surface())                 return nullptr;
+
+        // Make the content view first responder so synthetic input
+        // routes correctly without depending on the window having been
+        // shown / made key.
+        NSWindow* window = (__bridge NSWindow*)host->native_window_handle();
+        NSView*   view   = (__bridge NSView*)host->native_content_view_handle();
+        if (window && view) {
+            [window setInitialFirstResponder:view];
+            (void)[window makeFirstResponder:view];
+        }
+
+        return host;
+    }
+}
+
+bool simulate_mouse(pulp::view::WindowHost& host, const SimulatedMouse& event) {
+    @autoreleasepool {
+        NSWindow* window = (__bridge NSWindow*)host.native_window_handle();
+        NSView*   view   = (__bridge NSView*)host.native_content_view_handle();
+        if (!window || !view) return false;
+
+        const auto content = host.get_content_size();
+        if (content.width == 0 || content.height == 0) return false;
+
+        NSEvent* nsevent = build_event(window, content, event);
+        if (!nsevent) return false;
+
+        switch (event.phase) {
+            case SimulatedMouse::Phase::down:   [view mouseDown:nsevent];    break;
+            case SimulatedMouse::Phase::up:     [view mouseUp:nsevent];      break;
+            case SimulatedMouse::Phase::move:   [view mouseMoved:nsevent];   break;
+            case SimulatedMouse::Phase::drag:   [view mouseDragged:nsevent]; break;
+            case SimulatedMouse::Phase::scroll: [view scrollWheel:nsevent];  break;
+            default: return false;
+        }
+
+        // Settle the deferred click handler from PulpView::mouseUp:.
+        drain_main_queue_once();
+        return true;
+    }
+}
+
+std::vector<uint8_t> capture_back_buffer_png(pulp::view::WindowHost& host) {
+    drain_main_queue_once();
+    return host.capture_back_buffer_png();
+}
+
+} // namespace pulp::test::mac

--- a/test/test_mac_platform_harness.cpp
+++ b/test/test_mac_platform_harness.cpp
@@ -1,0 +1,83 @@
+// Mac-only Catch2 smoke for the platform-test harness — issue #2001.
+//
+// First customer (Phase B-1): asserts the harness can construct a
+// hidden GPU-backed NSWindow + CAMetalLayer host without ever calling
+// orderFront / makeKey, and that the new
+// `WindowHost::capture_back_buffer_png()` production seam returns
+// non-empty PNG bytes through the existing render_frame() path.
+//
+// Phase B-2 (next PR) will add `simulate_mouse` exercise + migrate one
+// PR-#1984 invariant (e.g. set_design_viewport overlay-inside-transform
+// from `test_view_design_viewport.cpp`) to the harness so the fixture
+// has a real production-bug consumer.
+//
+// Tag [issue-2001] so the coverage harness can attribute these to the
+// slice that introduced them.
+
+#include "mac_window_harness.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/view/view.hpp>
+#include <pulp/view/window_host.hpp>
+
+#include <vector>
+
+using pulp::view::View;
+using pulp::view::WindowHost;
+using pulp::view::WindowOptions;
+
+namespace pt = pulp::test::mac;
+
+TEST_CASE("mac harness constructs a hidden GPU-backed window",
+          "[mac][platform-harness][issue-2001]") {
+    View root;
+    auto host = pt::make_test_window(root);
+
+    REQUIRE(host != nullptr);
+    REQUIRE(host->is_visible() == false);
+    REQUIRE(host->native_window_handle() != nullptr);
+    REQUIRE(host->native_content_view_handle() != nullptr);
+    REQUIRE(host->gpu_surface() != nullptr);
+}
+
+TEST_CASE("mac harness back-buffer capture returns non-empty PNG bytes",
+          "[mac][platform-harness][issue-2001]") {
+    View root;
+    auto host = pt::make_test_window(root);
+    REQUIRE(host != nullptr);
+
+    auto png = pt::capture_back_buffer_png(*host);
+
+    // The harness's contract is "deterministic host-managed pixels".
+    // For the GPU host that means render_frame() succeeded and
+    // encode_rgba_to_png() produced a real PNG. An empty result here
+    // would indicate the back-buffer path is broken on hidden windows.
+    INFO("png byte count: " << png.size());
+    REQUIRE_FALSE(png.empty());
+
+    // PNG signature sanity-check (8-byte magic). Catches the case where
+    // the back-buffer readback returns raw RGBA without the encode step.
+    REQUIRE(png.size() >= 8);
+    REQUIRE(png[0] == 0x89);
+    REQUIRE(png[1] == 0x50);  // 'P'
+    REQUIRE(png[2] == 0x4E);  // 'N'
+    REQUIRE(png[3] == 0x47);  // 'G'
+}
+
+TEST_CASE("mac harness honors caller-provided window options size",
+          "[mac][platform-harness][issue-2001]") {
+    View root;
+    WindowOptions opts;
+    opts.width = 640;
+    opts.height = 480;
+
+    auto host = pt::make_test_window(root, opts);
+    REQUIRE(host != nullptr);
+
+    const auto content = host->get_content_size();
+    // CAMetalLayer drawableSize is the logical size scaled by
+    // contentsScale on Retina, so don't assert byte-equal — just
+    // assert the host rounded the request up to something plausible.
+    REQUIRE(content.width  >= 600);
+    REQUIRE(content.height >= 400);
+}


### PR DESCRIPTION
## Summary

Phase B-1 of the structural fast-follow on PR #1984's coverage gap. The Mac-only platform-test harness lets future tests exercise `core/view/platform/mac/window_host_mac.mm` (and similar Mac-only files like `skia_canvas.cpp`, `plugin_view_host_mac.mm`, etc.) from plain Catch2 — the surface area is reviewable in this PR; on-device-validated `simulate_mouse` exercise + the first "real" customer test land in Phase B-2.

### Production seam (one method, default delegates)

`core/view/include/pulp/view/window_host.hpp` adds:

```cpp
virtual std::vector<uint8_t> capture_back_buffer_png() {
    return capture_png();
}
```

"Host-managed pixels, deterministically." Bypasses `screencapture` / content-view caching so hidden test windows produce reproducible bytes. Default delegates to `capture_png()` so non-overriding hosts pay zero cost.

### macOS overrides

`core/view/platform/mac/window_host_mac.mm`:
- `MacWindowHost::capture_back_buffer_png` — content-view render only via the existing `capture_window_content_png()` helper.
- `MacGpuWindowHost::capture_back_buffer_png` — runs `render_frame()` synchronously, encodes the resulting RGBA via the existing `encode_rgba_to_png()` helper. Returns `{}` on failure (no exceptions). Skia-gated via `PULP_HAS_SKIA`.

### Catch2 fixture

`test/mac_window_harness.{hpp,mm}` — three entry points:

```cpp
namespace pulp::test::mac {
    std::unique_ptr<WindowHost> make_test_window(View&, WindowOptions = {});
    bool simulate_mouse(WindowHost&, const SimulatedMouse&);
    std::vector<uint8_t> capture_back_buffer_png(WindowHost&);
}
```

- `make_test_window` forces `use_gpu = true` + `initially_hidden = true` so the harness contract ("never visible") cannot be violated by a caller. Validates non-null host, native handles, and `gpu_surface()` before returning.
- `simulate_mouse` synthesizes real `NSEvent`s against the host content view (top-left → bottom-left coord conversion, `mouseDown:`/`mouseUp:`/`mouseMoved:`/`mouseDragged:`/`scrollWheel:` dispatch, one main-queue drain).
- `capture_back_buffer_png` drains the main queue, then calls the new production seam.

### POC smoke

`test/test_mac_platform_harness.cpp` — three Catch2 cases under `[issue-2001]`:

1. Hidden GPU window construction — host non-null, `!is_visible()`, native handles + `gpu_surface()` non-null.
2. `capture_back_buffer_png` returns non-empty PNG (with magic-bytes sanity assertion).
3. Caller-provided `WindowOptions.{width,height}` round-trips through `host->get_content_size()` (Retina-scaled).

### CMake wiring

`test/CMakeLists.txt` — new macOS-only target `pulp-test-mac-platform-harness` gated on `APPLE AND NOT PULP_IOS AND PULP_HAS_SKIA`. Mirrors the `pulp-test-widgets` pattern; explicit `-framework AppKit/Metal/QuartzCore` links for the ObjC++ helper's own AppKit / Metal / CAMetalLayer use.

### Planning

Full plan + risk-and-mitigation table + on-device validation checklist lives in the planning submodule (also bumps the submodule pointer in this commit):

  `planning/2026-05-14-mac-platform-test-harness.md`

## Phased shipping

- **B-1 (this PR):** scaffold + production seam + smoke. simulate_mouse exercise NOT included.
- **B-2 (next PR):** migrate one PR-#1984 invariant (e.g. `set_design_viewport` overlay-inside-transform Codex P1) to the harness as the first real consumer; add `simulate_mouse` exercise after on-device validation of the deferred-click drain semantics.
- **B-3 (later):** migrate `test_screenshot.cpp` / `test_screenshot_compare.cpp` to the harness for hidden-window deterministic capture.

## What this PR does NOT include (deferred to B-2)

- `simulate_mouse` exercise. Needs on-device validation of the deferred-click drain semantics (one drain may not be enough — captured as an "unknown" in the planning doc).
- First "real" customer test (e.g. migrating `test_view_design_viewport.cpp` invariants to the harness).

## Test plan

- [x] `pulp-view` builds clean — the new override compiles into both Mac hosts; Skia-gated GPU override correctly skipped under `PULP_HAS_SKIA=OFF`.
- [x] `mac_window_harness.mm` syntax-checks cleanly against the same include paths the target uses.
- [ ] `pulp-test-mac-platform-harness` builds + runs on a Skia-equipped macOS lane (Shipyard / local-CI).
- [ ] CI lane confirms hidden-window `capture_back_buffer_png` returns a valid PNG (the smoke's primary assertion).

## Risks / opt-outs

- Production seam is additive — no behavioral change to `capture_png()`. Documented contract in the header explicitly distinguishes "compositor pixels" vs "host-managed pixels".
- Test-only ObjC++ harness is gated to `APPLE AND NOT PULP_IOS AND PULP_HAS_SKIA` — never compiled into Linux/Windows/iOS lanes.
- No skill/version bump needed (verified `tools/scripts/skill_sync_check.py --mode=hint` reports no mapped paths touched).

Closes part of: #2001  
Refs: #1984 (the surfacing case), #2003 (Phase A coverage uplift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>