### PR TITLE
test: batch cli platform tooling coverage wave

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1567,6 +1567,23 @@ catch_discover_tests(pulp-test-render-loop
     PROPERTIES
         LABELS coverage)
 
+add_executable(pulp-test-sdl3-surface
+    test_sdl3_surface.cpp
+    ${CMAKE_SOURCE_DIR}/core/render/src/sdl3_surface.cpp)
+target_include_directories(pulp-test-sdl3-surface PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/render/include)
+target_link_libraries(pulp-test-sdl3-surface PRIVATE
+    pulp::runtime
+    Catch2::Catch2WithMain)
+if(PULP_HAS_SDL3)
+    target_link_libraries(pulp-test-sdl3-surface PRIVATE
+        $<BUILD_INTERFACE:SDL3::SDL3-static>)
+    target_compile_definitions(pulp-test-sdl3-surface PRIVATE PULP_HAS_SDL3=1)
+endif()
+catch_discover_tests(pulp-test-sdl3-surface
+    PROPERTIES
+        LABELS coverage)
+
 # GPU-stack tests — pulp::render only exists when PULP_ENABLE_GPU=ON.
 # The sanitizer matrix builds with GPU off; without the guard configure
 # fails with "Target ... links to: pulp::render but the target was not

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/tools/audio/excerpt_service.hpp>
+#include <pulp/tools/audio/model_registry.hpp>
 #include <pulp/tools/audio/model_store.hpp>
 #include <pulp/tools/audio/service.hpp>
 
@@ -10,6 +11,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <string>
 #include <string_view>
 
 #ifdef _WIN32
@@ -79,7 +81,115 @@ uint64_t stable_hash64(std::string_view text) {
     return hash;
 }
 
+void write_installed_model_metadata(const fs::path& pulp_home,
+                                    const fs::path& checkpoint,
+                                    std::string_view checkpoint_key = "resolved_checkpoint_path") {
+    write_text(pulp_home / "audio" / "models" / "clap_music_audioset_v1.json", R"JSON({
+  "model_id": "clap_music_audioset_v1",
+  "backend": "clap",
+  "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
+  ")JSON" + std::string(checkpoint_key) + R"JSON(": ")JSON" + checkpoint.generic_string() + R"JSON("
+}
+)JSON");
+}
+
 } // namespace
