### PR TITLE
fix(canvas/svg): emit fills + cubic Bezier curves in SvgImage::render (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
+## [0.101.1]
+
 <a id="v01010"></a>
 ## [0.101.0] - 2026-05-15
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.101.0
+    VERSION 0.101.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/src/svg.cpp
+++ b/core/canvas/src/svg.cpp
@@ -148,7 +148,16 @@ void SvgImage::render(Canvas& canvas, float x, float y, float w, float h) const 
             if (path->closed) canvas.close_path();
         }
 
-        if (has_fill)   canvas.fill_current_path();
+        if (has_fill) {
+            // Codex review on PR #2011 — honor `fill-rule="evenodd"`
+            // so SVGs with cutouts/holes (a common preset-thumbnail
+            // pattern) render correctly. nanosvg exposes the rule on
+            // the shape; default in SVG is nonzero.
+            FillRule rule = (shape->fillRule == NSVG_FILLRULE_EVENODD)
+                ? FillRule::evenodd
+                : FillRule::nonzero;
+            canvas.fill_current_path(rule);
+        }
         if (has_stroke) canvas.stroke_current_path();
     }
 

--- a/core/canvas/src/svg.cpp
+++ b/core/canvas/src/svg.cpp
@@ -80,6 +80,7 @@ void SvgImage::render(Canvas& canvas, float x, float y, float w, float h) const 
     if (!image_) return;
 
     auto* img = static_cast<NSVGimage*>(image_);
+    if (img->width <= 0 || img->height <= 0) return;
     float sx = w / img->width;
     float sy = h / img->height;
     float scale = std::min(sx, sy);
@@ -88,20 +89,39 @@ void SvgImage::render(Canvas& canvas, float x, float y, float w, float h) const 
     canvas.translate(x, y);
     canvas.scale(scale, scale);
 
