### PR TITLE
test(runtime): batch state utility edge coverage

### DIFF
--- a/test/test_properties_file.cpp
+++ b/test/test_properties_file.cpp
@@ -4,6 +4,7 @@
 #include <pulp/runtime/temporary_file.hpp>
 #include <filesystem>
 #include <fstream>
+#include <random>
 
 using namespace pulp::state;
 using namespace pulp::runtime;
@@ -35,6 +36,21 @@ TEST_CASE("PropertiesFile numeric getters reject invalid stored strings", "[stat
 
     REQUIRE_FALSE(props.get_int("count").has_value());
     REQUIRE_FALSE(props.get_double("gain").has_value());
+}
+
+TEST_CASE("PropertiesFile bool getter treats stored false-like values as false",
+          "[state][properties][issue-641]") {
+    PropertiesFile props;
+    props.set_string("word_false", "false");
+    props.set_string("zero", "0");
+    props.set_string("garbage", "not-a-bool");
+
+    REQUIRE(props.get_bool("word_false").has_value());
+    REQUIRE_FALSE(*props.get_bool("word_false"));
+    REQUIRE(props.get_bool("zero").has_value());
+    REQUIRE_FALSE(*props.get_bool("zero"));
+    REQUIRE(props.get_bool("garbage").has_value());
+    REQUIRE_FALSE(*props.get_bool("garbage"));
 }
 
 TEST_CASE("PropertiesFile set and get int", "[state][properties]") {
@@ -157,6 +173,21 @@ TEST_CASE("PropertiesFile load invalid JSON returns false", "[state][properties]
     REQUIRE_FALSE(props.load(tmp.path_string()));
 }
 
+TEST_CASE("PropertiesFile load non-object JSON leaves existing values intact",
+          "[state][properties][issue-641]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << "[\"not\", \"an\", \"object\"]";
+    }
+
+    PropertiesFile props;
+    props.set_string("stale", "value");
+    REQUIRE_FALSE(props.load(tmp.path_string()));
+    REQUIRE(props.get_string("stale").value_or("") == "value");
+    REQUIRE(props.path() == tmp.path_string());
+}
+
 TEST_CASE("PropertiesFile load empty file clears existing values", "[state][properties]") {
     TemporaryFile tmp(".json");
     {
@@ -171,11 +202,53 @@ TEST_CASE("PropertiesFile load empty file clears existing values", "[state][prop
     REQUIRE(props.size() == 0);
 }
 
+TEST_CASE("PropertiesFile load skips unsupported JSON member types",
+          "[state][properties][json][issue-641]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << R"JSON({
+            "name": "Pulp",
+            "enabled": true,
+            "count": 7,
+            "gain": 0.5,
+            "ignored_null": null,
+            "ignored_array": [1, 2],
+            "ignored_object": {"nested": true}
+        })JSON";
+    }
+
+    PropertiesFile props;
+    REQUIRE(props.load(tmp.path_string()));
+    REQUIRE(props.size() == 4);
+    REQUIRE(props.get_string("name").value_or("") == "Pulp");
+    REQUIRE(props.get_bool("enabled").value_or(false));
+    REQUIRE(props.get_int("count").value_or(0) == 7);
+    REQUIRE_THAT(props.get_double("gain").value_or(0.0), WithinAbs(0.5, 1e-9));
+    REQUIRE_FALSE(props.contains("ignored_null"));
+    REQUIRE_FALSE(props.contains("ignored_array"));
+    REQUIRE_FALSE(props.contains("ignored_object"));
+}
+
 TEST_CASE("PropertiesFile save without path returns false", "[state][properties]") {
     PropertiesFile props;
     props.set_string("key", "value");
 
     REQUIRE_FALSE(props.save());
+}
+
+TEST_CASE("PropertiesFile save fails when destination is a directory",
+          "[state][properties][issue-641]") {
+    auto dir = std::filesystem::temp_directory_path() /
+               ("pulp_props_dir_dest_" + std::to_string(std::random_device{}()));
+    std::filesystem::create_directories(dir);
+
+    PropertiesFile props;
+    props.set_string("key", "value");
+    REQUIRE_FALSE(props.save(dir.string()));
+    REQUIRE(props.path() == dir.string());
+
+    std::filesystem::remove_all(dir);
 }
 
 TEST_CASE("PropertiesFile save creates parent directories", "[state][properties]") {
@@ -207,6 +280,21 @@ TEST_CASE("PropertiesFile save and reload preserves path", "[state][properties]"
     PropertiesFile props2;
     REQUIRE(props2.load(tmp.path_string()));
     REQUIRE(props2.get_string("key2").value_or("") == "val2");
+}
+
+TEST_CASE("PropertiesFile remove missing key and clear empty file are no-ops",
+          "[state][properties][issue-641]") {
+    PropertiesFile props;
+    props.remove("missing");
+    REQUIRE(props.size() == 0);
+
+    props.clear();
+    REQUIRE(props.keys().empty());
+
+    props.set_string("present", "yes");
+    props.remove("missing");
+    REQUIRE(props.size() == 1);
+    REQUIRE(props.contains("present"));
 }
 
 // ── ApplicationProperties ───────────────────────────────────────────────

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/runtime/memory_mapped_file.hpp>
 #include <pulp/runtime/temporary_file.hpp>
 #include <pulp/runtime/dynamic_library.hpp>
@@ -46,6 +47,47 @@ TEST_CASE("TemporaryFile move semantics", "[runtime][temp_file]") {
     REQUIRE(std::filesystem::exists(path));
 }
 
+TEST_CASE("TemporaryFile normalizes extensions without leading dots",
+          "[runtime][temp_file][issue-641]") {
+    TemporaryFile tmp("raw");
+    REQUIRE(tmp.path().extension() == ".raw");
+    REQUIRE(std::filesystem::exists(tmp.path()));
+}
+
+TEST_CASE("TemporaryFile move assignment removes the previous active file",
+          "[runtime][temp_file][issue-641]") {
+    std::filesystem::path old_path;
+    std::filesystem::path new_path;
+    {
+        TemporaryFile old_file(".old");
+        TemporaryFile new_file(".new");
+        old_path = old_file.path();
+        new_path = new_file.path();
+
+        old_file = std::move(new_file);
+        REQUIRE(old_file.path() == new_path);
+        REQUIRE_FALSE(std::filesystem::exists(old_path));
+        REQUIRE(std::filesystem::exists(new_path));
+    }
+
+    REQUIRE_FALSE(std::filesystem::exists(new_path));
+}
+
+TEST_CASE("TemporaryFile self move assignment preserves ownership",
+          "[runtime][temp_file][issue-641]") {
+    std::filesystem::path path;
+    {
+        TemporaryFile tmp(".self");
+        path = tmp.path();
+        auto& ref = tmp;
+        tmp = std::move(ref);
+        REQUIRE(tmp.path() == path);
+        REQUIRE(std::filesystem::exists(path));
+    }
+
+    REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
 // ── MemoryMappedFile ────────────────────────────────────────────────────
 
 TEST_CASE("MemoryMappedFile maps a file", "[runtime][mmap]") {
@@ -85,6 +127,28 @@ TEST_CASE("MemoryMappedFile move semantics", "[runtime][mmap]") {
     MemoryMappedFile b = std::move(a);
     REQUIRE(b.is_open());
     REQUIRE_FALSE(a.is_open());
+}
+
+TEST_CASE("MemoryMappedFile reopen closes the previous mapping",
+          "[runtime][mmap][issue-641]") {
+    TemporaryFile first(".bin");
+    TemporaryFile second(".bin");
+    {
+        std::ofstream f(first.path(), std::ios::binary);
+        f << "first";
+    }
+    {
+        std::ofstream f(second.path(), std::ios::binary);
+        f << "second-file";
+    }
+
+    MemoryMappedFile mmap;
+    REQUIRE(mmap.open(first.path_string()));
+    REQUIRE(mmap.size() == 5);
+    REQUIRE(mmap.open(second.path_string()));
+    REQUIRE(mmap.is_open());
+    REQUIRE(mmap.size() == 11);
+    REQUIRE(std::string(reinterpret_cast<const char*>(mmap.data()), mmap.size()) == "second-file");
 }
 
 // ── DynamicLibrary ──────────────────────────────────────────────────────
@@ -361,6 +425,13 @@ TEST_CASE("Range constrain", "[runtime][range]") {
     REQUIRE(r.constrain(200) == 99);
 }
 
+TEST_CASE("Range constrain handles empty and reversed integer ranges",
+          "[runtime][range][coverage][issue-641]") {
+    REQUIRE(IntRange(5, 5).constrain(100) == 5);
+    REQUIRE(IntRange(10, 5).constrain(-100) == 10);
+    REQUIRE(IntRange(-3, -1).constrain(9) == -2);
+}
+
 TEST_CASE("Range from_start_length", "[runtime][range]") {
     auto r = IntRange::from_start_length(5, 10);
     REQUIRE(r.start == 5);
@@ -401,4 +472,18 @@ TEST_CASE("FloatRange", "[runtime][range]") {
     FloatRange r(0.0f, 1.0f);
     REQUIRE(r.contains(0.5f));
     REQUIRE_FALSE(r.contains(1.0f));
+}
+
+TEST_CASE("DoubleRange intersections and unions preserve fractional bounds",
+          "[runtime][range][coverage][issue-641]") {
+    DoubleRange a(0.25, 2.75);
+    DoubleRange b(1.5, 4.0);
+
+    auto intersection = a.intersection(b);
+    REQUIRE_THAT(intersection.start, Catch::Matchers::WithinAbs(1.5, 1e-12));
+    REQUIRE_THAT(intersection.end, Catch::Matchers::WithinAbs(2.75, 1e-12));
+
+    auto combined = a.enclosing_union(b);
+    REQUIRE_THAT(combined.start, Catch::Matchers::WithinAbs(0.25, 1e-12));
+    REQUIRE_THAT(combined.end, Catch::Matchers::WithinAbs(4.0, 1e-12));
 }

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -37,6 +37,23 @@ TEST_CASE("StateTree get with defaults", "[state][tree]") {
     REQUIRE(tree->get_bool("missing", true) == true);
 }
 
+TEST_CASE("StateTree typed getters keep defaults for mismatched property types",
+          "[state][tree][issue-641]") {
+    auto tree = StateTree::create("test");
+    tree->set("as_string", std::string("123"));
+    tree->set("as_bool", true);
+    tree->set("as_int", int64_t(9));
+    tree->set("as_double", 1.25);
+
+    REQUIRE(tree->get_int("as_string", 77) == 77);
+    REQUIRE(tree->get_bool("as_string", true));
+    REQUIRE(tree->get_string("as_int", "fallback") == "fallback");
+    REQUIRE_THAT(tree->get_double("as_int", 0.0), WithinAbs(9.0, 1e-9));
+    REQUIRE(tree->get_int("as_double", 44) == 44);
+    REQUIRE(tree->get_bool("as_int", false) == false);
+    REQUIRE(tree->get_bool("as_bool", false) == true);
+}
+
 TEST_CASE("StateTree has and remove", "[state][tree]") {
     auto tree = StateTree::create("test");
     tree->set("key", std::string("value"));
@@ -104,6 +121,23 @@ TEST_CASE("StateTree remove child by index", "[state][tree]") {
     REQUIRE(root->child(1)->type_name() == "c");
 }
 
+TEST_CASE("StateTree child access and removal ignore invalid indexes",
+          "[state][tree][issue-641]") {
+    auto root = StateTree::create("root");
+    root->add_child(StateTree::create("a"));
+
+    int removed_count = 0;
+    root->add_child_removed_listener(
+        [&](StateTree&, StateTree&, int) { removed_count++; });
+
+    REQUIRE(root->child(-1) == nullptr);
+    REQUIRE(root->child(1) == nullptr);
+    root->remove_child(-1);
+    root->remove_child(99);
+    REQUIRE(root->child_count() == 1);
+    REQUIRE(removed_count == 0);
+}
+
 TEST_CASE("StateTree insert child at index", "[state][tree]") {
     auto root = StateTree::create("root");
     root->add_child(StateTree::create("a"));
@@ -112,6 +146,21 @@ TEST_CASE("StateTree insert child at index", "[state][tree]") {
     root->insert_child(1, StateTree::create("b"));
     REQUIRE(root->child_count() == 3);
     REQUIRE(root->child(1)->type_name() == "b");
+}
+
+TEST_CASE("StateTree insert at end and missing child pointer removal are stable",
+          "[state][tree][issue-641]") {
+    auto root = StateTree::create("root");
+    auto missing = StateTree::create("missing");
+
+    root->add_child(StateTree::create("a"));
+    root->insert_child(root->child_count(), StateTree::create("b"));
+    root->remove_child(missing.get());
+
+    REQUIRE(root->child_count() == 2);
+    REQUIRE(root->child(0)->type_name() == "a");
+    REQUIRE(root->child(1)->type_name() == "b");
+    REQUIRE(missing->parent() == nullptr);
 }
 
 // ── Listeners ───────────────────────────────────────────────────────────
@@ -126,6 +175,44 @@ TEST_CASE("StateTree property change listener", "[state][tree]") {
 
     tree->set("volume", 0.5);
     REQUIRE(changed_prop == "volume");
+}
+
+TEST_CASE("StateTree property listener receives old and new values",
+          "[state][tree][issue-641]") {
+    auto tree = StateTree::create("test");
+    std::vector<PropertyValue> old_values;
+    std::vector<PropertyValue> new_values;
+
+    tree->add_listener(
+        [&](StateTree&, std::string_view, const PropertyValue& old_val,
+            const PropertyValue& new_val) {
+            old_values.push_back(old_val);
+            new_values.push_back(new_val);
+        });
+
+    tree->set("gain", 0.25);
+    tree->set("gain", 0.5);
+
+    REQUIRE(old_values.size() == 2);
+    REQUIRE(std::holds_alternative<std::monostate>(old_values[0]));
+    REQUIRE_THAT(std::get<double>(new_values[0]), WithinAbs(0.25, 1e-9));
+    REQUIRE_THAT(std::get<double>(old_values[1]), WithinAbs(0.25, 1e-9));
+    REQUIRE_THAT(std::get<double>(new_values[1]), WithinAbs(0.5, 1e-9));
+}
+
+TEST_CASE("StateTree remove does not emit property callbacks",
+          "[state][tree][issue-641]") {
+    auto tree = StateTree::create("test");
+    tree->set("name", std::string("before"));
+
+    int count = 0;
+    tree->add_listener([&](StateTree&, std::string_view, const PropertyValue&,
+                           const PropertyValue&) { count++; });
+
+    tree->remove("name");
+    tree->remove("missing");
+    REQUIRE(count == 0);
+    REQUIRE_FALSE(tree->has("name"));
 }
 
 TEST_CASE("StateTree child added listener", "[state][tree]") {
@@ -258,6 +345,42 @@ TEST_CASE("StateTree from_json with empty object", "[state][tree][json]") {
     REQUIRE(result->type_name() == "node");  // Default type
 }
 
+TEST_CASE("StateTree from_json skips unsupported properties and child values",
+          "[state][tree][json][issue-641]") {
+    auto result = StateTree::from_json(R"JSON({
+        "type": 123,
+        "properties": {
+            "name": "Patch",
+            "enabled": false,
+            "voice_count": 8,
+            "gain": 0.25,
+            "ignored_null": null,
+            "ignored_array": [1, 2],
+            "ignored_object": {"nested": true}
+        },
+        "children": [
+            {"type": "osc", "properties": {"wave": "sine"}},
+            null,
+            42,
+            {"properties": {"default_type": true}}
+        ]
+    })JSON");
+
+    REQUIRE(result != nullptr);
+    REQUIRE(result->type_name() == "node");
+    REQUIRE(result->get_string("name") == "Patch");
+    REQUIRE_FALSE(result->get_bool("enabled", true));
+    REQUIRE(result->get_int("voice_count") == 8);
+    REQUIRE_THAT(result->get_double("gain"), WithinAbs(0.25, 1e-9));
+    REQUIRE_FALSE(result->has("ignored_null"));
+    REQUIRE_FALSE(result->has("ignored_array"));
+    REQUIRE_FALSE(result->has("ignored_object"));
+    REQUIRE(result->child_count() == 2);
+    REQUIRE(result->child(0)->type_name() == "osc");
+    REQUIRE(result->child(1)->type_name() == "node");
+    REQUIRE(result->child(1)->get_bool("default_type"));
+}
+
 // ── Deep copy ───────────────────────────────────────────────────────────
 
 TEST_CASE("StateTree deep copy", "[state][tree]") {
@@ -273,6 +396,19 @@ TEST_CASE("StateTree deep copy", "[state][tree]") {
     // Modifying copy doesn't affect original
     copy->set("name", std::string("modified"));
     REQUIRE(root->get_string("name") == "original");
+}
+
+TEST_CASE("StateTree deep copy rewires child parent pointers",
+          "[state][tree][issue-641]") {
+    auto root = StateTree::create("root");
+    auto child = StateTree::create("child");
+    root->add_child(child);
+
+    auto copy = root->deep_copy();
+    REQUIRE(copy->child_count() == 1);
+    REQUIRE(copy->child(0).get() != child.get());
+    REQUIRE(copy->child(0)->parent() == copy.get());
+    REQUIRE(child->parent() == root.get());
 }
 
 // ── ObservableValue ─────────────────────────────────────────────────────
@@ -322,6 +458,27 @@ TEST_CASE("ObservableValue remove listener", "[state][observable]") {
     val.remove_listener(id);
     val.set(2);
     REQUIRE(count == 1);  // Listener removed
+}
+
+TEST_CASE("ObservableValue assignment operator emits one change",
+          "[state][observable][issue-641]") {
+    ObservableValue<int> val(1);
+    int old_value = 0;
+    int new_value = 0;
+    int count = 0;
+    val.add_listener([&](const int& old_val, const int& next_val) {
+        old_value = old_val;
+        new_value = next_val;
+        count++;
+    });
+
+    val = 5;
+    val = 5;
+
+    REQUIRE(val.get() == 5);
+    REQUIRE(old_value == 1);
+    REQUIRE(new_value == 5);
+    REQUIRE(count == 1);
 }
 
 // ── CachedProperty ──────────────────────────────────────────────────────
@@ -380,6 +537,19 @@ TEST_CASE("CachedProperty unbound set only updates local cache", "[state][cached
     REQUIRE(size.get() == 512);
 }
 
+TEST_CASE("CachedProperty ignores mismatched external updates",
+          "[state][cached][issue-641]") {
+    auto tree = StateTree::create("params");
+    tree->set("name", std::string("Initial"));
+    CachedProperty<std::string> name(tree, "name", "Default");
+
+    tree->set("name", int64_t(123));
+    REQUIRE(name.get() == "Initial");
+
+    name.set("Restored");
+    REQUIRE(tree->get_string("name") == "Restored");
+}
+
 // ── StateTreeSynchroniser ───────────────────────────────────────────────
 
 TEST_CASE("StateTreeSynchroniser records property and child deltas", "[state][sync]") {
@@ -409,6 +579,25 @@ TEST_CASE("StateTreeSynchroniser records property and child deltas", "[state][sy
     REQUIRE(deltas[2].child_index == 0);
 
     REQUIRE(sync.take_deltas().empty());
+}
+
+TEST_CASE("StateTreeSynchroniser attach replaces the previous tree",
+          "[state][sync][issue-641]") {
+    auto first = StateTree::create("first");
+    auto second = StateTree::create("second");
+    StateTreeSynchroniser sync;
+
+    sync.attach(first);
+    first->set("name", std::string("before"));
+    sync.attach(second);
+    first->set("name", std::string("ignored"));
+    second->set("name", std::string("recorded"));
+
+    auto deltas = sync.take_deltas();
+    REQUIRE(deltas.size() == 1);
+    REQUIRE(deltas[0].path == "second");
+    REQUIRE(deltas[0].key == "name");
+    REQUIRE(std::get<std::string>(deltas[0].value) == "recorded");
 }
 
 TEST_CASE("StateTreeSynchroniser detach clears pending and stops recording", "[state][sync]") {
@@ -465,6 +654,32 @@ TEST_CASE("StateTreeSynchroniser decode rejects undersized buffers", "[state][sy
 
     decoded = StateTreeSynchroniser::decode(nullptr, 0);
     REQUIRE(decoded.empty());
+}
+
+TEST_CASE("StateTreeSynchroniser encodes and decodes empty delta batches",
+          "[state][sync][issue-641]") {
+    auto encoded = StateTreeSynchroniser::encode({});
+    REQUIRE(encoded.size() == 2);
+
+    auto decoded = StateTreeSynchroniser::decode(encoded.data(), encoded.size());
+    REQUIRE(decoded.empty());
+}
+
+TEST_CASE("StateTreeSynchroniser decode keeps complete prefix on truncated batches",
+          "[state][sync][issue-641]") {
+    std::vector<SyncDelta> deltas = {
+        {SyncDeltaType::PropertySet, "root", "name", std::string("Lead"), 0},
+        {SyncDeltaType::PropertySet, "root", "count", int64_t(3), 0},
+    };
+    auto encoded = StateTreeSynchroniser::encode(deltas);
+    auto first_only = StateTreeSynchroniser::encode({deltas[0]});
+    encoded.resize(first_only.size() + 1);
+
+    auto decoded = StateTreeSynchroniser::decode(encoded.data(), encoded.size());
+    REQUIRE(decoded.size() == 1);
+    REQUIRE(decoded[0].type == SyncDeltaType::PropertySet);
+    REQUIRE(decoded[0].key == "name");
+    REQUIRE(std::get<std::string>(decoded[0].value) == "Lead");
 }
 
 TEST_CASE("StateTreeSynchroniser apply mutates properties and children", "[state][sync]") {


### PR DESCRIPTION
## Summary
- add PropertiesFile edge coverage for bool parsing, non-object/unsupported JSON loads, directory save failures, and missing-key no-ops
- add StateTree, ObservableValue, CachedProperty, and StateTreeSynchroniser edge coverage for type defaults, listeners, child bounds, JSON filtering, deep-copy parents, reattach, and truncated batches
- add runtime utility coverage for TemporaryFile move/extension behavior, MemoryMappedFile reopen, and Range boundary behavior

## Local validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Library/Caches/Pulp/fetchcontent-src/mbedtls-v3.6.2-tar`
- `cmake --build build --target pulp-test-properties pulp-test-state-tree pulp-test-runtime-utils -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-properties "[issue-641]" -r compact` (24 assertions / 5 cases)
- `./build/test/pulp-test-state-tree "[issue-641]" -r compact` (55 assertions / 12 cases)
- `./build/test/pulp-test-runtime-utils "[issue-641]" -r compact` (88 assertions / 18 cases)
- `./build/test/pulp-test-properties -r compact` (75 assertions / 22 cases)
- `./build/test/pulp-test-state-tree -r compact` (171 assertions / 43 cases)
- `./build/test/pulp-test-runtime-utils -r compact` (150 assertions / 43 cases)
- `ctest --test-dir build -R "PropertiesFile|StateTree|TemporaryFile|MemoryMappedFile|Range" --output-on-failure` (76/76 passed)
- `git diff --check origin/main...HEAD && git diff --check && git diff --cached --check`
- `python3 tools/scripts/skill_sync_check.py`
- `tools/scripts/cli_version_check.sh`
- `./tools/check-docs.sh` (passed with existing warnings)

## CI
GitHub-hosted pull-request checks only. Namespace and SSH targets were not used.
