### PR TITLE
fix(cmake): link fontconfig after libskia.a in pulp-import-design (#1986 follow-up)

### DIFF
--- a/tools/cmake/PulpLinkFontconfig.cmake
+++ b/tools/cmake/PulpLinkFontconfig.cmake
@@ -1,0 +1,45 @@
+# PulpLinkFontconfig.cmake — link-order fix for libskia.a → fontconfig
+# on Linux + GNU ld.
+#
+# Pulp #1962 / #1986 root cause: `libskia.a` (pulled in by
+# `pulp::canvas`'s PUBLIC `skia::skia` dep) contains
+# `SkFontMgr_New_FontConfig` which references `FcInit*` / `FcConfig*` /
+# `FcPattern*` / `FcGetVersion` / `FcFontSet*` etc. GNU ld processes
+# static archives left-to-right and only pulls in symbols that are
+# unresolved AT THE TIME the archive is processed; symbols referenced
+# AFTER the archive go unresolved even if a later library would have
+# satisfied them. Re-mentioning `fontconfig` here ensures it appears
+# AFTER `libskia.a` in the final link line.
+#
+# `PkgConfig::FONTCONFIG` is already wired PUBLIC on `pulp-canvas` per
+# pulp #1962 follow-up, so the include dirs and -L flags are already
+# correct — this helper just nails the link-line position down for
+# every downstream binary that pulls in pulp::view / pulp::canvas.
+#
+# Originally inlined in tools/cli/CMakeLists.txt (#1986). Extracted
+# here so the same fix can apply to pulp-import-design, pulp-design-debug,
+# pulp-screenshot, and any future Linux+Skia binary without copy-paste
+# drift. Pulp #1986 follow-up — also needed for v0.100.0 release-cli
+# linux-x64 build of pulp-import-design.
+#
+# Usage:
+#     include(${CMAKE_SOURCE_DIR}/tools/cmake/PulpLinkFontconfig.cmake)
+#     pulp_link_fontconfig_after_skia(my-target)
+#
+# No-op on non-Linux platforms (macOS uses CoreText, Windows uses
+# DirectWrite, Android bundles its own font manager).
+function(pulp_link_fontconfig_after_skia target)
+    if(NOT (UNIX AND NOT APPLE AND NOT ANDROID))
+        return()
+    endif()
+    find_package(PkgConfig)
+    if(NOT PkgConfig_FOUND)
+        return()
+    endif()
+    # Use a target-scoped variable name so multiple callers don't collide.
+    set(_var "_PULP_${target}_FONTCONFIG")
+    pkg_check_modules(${_var} IMPORTED_TARGET fontconfig)
+    if(${_var}_FOUND)
+        target_link_libraries(${target} PRIVATE PkgConfig::${_var})
+    endif()
+endfunction()

--- a/tools/import-design/CMakeLists.txt
+++ b/tools/import-design/CMakeLists.txt
@@ -9,3 +9,11 @@ add_executable(pulp-import-design
     widget_promotion.cpp)
 target_include_directories(pulp-import-design PRIVATE ${CMAKE_SOURCE_DIR})
 target_link_libraries(pulp-import-design PRIVATE pulp::view pulp::state)
+
+# Link-order fix for libskia.a → fontconfig on Linux+GNU ld (#1986
+# follow-up): re-mention fontconfig AFTER pulp::view's transitive
+# skia::skia so the linker resolves SkFontMgr_New_FontConfig's Fc*
+# references. Caused v0.100.0 release-cli linux-x64 to fail; was
+# already in place for pulp-cli.
+include(${CMAKE_SOURCE_DIR}/tools/cmake/PulpLinkFontconfig.cmake)
+pulp_link_fontconfig_after_skia(pulp-import-design)


### PR DESCRIPTION
## Summary
v0.100.0 release-cli linux-x64 failed at `pulp-import-design` link with hundreds of undefined references to `FcPatternAddString` / `FcConfigSubstitute` / `FcGetVersion` / `FcCharSetCreate` / `FcLangSetCreate` — same class of bug as #1962, same fix pattern as #1986 (which only fixed pulp-cli).

## Fix
Extracted the fontconfig-after-skia link-order fix into a reusable CMake helper:

```cmake
include(${CMAKE_SOURCE_DIR}/tools/cmake/PulpLinkFontconfig.cmake)
pulp_link_fontconfig_after_skia(<target>)
```

No-op on macOS / Windows / Android. Applied to `pulp-import-design`. `pulp-design` and `pulp-screenshot` are APPLE-only and don't need it. `pulp-cli` keeps its inlined block from #1986; can migrate in a follow-up.

## Test plan
- [x] CMake configure clean on macOS (helper no-ops)
- [x] `cmake --build build --target pulp-import-design` succeeds on macOS
- [ ] CI Linux-x64 build green — primary objective
- [ ] v0.100.0 SDK release publishes 11 assets after this lands and we tag v0.101.0

## Closes
Unblocks v0.100.0 SDK release (blocked at linux-x64 build step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)