+
+TEST_CASE("audio model registry resolves known models and checkpoint URLs",
+          "[audio][tools][issue-643]") {
+    const auto& models = registered_models();
+    REQUIRE_FALSE(models.empty());
+
+    auto* model = find_registered_model("clap_music_audioset_v1");
+    REQUIRE(model != nullptr);
+    REQUIRE(model->backend == "clap");
+    REQUIRE(model->auto_downloadable);
+    REQUIRE(find_registered_model("not_a_model") == nullptr);
+
+    REQUIRE(resolve_checkpoint_url("hf://user/repo/path/to/model.pt")
+            == "https://huggingface.co/user/repo/resolve/main/path/to/model.pt");
+    REQUIRE(resolve_checkpoint_url("https://example.test/model.bin")
+            == "https://example.test/model.bin");
+    REQUIRE(resolve_checkpoint_url("http://example.test/model.bin")
+            == "http://example.test/model.bin");
+    REQUIRE(resolve_checkpoint_url("hf://user-only").empty());
+    REQUIRE(resolve_checkpoint_url("hf://user/repo").empty());
+    REQUIRE(resolve_checkpoint_url("file:///tmp/model.pt").empty());
+}
+
+TEST_CASE("audio model store reads legacy metadata and malformed records fail closed",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    auto checkpoint = temp.path / "models" / "clap.pt";
+    write_text(checkpoint, "stub");
+    write_installed_model_metadata(temp.path, checkpoint, "checkpoint_path");
+
+    auto record = read_installed_model("clap_music_audioset_v1", temp.path);
+    REQUIRE(record.metadata_found);
+    REQUIRE(record.model_id == "clap_music_audioset_v1");
+    REQUIRE(record.backend == "clap");
+    REQUIRE(record.checkpoint_ref == "hf://lukewys/laion_clap/music.pt");
+    REQUIRE(record.resolved_checkpoint_path == checkpoint);
+    REQUIRE(record.checkpoint_exists);
+    REQUIRE(record.loadable());
+
+    write_text(temp.path / "audio" / "models" / "bad_model.json", "{");
+    auto bad = read_installed_model("bad_model", temp.path);
+    REQUIRE(bad.metadata_found);
+    REQUIRE(bad.model_id == "bad_model");
+    REQUIRE(bad.backend.empty());
+    REQUIRE_FALSE(bad.checkpoint_exists);
+    REQUIRE_FALSE(bad.loadable());
+}
+
+TEST_CASE("audio model list and activation JSON report inactive and error states",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+
+    auto list = list_models(temp.path);
+    REQUIRE(list.error.empty());
+    REQUIRE(list.active_model_id.empty());
+    REQUIRE(list.models.size() == 1);
+    REQUIRE(list.models[0].status == "not_installed");
+    REQUIRE_FALSE(list.models[0].active);
+
+    auto list_json = to_json(list);
+    REQUIRE(list_json.find("\"status\": \"not_installed\"") != std::string::npos);
+    REQUIRE(list_json.find("\"active\": false") != std::string::npos);
+
+    auto activation = activate_model("not_a_model", temp.path);
+    REQUIRE_FALSE(activation.ok);
+    auto activation_json = to_json(activation);
+    REQUIRE(activation_json.find("\"ok\": false") != std::string::npos);
+    REQUIRE(activation_json.find("unknown model_id: not_a_model") != std::string::npos);
+}
+
+TEST_CASE("audio model status falls back to legacy model.json and installed metadata",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    auto checkpoint = temp.path / "models" / "clap.pt";
+    write_text(checkpoint, "stub");
+    write_installed_model_metadata(temp.path, checkpoint, "checkpoint_path");
+    write_text(temp.path / "audio" / "model.json", R"JSON({
+  "model_id": "clap_music_audioset_v1"
+}
+)JSON");
+
+    auto status = query_model_status(temp.path);
+
+    REQUIRE(status.state_file_found);
+    REQUIRE(status.state_path.filename() == "model.json");
+    REQUIRE(status.configured_model_id == "clap_music_audioset_v1");
+    REQUIRE(status.backend == "clap");
+    REQUIRE(status.checkpoint_ref == "hf://lukewys/laion_clap/music.pt");
+    REQUIRE(status.resolved_checkpoint_path == checkpoint);
+    REQUIRE(status.checkpoint_exists);
+    REQUIRE(status.loadable());
+
+    auto json = to_json(status);
+    REQUIRE(json.find("\"loadable\": true") != std::string::npos);
+    REQUIRE(json.find("\"message\": \"configured model is loadable\"") != std::string::npos);
+}
 
 TEST_CASE("audio model list reports registry and install state", "[audio][tools]") {
     TempDir temp;
@@ -270,6 +380,76 @@ TEST_CASE("excerpt bundle reader fails clearly without manifest", "[audio][tools
     REQUIRE(result.error.find("bundle path does not exist") != std::string::npos);
 }
 
+TEST_CASE("excerpt bundle reader fills defaults from model and ranked result files",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    auto bundle = temp.path / "bundle";
+    fs::create_directories(bundle);
+
+    write_text(bundle / "manifest.json", R"JSON({
+  "tool": "pulp audio excerpt-find",
+  "bundle_version": 1
+}
+)JSON");
+
+    write_text(bundle / "model.json", R"JSON({
+  "model_id": "clap_music_audioset_v1",
+  "backend": "clap"
+}
+)JSON");
+
+    write_text(bundle / "ranked_results.json", R"JSON({
+  "results": [
+    {
+      "score": 0.25,
+      "source_path": "/tmp/source.wav",
+      "end_ms": 100
+    },
+    42,
+    {
+      "rank": 5,
+      "source_file": "/tmp/other.wav"
+    }
+  ]
+}
+)JSON");
+
+    auto result = read_excerpt_bundle(bundle);
+
+    REQUIRE(result.ok);
+    REQUIRE(result.requested_model_id == "clap_music_audioset_v1");
+    REQUIRE(result.loaded_model_id == "clap_music_audioset_v1");
+    REQUIRE(result.backend == "clap");
+    REQUIRE(result.result_count == 2);
+    REQUIRE(result.results.size() == 2);
+    REQUIRE(result.results[0].rank == 1);
+    REQUIRE(result.results[0].score == Catch::Approx(0.25));
+    REQUIRE(result.results[0].source_file == "/tmp/source.wav");
+    REQUIRE(result.results[1].rank == 5);
+
+    auto json = to_json(result);
+    REQUIRE(json.find("\"result_count\": 2") != std::string::npos);
+    REQUIRE(json.find("\"source_file\": \"/tmp/source.wav\"") != std::string::npos);
+}
+
+TEST_CASE("excerpt bundle reader rejects missing ranked result file",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    auto bundle = temp.path / "bundle";
+    fs::create_directories(bundle);
+
+    write_text(bundle / "manifest.json", R"JSON({
+  "tool": "pulp audio excerpt-find",
+  "bundle_version": 1
+}
+)JSON");
+
+    auto result = read_excerpt_bundle(bundle);
+
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.error.find("missing ranked results file") != std::string::npos);
+}
+
 TEST_CASE("excerpt find writes a deterministic WAV-first bundle", "[audio][tools]") {
     TempDir temp;
     auto checkpoint = temp.path / "models" / "clap.pt";
@@ -356,6 +536,93 @@ TEST_CASE("excerpt find deterministic scores use a stable hash", "[audio][tools]
     const auto key = request.text + "|" + input.string() + "|0|48000";
     const auto expected = static_cast<double>(stable_hash64(key) % 1000000ULL) / 1000000.0;
     REQUIRE(result.results.front().score == Catch::Approx(expected));
+}
+
+TEST_CASE("excerpt find validates request guard fields before model resolution",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    ExcerptFindRequest request;
+    request.input_path = temp.path;
+    request.top_k = 1;
+    request.max_candidates_per_file = 1;
+    request.window_ms = 1000;
+    request.hop_ms = 1000;
+
+    auto empty_text = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(empty_text.ok);
+    REQUIRE(empty_text.error == "text query is required");
+
+    request.text = "query";
+    request.input_path = fs::path{};
+    auto empty_input = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(empty_input.ok);
+    REQUIRE(empty_input.error == "input path is required");
+
+    request.input_path = temp.path / "missing.wav";
+    auto missing_input = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(missing_input.ok);
+    REQUIRE(missing_input.error.find("input path does not exist") != std::string::npos);
+
+    request.input_path = temp.path;
+    request.top_k = 0;
+    auto zero_top = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(zero_top.ok);
+    REQUIRE(zero_top.error == "top and max_candidates_per_file must be >= 1");
+
+    request.top_k = 1;
+    request.max_candidates_per_file = 0;
+    auto zero_candidates = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(zero_candidates.ok);
+    REQUIRE(zero_candidates.error == "top and max_candidates_per_file must be >= 1");
+
+    request.max_candidates_per_file = 1;
+    request.window_ms = 0;
+    auto zero_window = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(zero_window.ok);
+    REQUIRE(zero_window.error == "window_ms and hop_ms must be >= 1");
+
+    request.window_ms = 1000;
+    request.hop_ms = 0;
+    auto zero_hop = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(zero_hop.ok);
+    REQUIRE(zero_hop.error == "window_ms and hop_ms must be >= 1");
+}
+
+TEST_CASE("excerpt find reports unsupported inputs after model resolution",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    auto checkpoint = temp.path / "models" / "clap.pt";
+    write_text(checkpoint, "stub");
+    write_installed_model_metadata(temp.path, checkpoint);
+    write_text(temp.path / "audio" / "model-state.json", R"JSON({
+  "active_model_id": "clap_music_audioset_v1"
+}
+)JSON");
+
+    auto unsupported = temp.path / "notes.txt";
+    write_text(unsupported, "not audio");
+
+    ExcerptFindRequest request;
+    request.text = "query";
+    request.input_path = unsupported;
+    request.top_k = 1;
+    request.max_candidates_per_file = 1;
+    request.window_ms = 1000;
+    request.hop_ms = 1000;
+    request.dry_run = true;
+
+    auto result = run_excerpt_find(request, temp.path);
+
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.requested_model_id == "clap_music_audioset_v1");
+    REQUIRE(result.error == "no supported WAV inputs found");
+    REQUIRE(result.scanned_file_count == 0);
+    REQUIRE(result.skipped_files.size() == 1);
+    REQUIRE(result.skipped_files[0].find("unsupported; WAV only") != std::string::npos);
+
+    auto json = to_json(result);
+    REQUIRE(json.find("\"ok\": false") != std::string::npos);
+    REQUIRE(json.find("unsupported; WAV only") != std::string::npos);
 }
 
 #if !defined(_WIN32)

