### PR TITLE
test(events): batch ipc and discovery edge coverage

### DIFF
--- a/test/test_events_async_helpers.cpp
+++ b/test/test_events_async_helpers.cpp
@@ -140,6 +140,26 @@ TEST_CASE("ActionBroadcaster ignores missing listener removals",
     REQUIRE(seen.size() == 3);
 }
 
+TEST_CASE("ActionBroadcaster handles empty actions and no-listener sends",
+          "[events][async_updater][action_broadcaster][issue-642]") {
+    ActionBroadcaster broadcaster;
+
+    broadcaster.send_action("");
+    broadcaster.remove_listener(123);
+
+    std::vector<std::string> seen;
+    auto listener = broadcaster.add_listener(
+        [&](std::string_view action) { seen.emplace_back(action); });
+
+    broadcaster.send_action("");
+    broadcaster.send_action("named");
+    REQUIRE(seen == std::vector<std::string>{"", "named"});
+
+    broadcaster.remove_listener(listener);
+    broadcaster.send_action("ignored");
+    REQUIRE(seen.size() == 2);
+}
+
 TEST_CASE("MultiTimer stop all permits selective restart",
           "[events][async_updater][multi_timer][issue-642]") {
     RecordingMultiTimer timers;
@@ -161,6 +181,26 @@ TEST_CASE("MultiTimer stop all permits selective restart",
     timers.stop_timer(42);
     REQUIRE_FALSE(timers.is_timer_running(1));
     REQUIRE_FALSE(timers.is_timer_running(2));
+}
+
+TEST_CASE("MultiTimer restart keeps one running entry per id",
+          "[events][async_updater][multi_timer][issue-642]") {
+    RecordingMultiTimer timers;
+
+    timers.start_timer(7, 20);
+    timers.start_timer(7, 10);
+    timers.start_timer(7, 5);
+    REQUIRE(timers.is_timer_running(7));
+
+    timers.stop_timer(7);
+    REQUIRE_FALSE(timers.is_timer_running(7));
+
+    timers.start_timer(7, 1);
+    REQUIRE(timers.is_timer_running(7));
+
+    timers.stop_all_timers();
+    timers.stop_all_timers();
+    REQUIRE_FALSE(timers.is_timer_running(7));
 }
 
 TEST_CASE("ScopedLowPowerModeDisabler has no observable test-lane side effects",

--- a/test/test_ipc_endpoints.cpp
+++ b/test/test_ipc_endpoints.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/events/interprocess_connection.hpp>
 
+#include <string_view>
+#include <vector>
+
 using namespace pulp::events;
 
 TEST_CASE("IPC socket endpoints reject empty ports without opening connections",
@@ -31,4 +34,92 @@ TEST_CASE("IPC socket listener rejects empty endpoint strings",
 
     server.stop();
     REQUIRE_FALSE(server.is_running());
+}
+
+TEST_CASE("IPC socket client rejects malformed port strings without connecting",
+          "[events][ipc][endpoint][issue-642]") {
+    const std::vector<std::string_view> endpoints = {
+        "127.0.0.1:not-a-port",
+        "127.0.0.1:12x",
+        "127.0.0.1:+12",
+        "127.0.0.1:-1",
+        "127.0.0.1: 12",
+        "127.0.0.1:12 ",
+        "127.0.0.1:65536",
+        "127.0.0.1:999999999999",
+    };
+
+    for (auto endpoint : endpoints) {
+        InterprocessConnection client;
+        REQUIRE_FALSE(client.connect(endpoint, IpcTransport::Socket));
+        REQUIRE(client.state() == IpcState::Error);
+        REQUIRE_FALSE(client.is_connected());
+    }
+}
+
+TEST_CASE("IPC socket connection-server rejects malformed port strings",
+          "[events][ipc][endpoint][issue-642]") {
+    const std::vector<std::string_view> endpoints = {
+        "127.0.0.1:not-a-port",
+        "127.0.0.1:12x",
+        "127.0.0.1:+12",
+        "127.0.0.1:-1",
+        "127.0.0.1: 12",
+        "127.0.0.1:12 ",
+        "127.0.0.1:65536",
+        "127.0.0.1:999999999999",
+    };
+
+    for (auto endpoint : endpoints) {
+        InterprocessConnection connection;
+        REQUIRE_FALSE(connection.create_server(endpoint, IpcTransport::Socket));
+        REQUIRE(connection.state() == IpcState::Error);
+        REQUIRE_FALSE(connection.is_connected());
+    }
+}
+
+TEST_CASE("IPC socket listener rejects malformed port strings without staying running",
+          "[events][ipc][endpoint][issue-642]") {
+    const std::vector<std::string_view> endpoints = {
+        "not-a-port",
+        "12x",
+        "+12",
+        "-1",
+        " 12",
+        "12 ",
+        "127.0.0.1:not-a-port",
+        "127.0.0.1:12x",
+        "127.0.0.1:+12",
+        "127.0.0.1:-1",
+        "127.0.0.1: 12",
+        "127.0.0.1:12 ",
+        "127.0.0.1:65536",
+        "127.0.0.1:999999999999",
+    };
+
+    for (auto endpoint : endpoints) {
+        InterprocessConnectionServer server;
+        REQUIRE_FALSE(server.start(endpoint, IpcTransport::Socket));
+        REQUIRE_FALSE(server.is_running());
+        server.stop();
+        REQUIRE_FALSE(server.is_running());
+    }
+}
+
+TEST_CASE("IPC socket endpoint failure can be reset with disconnect",
+          "[events][ipc][endpoint][issue-642]") {
+    InterprocessConnection connection;
+
+    REQUIRE_FALSE(connection.connect("127.0.0.1:bad", IpcTransport::Socket));
+    REQUIRE(connection.state() == IpcState::Error);
+
+    connection.disconnect();
+    REQUIRE(connection.state() == IpcState::Disconnected);
+    REQUIRE_FALSE(connection.is_connected());
+
+    REQUIRE_FALSE(connection.create_server("127.0.0.1:bad", IpcTransport::Socket));
+    REQUIRE(connection.state() == IpcState::Error);
+
+    connection.disconnect();
+    REQUIRE(connection.state() == IpcState::Disconnected);
 }

--- a/test/test_network_service_discovery.cpp
+++ b/test/test_network_service_discovery.cpp
@@ -318,6 +318,96 @@ TEST_CASE("NSD removing backend stops old backend and evicts discoveries",
     REQUIRE_FALSE(nsd.register_service("svc", "_pulp._tcp", 1234));
 }
 
+TEST_CASE("NSD caches same-name services separately by type",
+          "[events][service-discovery][issue-642]") {
+    NetworkServiceDiscovery nsd;
+    nsd.install_backend(std::make_unique<FakeBackend>());
+
+    NetworkServiceDiscovery::Service http;
+    http.name = "pulpd";
+    http.type = "_http._tcp";
+    http.hostname = "http.local";
+    http.port = 80;
+
+    NetworkServiceDiscovery::Service pulp = http;
+    pulp.type = "_pulp._tcp";
+    pulp.hostname = "pulp.local";
+    pulp.port = 4321;
+
+    nsd.notify_service_found(http);
+    nsd.notify_service_found(pulp);
+    REQUIRE(nsd.discovered().size() == 2);
+
+    nsd.notify_service_lost(http);
+    REQUIRE(nsd.discovered().size() == 1);
+    REQUIRE(nsd.discovered().front().type == "_pulp._tcp");
+    REQUIRE(nsd.discovered().front().hostname == "pulp.local");
+}
+
+TEST_CASE("NSD install_backend nullptr without discoveries only stops old backend",
+          "[events][service-discovery][issue-642]") {
+    NetworkServiceDiscovery nsd;
+    auto backend = std::make_unique<FakeBackend>();
+    auto log = backend->log;
+    nsd.install_backend(std::move(backend));
+
+    int lost_count = 0;
+    nsd.on_service_lost = [&](const NetworkServiceDiscovery::Service&) {
+        ++lost_count;
+    };
+
+    nsd.install_backend(nullptr);
+    REQUIRE_FALSE(nsd.has_backend());
+    REQUIRE(nsd.discovered().empty());
+    REQUIRE(lost_count == 0);
+    REQUIRE(log->stopped == 1);
+    REQUIRE_FALSE(nsd.register_service("svc", "_pulp._tcp", 1234));
+}
+
+TEST_CASE("NSD stop forwards to backend even before browsing",
+          "[events][service-discovery][issue-642]") {
+    NetworkServiceDiscovery nsd;
+    auto backend = std::make_unique<FakeBackend>();
+    auto log = backend->log;
+    nsd.install_backend(std::move(backend));
+
+    nsd.stop();
+    nsd.stop();
+
+    REQUIRE(log->stopped == 2);
+    REQUIRE(nsd.has_backend());
+}
+
+TEST_CASE("NSD discovery stores entries when callbacks are absent",
+          "[events][service-discovery][issue-642]") {
+    NetworkServiceDiscovery nsd;
+    nsd.install_backend(std::make_unique<FakeBackend>());
+
+    NetworkServiceDiscovery::Service svc;
+    svc.name = "pulpd";
+    svc.type = "_pulp._tcp";
+    svc.hostname = "pulpd.local";
+    svc.address = "127.0.0.1";
+    svc.port = 4321;
+
+    nsd.notify_service_found(svc);
+    REQUIRE(nsd.discovered().size() == 1);
+
+    nsd.notify_service_lost(svc);
+    REQUIRE(nsd.discovered().empty());
+}
+
+TEST_CASE("LockingAsyncUpdater trigger_and_wait handles every call synchronously",
+          "[events][service-discovery][locking-updater][issue-642]") {
+    RecordingLockingUpdater updater;
+
+    updater.trigger_and_wait();
+    updater.trigger_and_wait();
+    updater.trigger_and_wait();
+
+    REQUIRE(updater.handles.load() == 3);
+}
+
 TEST_CASE("NSD backend swap clears discoveries without lost callback",
           "[events][service-discovery][issue-642]") {
     NetworkServiceDiscovery nsd;


### PR DESCRIPTION
## Summary
- add IPC endpoint parser coverage for malformed client, connection-server, listener, and reset paths
- add NetworkServiceDiscovery backend/cache lifecycle coverage including same-name different-type services, callback-less discovery, backend removal, and stop forwarding
- add ActionBroadcaster, MultiTimer, and LockingAsyncUpdater helper edge coverage

## Local validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Library/Caches/Pulp/fetchcontent-src/mbedtls-v3.6.2-tar`
- `cmake --build build --target pulp-test-ipc-endpoints pulp-test-network-service-discovery pulp-test-events-async-helpers pulp-test-events -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-ipc-endpoints "[issue-642]" -r compact` (109 assertions / 6 cases)
- `./build/test/pulp-test-network-service-discovery "[issue-642]" -r compact` (47 assertions / 11 cases)
- `./build/test/pulp-test-events-async-helpers "[issue-642]" -r compact` (39 assertions / 9 cases)
- `./build/test/pulp-test-events "[issue-642]" -r compact` (38 assertions / 8 cases)
- `./build/test/pulp-test-ipc-endpoints -r compact` (109 assertions / 6 cases)
- `./build/test/pulp-test-network-service-discovery -r compact` (90 assertions / 21 cases)
- `./build/test/pulp-test-events-async-helpers -r compact` (39 assertions / 9 cases)
- `./build/test/pulp-test-events -r compact` (99 assertions / 24 cases)
- `ctest --test-dir build -R "IPC socket|NSD|ActionBroadcaster|MultiTimer|LockingAsyncUpdater|InterprocessConnection|ChildProcessManager|AsyncUpdater|EventLoop|Timer" --output-on-failure` (55/55 passed)
- `git diff --check origin/main...HEAD && git diff --check && git diff --cached --check`
- `python3 tools/scripts/skill_sync_check.py`
- `tools/scripts/cli_version_check.sh`
- `./tools/check-docs.sh` (passed with existing warnings)

## CI
GitHub-hosted pull-request checks only. Namespace and SSH targets were not used.