-    // Walk SVG shapes and render using Canvas primitives
+    // pulp #72 — render fills + cubic Bezier curves via Canvas's path API
+    // instead of approximating each path as straight lines between control
+    // handles. The previous implementation:
+    //   for (i = 0; i < npts - 1; i += 3)
+    //       stroke_line(pts[i*2], pts[i*2+1], pts[(i+3)*2], pts[(i+3)*2+1])
+    // had two latent bugs that surfaced as "preset preview blank":
+    //   1. Fills were never emitted — no fill_current_path() call. A path
+    //      with `fill="#abc"` and no stroke would render NOTHING.
+    //   2. Strokes stepped through Bezier control points as if they were
+    //      line endpoints, producing jagged polylines connecting handles
+    //      rather than the smooth curves the SVG actually defined.
+    //
+    // The nanosvg point layout for one cubic-Bezier subpath of N segments
+    // is (3N+1) flat (x,y) pairs:
+    //   pts[0..1]    = subpath start
+    //   pts[2..7]    = (cp1, cp2, end) of segment 0
+    //   pts[8..13]   = (cp1, cp2, end) of segment 1
+    //   ...
+    // Starting from index 1 we step in groups of 3 control points, each
+    // group encoding one cubic_to(cp1x, cp1y, cp2x, cp2y, x, y).
     for (auto* shape = img->shapes; shape; shape = shape->next) {
         if (!(shape->flags & NSVG_FLAGS_VISIBLE)) continue;
 
-        // Set fill color
-        if (shape->fill.type == NSVG_PAINT_COLOR) {
+        bool has_fill   = (shape->fill.type   == NSVG_PAINT_COLOR);
+        bool has_stroke = (shape->stroke.type == NSVG_PAINT_COLOR);
+
+        if (has_fill) {
             uint32_t c = shape->fill.color;
             canvas.set_fill_color(Color::rgba8(
                 c & 0xFF, (c >> 8) & 0xFF, (c >> 16) & 0xFF,
                 static_cast<uint8_t>(shape->opacity * 255)));
         }
-
-        // Set stroke
-        if (shape->stroke.type == NSVG_PAINT_COLOR) {
+        if (has_stroke) {
             uint32_t c = shape->stroke.color;
             canvas.set_stroke_color(Color::rgba8(
                 c & 0xFF, (c >> 8) & 0xFF, (c >> 16) & 0xFF,
@@ -109,19 +129,27 @@ void SvgImage::render(Canvas& canvas, float x, float y, float w, float h) const 
             canvas.set_line_width(shape->strokeWidth);
         }
 
-        // Render paths as line segments (simplified — full path rendering
-        // would require Canvas path API which we don't have yet)
-        for (auto* path = shape->paths; path; path = path->next) {
-            if (path->npts < 2) continue;
+        if (!has_fill && !has_stroke) continue;
 
-            // Draw as connected lines between control points
-            for (int i = 0; i < path->npts - 1; i += 3) {
-                float* p = &path->pts[i * 2];
-                float* q = &path->pts[(i + 3 < path->npts ? i + 3 : 0) * 2];
-                if (shape->stroke.type != NSVG_PAINT_NONE)
-                    canvas.stroke_line(p[0], p[1], q[0], q[1]);
+        // Build a single path covering all subpaths of this shape so the
+        // fill operates on the union (matches SVG winding semantics; the
+        // Canvas API defaults to FillRule::nonzero).
+        canvas.begin_path();
+        for (auto* path = shape->paths; path; path = path->next) {
+            if (path->npts < 1) continue;
+            const float* pts = path->pts;
+            canvas.move_to(pts[0], pts[1]);
+            // Each cubic segment consumes 3 control points (cp1, cp2, end).
+            // i steps through the start-index of each group.
+            for (int i = 1; i + 2 < path->npts; i += 3) {
+                const float* g = &pts[i * 2];
+                canvas.cubic_to(g[0], g[1], g[2], g[3], g[4], g[5]);
             }
+            if (path->closed) canvas.close_path();
         }
+
+        if (has_fill)   canvas.fill_current_path();
+        if (has_stroke) canvas.stroke_current_path();
     }
 
     canvas.restore();

--- a/test/test_svg.cpp
+++ b/test/test_svg.cpp
@@ -183,6 +183,53 @@ TEST_CASE("SvgImage::render emits cubic_to for curved paths [issue-72]",
     REQUIRE(canvas.count(DrawCommand::Type::stroke_line) == 0);
 }
 
+TEST_CASE("SvgImage::render forwards evenodd fill-rule [issue-72]",
+          "[canvas][svg][issue-72]") {
+    // Codex review on PR #2011 — paths with `fill-rule="evenodd"` are
+    // common in preset-thumbnail SVGs that use cutouts/holes. The fill
+    // rule must reach Canvas's path API, not be hardcoded to nonzero.
+    auto evenodd = SvgImage::from_string(R"(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <path d="M 10 10 L 90 10 L 90 90 L 10 90 Z M 30 30 L 70 30 L 70 70 L 30 70 Z"
+        fill="#000" fill-rule="evenodd"/>
+</svg>
+)");
+    REQUIRE(evenodd.is_valid());
+    RecordingCanvas eo_canvas;
+    evenodd.render(eo_canvas, 0, 0, 100, 100);
+    REQUIRE(eo_canvas.count(DrawCommand::Type::fill_current_path) >= 1);
+    // RecordingCanvas stores the FillRule in cmd.f[0] (1.0 = evenodd,
+    // 0.0 = nonzero). See test_widget_bridge.cpp `ctx.fill('evenodd')`
+    // case for the same encoding.
+    bool saw_evenodd = false;
+    for (const auto& c : eo_canvas.commands()) {
+        if (c.type == DrawCommand::Type::fill_current_path && c.f[0] == 1.0f) {
+            saw_evenodd = true;
+            break;
+        }
+    }
+    REQUIRE(saw_evenodd);
+
+    // Default rule (nonzero) should still pass through as nonzero.
+    auto nonzero = SvgImage::from_string(R"(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <path d="M 10 10 L 90 10 L 90 90 L 10 90 Z" fill="#f00"/>
+</svg>
+)");
+    REQUIRE(nonzero.is_valid());
+    RecordingCanvas nz_canvas;
+    nonzero.render(nz_canvas, 0, 0, 100, 100);
+    REQUIRE(nz_canvas.count(DrawCommand::Type::fill_current_path) >= 1);
+    bool saw_nonzero = false;
+    for (const auto& c : nz_canvas.commands()) {
+        if (c.type == DrawCommand::Type::fill_current_path && c.f[0] == 0.0f) {
+            saw_nonzero = true;
+            break;
+        }
+    }
+    REQUIRE(saw_nonzero);
+}
+
 TEST_CASE("SvgImage::render emits both fill + stroke for filled+stroked path [issue-72]",
           "[canvas][svg][issue-72]") {
     auto img = SvgImage::from_string(R"(

--- a/test/test_svg.cpp
+++ b/test/test_svg.cpp
@@ -131,6 +131,74 @@ TEST_CASE("SvgImage move semantics", "[canvas][svg]") {
     REQUIRE_FALSE(img1.is_valid());
 }
 
+// pulp #72 — preset previews (Spectr's band-shape thumbnails were the
+// live-traffic example) render through SvgImage::render() into a Canvas,
+// not through nsvgRasterize() directly. The previous implementation:
+//   (a) only emitted `stroke_line` commands — fills were dropped silently;
+//   (b) treated each Bezier control point as a line endpoint, producing
+//       jagged polylines connecting handles instead of smooth curves.
+// A path with `fill="#abc"` and no stroke would render NOTHING — which
+// is what the user observed as "preset preview blank."
+//
+// These regression tests enforce both contracts at the RecordingCanvas
+// level so a refactor that drops the path-API calls fails CI before the
+// user sees blank thumbnails again.
+TEST_CASE("SvgImage::render emits fill_current_path for fill-only path [issue-72]",
+          "[canvas][svg][issue-72]") {
+    // Filled rect with NO stroke — the case that previously rendered nothing.
+    auto img = SvgImage::from_string(R"(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" width="10" height="10">
+  <rect x="0" y="0" width="10" height="10" fill="#ff0000"/>
+</svg>
+)");
+    REQUIRE(img.is_valid());
+
+    RecordingCanvas canvas;
+    img.render(canvas, 0, 0, 100, 100);
+
+    REQUIRE(canvas.count(DrawCommand::Type::fill_current_path) >= 1);
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_current_path) == 0);
+    // Pre-fix bug: emitted stroke_line commands instead of building a path.
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_line) == 0);
+}
+
+TEST_CASE("SvgImage::render emits cubic_to for curved paths [issue-72]",
+          "[canvas][svg][issue-72]") {
+    // A cubic Bezier curve — the band-shape preview pattern. Pre-fix this
+    // would have stepped through control points as straight-line endpoints.
+    auto img = SvgImage::from_string(R"(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <path d="M 10 50 C 30 10, 70 90, 90 50" stroke="#000" stroke-width="2" fill="none"/>
+</svg>
+)");
+    REQUIRE(img.is_valid());
+
+    RecordingCanvas canvas;
+    img.render(canvas, 0, 0, 100, 100);
+
+    REQUIRE(canvas.count(DrawCommand::Type::move_to) >= 1);
+    REQUIRE(canvas.count(DrawCommand::Type::cubic_to) >= 1);
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_current_path) >= 1);
+    // Pre-fix bug: emitted stroke_line commands.
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_line) == 0);
+}
+
+TEST_CASE("SvgImage::render emits both fill + stroke for filled+stroked path [issue-72]",
+          "[canvas][svg][issue-72]") {
+    auto img = SvgImage::from_string(R"(
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <circle cx="50" cy="50" r="40" fill="#f00" stroke="#000" stroke-width="2"/>
+</svg>
+)");
+    REQUIRE(img.is_valid());
+
+    RecordingCanvas canvas;
+    img.render(canvas, 0, 0, 100, 100);
+
+    REQUIRE(canvas.count(DrawCommand::Type::fill_current_path) >= 1);
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_current_path) >= 1);
+}
+
 TEST_CASE("SvgImage move assignment", "[canvas][svg]") {
     auto img1 = SvgImage::from_string(test_svg);
     REQUIRE(img1.is_valid());


### PR DESCRIPTION
## Summary
Pulp's `SvgImage::render()` walks an nsvg-parsed tree and emits Canvas commands. Previously it:
1. Emitted **no** `fill_current_path` calls — paths with `fill=` and no stroke rendered NOTHING.
2. Stepped through Bezier control points as if they were line endpoints, producing jagged polylines connecting handles.

This is the smoking-gun cause of "preset preview blank" in Spectr's preset-manager band-shape thumbnails (#72) — those thumbnails are filled paths with no stroke.

Fix: build paths through Canvas's path API (`begin_path` / `move_to` / `cubic_to` / `close_path`) and emit `fill_current_path` and/or `stroke_current_path` based on the shape's paint state.

## Test plan
- 13 SVG tests / 52 assertions pass locally
- New `[issue-72]` cases verify fill-only paths emit `fill_current_path`, curved paths emit `cubic_to`, filled+stroked paths emit both.

Closes #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)