### PR TITLE
fix(view/host/mac): host-level ESC closes ComboBox even with stolen focus (#68)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.101.5
+    VERSION 0.101.7
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -817,6 +817,21 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                     return;
                 }
             }
+            // pulp #68 — host-level ESC fallback for an open ComboBox dropdown
+            // whose focus has been stolen by a sibling JS-driven element
+            // (common pattern: React mounts a popover next to the combo,
+            // grabs focus inside it, but the user hits ESC expecting the
+            // dropdown they can still see to close). The ComboBox's own
+            // on_key_event handler only fires when ComboBox owns focus,
+            // so a stolen-focus case wedges the dropdown open with no
+            // keyboard escape route. Close at host level the same way
+            // active_overlay_ does below.
+            if (pulp::view::ComboBox::active_popup_) {
+                pulp::view::ComboBox::close_active_popup();
+                [self startAnimationTimerIfNeeded];
+                [self setNeedsDisplay:YES];
+                return;
+            }
             // pulp #1361 — generic active_overlay_ ESC dismissal. ModalOverlay,
             // ComboBox, and CallOutBox already have their own ESC handlers
             // (ComboBox/CallOutBox sit on the focused view and consume their

--- a/test/test_combo_dropdown.cpp
+++ b/test/test_combo_dropdown.cpp
@@ -253,3 +253,52 @@ TEST_CASE("View: dtor clears active_overlay_ when destroyed while claimed [issue
     REQUIRE(pulp::view::View::active_overlay_ == nullptr);
 }
 
+// pulp #68 — host-level ESC fallback contract. The macOS window host's
+// keyDown: dispatches `ComboBox::close_active_popup()` when ESC is
+// pressed and `active_popup_` is set, even if the focused view is not
+// the ComboBox itself. This covers the React-popover focus-steal case:
+// dropdown is open, sibling JS-driven element grabbed focus, ESC must
+// still close the still-visible dropdown.
+//
+// The macOS host code (window_host_mac.mm keyDown:) is the actual
+// dispatcher and is not unit-testable in the Catch2 harness yet
+// (tracked by pulp #2001 — Mac platform-test harness). What IS
+// testable is the contract the host relies on:
+//
+//   close_active_popup() must close the dropdown unconditionally,
+//   regardless of which view currently owns input focus.
+//
+// A regression that gated close_active_popup on focus ownership would
+// silently break the host-level ESC path and surface only as "ESC
+// doesn't close popovers" in the live host. This test fences that.
+TEST_CASE("ComboBox: close_active_popup is focus-independent [issue-68]",
+          "[combo][regression][issue-68]") {
+    ComboBox::close_active_popup();
+    REQUIRE(ComboBox::active_popup_ == nullptr);
+
+    ComboBox combo;
+    combo.set_items({"one", "two"});
+    combo.set_bounds({0, 0, 100, 28});
+
+    // Open via mouse — combo is the implicit focused view in this path.
+    MouseEvent click;
+    click.position = {50.0f, 14.0f};
+    click.is_down = true;
+    combo.on_mouse_event(click);
+    REQUIRE(combo.is_open());
+    REQUIRE(ComboBox::active_popup_ == &combo);
+
+    // Simulate focus being stolen by a sibling — focus_changed(false)
+    // is what the host calls when input focus moves elsewhere. The
+    // dropdown should remain visually open (active_popup_ unchanged).
+    combo.on_focus_changed(false);
+    REQUIRE(combo.is_open());
+    REQUIRE(ComboBox::active_popup_ == &combo);
+
+    // The host-level ESC fallback simply calls close_active_popup().
+    // It MUST close the popup despite combo not owning focus.
+    ComboBox::close_active_popup();
+    REQUIRE_FALSE(combo.is_open());
+    REQUIRE(ComboBox::active_popup_ == nullptr);
+}
+


### PR DESCRIPTION
## Summary
- ComboBox's `on_key_event` only handles ESC when ComboBox owns input focus. In React-popover scenarios (Spectr's Settings dropdowns are the live-traffic example) a sibling JS-driven element grabs focus while the dropdown stays visually open — leaves no keyboard route to close.
- Fix: in `window_host_mac.mm` keyDown:'s ESC fallback chain, dispatch to `ComboBox::close_active_popup()` when `active_popup_` is set — symmetric with the existing `View::active_overlay_` ESC fallback (pulp #1361).
- Order: modal → combo popup → active overlay → focused view.

## Context
- Closes #68 (paused-items doc — "Default UX behaviors in live host")
- Other platforms (Windows/Linux/iOS/Android) don't have a window_host yet; this is macOS-only by definition. Pattern carries over when those hosts land.
- The macOS Obj-C++ keyDown: dispatch itself isn't unit-testable yet — that's tracked by #2001 (Mac platform-test harness, in flight via PR #2009). The new test exercises the `close_active_popup()` contract the host fix relies on.

## Test plan
- [x] `pulp-test-combo-dropdown` passes (40 assertions, 11 cases) including new `[issue-68]` regression
- [x] Local Catch2 build green
- [ ] CI green on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)