### PR TITLE
fix(test/mac-harness): real scroll deltas + per-button selector routing

### DIFF
--- a/test/mac_window_harness.mm
+++ b/test/mac_window_harness.mm
@@ -17,6 +17,7 @@
 #import "mac_window_harness.hpp"
 
 #import <AppKit/AppKit.h>
+#import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
 #import <pulp/view/view.hpp>
 #import <pulp/view/window_host.hpp>
@@ -68,17 +69,25 @@ NSEvent* build_event(NSWindow* window,
     }
 
     if (type == NSEventTypeScrollWheel) {
-        // ScrollWheel events use a different constructor.
-        return [NSEvent
-            mouseEventWithType:type
-                      location:location
-                 modifierFlags:0
-                     timestamp:[[NSProcessInfo processInfo] systemUptime]
-                  windowNumber:[window windowNumber]
-                       context:nil
-                   eventNumber:0
-                    clickCount:0
-                      pressure:0.0f];
+        // Codex review (PR #2009): `+[NSEvent mouseEventWithType:]` does
+        // NOT carry scrolling deltas — the produced event reports
+        // `scrollingDeltaX/Y == 0`, so the synthetic scroll falls
+        // through `PulpView::scrollWheel:` as a no-op and tests pass
+        // while exercising nothing. Build the event via a CGEvent
+        // source so `event.scrollingDeltaX/Y` reflect the requested
+        // deltas. Axis order: CGEventCreateScrollWheelEvent2's
+        // variadic wheel args are (wheel1, wheel2) ≡ (Y, X).
+        CGEventRef cge = CGEventCreateScrollWheelEvent2(
+            /* source */ NULL,
+            kCGScrollEventUnitPixel,
+            /* wheelCount */ 2,
+            static_cast<int32_t>(ev.scroll_delta_y),
+            static_cast<int32_t>(ev.scroll_delta_x),
+            0);
+        if (!cge) return nil;
+        NSEvent* event = [NSEvent eventWithCGEvent:cge];
+        CFRelease(cge);
+        return event;
     }
 
     return [NSEvent
@@ -142,13 +151,47 @@ bool simulate_mouse(pulp::view::WindowHost& host, const SimulatedMouse& event) {
         NSEvent* nsevent = build_event(window, content, event);
         if (!nsevent) return false;
 
+        // Codex review (PR #2009): `build_event` correctly stamped
+        // NSEventType{Right,Other}Mouse* based on `event.button`, but the
+        // dispatch below previously routed every phase through
+        // `mouseDown:`/`mouseUp:`/`mouseDragged:`. That meant a right-
+        // click test exercised `mouseDown:` (single-click path) instead
+        // of `rightMouseDown:` (context-menu path), and middle-clicks
+        // never reached `otherMouseDown:`. Route by button so synthetic
+        // right/middle clicks hit the matching selectors on PulpView.
         switch (event.phase) {
-            case SimulatedMouse::Phase::down:   [view mouseDown:nsevent];    break;
-            case SimulatedMouse::Phase::up:     [view mouseUp:nsevent];      break;
-            case SimulatedMouse::Phase::move:   [view mouseMoved:nsevent];   break;
-            case SimulatedMouse::Phase::drag:   [view mouseDragged:nsevent]; break;
-            case SimulatedMouse::Phase::scroll: [view scrollWheel:nsevent];  break;
-            default: return false;
+            case SimulatedMouse::Phase::down:
+                if (event.button == pulp::view::MouseButton::right)
+                    [view rightMouseDown:nsevent];
+                else if (event.button == pulp::view::MouseButton::middle)
+                    [view otherMouseDown:nsevent];
+                else
+                    [view mouseDown:nsevent];
+                break;
+            case SimulatedMouse::Phase::up:
+                if (event.button == pulp::view::MouseButton::right)
+                    [view rightMouseUp:nsevent];
+                else if (event.button == pulp::view::MouseButton::middle)
+                    [view otherMouseUp:nsevent];
+                else
+                    [view mouseUp:nsevent];
+                break;
+            case SimulatedMouse::Phase::move:
+                [view mouseMoved:nsevent];
+                break;
+            case SimulatedMouse::Phase::drag:
+                if (event.button == pulp::view::MouseButton::right)
+                    [view rightMouseDragged:nsevent];
+                else if (event.button == pulp::view::MouseButton::middle)
+                    [view otherMouseDragged:nsevent];
+                else
+                    [view mouseDragged:nsevent];
+                break;
+            case SimulatedMouse::Phase::scroll:
+                [view scrollWheel:nsevent];
+                break;
+            default:
+                return false;
         }
 
         // Settle the deferred click handler from PulpView::mouseUp:.

--- a/test/mac_window_harness.mm
+++ b/test/mac_window_harness.mm
@@ -85,6 +85,22 @@ NSEvent* build_event(NSWindow* window,
             static_cast<int32_t>(ev.scroll_delta_x),
             0);
         if (!cge) return nil;
+        // Codex P2 on PR #2015 — set the CGEvent location so
+        // `event.locationInWindow` lands at the harness-requested
+        // coordinates instead of the current OS cursor position.
+        // PulpView::scrollWheel: hit-tests from locationInWindow, so
+        // without this, scroll tests targeted at a specific subview
+        // are dropped or routed wherever the cursor happened to be.
+        // CGEvent uses screen-space; convert via window/screen frames.
+        NSPoint screen_pt = [window convertPointToScreen:location];
+        // Cocoa screen origin = bottom-left of primary screen, but
+        // CoreGraphics uses top-left. Flip via primary screen height.
+        NSScreen* primary = [[NSScreen screens] firstObject];
+        if (primary) {
+            CGFloat screen_h = NSHeight([primary frame]);
+            CGEventSetLocation(cge,
+                CGPointMake(screen_pt.x, screen_h - screen_pt.y));
+        }
         NSEvent* event = [NSEvent eventWithCGEvent:cge];
         CFRelease(cge);
         return event;

--- a/test/test_mac_platform_harness.cpp
+++ b/test/test_mac_platform_harness.cpp
@@ -17,11 +17,15 @@
 #include "mac_window_harness.hpp"
 
 #include <catch2/catch_test_macros.hpp>
+#include <pulp/view/input_events.hpp>
 #include <pulp/view/view.hpp>
 #include <pulp/view/window_host.hpp>
 
 #include <vector>
 
+using pulp::view::MouseButton;
+using pulp::view::MouseEvent;
+using pulp::view::Rect;
 using pulp::view::View;
 using pulp::view::WindowHost;
 using pulp::view::WindowOptions;
@@ -80,4 +84,104 @@ TEST_CASE("mac harness honors caller-provided window options size",
     // assert the host rounded the request up to something plausible.
     REQUIRE(content.width  >= 600);
     REQUIRE(content.height >= 400);
+}
+
+// ── Codex review P2 fixes (PR #2009) ────────────────────────────────────
+//
+// Before these fixes:
+//   1. `build_event` constructed scroll wheel events via
+//      `+[NSEvent mouseEventWithType:]`, which does not carry
+//      `scrollingDeltaX/Y`. `PulpView::scrollWheel:` reads those, so the
+//      synthetic event delivered a zero-delta wheel — scroll tests
+//      passed without ever exercising real scroll math.
+//   2. `simulate_mouse` routed every phase through `mouseDown:` /
+//      `mouseUp:` / `mouseDragged:` regardless of `event.button`, so a
+//      right-click in a test reached the left-click selector instead of
+//      `rightMouseDown:` (which is what triggers the context-menu path).
+//
+// These two tests pin both behaviors. They build a hidden GPU window,
+// install a child view with a known hit-test rect, and assert the
+// production selectors actually fired.
+
+TEST_CASE("mac harness scroll event carries non-zero deltas through PulpView",
+          "[mac][platform-harness][issue-2001]") {
+    View root;
+    root.set_bounds({0, 0, 320, 240});
+
+    // Child fills the window. on_pointer_event is the callback
+    // `PulpView::scrollWheel:` invokes once it has walked ancestors to
+    // dispatch a wheel-flagged MouseEvent.
+    auto child = std::make_unique<View>();
+    child->set_bounds({0, 0, 320, 240});
+
+    int wheel_calls = 0;
+    float captured_dx = 0.0f;
+    float captured_dy = 0.0f;
+    child->on_pointer_event = [&](const MouseEvent& me) {
+        if (!me.is_wheel) return;
+        ++wheel_calls;
+        captured_dx = me.scroll_delta_x;
+        captured_dy = me.scroll_delta_y;
+    };
+    root.add_child(std::move(child));
+
+    auto host = pt::make_test_window(root);
+    REQUIRE(host != nullptr);
+
+    pt::SimulatedMouse ev;
+    ev.phase = pt::SimulatedMouse::Phase::scroll;
+    ev.x = 100.0f;
+    ev.y = 100.0f;
+    ev.scroll_delta_y = 10.0f;
+    ev.scroll_delta_x = 0.0f;
+    REQUIRE(pt::simulate_mouse(*host, ev));
+
+    REQUIRE(wheel_calls == 1);
+    // PulpView::scrollWheel: negates the Y axis (Cocoa wheel deltas are
+    // bottom-up; the View MouseEvent is top-down). The harness already
+    // hands the CGEvent the caller's raw scroll_delta_y, so the View
+    // callback observes |delta| > 0 with the production sign.
+    REQUIRE(captured_dy != 0.0f);
+    REQUIRE(captured_dx == 0.0f);
+}
+
+TEST_CASE("mac harness right-click reaches PulpView::rightMouseDown: not mouseDown:",
+          "[mac][platform-harness][issue-2001]") {
+    View root;
+    root.set_bounds({0, 0, 320, 240});
+
+    auto child = std::make_unique<View>();
+    child->set_bounds({0, 0, 320, 240});
+
+    // `on_click` is the left-click signal: PulpView::mouseUp: posts it
+    // via dispatch_async. `on_context_menu` is the right-click signal:
+    // PulpView::rightMouseDown: invokes it synchronously. Wiring both
+    // here lets us prove the synthetic right-click did NOT fall into
+    // the left-click path.
+    int left_clicks = 0;
+    int context_menus = 0;
+    child->on_click = [&] { ++left_clicks; };
+    child->on_context_menu = [&](pulp::view::Point) { ++context_menus; };
+    root.add_child(std::move(child));
+
+    auto host = pt::make_test_window(root);
+    REQUIRE(host != nullptr);
+
+    pt::SimulatedMouse down;
+    down.phase = pt::SimulatedMouse::Phase::down;
+    down.button = MouseButton::right;
+    down.x = 50.0f;
+    down.y = 50.0f;
+    REQUIRE(pt::simulate_mouse(*host, down));
+
+    // Right-click only fires on rightMouseDown:; the matching up event
+    // is exercised here mainly to keep the gesture symmetrical and to
+    // confirm `simulate_mouse` does not crash when routing to
+    // `rightMouseUp:` (which PulpView does not override).
+    pt::SimulatedMouse up = down;
+    up.phase = pt::SimulatedMouse::Phase::up;
+    REQUIRE(pt::simulate_mouse(*host, up));
+
+    REQUIRE(context_menus == 1);
+    REQUIRE(left_clicks == 0);
 }


### PR DESCRIPTION
## Summary

Address two Codex P2 review comments on PR #2009 (the mac platform-test harness scaffold, since merged).

- **Scroll-wheel deltas were dropped.** `+[NSEvent mouseEventWithType:]` does not carry `scrollingDeltaX/Y`, so synthetic scroll events arrived at `PulpView::scrollWheel:` with zero deltas. Tests passed without exercising real scroll math. Build the event via `CGEventCreateScrollWheelEvent2` + `+[NSEvent eventWithCGEvent:]` so `event.scrollingDeltaX/Y` reflect the requested deltas.
- **Right/middle-click selector routing.** `simulate_mouse` always dispatched through `mouseDown:` / `mouseUp:` / `mouseDragged:` regardless of `event.button`, so right-click tests reached the left-click path instead of `rightMouseDown:` (the context-menu trigger). Route by button to `right*` / `other*` selectors.

Both were correctness-of-test-infrastructure issues — without them, scroll-related and secondary-button tests provided false confidence.

## Test plan

Two new tests in `test_mac_platform_harness.cpp` (gated `APPLE AND PULP_HAS_SKIA`):

- [ ] `mac harness scroll event carries non-zero deltas through PulpView` — synthesizes a scroll with `delta_y = 10`, asserts `on_pointer_event` fires once with non-zero `scroll_delta_y`.
- [ ] `mac harness right-click reaches PulpView::rightMouseDown: not mouseDown:` — synthesizes a right-click, asserts `on_context_menu` fires and `on_click` does not.
- [ ] Local syntax-check via `pulp-view` build clean (Skia static libs not installed locally; `pulp-test-mac-platform-harness` runtime exercise deferred to CI macOS lane).

Direct `clang -fsyntax-only` of both touched files clean against the production headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)