### PR TITLE
test(format): batch midi and host edge coverage

### DIFF
--- a/test/test_descriptor_validation.cpp
+++ b/test/test_descriptor_validation.cpp
@@ -248,3 +248,44 @@ TEST_CASE("DescriptorValidation: reverse-DNS bundle_id passes",
         REQUIRE(i.field != "bundle_id");
     }
 }
+
+TEST_CASE("DescriptorValidation: mixed warnings and errors remain invalid",
+          "[format][descriptor-validation][issue-493]") {
+    auto d = well_formed_effect();
+    d.name.clear();
+    d.bundle_id = "Not Reverse DNS";
+    d.output_buses = {{"Broken Out", 0, false}};
+
+    auto issues = validate_descriptor(d);
+    REQUIRE(has_error_on(issues, "name"));
+    REQUIRE(has_warning_on(issues, "bundle_id"));
+    REQUIRE(has_error_on(issues, "output_buses"));
+    REQUIRE_FALSE(descriptor_is_valid(issues));
+}
+
+TEST_CASE("DescriptorValidation: optional zero-channel side inputs are accepted",
+          "[format][descriptor-validation][issue-493]") {
+    auto d = well_formed_effect();
+    d.input_buses = {
+        {"Main In", 2, false},
+        {"Sidechain", 0, true},
+    };
+    d.output_buses = {{"Main Out", 2, false}};
+
+    auto issues = validate_descriptor(d);
+    REQUIRE_FALSE(has_error_on(issues, "input_buses"));
+    REQUIRE(descriptor_is_valid(issues));
+}
+
+TEST_CASE("DescriptorValidation: MIDI sidecar capabilities are warning-only without MIDI input",
+          "[format][descriptor-validation][issue-493]") {
+    auto d = well_formed_effect();
+    d.accepts_midi = false;
+    d.produces_midi = true;
+    d.supports_mpe = true;
+    d.supports_ump = true;
+
+    auto issues = validate_descriptor(d);
+    REQUIRE(has_warning_on(issues, "accepts_midi"));
+    REQUIRE(descriptor_is_valid(issues));
+}

--- a/test/test_diagnostic_reporter.cpp
+++ b/test/test_diagnostic_reporter.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/format/diagnostic_reporter.hpp>
+#include <pulp/format/host_type.hpp>
 #include <pulp/state/store.hpp>
 
 using namespace pulp::format;
@@ -135,4 +136,60 @@ TEST_CASE("DiagnosticReporter instrument type", "[format][diagnostic]") {
 
     auto report = diag.generate_report();
     REQUIRE(report.find("Instrument") != std::string::npos);
+}
+
+TEST_CASE("DiagnosticReporter default report omits optional sections until set",
+          "[format][diagnostic][issue-493]") {
+    DiagnosticReporter diag;
+    auto report = diag.generate_report();
+    auto json = diag.generate_json();
+
+    REQUIRE(report.find("--- Plugin ---") != std::string::npos);
+    REQUIRE(report.find("Format:") == std::string::npos);
+    REQUIRE(report.find("Host:") == std::string::npos);
+    REQUIRE(report.find("CPU Load:") == std::string::npos);
+    REQUIRE(report.find("--- Custom ---") == std::string::npos);
+    REQUIRE(report.find("--- Parameters (0) ---") != std::string::npos);
+    REQUIRE(json.find("\"parameters\": [") != std::string::npos);
+    REQUIRE(json.find("\"name\": \"\"") != std::string::npos);
+}
+
+TEST_CASE("DiagnosticReporter JSON reflects instrument/effect type and parameter values",
+          "[format][diagnostic][issue-493]") {
+    DiagnosticReporter diag;
+    auto desc = make_desc();
+    desc.category = PluginCategory::Instrument;
+    StateStore store;
+    setup_store(store);
+    store.set_value(1, -18.0f);
+    store.set_value(2, 25.0f);
+
+    diag.set_plugin_info(desc, store);
+    diag.set_audio_config(96000, 128, 0, 2);
+
+    auto json = diag.generate_json();
+    REQUIRE(json.find("\"type\": \"instrument\"") != std::string::npos);
+    REQUIRE(json.find("\"sampleRate\": 96000") != std::string::npos);
+    REQUIRE(json.find("\"bufferSize\": 128") != std::string::npos);
+    REQUIRE(json.find("\"inputChannels\": 0") != std::string::npos);
+    REQUIRE(json.find("\"outputChannels\": 2") != std::string::npos);
+    REQUIRE(json.find("\"value\": -18.0000") != std::string::npos);
+    REQUIRE(json.find("\"value\": 25.0000") != std::string::npos);
+}
+
+TEST_CASE("HostType names and feature heuristics cover fixed-size and no-sidechain hosts",
+          "[format][host-type][issue-493]") {
+    REQUIRE(host_type_name(HostType::Unknown) == "Unknown");
+    REQUIRE(host_type_name(HostType::Other) == "Other");
+    REQUIRE(host_type_name(static_cast<HostType>(255)) == "Unknown");
+
+    REQUIRE_FALSE(host_supports_resize(HostType::ProTools));
+    REQUIRE_FALSE(host_supports_resize(HostType::GarageBand));
+    REQUIRE(host_supports_resize(HostType::LogicPro));
+    REQUIRE(host_supports_resize(HostType::Unknown));
+
+    REQUIRE_FALSE(host_supports_sidechain(HostType::GarageBand));
+    REQUIRE_FALSE(host_supports_sidechain(HostType::AudacityTenacity));
+    REQUIRE(host_supports_sidechain(HostType::Reaper));
+    REQUIRE(host_supports_sidechain(HostType::Unknown));
 }

