### PR TITLE
test(host): batch graph serializer edge coverage

### DIFF
--- a/core/host/src/graph_serializer.cpp
+++ b/core/host/src/graph_serializer.cpp
@@ -253,7 +253,7 @@ GraphSerializer::LoadResult GraphSerializer::from_json(SignalGraph& graph, const
                             std::string(format_str(info.format)) + ":" + info.unique_id);
                         // Still create a placeholder Plugin node with no slot so
                         // connection IDs remain stable.
-                        new_id = graph.add_plugin_node(std::unique_ptr<PluginSlot>{}, in_ch, out_ch, name);
+                        new_id = graph.add_plugin_node(info);
                     } else {
                         if (pv.hasObjectMember("state_b64")) {
                             auto blob = b64_decode(pv["state_b64"].getString());

--- a/test/test_graph_serializer.cpp
+++ b/test/test_graph_serializer.cpp
@@ -445,6 +445,75 @@ TEST_CASE("GraphSerializer serializes plugin formats and state blobs",
     }
 }
 
+TEST_CASE("GraphSerializer preserves unresolved plugin identity when reserializing",
+          "[host][serializer][issue-493]") {
+    SignalGraph src;
+    auto info = make_fake_plugin_info("MissingEcho", "pulp.test.missing.echo",
+                                      PluginFormat::CLAP, 2, 2);
+    src.add_plugin_node(info);
+
+    const auto first_json = GraphSerializer::to_json(src);
+    REQUIRE(first_json.find("\"unique_id\": \"pulp.test.missing.echo\"") !=
+            std::string::npos);
+    REQUIRE(first_json.find("\"state_b64\"") == std::string::npos);
+
+    SignalGraph dst;
+    auto result = GraphSerializer::from_json(dst, first_json);
+    REQUIRE(result.ok);
+    REQUIRE(missing_plugins_contain(result, "clap:pulp.test.missing.echo"));
+    REQUIRE(dst.nodes().size() == 1);
+    REQUIRE(dst.nodes().front().type == NodeType::Plugin);
+    REQUIRE(dst.nodes().front().plugin == nullptr);
+
+    const auto second_json = GraphSerializer::to_json(dst);
+    REQUIRE(second_json.find("\"format\": \"clap\"") != std::string::npos);
+    REQUIRE(second_json.find("\"unique_id\": \"pulp.test.missing.echo\"") !=
+            std::string::npos);
+    REQUIRE(second_json.find("\"last_path\": \"/nonexistent/MissingEcho.clap\"") !=
+            std::string::npos);
+    REQUIRE(second_json.find("\"state_b64\"") == std::string::npos);
+}
+
+TEST_CASE("GraphSerializer clears partially loaded graphs after plugin field errors",
+          "[host][serializer][issue-493]") {
+    SignalGraph dst;
+    auto result = GraphSerializer::from_json(dst, R"({
+  "format_version": 1,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "audio_in",
+      "name": "Input",
+      "num_input_ports": 0,
+      "num_output_ports": 1,
+      "gain": 1
+    },
+    {
+      "id": 2,
+      "type": "plugin",
+      "name": "Broken plugin",
+      "num_input_ports": 1,
+      "num_output_ports": 1,
+      "gain": 1,
+      "plugin": {
+        "format": "clap",
+        "unique_id": 123,
+        "name": "Broken plugin",
+        "manufacturer": "PulpTest",
+        "version": "1.0.0",
+        "last_path": "/missing/broken.clap"
+      }
+    }
+  ],
+  "connections": []
+})");
+
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.error.find("field deserialization failed") != std::string::npos);
+    REQUIRE(dst.nodes().empty());
+    REQUIRE(dst.connections().empty());
+}
+
 TEST_CASE("GraphSerializer round-trips MIDI routing", "[host][serializer]") {
     SignalGraph src;
     auto midi_in = src.add_midi_input_node();

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -481,6 +481,35 @@ TEST_CASE("SignalGraph connections", "[host][graph]") {
     REQUIRE(graph.connections().size() == 1);
 }
 
+TEST_CASE("SignalGraph rejects missing-node and duplicate edge variants",
+          "[host][graph][issue-493]") {
+    SignalGraph graph;
+    auto input = graph.add_input_node(2);
+    auto gain = graph.add_gain_node("Gain");
+    auto output = graph.add_output_node(2);
+    auto midi_in = graph.add_midi_input_node("MIDI In");
+    auto midi_out = graph.add_midi_output_node("MIDI Out");
+
+    REQUIRE_FALSE(graph.connect(999, 0, gain, 0));
+    REQUIRE_FALSE(graph.connect(input, 0, 999, 0));
+    REQUIRE_FALSE(graph.disconnect(input, 0, gain, 0));
+
+    REQUIRE(graph.connect(input, 0, gain, 0));
+    REQUIRE_FALSE(graph.connect(input, 0, gain, 0));
+    REQUIRE(graph.disconnect(input, 0, gain, 0));
+    REQUIRE_FALSE(graph.disconnect(input, 0, gain, 0));
+
+    REQUIRE_FALSE(graph.connect_feedback(999, 0, output, 0));
+    REQUIRE_FALSE(graph.connect_feedback(gain, 0, 999, 0));
+    REQUIRE(graph.connect_feedback(gain, 0, output, 0));
+    REQUIRE_FALSE(graph.connect_feedback(gain, 0, output, 0));
+
+    REQUIRE_FALSE(graph.connect_midi(999, midi_out));
+    REQUIRE_FALSE(graph.connect_midi(midi_in, 999));
+    REQUIRE(graph.connect_midi(midi_in, midi_out));
+    REQUIRE_FALSE(graph.connect_midi(midi_in, midi_out));
+}
+
 TEST_CASE("SignalGraph cycle detection", "[host][graph]") {
     SignalGraph graph;
     auto a = graph.add_input_node(2);
@@ -567,6 +596,71 @@ TEST_CASE("SignalGraph routes input -> gain -> output", "[host][graph][routing]"
         REQUIRE(std::abs(out_r[i] - 0.2f) < 1e-6f);
     }
     graph.release();
+}
+
+TEST_CASE("SignalGraph live gain updates and release silence output",
+          "[host][graph][routing][issue-493]") {
+    SignalGraph graph;
+    auto in  = graph.add_input_node(1, "in");
+    auto gain = graph.add_gain_node("gain");
+    auto out = graph.add_output_node(1, "out");
+
+    REQUIRE(graph.connect(in, 0, gain, 0));
+    REQUIRE(graph.connect(gain, 0, out, 0));
+    REQUIRE(graph.prepare(48000.0, 16));
+
+    std::vector<float> input(16, 0.8f);
+    std::vector<float> output(16, -1.0f);
+    const float* in_ptrs[1] = {input.data()};
+    float* out_ptrs[1] = {output.data()};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 1, 16);
+    pulp::audio::BufferView<float> out_view(out_ptrs, 1, 16);
+
+    graph.process(out_view, in_view, 16);
+    for (float sample : output) REQUIRE_THAT(sample, WithinAbs(0.8f, 1e-6f));
+
+    REQUIRE(graph.set_node_gain(gain, 0.25f));
+    REQUIRE(graph.node_gain(gain) == 0.25f);
+    std::fill(output.begin(), output.end(), -1.0f);
+    graph.process(out_view, in_view, 16);
+    for (float sample : output) REQUIRE_THAT(sample, WithinAbs(0.2f, 1e-6f));
+
+    graph.release();
+    std::fill(output.begin(), output.end(), -1.0f);
+    graph.process(out_view, in_view, 16);
+    for (float sample : output) REQUIRE(sample == 0.0f);
+    REQUIRE(graph.latency_samples() == 0);
+    REQUIRE(graph.node_latency_samples(gain) == 0);
+}
+
+TEST_CASE("SignalGraph query helpers handle non-plugin and cleared nodes",
+          "[host][graph][issue-493]") {
+    SignalGraph graph;
+    auto input = graph.add_input_node(2);
+    auto gain = graph.add_gain_node("Gain");
+    auto output = graph.add_output_node(2);
+
+    REQUIRE_FALSE(graph.prepare(48000.0, 0));
+    REQUIRE_FALSE(graph.prepare(48000.0, -16));
+    REQUIRE_FALSE(graph.set_node_gain(999, 0.5f));
+    REQUIRE(graph.node_gain(999) == 1.0f);
+    REQUIRE_FALSE(graph.set_node_parameter(gain, 7, 0.25f));
+    REQUIRE(graph.get_node_parameter(gain, 7) == 0.0f);
+    REQUIRE_FALSE(graph.set_node_parameter(999, 7, 0.25f));
+    REQUIRE(graph.get_node_parameter(999, 7) == 0.0f);
+    REQUIRE(graph.node_latency_samples(999) == 0);
+
+    REQUIRE(graph.connect(input, 0, gain, 0));
+    REQUIRE(graph.connect(gain, 0, output, 0));
+    REQUIRE(graph.prepare(48000.0, 16));
+    REQUIRE(graph.node_latency_samples(gain) == 0);
+
+    graph.clear();
+    REQUIRE(graph.nodes().empty());
+    REQUIRE(graph.connections().empty());
+    REQUIRE(graph.latency_samples() == 0);
+    REQUIRE(graph.node_latency_samples(gain) == 0);
+    REQUIRE(graph.node_gain(gain) == 1.0f);
 }
 
 TEST_CASE("SignalGraph disconnected output stays silent", "[host][graph][routing]") {


### PR DESCRIPTION
## Summary
- add SignalGraph coverage for invalid duplicate edge variants, live gain updates, release silence, and helper behavior after clear
- add GraphSerializer coverage for unresolved plugin identity reserialization and plugin field error cleanup
- preserve missing-plugin identity when GraphSerializer creates placeholder plugin nodes

## Validation
- cmake --build build --target pulp-test-host pulp-test-graph-serializer -j10
- ./build/test/pulp-test-host "[host][graph][issue-493]" -r compact
- ./build/test/pulp-test-graph-serializer "[host][serializer][issue-493]" -r compact
- ./build/test/pulp-test-host -r compact
- ./build/test/pulp-test-graph-serializer -r compact
- git diff --check origin/main...HEAD && git diff --check && git diff --cached --check
- python3 tools/scripts/skill_sync_check.py
- tools/scripts/cli_version_check.sh
- ./tools/check-docs.sh (passes with existing warnings)

Note: local pre-push diff-cover was demoted because its coverage configure path failed fetching Highway at 457c891775a7397bdb0376bb1031e6e027af1c48 before test execution; GitHub CI remains the validation source.