### PR TITLE
test(tools): batch python control-plane coverage

### DIFF
--- a/tools/scripts/test_fetch_skia_for_release_extra.py
+++ b/tools/scripts/test_fetch_skia_for_release_extra.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Additional unit tests for tools/scripts/fetch_skia_for_release.py."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import importlib.util
+import io
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+import zipfile
+from unittest import mock
+
+
+SCRIPT = pathlib.Path(__file__).parent / "fetch_skia_for_release.py"
+
+spec = importlib.util.spec_from_file_location("fetch_skia_for_release_extra_target", SCRIPT)
+assert spec and spec.loader
+skia = importlib.util.module_from_spec(spec)
+sys.modules["fetch_skia_for_release_extra_target"] = skia
+spec.loader.exec_module(skia)
+
+
+class _FakeResponse:
+    def __init__(self, data: bytes):
+        self._data = data
+        self._offset = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self, size: int = -1) -> bytes:
+        if self._offset >= len(self._data):
+            return b""
+        if size < 0:
+            size = len(self._data) - self._offset
+        chunk = self._data[self._offset:self._offset + size]
+        self._offset += len(chunk)
+        return chunk
+
+
+def make_zip_bytes(rel_path: pathlib.Path, payload: bytes = b"skia") -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(rel_path.as_posix(), payload)
+    return buf.getvalue()
+
+
+@contextlib.contextmanager
+def cwd(path: pathlib.Path):
+    old = pathlib.Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old)
+
+
+class FetchSkiaForReleaseExtraTests(unittest.TestCase):
+    def test_main_usage_unknown_platform_and_missing_manifest_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(skia.main(["fetch"]), 2)
+            self.assertIn("usage:", err.getvalue())
+
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(skia.main(["fetch", "weird-platform"]), 0)
+            self.assertIn("unknown matrix platform", err.getvalue())
+
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 1)
+            self.assertIn("manifest.json not found", err.getvalue())
+
+    def test_main_skips_platform_without_release_asset(self) -> None:
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            manifest = pathlib.Path("tools/deps/manifest.json")
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(
+                json.dumps({"dependencies": [{"name": "Skia", "determinism": {"release_assets": {}}}]}),
+                encoding="utf-8",
+            )
+
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                self.assertEqual(skia.main(["fetch", "linux-arm64"]), 0)
+            self.assertIn("no Skia release asset", out.getvalue())
+
+    def test_main_reports_missing_skia_entry_and_checksum_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            manifest = pathlib.Path("tools/deps/manifest.json")
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(json.dumps({"dependencies": []}), encoding="utf-8")
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 1)
+            self.assertIn("no 'Skia' dependency", err.getvalue())
+
+            manifest.write_text(
+                json.dumps({
+                    "dependencies": [{
+                        "name": "Skia",
+                        "determinism": {
+                            "release_assets": {
+                                "mac-arm64": {"url": "https://example.invalid/skia.zip", "sha256": "0" * 64}
+                            }
+                        },
+                    }]
+                }),
+                encoding="utf-8",
+            )
+            with mock.patch.object(skia.urllib.request, "urlopen", return_value=_FakeResponse(b"not a zip")), \
+                 contextlib.redirect_stderr(err := io.StringIO()), \
+                 contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 1)
+            self.assertIn("sha256 mismatch", err.getvalue())
+
+    def test_main_unpacks_valid_asset_and_reports_zip_layout_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            data = make_zip_bytes(pathlib.Path("build/mac-gpu/lib/Release/libskia.a"), b"abc")
+            digest = hashlib.sha256(data).hexdigest()
+            manifest = pathlib.Path("tools/deps/manifest.json")
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(
+                json.dumps({
+                    "dependencies": [{
+                        "name": "skia",
+                        "determinism": {
+                            "release_assets": {
+                                "mac-arm64": {"url": "https://example.invalid/skia.zip", "sha256": digest}
+                            }
+                        },
+                    }]
+                }),
+                encoding="utf-8",
+            )
+
+            out = io.StringIO()
+            with mock.patch.object(skia.urllib.request, "urlopen", return_value=_FakeResponse(data)), \
+                 contextlib.redirect_stdout(out):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 0)
+
+            self.assertTrue(skia.expected_library_path("darwin-arm64").is_file())
+            self.assertFalse(pathlib.Path("skia-release-asset.zip").exists())
+            self.assertIn("OK:", out.getvalue())
+
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            data = make_zip_bytes(pathlib.Path("wrong/place/libskia.a"), b"abc")
+            digest = hashlib.sha256(data).hexdigest()
+            manifest = pathlib.Path("tools/deps/manifest.json")
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(
+                json.dumps({
+                    "dependencies": [{
+                        "name": "Skia",
+                        "determinism": {
+                            "release_assets": {
+                                "mac-arm64": {"url": "https://example.invalid/skia.zip", "sha256": digest}
+                            }
+                        },
+                    }]
+                }),
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(skia.urllib.request, "urlopen", return_value=_FakeResponse(data)), \
+                 contextlib.redirect_stdout(io.StringIO()), \
+                 contextlib.redirect_stderr(err := io.StringIO()):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 1)
+            self.assertIn("expected library not found", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/test_host_pump_lint.py
+++ b/tools/scripts/test_host_pump_lint.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/scripts/host_pump_lint.py."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPT = pathlib.Path(__file__).parent / "host_pump_lint.py"
+
+spec = importlib.util.spec_from_file_location("host_pump_lint", SCRIPT)
+assert spec and spec.loader
+hpl = importlib.util.module_from_spec(spec)
+sys.modules["host_pump_lint"] = hpl
+spec.loader.exec_module(hpl)
+
+
+class HostPumpLintTests(unittest.TestCase):
+    def test_scan_file_ignores_missing_files(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            missing = pathlib.Path(td) / "missing.cpp"
+            self.assertEqual(hpl.scan_file(missing), [])
+
+    def test_scan_file_accepts_paired_calls_in_same_block(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            source = pathlib.Path(td) / "main.cpp"
+            source.write_text(
+                """
+void tick() {
+    bridge->poll_async_results();
+    bridge->service_frame_callbacks();
+}
+""",
+                encoding="utf-8",
+            )
+            self.assertEqual(hpl.scan_file(source), [])
+
+    def test_scan_file_flags_unpaired_poll_before_block_close(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            source = root / "examples" / "design-tool" / "main.cpp"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                """
+void tick() {
+    bridge->poll_async_results();
+}
+void later() {
+    bridge->service_frame_callbacks();
+}
+""",
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(hpl, "REPO_ROOT", root):
+                violations = hpl.scan_file(source)
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("examples/design-tool/main.cpp:3", violations[0])
+            self.assertIn("not paired", violations[0])
+
+    def test_scan_file_accepts_inline_skip_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            source = pathlib.Path(td) / "main.cpp"
+            source.write_text(
+                f"bridge->poll_async_results(); // {hpl.SKIP_MARKER} - one-shot\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(hpl.scan_file(source), [])
+
+    def test_scan_file_respects_window_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            source = pathlib.Path(td) / "main.cpp"
+            gap = "\n".join("    do_work();" for _ in range(hpl.WINDOW_LINES + 1))
+            source.write_text(
+                f"""
+void tick() {{
+    bridge->poll_async_results();
+{gap}
+    bridge->service_frame_callbacks();
+}}
+""",
+                encoding="utf-8",
+            )
+            self.assertEqual(len(hpl.scan_file(source)), 1)
+
+    def test_main_reports_violations_and_read_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            host = root / "host.cpp"
+            host.write_text("bridge->poll_async_results();\n", encoding="utf-8")
+
+            err = io.StringIO()
+            with mock.patch.object(hpl, "REPO_ROOT", root), \
+                 mock.patch.object(hpl, "HOST_FILES", ["host.cpp"]), \
+                 contextlib.redirect_stderr(err):
+                self.assertEqual(hpl.main(), 1)
+            self.assertIn("idle-pump pairing violations", err.getvalue())
+
+            with mock.patch.object(hpl, "HOST_FILES", ["host.cpp"]), \
+                 mock.patch.object(hpl, "scan_file", side_effect=OSError("denied")), \
+                 contextlib.redirect_stderr(err := io.StringIO()):
+                self.assertEqual(hpl.main(), 2)
+            self.assertIn("failed to read", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/test_macos_reroute_watcher.py
+++ b/tools/scripts/test_macos_reroute_watcher.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/scripts/macos_reroute_watcher.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+
+SCRIPT = pathlib.Path(__file__).parent / "macos_reroute_watcher.py"
+
+spec = importlib.util.spec_from_file_location("macos_reroute_watcher", SCRIPT)
+assert spec and spec.loader
+watcher = importlib.util.module_from_spec(spec)
+sys.modules["macos_reroute_watcher"] = watcher
+spec.loader.exec_module(watcher)
+
+
+class MacosRerouteWatcherTests(unittest.TestCase):
+    def test_gh_returns_stripped_stdout(self) -> None:
+        completed = subprocess.CompletedProcess(["gh"], 0, stdout="  ok\n")
+        with mock.patch.object(watcher.subprocess, "run", return_value=completed) as run:
+            self.assertEqual(watcher._gh(["repos/acme/project"]), "ok")
+        run.assert_called_once()
+        self.assertEqual(run.call_args.args[0], ["gh", "api", "repos/acme/project"])
+        self.assertEqual(run.call_args.kwargs["timeout"], 20)
+
+    def test_local_is_busy_detects_runner_processes_and_failures(self) -> None:
+        busy_output = (
+            "/Users/runner/actions-runner/_work/pulp/pulp/_temp cmake --build build\n"
+            "/usr/bin/other\n"
+        )
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["ps"], 0, stdout=busy_output),
+        ):
+            self.assertTrue(watcher.local_is_busy())
+
+        worker_output = "/Users/runner/actions-runner/_work/pulp/pulp Runner.Worker spawnclient\n"
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["ps"], 0, stdout=worker_output),
+        ):
+            self.assertTrue(watcher.local_is_busy())
+
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["ps"], 0, stdout="/usr/bin/idle\n"),
+        ):
+            self.assertFalse(watcher.local_is_busy())
+
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["ps"], timeout=10),
+        ):
+            self.assertIsNone(watcher.local_is_busy())
+
+    def test_macos_job_target_detection(self) -> None:
+        with mock.patch.object(watcher, "_gh", return_value="self-hosted,macOS"):
+            self.assertFalse(watcher._macos_job_targets_cloud(10))
+
+        for labels in ("macos-15,ARM64", "nscloud-macos,macOS", "namespace-profile-macos"):
+            with self.subTest(labels=labels), mock.patch.object(watcher, "_gh", return_value=labels):
+                self.assertTrue(watcher._macos_job_targets_cloud(10))
+
+        with mock.patch.object(watcher, "_gh", return_value=""):
+            self.assertFalse(watcher._macos_job_targets_cloud(10))
+
+        with mock.patch.object(watcher, "_gh", side_effect=subprocess.CalledProcessError(1, ["gh"])):
+            self.assertFalse(watcher._macos_job_targets_cloud(10))
+
+    def test_list_queued_cloud_bat_runs_filters_invalid_and_local_rows(self) -> None:
+        raw = "\n".join([
+            json.dumps({"id": 101, "pr": 11}),
+            "{not json",
+            json.dumps({"id": None, "pr": 12}),
+            json.dumps({"id": 102, "pr": None}),
+            json.dumps({"id": 103, "pr": 13}),
+        ])
+
+        def fake_cloud(run_id: int) -> bool:
+            return run_id == 101
+
+        with mock.patch.object(watcher, "_gh", return_value=raw), \
+             mock.patch.object(watcher, "_macos_job_targets_cloud", side_effect=fake_cloud):
+            self.assertEqual(watcher.list_queued_cloud_bat_runs(), [(11, 101)])
+
+        with mock.patch.object(watcher, "_gh", side_effect=subprocess.CalledProcessError(1, ["gh"])):
+            self.assertEqual(watcher.list_queued_cloud_bat_runs(), [])
+
+    def test_reroute_to_local_reports_success_and_failure(self) -> None:
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["pulp"], 0, stdout="done\n", stderr=""),
+        ) as run:
+            self.assertTrue(watcher.reroute_to_local(42))
+        self.assertEqual(
+            run.call_args.args[0],
+            ["pulp", "macos", "retarget", "--pr", "42", "--to", "local"],
+        )
+
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["pulp"], 2, stdout="", stderr="nope"),
+        ):
+            self.assertFalse(watcher.reroute_to_local(42))
+
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["pulp"], timeout=60),
+        ):
+            self.assertFalse(watcher.reroute_to_local(42))
+
+    def test_flap_guard_window_and_trim(self) -> None:
+        guard = watcher.FlapGuard(window_seconds=10)
+        with mock.patch.object(watcher.time, "time", return_value=100.0):
+            self.assertTrue(guard.can_reroute(1))
+            guard.record(1)
+            self.assertFalse(guard.can_reroute(1))
+        with mock.patch.object(watcher.time, "time", return_value=111.0):
+            self.assertTrue(guard.can_reroute(1))
+
+        guard = watcher.FlapGuard(window_seconds=10)
+        guard._last[2] = 80.0
+        guard._last[3] = 95.0
+        with mock.patch.object(watcher.time, "time", return_value=111.0):
+            guard.record(4)
+        self.assertNotIn(2, guard._last)
+        self.assertIn(3, guard._last)
+        self.assertIn(4, guard._last)
+
+    def test_tick_respects_busy_probe_candidates_flap_guard_and_one_reroute(self) -> None:
+        guard = watcher.FlapGuard(window_seconds=300)
+
+        with mock.patch.object(watcher, "local_is_busy", return_value=None), \
+             mock.patch.object(watcher, "list_queued_cloud_bat_runs") as queued:
+            watcher.tick(guard)
+            queued.assert_not_called()
+
+        with mock.patch.object(watcher, "local_is_busy", return_value=True), \
+             mock.patch.object(watcher, "list_queued_cloud_bat_runs") as queued:
+            watcher.tick(guard)
+            queued.assert_not_called()
+
+        with mock.patch.object(watcher, "local_is_busy", return_value=False), \
+             mock.patch.object(watcher, "list_queued_cloud_bat_runs", return_value=[]), \
+             mock.patch.object(watcher, "reroute_to_local") as reroute:
+            watcher.tick(guard)
+            reroute.assert_not_called()
+
+        with mock.patch.object(watcher, "local_is_busy", return_value=False), \
+             mock.patch.object(watcher, "list_queued_cloud_bat_runs", return_value=[(10, 100), (11, 101)]), \
+             mock.patch.object(watcher, "reroute_to_local", return_value=True) as reroute, \
+             mock.patch.object(watcher.time, "time", return_value=1000.0):
+            watcher.tick(guard)
+            reroute.assert_called_once_with(10)
+
+        with mock.patch.object(watcher, "local_is_busy", return_value=False), \
+             mock.patch.object(watcher, "list_queued_cloud_bat_runs", return_value=[(10, 102), (11, 103)]), \
+             mock.patch.object(watcher, "reroute_to_local", return_value=True) as reroute, \
+             mock.patch.object(watcher.time, "time", return_value=1001.0):
+            watcher.tick(guard)
+            reroute.assert_called_once_with(11)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add host_pump_lint unit coverage for paired calls, skip markers, block/window violations, and main error handling
- add fetch_skia_for_release extra coverage for usage errors, missing manifests, absent assets, checksum mismatches, valid extraction, and layout drift
- add macos_reroute_watcher unit coverage for runner busy detection, cloud target classification, queued run parsing, reroute subprocess handling, flap guard trimming, and tick decisions