--- a/test/test_child_process.cpp
+++ b/test/test_child_process.cpp
@@ -161,6 +161,35 @@ TEST_CASE("wait and read before start return default results",
     REQUIRE_FALSE(r.was_cancelled);
 }
 
+TEST_CASE("read_available_output drains stdout while process is running",
+          "[child_process][edge][issue-640]") {
+    ChildProcess cp;
+
+#ifdef _WIN32
+    REQUIRE(cp.start("cmd",
+                     {"/c", "<nul set /p dummy=available& ping -n 3 127.0.0.1 >nul"}));
+#else
+    REQUIRE(cp.start("/bin/sh", {"-c", "printf available; sleep 1"}));
+#endif
+
+    std::string observed;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (observed.find("available") == std::string::npos
+           && std::chrono::steady_clock::now() < deadline) {
+        observed += cp.read_available_output();
+        if (observed.find("available") == std::string::npos) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+
+    REQUIRE(observed.find("available") != std::string::npos);
+
+    auto r = cp.wait();
+    REQUIRE(r.exit_code == 0);
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE_FALSE(r.was_cancelled);
+}
+
 TEST_CASE("run honors working directory",
           "[child_process][edge][issue-640]") {
     auto dir = std::filesystem::temp_directory_path()

--- a/test/test_cli_fetchcontent_cache.cpp
+++ b/test/test_cli_fetchcontent_cache.cpp
@@ -88,6 +88,14 @@ std::string json_field_fragment(const std::string& key,
 
 }  // namespace
 
+TEST_CASE("status and fix labels fall back to unknown",
+          "[fetchcontent_cache][issue-643]") {
+    CHECK(std::string(fcc::status_label(fcc::CacheStatus::Healthy)) == "healthy");
+    CHECK(std::string(fcc::fix_outcome_label(fcc::FixOutcome::Removed)) == "removed");
+    CHECK(std::string(fcc::status_label(static_cast<fcc::CacheStatus>(99))) == "unknown");
+    CHECK(std::string(fcc::fix_outcome_label(static_cast<fcc::FixOutcome>(99))) == "unknown");
+}
+
 // ── Acceptance scenario 1: healthy ──────────────────────────────────────────
 
 TEST_CASE("discover: healthy entries report Healthy and exit 0",
@@ -268,6 +276,75 @@ TEST_CASE("discover: missing cache root returns empty and renders OK",
     CHECK(out.str().find("no entries") != std::string::npos);
 }
 
+TEST_CASE("discover: undeclared entries use fallback splitting and stable order",
+          "[fetchcontent_cache][issue-643]") {
+    fs::path root = "/fake/cache";
+    fs::path plain = root / "zlib";
+    fs::path split = root / "foo-bar-baz";
+    fs::path alpha = root / "alpha-v1";
+    MockState state;
+    state.children = {plain, split, alpha};
+
+    fcc::StatInfo info;
+    info.exists = true;
+    info.is_symlink = false;
+    info.is_directory = true;
+    info.is_user_writable = true;
+    state.lstat_results[plain] = info;
+    state.lstat_results[split] = info;
+    state.lstat_results[alpha] = info;
+
+    auto env = make_mock_env(root, {}, state);
+    auto entries = fcc::discover_fetchcontent_cache(env);
+
+    REQUIRE(entries.size() == 3);
+    CHECK(entries[0].name == "alpha-v1");
+    CHECK(entries[0].dep_name == "alpha");
+    CHECK(entries[0].cached_ref == "v1");
+    CHECK(entries[1].name == "foo-bar-baz");
+    CHECK(entries[1].dep_name == "foo-bar");
+    CHECK(entries[1].cached_ref == "baz");
+    CHECK(entries[2].name == "zlib");
+    CHECK(entries[2].dep_name == "zlib");
+    CHECK(entries[2].cached_ref.empty());
+    for (const auto& entry : entries) {
+        CHECK(entry.status == fcc::CacheStatus::Healthy);
+    }
+}
+
+TEST_CASE("discover: live symlink follows target and stays healthy",
+          "[fetchcontent_cache][issue-643]") {
+    fs::path root = "/fake/cache";
+    fs::path entry = root / "threejs-077dd13c0e869d9f3dbe55875686f920367de457";
+    MockState state;
+    state.children = {entry};
+
+    fcc::StatInfo link_info;
+    link_info.exists = true;
+    link_info.is_symlink = true;
+    link_info.symlink_target = "/Users/me/Code/three.js";
+    link_info.is_user_writable = true;
+    state.lstat_results[entry] = link_info;
+
+    fcc::StatInfo target_info;
+    target_info.exists = true;
+    target_info.is_directory = true;
+    target_info.is_user_writable = true;
+    state.stat_follow_results[entry] = target_info;
+
+    fcc::DeclaredRefs refs{
+        {"threejs", "077dd13c0e869d9f3dbe55875686f920367de457"}};
+    auto env = make_mock_env(root, refs, state);
+
+    auto entries = fcc::discover_fetchcontent_cache(env);
+    REQUIRE(entries.size() == 1);
+    CHECK(entries[0].status == fcc::CacheStatus::Healthy);
+    CHECK(entries[0].is_symlink);
+    CHECK(entries[0].resolved_target == fs::path("/Users/me/Code/three.js"));
+    CHECK_FALSE(fcc::any_unhealthy(entries));
+    CHECK_FALSE(fcc::blocks_preflight(entries));
+}
+
 TEST_CASE("discover: lstat miss reports Unknown and blocks preflight",
           "[fetchcontent_cache][issue-643]") {
     fs::path root = "/fake/cache";
@@ -348,6 +425,39 @@ TEST_CASE("apply_fixes: removes a real fixable entry from a tempdir",
     fs::remove_all(tmp, ec);
 }
 
+TEST_CASE("apply_fixes: removes symlinks without deleting their targets",
+          "[fetchcontent_cache][issue-643]") {
+#ifdef _WIN32
+    SKIP("symlink creation requires privileges on Windows");
+#else
+    auto tmp = fs::temp_directory_path() / "pulp-fcc-symlink-test-643";
+    std::error_code ec;
+    fs::remove_all(tmp, ec);
+    fs::create_directories(tmp / "target");
+    auto link = tmp / "stale-link";
+    fs::create_directory_symlink(tmp / "target", link, ec);
+    if (ec) {
+        fs::remove_all(tmp, ec);
+        SKIP("symlink creation unavailable in this filesystem");
+    }
+    REQUIRE(fs::is_symlink(fs::symlink_status(link)));
+    REQUIRE(fs::exists(tmp / "target"));
+
+    fcc::CacheEntry e;
+    e.name = "stale-link";
+    e.path = link;
+    e.status = fcc::CacheStatus::Dangling;
+    e.fixable = true;
+
+    auto results = fcc::apply_fixes({e}, /*dry_run=*/false);
+    REQUIRE(results.size() == 1);
+    CHECK(results[0].outcome == fcc::FixOutcome::Removed);
+    CHECK_FALSE(fs::exists(fs::symlink_status(link)));
+    CHECK(fs::exists(tmp / "target"));
+    fs::remove_all(tmp, ec);
+#endif
+}
+
 // ── parse_declared_refs_from_text: handles the real CMakeLists shape ───────
 
 TEST_CASE("parse_declared_refs_from_text: extracts name → REF map",
@@ -371,6 +481,27 @@ TEST_CASE("parse_declared_refs_from_text: extracts name → REF map",
     // is what protects stale-commit detection from false positives on
     // example/documentation snippets in CMakeLists.
     CHECK(refs.count("commented") == 0);
+}
+
+TEST_CASE("parse_declared_refs_from_file reads files and ignores missing paths",
+          "[fetchcontent_cache][issue-643]") {
+    auto tmp = fs::temp_directory_path() / "pulp-fcc-parse-file-643";
+    std::error_code ec;
+    fs::remove_all(tmp, ec);
+    fs::create_directories(tmp);
+    auto cmake = tmp / "CMakeLists.txt";
+    {
+        std::ofstream out(cmake);
+        out << "pulp_register_fetchcontent_source(Yoga REF release/3.2.12)\n";
+        out << "pulp_register_fetchcontent_source(no_ref URL https://example.invalid)\n";
+    }
+
+    auto refs = fcc::parse_declared_refs_from_file(cmake);
+    REQUIRE(refs.size() == 1);
+    CHECK(refs.at("yoga") == "release/3.2.12");
+    CHECK(refs.count("no_ref") == 0);
+    CHECK(fcc::parse_declared_refs_from_file(tmp / "missing.txt").empty());
+    fs::remove_all(tmp, ec);
 }
 
 // ── Multi-hyphen dep names split correctly ─────────────────────────────────

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -593,6 +593,90 @@ TEST_CASE("pulp status reports shipyard version and pin health",
 }
 #endif
 
+TEST_CASE("pulp config set/get/list round-trips isolated update settings",
+          "[cli][shellout][config][issue-643]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto home = unique_temp_dir("pulp-config-roundtrip");
+    fs::remove_all(home);
+    fs::create_directories(home);
+    write_text(home / "update-snooze", "dismissed\n");
+
+    ScopedEnvVar pulp_home("PULP_HOME");
+    pulp_home.set(home.string());
+    ScopedEnvVar update_disabled("PULP_UPDATE_CHECK_DISABLED");
+    update_disabled.set("1");
+
+    auto set_mode = run_pulp({"config", "set", "update.mode", "manual"}, 10000);
+    REQUIRE_FALSE(set_mode.timed_out);
+    REQUIRE(set_mode.exit_code == 0);
+    REQUIRE(set_mode.stdout_output.find("Set update.mode = manual") != std::string::npos);
+    REQUIRE_FALSE(fs::exists(home / "update-snooze"));
+
+    auto get_mode = run_pulp({"config", "get", "update.mode"}, 10000);
+    REQUIRE_FALSE(get_mode.timed_out);
+    REQUIRE(get_mode.exit_code == 0);
+    REQUIRE(get_mode.stdout_output == "manual\n");
+
+    auto set_channel = run_pulp({"config", "set", "update.channel", "beta"}, 10000);
+    REQUIRE_FALSE(set_channel.timed_out);
+    REQUIRE(set_channel.exit_code == 0);
+    REQUIRE(set_channel.stdout_output.find("Set update.channel = beta") != std::string::npos);
+
+    auto list = run_pulp({"config", "list"}, 10000);
+    const auto config_body = read_file(home / "config.toml");
+    fs::remove_all(home);
+
+    REQUIRE_FALSE(list.timed_out);
+    REQUIRE(list.exit_code == 0);
+    REQUIRE(list.stdout_output.find("update.mode = manual") != std::string::npos);
+    REQUIRE(list.stdout_output.find("update.check_interval_hours = 24") != std::string::npos);
+    REQUIRE(list.stdout_output.find("update.channel = beta") != std::string::npos);
+    REQUIRE(list.stdout_output.find("update.bump_projects = prompt") != std::string::npos);
+    REQUIRE(config_body.find("[update]") != std::string::npos);
+    REQUIRE(config_body.find("mode = \"manual\"") != std::string::npos);
+    REQUIRE(config_body.find("channel = \"beta\"") != std::string::npos);
+}
+
+TEST_CASE("pulp config rejects malformed and invalid update keys",
+          "[cli][shellout][config][issue-643]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto home = unique_temp_dir("pulp-config-invalid");
+    fs::remove_all(home);
+    fs::create_directories(home);
+
+    ScopedEnvVar pulp_home("PULP_HOME");
+    pulp_home.set(home.string());
+    ScopedEnvVar update_disabled("PULP_UPDATE_CHECK_DISABLED");
+    update_disabled.set("1");
+
+    auto malformed_get = run_pulp({"config", "get", "update"}, 10000);
+    REQUIRE_FALSE(malformed_get.timed_out);
+    REQUIRE(malformed_get.exit_code != 0);
+    REQUIRE(malformed_get.stderr_output.find("key must be dotted") != std::string::npos);
+
+    auto unknown_key = run_pulp({"config", "set", "update.not_a_key", "value"}, 10000);
+    REQUIRE_FALSE(unknown_key.timed_out);
+    REQUIRE(unknown_key.exit_code != 0);
+    REQUIRE(unknown_key.stderr_output.find("unknown config key") != std::string::npos);
+
+    auto bad_mode = run_pulp({"config", "set", "update.mode", "weekly"}, 10000);
+    REQUIRE_FALSE(bad_mode.timed_out);
+    REQUIRE(bad_mode.exit_code != 0);
+    REQUIRE(bad_mode.stderr_output.find("update.mode must be one of") != std::string::npos);
+
+    auto bad_interval =
+        run_pulp({"config", "set", "update.check_interval_hours", "-1"}, 10000);
+    const bool config_written = fs::exists(home / "config.toml");
+    fs::remove_all(home);
+
+    REQUIRE_FALSE(bad_interval.timed_out);
+    REQUIRE(bad_interval.exit_code != 0);
+    REQUIRE(bad_interval.stderr_output.find("non-negative integer") != std::string::npos);
+    REQUIRE_FALSE(config_written);
+}
+
 TEST_CASE("pulp version subcommand runs and mentions the SDK",
           "[cli][shellout][version]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -191,6 +191,22 @@ TEST_CASE("Environment: token move assignment replaces prior subscription",
     REQUIRE(second_calls == 1);
 }
 
+TEST_CASE("Environment: token self move assignment preserves subscription",
+          "[environment][issue-640]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+    REQUIRE(token.valid());
+
+    Environment::Token& alias = token;
+    token = std::move(alias);
+    REQUIRE(token.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(calls == 1);
+}
+
 TEST_CASE("Environment: keyboard inset change propagates separately",
           "[environment]") {
     Environment::reset_for_test();
@@ -438,6 +454,63 @@ TEST_CASE("Environment: listener unsubscribed mid-dispatch is not invoked "
     Environment::inject_for_test(make_state(ColorScheme::light));
     REQUIRE(a_calls == 2);
     REQUIRE(b_calls == 1);
+}
+
+TEST_CASE("Environment: listener removed before its dispatch turn is skipped",
+          "[environment][issue-640]") {
+    Environment::reset_for_test();
+
+    int victim_calls = 0;
+    int survivor_calls = 0;
+    Environment::Token victim;
+
+    auto killer = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { victim.reset(); });
+    victim = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++victim_calls; });
+    auto survivor = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++survivor_calls; });
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+
+    REQUIRE(killer.valid());
+    REQUIRE_FALSE(victim.valid());
+    REQUIRE(survivor.valid());
+    REQUIRE(victim_calls == 0);
+    REQUIRE(survivor_calls == 1);
+}
+
+TEST_CASE("Environment: reset during dispatch clears later callbacks",
+          "[environment][issue-640]") {
+    Environment::reset_for_test();
+
+    int resetter_calls = 0;
+    int later_calls = 0;
+    auto resetter = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) {
+            ++resetter_calls;
+            Environment::reset_for_test();
+        });
+    auto later = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++later_calls; });
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+
+    REQUIRE(resetter_calls == 1);
+    REQUIRE(later_calls == 0);
+    REQUIRE(resetter.valid());
+    REQUIRE(later.valid());
+    REQUIRE(Environment::instance().snapshot().color_scheme
+            == ColorScheme::unknown);
+
+    resetter.reset();
+    later.reset();
+    REQUIRE_FALSE(resetter.valid());
+    REQUIRE_FALSE(later.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(resetter_calls == 1);
+    REQUIRE(later_calls == 0);
 }
 
 TEST_CASE("Environment: snapshot is consistent with last publish",

--- a/test/test_sdl3_surface.cpp
+++ b/test/test_sdl3_surface.cpp
@@ -1,0 +1,37 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/render/sdl3_surface.hpp>
+
+using namespace pulp;
+
+TEST_CASE("SDL3 surface info validity follows backend state - issue-646",
+          "[render][sdl3][issue-646]") {
+    render::Sdl3SurfaceInfo info;
+    REQUIRE_FALSE(info.is_valid());
+
+    info.x11_display = reinterpret_cast<void*>(0x1);
+    info.x11_window = 42;
+    REQUIRE_FALSE(info.is_valid());
+
+    info.backend = render::Sdl3SurfaceInfo::Backend::vulkan_x11;
+    REQUIRE(info.is_valid());
+
+    info = {};
+    info.hwnd = reinterpret_cast<void*>(0x2);
+    info.hinstance = reinterpret_cast<void*>(0x3);
+    info.backend = render::Sdl3SurfaceInfo::Backend::d3d12;
+    REQUIRE(info.is_valid());
+}
+
+TEST_CASE("SDL3 surface extraction rejects null windows - issue-646",
+          "[render][sdl3][issue-646]") {
+    auto info = render::extract_sdl3_surface(nullptr);
+    REQUIRE_FALSE(info.is_valid());
+    REQUIRE(info.backend == render::Sdl3SurfaceInfo::Backend::none);
+    REQUIRE(info.metal_layer == nullptr);
+    REQUIRE(info.hwnd == nullptr);
+    REQUIRE(info.hinstance == nullptr);
+    REQUIRE(info.x11_display == nullptr);
+    REQUIRE(info.x11_window == 0);
+    REQUIRE(info.wayland_display == nullptr);
+    REQUIRE(info.wayland_surface == nullptr);
+}

--- a/tools/packages/test_freshness_check_extra.py
+++ b/tools/packages/test_freshness_check_extra.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Additional unit tests for package freshness checking edge paths.
+
+Run:
+    python3 tools/packages/test_freshness_check_extra.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).parent
+
+
+def load_module(name: str, path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+fc = load_module("freshness_check_extra_target", ROOT / "freshness_check.py")
+
+
+@contextlib.contextmanager
+def argv(args: list[str]):
+    old = sys.argv[:]
+    sys.argv = args[:]
+    try:
+        yield
+    finally:
+        sys.argv = old
+
+
+@contextlib.contextmanager
+def module_attr(module, name: str, value):
+    old = getattr(module, name)
+    setattr(module, name, value)
+    try:
+        yield
+    finally:
+        setattr(module, name, old)
+
+
+class FreshnessCheckExtraTests(unittest.TestCase):
+    def test_result_preserves_explicit_issue_list(self) -> None:
+        issues = ["already known"]
+
+        result = fc.CheckResult(
+            package="audio-lib",
+            pinned_version="1.0.0",
+            issues=issues,
+        )
+
+        self.assertIs(result.issues, issues)
+
+    def test_extract_owner_repo_rejects_incomplete_github_url(self) -> None:
+        self.assertIsNone(fc.extract_owner_repo("https://github.com/acme"))
+
+    def test_check_package_falls_back_to_tags_without_release(self) -> None:
+        responses = {
+            "repos/acme/audio-lib": {"archived": False, "pushed_at": ""},
+            "repos/acme/audio-lib/releases?per_page=1": [],
+            "repos/acme/audio-lib/tags?per_page=1": [{"name": "v1.2.3"}],
+            "repos/acme/audio-lib/license": {"license": {"spdx_id": "NOASSERTION"}},
+        }
+
+        with mock.patch.object(fc, "run_gh", side_effect=lambda args: responses[args[0]]):
+            result = fc.check_package(
+                "audio-lib",
+                {
+                    "version": "v1.2.3",
+                    "license": "MIT",
+                    "fetch": {"git_repository": "https://github.com/acme/audio-lib"},
+                },
+            )
+
+        self.assertEqual(result.latest_version, "v1.2.3")
+        self.assertIsNone(result.last_commit_date)
+        self.assertFalse(result.archived)
+        self.assertFalse(result.license_changed)
+        self.assertEqual(result.issues, [])
+
+    def test_check_package_tolerates_missing_tags_and_license(self) -> None:
+        responses = {
+            "repos/acme/audio-lib": {"archived": False},
+            "repos/acme/audio-lib/releases?per_page=1": None,
+            "repos/acme/audio-lib/tags?per_page=1": [],
+            "repos/acme/audio-lib/license": None,
+        }
+
+        with mock.patch.object(fc, "run_gh", side_effect=lambda args: responses[args[0]]):
+            result = fc.check_package(
+                "audio-lib",
+                {
+                    "version": "v1.2.3",
+                    "license": "MIT",
+                    "fetch": {"git_repository": "https://github.com/acme/audio-lib"},
+                },
+            )
+
+        self.assertIsNone(result.latest_version)
+        self.assertIsNone(result.last_commit_date)
+        self.assertEqual(result.issues, [])
+
+    def test_main_emits_markdown_for_all_packages(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            registry_path = pathlib.Path(td) / "registry.json"
+            registry_path.write_text(
+                json.dumps(
+                    {
+                        "packages": {
+                            "ok": {"version": "1.0.0"},
+                            "stale": {"version": "1.0.0"},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            def fake_check(slug: str, pkg: dict):
+                if slug == "stale":
+                    return fc.CheckResult(
+                        package=slug,
+                        pinned_version=pkg["version"],
+                        latest_version="2.0.0",
+                        issues=["Newer version available"],
+                    )
+                return fc.CheckResult(
+                    package=slug,
+                    pinned_version=pkg["version"],
+                    latest_version=pkg["version"],
+                    last_commit_date="2026-04-01",
+                )
+
+            out = io.StringIO()
+            err = io.StringIO()
+            with module_attr(fc, "REGISTRY", registry_path), mock.patch.object(fc, "check_package", fake_check):
+                with argv(["freshness_check.py", "--format", "markdown"]):
+                    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                        rc = fc.main()
+
+        self.assertEqual(rc, 1)
+        text = out.getvalue()
+        self.assertIn("| Package | Pinned | Latest | Last Commit | Issues |", text)
+        self.assertIn("| ok | 1.0.0 | 1.0.0 | 2026-04-01 | OK |", text)
+        self.assertIn("| stale | 1.0.0 | 2.0.0 | ? | Newer version available |", text)
+        self.assertIn("2 packages checked, 1 issues", err.getvalue())
+
+    def test_main_emits_text_for_ok_and_issue_results(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            registry_path = pathlib.Path(td) / "registry.json"
+            registry_path.write_text(
+                json.dumps(
+                    {
+                        "packages": {
+                            "ok": {"version": "1.0.0"},
+                            "stale": {"version": "1.0.0"},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            def fake_check(slug: str, pkg: dict):
+                if slug == "stale":
+                    return fc.CheckResult(
+                        package=slug,
+                        pinned_version=pkg["version"],
+                        issues=["Cannot reach GitHub API"],
+                    )
+                return fc.CheckResult(package=slug, pinned_version=pkg["version"])
+
+            out = io.StringIO()
+            err = io.StringIO()
+            with module_attr(fc, "REGISTRY", registry_path), mock.patch.object(fc, "check_package", fake_check):
+                with argv(["freshness_check.py"]):
+                    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                        rc = fc.main()
+
+        self.assertEqual(rc, 1)
+        text = out.getvalue()
+        self.assertRegex(text, r"ok\s+\.+\s+OK")
+        self.assertRegex(text, r"stale\s+\.+\s+ISSUES")
+        self.assertIn("    - Cannot reach GitHub API", text)
+        self.assertIn("2 packages checked, 1 issues", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/scripts/test_auto_release_decision_extra.py
+++ b/tools/scripts/test_auto_release_decision_extra.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Additional edge coverage for auto_release_decision.py."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import pathlib
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+
+HERE = pathlib.Path(__file__).resolve().parent
+SCRIPT = HERE / "auto_release_decision.py"
+
+spec = importlib.util.spec_from_file_location("auto_release_decision", SCRIPT)
+ard = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(ard)
+
+
+class ParseVersionEdgeTests(unittest.TestCase):
+    def test_parse_version_returns_tuple_for_exact_semver(self) -> None:
+        self.assertEqual(ard.parse_version("10.2.300"), (10, 2, 300))
+
+    def test_parse_version_rejects_wrong_part_counts(self) -> None:
+        self.assertIsNone(ard.parse_version("1.2"))
+        self.assertIsNone(ard.parse_version("1.2.3.4"))
+
+    def test_parse_version_rejects_non_numeric_parts(self) -> None:
+        self.assertIsNone(ard.parse_version("1.two.3"))
+
+
+class MainCliEdgeTests(unittest.TestCase):
+    def test_main_prints_json_decision_for_plugin_surface(self) -> None:
+        argv = [
+            str(SCRIPT),
+            "--head-version",
+            "2.0.0",
+            "--tag-version",
+            "1.9.9",
+            "--bump-commit-has-skip",
+            "0",
+            "--surface",
+            "plugin",
+        ]
+        output = io.StringIO()
+        with mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(output):
+            self.assertEqual(ard.main(), 0)
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(payload["should_tag"], 1)
+        self.assertEqual(payload["surface"], "plugin")
+        self.assertIn("tagging", payload["reason"])
+
+    def test_script_entrypoint_handles_empty_head_version(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT), "--surface", "sdk"],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["should_tag"], 0)
+        self.assertIn("no sdk version", payload["reason"])
+
+    def test_script_entrypoint_rejects_invalid_skip_flag(self) -> None:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--head-version",
+                "1.0.0",
+                "--bump-commit-has-skip",
+                "2",
+            ],
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("invalid choice", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/scripts/test_check_format_validation.py
+++ b/tools/scripts/test_check_format_validation.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/check_format_validation.py."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "tools" / "check_format_validation.py"
+
+spec = importlib.util.spec_from_file_location("check_format_validation", SCRIPT)
+assert spec and spec.loader
+cfv = importlib.util.module_from_spec(spec)
+sys.modules["check_format_validation"] = cfv
+spec.loader.exec_module(cfv)
+
+
+class ExtractFormatsTests(unittest.TestCase):
+    def test_extract_formats_reads_nested_platform_statuses(self) -> None:
+        text = """\
+formats:
+  vst3:
+    macos: stable
+    windows: usable
+  clap:
+    linux: experimental
+production_validated:
+  vst3:
+    macos: [Reaper]
+"""
+
+        self.assertEqual(
+            cfv.extract_formats(text),
+            {
+                "vst3": {"macos": "stable", "windows": "usable"},
+                "clap": {"linux": "experimental"},
+            },
+        )
+
+    def test_extract_formats_returns_empty_when_block_absent(self) -> None:
+        self.assertEqual(cfv.extract_formats("production_validated:\n"), {})
+
+
+class ExtractProductionTests(unittest.TestCase):
+    def test_extract_production_reads_empty_and_populated_inline_lists(self) -> None:
+        text = """\
+production_validated:
+  vst3:
+    macos: [Reaper, "Logic Pro", 'Cubase']
+    windows: []
+  clap:
+    linux: [Bitwig]
+formats:
+  vst3:
+    macos: stable
+"""
+
+        self.assertEqual(
+            cfv.extract_production(text),
+            {
+                "vst3": {
+                    "macos": ["Reaper", "Logic Pro", "Cubase"],
+                    "windows": [],
+                },
+                "clap": {"linux": ["Bitwig"]},
+            },
+        )
+
+    def test_extract_production_ignores_comments_and_blank_lines(self) -> None:
+        text = """\
+production_validated:
+  # Populated during host smoke validation.
+
+  auv2:
+    macos: []
+"""
+
+        self.assertEqual(cfv.extract_production(text), {"auv2": {"macos": []}})
+
+    def test_extract_production_returns_empty_when_block_absent(self) -> None:
+        self.assertEqual(cfv.extract_production("formats:\n"), {})
+
+
+class MainTests(unittest.TestCase):
+    def _run_main(self, matrix_text: str, *args: str) -> tuple[int, str, str]:
+        with tempfile.TemporaryDirectory() as td:
+            matrix = pathlib.Path(td) / "support-matrix.yaml"
+            matrix.write_text(matrix_text, encoding="utf-8")
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with mock.patch.object(cfv, "MATRIX_PATH", matrix), \
+                 mock.patch.object(sys, "argv", ["check_format_validation.py", *args]), \
+                 contextlib.redirect_stdout(stdout), \
+                 contextlib.redirect_stderr(stderr):
+                rc = cfv.main()
+            return rc, stdout.getvalue(), stderr.getvalue()
+
+    def test_warn_mode_reports_gaps_but_exits_zero(self) -> None:
+        rc, out, err = self._run_main(
+            """\
+formats:
+  vst3:
+    macos: stable
+    windows: usable
+    linux: experimental
+  clap:
+    linux: stable
+production_validated:
+  vst3:
+    macos: [Reaper]
+    windows: []
+""",
+        )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(err, "")
+        self.assertIn("1 format/platform pairs host-validated", out)
+        self.assertIn("1 acknowledged but empty", out)
+        self.assertIn("1 missing from production_validated", out)
+        self.assertIn("EMPTY:   vst3.windows is 'usable'", out)
+        self.assertIn("MISSING: production_validated.clap.linux absent", out)
+        self.assertNotIn("vst3.linux", out)
+
+    def test_report_mode_returns_one_when_required_validation_is_missing(self) -> None:
+        rc, out, _ = self._run_main(
+            """\
+formats:
+  vst3:
+    macos: stable
+production_validated:
+  vst3:
+    macos: []
+""",
+            "--mode=report",
+        )
+
+        self.assertEqual(rc, 1)
+        self.assertIn("mode=report", out)
+        self.assertIn("EMPTY:   vst3.macos is 'stable'", out)
+
+    def test_report_mode_returns_zero_when_all_required_pairs_have_hosts(self) -> None:
+        rc, out, err = self._run_main(
+            """\
+formats:
+  vst3:
+    macos: stable
+  clap:
+    linux: usable
+production_validated:
+  vst3:
+    macos: [Reaper]
+  clap:
+    linux: [Bitwig]
+""",
+            "--mode=report",
+        )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(err, "")
+        self.assertIn("2 format/platform pairs host-validated", out)
+        self.assertIn("0 acknowledged but empty", out)
+        self.assertIn("0 missing from production_validated", out)
+
+    def test_read_error_returns_two_and_writes_stderr(self) -> None:
+        missing = pathlib.Path(tempfile.gettempdir()) / "pulp-missing-support-matrix.yaml"
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with mock.patch.object(cfv, "MATRIX_PATH", missing), \
+             mock.patch.object(sys, "argv", ["check_format_validation.py"]), \
+             contextlib.redirect_stdout(stdout), \
+             contextlib.redirect_stderr(stderr):
+            rc = cfv.main()
+
+        self.assertEqual(rc, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("Failed to read", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/test_ruleset_drift_config.py
+++ b/tools/scripts/test_ruleset_drift_config.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Structural tests for the ruleset drift workflow.
+
+These tests keep the checked-in branch protection intent aligned with the
+workflow that compares it to GitHub's live ruleset. They are intentionally
+offline: no GitHub API calls, no workflow dispatch, and no runner access.
+
+Run:
+    python3 tools/scripts/test_ruleset_drift_config.py
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import unittest
+
+import yaml
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ruleset-drift-check.yml"
+RULESET = REPO_ROOT / ".github" / "rulesets" / "main-protection.json"
+
+EXPECTED_REQUIRED_CONTEXTS = {
+    "macos",
+    "linux",
+    "windows",
+    "Enforce version & skill sync",
+}
+
+EXPECTED_ADVISORY_CONTEXTS = {
+    "AddressSanitizer (macOS ARM64)",
+    "ThreadSanitizer (macOS ARM64)",
+    "UndefinedBehaviorSanitizer (macOS ARM64)",
+    "RealtimeSanitizer (Linux x86_64, Clang 18)",
+}
+
+
+def workflow_on(doc: dict) -> dict:
+    """Return the GitHub Actions `on:` block from a PyYAML-loaded document."""
+    # PyYAML's YAML 1.1 resolver treats the bare word "on" as boolean True.
+    # GitHub Actions treats it as a literal key.
+    return doc.get("on") or doc.get(True) or {}
+
+
+def required_contexts(ruleset: dict) -> set[str]:
+    contexts: set[str] = set()
+    for rule in ruleset.get("rules", []):
+        if rule.get("type") != "required_status_checks":
+            continue
+        params = rule.get("parameters", {})
+        for check in params.get("required_status_checks", []):
+            context = check.get("context")
+            if context:
+                contexts.add(context)
+    return contexts
+
+
+def advisory_contexts(ruleset: dict) -> set[str]:
+    advisory = ruleset.get("advisory_status_checks", {})
+    return {
+        check["context"]
+        for check in advisory.get("checks", [])
+        if check.get("context")
+    }
+
+
+class RulesetDriftConfig(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow_text = WORKFLOW.read_text(encoding="utf-8")
+        cls.workflow = yaml.safe_load(cls.workflow_text)
+        cls.ruleset = json.loads(RULESET.read_text(encoding="utf-8"))
+
+    def test_pull_request_trigger_is_scoped_to_ruleset_files(self) -> None:
+        trigger = workflow_on(self.workflow)
+        pull_request = trigger.get("pull_request", {})
+
+        self.assertEqual(pull_request.get("branches"), ["main"])
+        self.assertEqual(
+            set(pull_request.get("paths", [])),
+            {
+                ".github/rulesets/**",
+                ".github/workflows/ruleset-drift-check.yml",
+            },
+        )
+
+    def test_manual_trigger_can_override_drift_failure(self) -> None:
+        trigger = workflow_on(self.workflow)
+        dispatch = trigger.get("workflow_dispatch", {})
+        fail_on_drift = dispatch.get("inputs", {}).get("fail_on_drift", {})
+
+        self.assertEqual(
+            fail_on_drift.get("default"),
+            "",
+            "manual runs should default to the workflow's event-sensitive "
+            "failure policy instead of forcing failures on every dispatch",
+        )
+        self.assertFalse(fail_on_drift.get("required", True))
+
+    def test_workflow_points_at_checked_in_ruleset_name(self) -> None:
+        diff_job = self.workflow["jobs"]["diff"]
+        env = diff_job["env"]
+
+        self.assertEqual(
+            env["CHECKED_IN_PATH"],
+            ".github/rulesets/main-protection.json",
+        )
+        self.assertEqual(env["RULESET_NAME"], self.ruleset["name"])
+        self.assertEqual(self.ruleset["target"], "branch")
+        self.assertEqual(self.ruleset["source_type"], "Repository")
+        self.assertEqual(self.ruleset["enforcement"], "active")
+
+    def test_required_and_advisory_contexts_stay_separate(self) -> None:
+        required = required_contexts(self.ruleset)
+        advisory = advisory_contexts(self.ruleset)
+
+        self.assertEqual(required, EXPECTED_REQUIRED_CONTEXTS)
+        self.assertEqual(advisory, EXPECTED_ADVISORY_CONTEXTS)
+        self.assertTrue(
+            required.isdisjoint(advisory),
+            "slow sanitizer contexts must remain advisory-only unless branch "
+            "protection policy changes explicitly",
+        )
+
+    def test_fetch_filters_out_inherited_org_rulesets(self) -> None:
+        self.assertIn(
+            "includes_parents=false",
+            self.workflow_text,
+            "ruleset drift fetch must ignore inherited org rulesets so a "
+            "same-named org ruleset cannot mask repo-local drift",
+        )
+        self.assertIn(
+            "source_type')=='Repository'",
+            self.workflow_text,
+            "ruleset id selection must require Repository source_type",
+        )
+
+    def test_pr_comment_is_fork_safe_and_scheduled_drift_fails(self) -> None:
+        self.assertIn(
+            "github.event.pull_request.head.repo.full_name == github.repository",
+            self.workflow_text,
+            "PR drift comments must be skipped for fork heads because their "
+            "GITHUB_TOKEN cannot write issue comments",
+        )
+        self.assertIn(
+            "steps.diff.outputs.drift == 'true' && github.event_name != 'pull_request'",
+            self.workflow_text,
+            "scheduled/manual drift must surface as a failing check while PR "
+            "drift remains advisory",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- batch Phase 3 coverage into one broad GitHub-hosted CI run across CLI shellout/config, FetchContent cache, audio tooling, platform environment/child-process, SDL3 surface fallback, and Python tooling/package freshness guards
- folds the earlier platform-runtime batch into this PR so the tests land on main here, not through the standalone durability branch
- leaves Namespace and SSH validation out of scope; macOS local validation only before GitHub Actions

## Local validation
- cmake --build build --target pulp-test-audio-tools pulp-test-cli-shellout pulp-test-cli-fetchcontent-cache pulp-test-environment pulp-test-child-process pulp-test-sdl3-surface -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-audio-tools "[audio][tools][issue-643]" -r compact
- ./build/test/pulp-test-cli-shellout "[cli][shellout][config][issue-643]" -r compact
- ./build/test/pulp-test-cli-fetchcontent-cache "[fetchcontent_cache][issue-643]" -r compact
- ./build/test/pulp-test-environment "[environment][issue-640]" -r compact
- ./build/test/pulp-test-child-process "[child_process][edge][issue-640]" -r compact
- ./build/test/pulp-test-sdl3-surface "[render][sdl3][issue-646]" -r compact
- full touched binaries: pulp-test-audio-tools, pulp-test-cli-fetchcontent-cache, pulp-test-environment, pulp-test-child-process, pulp-test-sdl3-surface
- python3 tools/scripts/test_auto_release_decision_extra.py
- python3 tools/scripts/test_check_format_validation.py
- python3 tools/scripts/test_ruleset_drift_config.py
- python3 tools/packages/test_freshness_check_extra.py
- skill/version/compat/docs sync reports

## Notes
- Local pre-push diff-cover was demoted because its coverage build could not fetch the pinned Highway tree locally; GitHub CI will run the actual gates.