### PR TITLE
test(canvas): batch osc and render edge coverage

### DIFF
--- a/test/test_attributed_string.cpp
+++ b/test/test_attributed_string.cpp
@@ -116,6 +116,34 @@ TEST_CASE("AttributedString empty span has zero text length but remains a span",
     REQUIRE(str.spans().size() == 1);
 }
 
+TEST_CASE("AttributedString bulk style setters are no-ops on empty strings",
+          "[canvas][text][issue-644]") {
+    AttributedString str;
+    str.set_font("mono", 22.0f);
+    str.set_color(Color::rgba(1, 2, 3));
+
+    REQUIRE(str.empty());
+    REQUIRE(str.length() == 0);
+    REQUIRE(str.plain_text().empty());
+}
+
+TEST_CASE("AttributedString clear drops spans and accepts reuse",
+          "[canvas][text][issue-644]") {
+    AttributedString str("before");
+    str.append(" after", Color::rgba(9, 8, 7));
+    REQUIRE(str.spans().size() == 2);
+
+    str.clear();
+    REQUIRE(str.empty());
+
+    str.append("again", 18.0f, Color::rgba(1, 2, 3));
+    REQUIRE_FALSE(str.empty());
+    REQUIRE(str.plain_text() == "again");
+    REQUIRE(str.spans().size() == 1);
+    REQUIRE(str.spans()[0].font_size == 18.0f);
+    REQUIRE(str.spans()[0].color.g == 2);
+}
+
 // ── TextLayout word wrapping ────────────────────────────────────────────
 
 TEST_CASE("TextLayout empty string", "[canvas][layout]") {
@@ -221,6 +249,18 @@ TEST_CASE("TextLayout empty span creates blank line", "[canvas][layout]") {
     REQUIRE(layout.lines[0].width == 0);
     REQUIRE_THAT(layout.lines[0].height, WithinAbs(12.0f, 1e-5));
     REQUIRE_THAT(layout.total_height, WithinAbs(12.0f, 1e-5));
+}
+
+TEST_CASE("TextLayout skips the delimiter that triggered word wrapping",
+          "[canvas][layout][issue-644]") {
+    AttributedString str("alpha beta gamma");
+    auto layout = layout_attributed_string(str, 48.0f, 10.0f);
+
+    REQUIRE(layout.lines.size() == 3);
+    REQUIRE(layout.lines[0].spans[0].text == "alpha");
+    REQUIRE(layout.lines[1].spans[0].text == "beta");
+    REQUIRE(layout.lines[2].spans[0].text == "gamma");
+    REQUIRE_THAT(layout.total_height, WithinAbs(30.0f, 1e-5));
 }
 
 TEST_CASE("TextLayout narrow width forces word break", "[canvas][layout]") {

--- a/test/test_dirty_tracker.cpp
+++ b/test/test_dirty_tracker.cpp
@@ -70,6 +70,24 @@ TEST_CASE("DirtyTracker invalidate_all forces full repaint", "[render][dirty]") 
     REQUIRE(dt.dirty_rects().empty());
 }
 
+TEST_CASE("DirtyTracker full repaint keeps empty partial bounds",
+          "[render][dirty][issue-644]") {
+    DirtyTracker dt;
+    dt.clear();
+    dt.invalidate(1, 2, 3, 4);
+    REQUIRE_FALSE(dt.dirty_rects().empty());
+
+    dt.invalidate_all();
+    REQUIRE(dt.is_dirty());
+    REQUIRE(dt.needs_full_repaint());
+    REQUIRE(dt.dirty_rects().empty());
+    auto b = dt.bounds();
+    REQUIRE(b.x == Catch::Approx(0.0f));
+    REQUIRE(b.y == Catch::Approx(0.0f));
+    REQUIRE(b.w == Catch::Approx(0.0f));
+    REQUIRE(b.h == Catch::Approx(0.0f));
+}
+
 TEST_CASE("DirtyTracker frame counter increments", "[render][dirty]") {
     DirtyTracker dt;
     REQUIRE(dt.frame_count() == 0);
@@ -129,6 +147,30 @@ TEST_CASE("DirtyTracker threshold sums partial dirty regions", "[render][dirty][
     dt.invalidate(50, 50, 30, 30);
     REQUIRE(dt.needs_full_repaint());
     REQUIRE(dt.dirty_rects().empty());
+}
+
+TEST_CASE("DirtyTracker threshold equality remains partial repaint",
+          "[render][dirty][issue-644]") {
+    DirtyTracker dt;
+    dt.set_viewport(100, 100, 0.25f);
+    dt.clear();
+
+    dt.invalidate(0, 0, 50, 50);
+    REQUIRE(dt.is_dirty());
+    REQUIRE_FALSE(dt.needs_full_repaint());
+    REQUIRE(dt.dirty_rects().size() == 1);
+}
+
+TEST_CASE("DirtyTracker ignores invalid viewport dimensions for promotion",
+          "[render][dirty][issue-644]") {
+    DirtyTracker dt;
+    dt.set_viewport(-100, 100, 0.01f);
+    dt.clear();
+    dt.invalidate(0, 0, 1000, 1000);
+
+    REQUIRE(dt.is_dirty());
+    REQUIRE_FALSE(dt.needs_full_repaint());
+    REQUIRE(dt.dirty_rects().size() == 1);
 }
 
 TEST_CASE("DirtyTracker does not promote to full repaint without viewport", "[render][dirty][issue-646]") {

--- a/test/test_osc.cpp
+++ b/test/test_osc.cpp
@@ -43,6 +43,18 @@ TEST_CASE("OSC Message get with defaults", "[osc][message]") {
     REQUIRE(msg.get_string(0, "nope") == "nope");
 }
 
+TEST_CASE("OSC Message typed defaults cover every wrong-type accessor", "[osc][message][issue-644]") {
+    Message msg("/defaults");
+    msg.add(std::string("label"));
+    msg.add(std::vector<uint8_t>{0x01, 0x02});
+    msg.add(1.5f);
+
+    REQUIRE(msg.get_int(0, -10) == -10);
+    REQUIRE(msg.get_float(1, -2.0f) == -2.0f);
+    REQUIRE(msg.get_string(2, "fallback") == "fallback");
+    REQUIRE(msg.get_string(99, "missing") == "missing");
+}
+
 // ── Encoding/Decoding ────────────────────────────────────────────────────────
 
 TEST_CASE("OSC encode/decode round-trip int+float", "[osc][codec]") {
@@ -418,4 +430,57 @@ TEST_CASE("OSC Sender::send without connect is rejected", "[osc][udp][sender]") 
     Message msg("/x");
     msg.add(1);
     REQUIRE_FALSE(tx.send(msg));
+}
+
+TEST_CASE("OSC decode preserves empty strings and padded string arguments", "[osc][codec][issue-644]") {
+    Message msg("/strings");
+    msg.add(std::string{});
+    msg.add(std::string{"abc"});
+    msg.add(std::string{"abcd"});
+
+    auto data = encode(msg);
+    REQUIRE(data.size() % 4 == 0);
+
+    auto decoded = decode(data.data(), data.size());
+    REQUIRE(decoded.address == "/strings");
+    REQUIRE(decoded.args.size() == 3);
+    REQUIRE(decoded.get_string(0, "fallback").empty());
+    REQUIRE(decoded.get_string(1) == "abc");
+    REQUIRE(decoded.get_string(2) == "abcd");
+}
+
+TEST_CASE("OSC decode of truncated string argument returns empty string", "[osc][codec][issue-644]") {
+    std::vector<uint8_t> buf;
+    const char addr[] = "/truncated";
+    buf.insert(buf.end(), addr, addr + sizeof(addr));
+    while (buf.size() % 4 != 0) buf.push_back(0);
+    const char tags[] = ",s";
+    buf.insert(buf.end(), tags, tags + sizeof(tags));
+    while (buf.size() % 4 != 0) buf.push_back(0);
+
+    auto decoded = decode(buf.data(), buf.size());
+    REQUIRE(decoded.address == "/truncated");
+    REQUIRE(decoded.args.size() == 1);
+    REQUIRE(decoded.get_string(0, "fallback").empty());
+}
+
+TEST_CASE("OSC decode tolerates extra trailing padding bytes", "[osc][codec][issue-644]") {
+    Message msg("/trail");
+    msg.add(123);
+    auto data = encode(msg);
+    data.insert(data.end(), {0, 0, 0, 0});
+
+    auto decoded = decode(data.data(), data.size());
+    REQUIRE(decoded.address == "/trail");
+    REQUIRE(decoded.args.size() == 1);
+    REQUIRE(decoded.get_int(0) == 123);
+}
+
+TEST_CASE("OSC Sender::send_raw without connect is rejected", "[osc][udp][sender][issue-644]") {
+    Sender tx;
+    uint8_t payload[] = {0, 1, 2, 3};
+    REQUIRE_FALSE(tx.is_connected());
+    REQUIRE_FALSE(tx.send_raw(payload, sizeof(payload)));
+    tx.disconnect();
+    REQUIRE_FALSE(tx.is_connected());
 }

--- a/test/test_osc_bundle.cpp
+++ b/test/test_osc_bundle.cpp
@@ -54,6 +54,13 @@ TEST_CASE("OSC TimeTag equality", "[osc][bundle]") {
     REQUIRE(a == b);
 }
 
+TEST_CASE("OSC TimeTag keeps fractional unix seconds near one-second boundary",
+          "[osc][bundle][issue-644]") {
+    auto tt = TimeTag::from_unix(12345.999);
+    REQUIRE_THAT(tt.to_unix(), WithinAbs(12345.999, 0.001));
+    REQUIRE_FALSE(tt == TimeTag::from_unix(12345.0));
+}
+
 // ── Bundle construction ─────────────────────────────────────────────────
 
 TEST_CASE("OSC Bundle add message", "[osc][bundle]") {
@@ -81,6 +88,15 @@ TEST_CASE("OSC Bundle add nested bundle", "[osc][bundle]") {
     REQUIRE(outer.elements.size() == 1);
     REQUIRE(outer.elements[0].is_bundle());
     REQUIRE(outer.elements[0].bundle().elements.size() == 1);
+}
+
+TEST_CASE("OSC default BundleElement is an empty message element",
+          "[osc][bundle][issue-644]") {
+    BundleElement elem;
+    REQUIRE(elem.is_message());
+    REQUIRE_FALSE(elem.is_bundle());
+    REQUIRE(elem.message().address.empty());
+    REQUIRE(elem.message().args.empty());
 }
 
 // ── Bundle serialization ────────────────────────────────────────────────
@@ -146,6 +162,13 @@ TEST_CASE("OSC address wildcard ?", "[osc][bundle]") {
     REQUIRE(address_matches("/foo/ba?", "/foo/bar"));
     REQUIRE(address_matches("/foo/ba?", "/foo/baz"));
     REQUIRE_FALSE(address_matches("/foo/ba?", "/foo/ba"));
+}
+
+TEST_CASE("OSC address wildcard question mark does not cross path separator",
+          "[osc][bundle][pattern][issue-644]") {
+    REQUIRE_FALSE(address_matches("/foo/?/bar", "/foo//bar"));
+    REQUIRE_FALSE(address_matches("/foo/?", "/foo//"));
+    REQUIRE(address_matches("/foo/?", "/foo/a"));
 }
 
 // ── TimeTag edges ──────────────────────────────────────────────────────
@@ -375,4 +398,17 @@ TEST_CASE("Malformed address patterns fail closed",
     REQUIRE_FALSE(address_matches("/note/[ab", "/note/a"));
     REQUIRE_FALSE(address_matches("/note/[!0-9", "/note/a"));
     REQUIRE_FALSE(address_matches("/{foo,bar/gain", "/foo/gain"));
+}
+
+TEST_CASE("Address pattern alternatives support first and later branches",
+          "[osc][bundle][pattern][issue-644]") {
+    REQUIRE(address_matches("/{foo,bar,baz}/gain", "/foo/gain"));
+    REQUIRE(address_matches("/{foo,bar,baz}/gain", "/baz/gain"));
+    REQUIRE_FALSE(address_matches("/{foo,bar,baz}/gain", "/ba/gain"));
+}
+
+TEST_CASE("Address pattern character class negated enumeration",
+          "[osc][bundle][pattern][issue-644]") {
+    REQUIRE(address_matches("/pad/[!abc]", "/pad/z"));
+    REQUIRE_FALSE(address_matches("/pad/[!abc]", "/pad/b"));
 }


### PR DESCRIPTION
## Summary
- add OSC message/codec/sender edge coverage for typed defaults, empty/padded/truncated strings, trailing padding, and unconnected raw sends
- add OSC bundle coverage for fractional timetag round-trips, default bundle elements, wildcard separator boundaries, alternatives, and negated classes
- add AttributedString/TextLayout and DirtyTracker edge coverage for empty setter no-ops, reuse after clear, wrap delimiter handling, full repaint bounds, threshold equality, and invalid viewport promotion

## Local validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Library/Caches/Pulp/fetchcontent-src/mbedtls-v3.6.2-tar`
- `cmake --build build --target pulp-test-osc pulp-test-osc-bundle pulp-test-attributed-string pulp-test-dirty-tracker -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-osc "[issue-644]" -r compact` (19 assertions / 5 cases)
- `./build/test/pulp-test-osc-bundle "[issue-644]" -r compact` (14 assertions / 5 cases)
- `./build/test/pulp-test-attributed-string "[issue-644]" -r compact` (15 assertions / 3 cases)
- `./build/test/pulp-test-dirty-tracker "[issue-644]" -r compact` (14 assertions / 3 cases)
- `./build/test/pulp-test-osc -r compact` (116 assertions / 32 cases)
- `./build/test/pulp-test-osc-bundle -r compact` (93 assertions / 36 cases)
- `./build/test/pulp-test-attributed-string -r compact` (112 assertions / 25 cases)
- `./build/test/pulp-test-dirty-tracker -r compact` (66 assertions / 21 cases)
- `ctest --test-dir build -R "OSC|AttributedString|TextLayout|DirtyTracker" --output-on-failure` (87/87 passed)
- `git diff --check origin/main...HEAD && git diff --check`
- `python3 tools/scripts/skill_sync_check.py`
- `tools/scripts/cli_version_check.sh`
- `./tools/check-docs.sh` (passed with existing warnings)

## CI
GitHub-hosted pull-request checks only. Namespace and SSH targets were not used.