## Validation
- python3 -m unittest tools.scripts.test_host_pump_lint tools.scripts.test_fetch_skia_for_release_extra tools.scripts.test_macos_reroute_watcher
- python3 -m unittest tools.scripts.test_fetch_skia_for_release tools.scripts.test_fetch_skia_for_release_extra tools.scripts.test_host_pump_lint tools.scripts.test_macos_reroute_watcher
- python3 tools/scripts/test_fetch_skia_for_release.py && python3 tools/scripts/test_fetch_skia_for_release_extra.py && python3 tools/scripts/test_host_pump_lint.py && python3 tools/scripts/test_macos_reroute_watcher.py
- python3 -m py_compile tools/scripts/host_pump_lint.py tools/scripts/fetch_skia_for_release.py tools/scripts/macos_reroute_watcher.py tools/scripts/test_host_pump_lint.py tools/scripts/test_fetch_skia_for_release_extra.py tools/scripts/test_macos_reroute_watcher.py
- git diff --check origin/main...HEAD && git diff --check && git diff --cached --check
- python3 tools/scripts/skill_sync_check.py
- tools/scripts/cli_version_check.sh
- ./tools/check-docs.sh (passes with existing warnings)

Notes: local tools/scripts/test_workflow_lint.py still has an unrelated existing workflow-step expectation failure when discovered by broad pattern. Local Python coverage runner also requires coverage.py >= 7.10, which is not installed here. Local pre-push diff-cover was demoted because its coverage configure path failed fetching Highway at 457c891775a7397bdb0376bb1031e6e027af1c48 before test execution; GitHub CI remains authoritative.