--- a/test/test_mpe_buffer.cpp
+++ b/test/test_mpe_buffer.cpp
@@ -62,6 +62,78 @@ TEST_CASE("MpeBuffer clear and sort", "[midi][mpe]") {
     REQUIRE(buffer.empty());
 }
 
+TEST_CASE("MpeBuffer groups equal sample offsets without dropping events",
+          "[midi][mpe][issue-645]") {
+    MpeBuffer buffer;
+    MpeNoteState first;
+    first.note = 60;
+    MpeNoteState second;
+    second.note = 64;
+    MpeNoteState third;
+    third.note = 67;
+
+    buffer.add({12, Kind::NoteOn, first});
+    buffer.add({12, Kind::Pressure, second});
+    buffer.add({20, Kind::Timbre, third});
+    buffer.sort();
+
+    REQUIRE(buffer.size() == 3);
+    REQUIRE(buffer[0].sample_offset == 12);
+    REQUIRE(buffer[1].sample_offset == 12);
+    REQUIRE(buffer[2].sample_offset == 20);
+    const bool saw_first_equal_offset = buffer[0].state.note == 60
+                                     || buffer[1].state.note == 60;
+    const bool saw_second_equal_offset = buffer[0].state.note == 64
+                                      || buffer[1].state.note == 64;
+    REQUIRE(saw_first_equal_offset);
+    REQUIRE(saw_second_equal_offset);
+    REQUIRE(buffer[2].state.note == 67);
+}
+
+TEST_CASE("MpeBuffer accepts moved expression events and supports const iteration",
+          "[midi][mpe][issue-645]") {
+    MpeBuffer buffer;
+    MpeExpressionEvent event;
+    event.sample_offset = 7;
+    event.kind = Kind::NoteOn;
+    event.state.channel = 3;
+    event.state.note = 72;
+    event.state.velocity = 100;
+
+    buffer.add(std::move(event));
+
+    const MpeBuffer& const_buffer = buffer;
+    int seen = 0;
+    for (const auto& e : const_buffer) {
+        REQUIRE(e.sample_offset == 7);
+        REQUIRE(e.kind == Kind::NoteOn);
+        REQUIRE(e.state.channel == 3);
+        REQUIRE(e.state.note == 72);
+        REQUIRE(e.state.velocity == 100);
+        ++seen;
+    }
+    REQUIRE(seen == 1);
+}
+
+TEST_CASE("bind_tracker_to_buffer uses the latest referenced sample offset",
+          "[midi][mpe][issue-645]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    MpeBuffer buffer;
+    int32_t offset = 0;
+    bind_tracker_to_buffer(tracker, buffer, offset);
+
+    offset = 3;
+    REQUIRE(tracker.process(MidiEvent::note_on(1, 60, 100)));
+    offset = 99;
+    REQUIRE(tracker.process(MidiEvent::note_off(1, 60)));
+
+    REQUIRE(buffer.size() == 2);
+    REQUIRE(buffer[0].sample_offset == 3);
+    REQUIRE(buffer[0].kind == Kind::NoteOn);
+    REQUIRE(buffer[1].sample_offset == 99);
+    REQUIRE(buffer[1].kind == Kind::NoteOff);
+}
+
 TEST_CASE("Processor::supports_mpe defaults to false", "[midi][mpe]") {
     pulp::format::PluginDescriptor desc;
     REQUIRE_FALSE(desc.supports_mpe);

--- a/test/test_scan_blacklist.cpp
+++ b/test/test_scan_blacklist.cpp
@@ -143,3 +143,41 @@ TEST_CASE("load_from and save_to report unavailable paths",
     fs::create_directories(f.path);
     REQUIRE_FALSE(bl.save_to(f.path.string()));
 }
+
+TEST_CASE("from_text accepts empty/comment-only files and clears previous entries",
+          "[host][blacklist][issue-493]") {
+    ScanBlacklist bl;
+    REQUIRE(bl.from_text("/old|1|2|stale\n"));
+    REQUIRE(bl.size() == 1);
+
+    REQUIRE(bl.from_text("# only comments\n\n   \n"));
+    REQUIRE(bl.size() == 0);
+    REQUIRE_FALSE(bl.is_blacklisted("/old"));
+}
+
+TEST_CASE("from_text preserves reasons containing delimiter-like escaped data",
+          "[host][blacklist][issue-493]") {
+    ScanBlacklist bl;
+    REQUIRE(bl.from_text("/plugin.vst3|10|20|first%7Csecond%25third\n"));
+
+    auto entry = bl.entries().find("/plugin.vst3");
+    REQUIRE(entry != bl.entries().end());
+    REQUIRE(entry->second.mtime == 10);
+    REQUIRE(entry->second.size == 20);
+    REQUIRE(entry->second.reason == "first|second%third");
+
+    const auto text = bl.to_text();
+    REQUIRE(text.find("first%7Csecond%25third") != std::string::npos);
+}
+
+TEST_CASE("from_text tolerates signed stamp values from old blacklist files",
+          "[host][blacklist][issue-493]") {
+    ScanBlacklist bl;
+    REQUIRE(bl.from_text("/plugin.vst3|-1|-2|old stamp\n"));
+
+    auto entry = bl.entries().find("/plugin.vst3");
+    REQUIRE(entry != bl.entries().end());
+    REQUIRE(entry->second.mtime == -1);
+    REQUIRE(entry->second.size == -2);
+    REQUIRE(entry->second.reason == "old stamp");
+}


### PR DESCRIPTION
## Summary
- add MPE buffer ordering, move-add, and tracker sample-offset coverage
- cover diagnostic reporter default/json output and host type feature heuristics
- add descriptor validation warning/error combinations and scan blacklist parser edge coverage

## Local validation
- `cmake --build build --target pulp-test-mpe-buffer pulp-test-diagnostic pulp-test-descriptor-validation pulp-test-scan-blacklist -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-mpe-buffer "[issue-645]" -r compact`
- `./build/test/pulp-test-diagnostic "[issue-493]" -r compact`
- `./build/test/pulp-test-descriptor-validation "[issue-493]" -r compact`
- `./build/test/pulp-test-scan-blacklist "[issue-493]" -r compact`
- full touched binaries: `pulp-test-mpe-buffer`, `pulp-test-diagnostic`, `pulp-test-descriptor-validation`, `pulp-test-scan-blacklist`
- guard reports: skill-sync, version-bump, docs-sync, compat-sync, diff checks

GitHub-hosted CI only; no Namespace or SSH dispatch.