### PR TITLE
test(runtime): batch services edge coverage

### DIFF
--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -2,6 +2,7 @@
 #include <pulp/runtime/analytics.hpp>
 #include <pulp/runtime/temporary_file.hpp>
 #include <fstream>
+#include <filesystem>
 #include <memory>
 #include <vector>
 
@@ -73,6 +74,21 @@ TEST_CASE("Analytics forwards event details and flushes destinations", "[runtime
 
     a.flush();
     REQUIRE(*flushes == 1);
+}
+
+TEST_CASE("Analytics flush reaches destinations even when disabled", "[runtime][analytics][issue-641]") {
+    auto events = std::make_shared<std::vector<AnalyticsEvent>>();
+    auto flushes = std::make_shared<int>(0);
+
+    auto& a = Analytics::instance();
+    a.add_destination(std::make_unique<RecordingDestination>(events, flushes));
+
+    a.set_enabled(false);
+    a.flush();
+    REQUIRE(*flushes == 1);
+    REQUIRE(events->empty());
+
+    a.set_enabled(true);
 }
 
 TEST_CASE("Analytics disabled skips destinations", "[runtime][analytics]") {
@@ -148,6 +164,33 @@ TEST_CASE("FileAnalyticsDestination appends multiple flushes", "[runtime][analyt
     REQUIRE(content.find("\"event\":\"second\"") != std::string::npos);
 }
 
+TEST_CASE("FileAnalyticsDestination empty flush does not create output", "[runtime][analytics][issue-641]") {
+    TemporaryFile tmp(".jsonl");
+    auto path = tmp.path();
+    std::filesystem::remove(path);
+
+    FileAnalyticsDestination dest(tmp.path_string());
+    dest.flush();
+
+    REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
+TEST_CASE("FileAnalyticsDestination writes property map in key order", "[runtime][analytics][issue-641]") {
+    TemporaryFile tmp(".jsonl");
+    FileAnalyticsDestination dest(tmp.path_string());
+
+    AnalyticsEvent event;
+    event.name = "ordered";
+    event.properties = {{"z", "last"}, {"a", "first"}};
+    dest.log_event(event);
+    dest.flush();
+
+    std::ifstream f(tmp.path());
+    std::string line;
+    REQUIRE(std::getline(f, line));
+    REQUIRE(line.find("\"a\":\"first\"") < line.find("\"z\":\"last\""));
+}
+
 TEST_CASE("WidgetTracker logs events", "[runtime][analytics]") {
     auto& a = Analytics::instance();
     a.set_enabled(true);
@@ -158,4 +201,27 @@ TEST_CASE("WidgetTracker logs events", "[runtime][analytics]") {
     WidgetTracker::track_preset_select("Default");
 
     REQUIRE(a.event_count() == before + 3);
+}
+
+TEST_CASE("WidgetTracker forwards expected event names and properties",
+          "[runtime][analytics][issue-641]") {
+    auto events = std::make_shared<std::vector<AnalyticsEvent>>();
+    auto flushes = std::make_shared<int>(0);
+
+    auto& a = Analytics::instance();
+    a.set_enabled(true);
+    a.add_destination(std::make_unique<RecordingDestination>(events, flushes));
+
+    WidgetTracker::track_click("bypass");
+    WidgetTracker::track_value_change("gain", "-6");
+    WidgetTracker::track_preset_select("Init");
+
+    REQUIRE(events->size() == 3);
+    REQUIRE((*events)[0].name == "widget_click");
+    REQUIRE((*events)[0].properties.at("widget") == "bypass");
+    REQUIRE((*events)[1].name == "value_change");
+    REQUIRE((*events)[1].properties.at("widget") == "gain");
+    REQUIRE((*events)[1].properties.at("value") == "-6");
+    REQUIRE((*events)[2].name == "preset_select");
+    REQUIRE((*events)[2].properties.at("preset") == "Init");
 }

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -15,6 +15,15 @@ TEST_CASE("i18n add and translate", "[runtime][i18n]") {
     REQUIRE(strings.count() == 1);
 }
 
+TEST_CASE("i18n add overwrites existing translation", "[runtime][i18n][issue-641]") {
+    LocalisedStrings strings;
+    strings.add("mode", "Old");
+    strings.add("mode", "New");
+
+    REQUIRE(strings.count() == 1);
+    REQUIRE(strings.translate("mode") == "New");
+}
+
 TEST_CASE("i18n translate missing key returns key", "[runtime][i18n]") {
     LocalisedStrings strings;
     REQUIRE(strings.translate("missing_key") == "missing_key");
@@ -40,6 +49,12 @@ TEST_CASE("i18n argument substitution leaves unmatched placeholders", "[runtime]
 
     REQUIRE(strings.translate("mixed", {"left", "right"}) == "left/{2}/right/left");
     REQUIRE(strings.translate("empty", {""}) == "beforeafter");
+}
+
+TEST_CASE("i18n argument substitution also applies to missing-key fallback",
+          "[runtime][i18n][issue-641]") {
+    LocalisedStrings strings;
+    REQUIRE(strings.translate("missing {0}/{1}/{2}", {"a", "b"}) == "missing a/b/{2}");
 }
 
 TEST_CASE("i18n clear removes all translations", "[runtime][i18n]") {
@@ -96,6 +111,22 @@ TEST_CASE("i18n .strings parser ignores malformed lines", "[runtime][i18n]") {
     REQUIRE_FALSE(strings.has("missing_value"));
 }
 
+TEST_CASE("i18n .strings parser overwrites duplicate keys", "[runtime][i18n][issue-641]") {
+    TemporaryFile tmp(".strings");
+    {
+        std::ofstream f(tmp.path());
+        f << "\"name\" = \"Old\";\n";
+        f << "\"other\" = \"Kept\";\n";
+        f << "\"name\" = \"New\";\n";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_strings_file(tmp.path_string()));
+    REQUIRE(strings.count() == 2);
+    REQUIRE(strings.translate("name") == "New");
+    REQUIRE(strings.translate("other") == "Kept");
+}
+
 // ── .po file format ─────────────────────────────────────────────────────
 
 TEST_CASE("i18n load .po file", "[runtime][i18n]") {
@@ -139,6 +170,24 @@ TEST_CASE("i18n .po parser handles continuations and empty entries", "[runtime][
     REQUIRE(strings.count() == 1);
     REQUIRE(strings.translate("long_key") == "lange_wert");
     REQUIRE_FALSE(strings.has("empty_translation"));
+}
+
+TEST_CASE("i18n .po parser commits previous entry when new msgid starts",
+          "[runtime][i18n][issue-641]") {
+    TemporaryFile tmp(".po");
+    {
+        std::ofstream f(tmp.path());
+        f << "msgid \"first\"\n";
+        f << "msgstr \"one\"\n";
+        f << "msgid \"second\"\n";
+        f << "msgstr \"two\"\n";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_po_file(tmp.path_string()));
+    REQUIRE(strings.count() == 2);
+    REQUIRE(strings.translate("first") == "one");
+    REQUIRE(strings.translate("second") == "two");
 }
 
 // ── JSON file format ────────────────────────────────────────────────────
@@ -205,6 +254,25 @@ TEST_CASE("i18n JSON parser rejects missing object opener", "[runtime][i18n]") {
     REQUIRE(strings.count() == 0);
 }
 
+TEST_CASE("i18n JSON parser allows duplicate keys and trailing comma",
+          "[runtime][i18n][issue-641]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << "{\n";
+        f << "  \"name\": \"Old\",\n";
+        f << "  \"name\": \"New\",\n";
+        f << "  \"last\": \"value\",\n";
+        f << "}\n";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_json_file(tmp.path_string()));
+    REQUIRE(strings.count() == 2);
+    REQUIRE(strings.translate("name") == "New");
+    REQUIRE(strings.translate("last") == "value");
+}
+
 // ── File load failures ──────────────────────────────────────────────────
 
 TEST_CASE("i18n load nonexistent file returns false", "[runtime][i18n]") {
@@ -220,6 +288,16 @@ TEST_CASE("i18n global instance", "[runtime][i18n]") {
     auto& inst = LocalisedStrings::instance();
     inst.add("test_global", "works");
     REQUIRE(tr("test_global") == "works");
+    inst.clear();
+}
+
+TEST_CASE("i18n global tr supports argument substitution", "[runtime][i18n][issue-641]") {
+    auto& inst = LocalisedStrings::instance();
+    inst.clear();
+    inst.add("global_args", "{0}:{1}");
+
+    REQUIRE(tr("global_args", {"left", "right"}) == "left:right");
+
     inst.clear();
 }
 

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -79,6 +79,27 @@ TEST_CASE("Uuid string round-trip", "[runtime][identity]") {
     }
 }
 
+TEST_CASE("Uuid parsing accepts uppercase dashed and compact hex",
+          "[runtime][identity][issue-641]") {
+    Uuid id;
+    id.hi = 0x0123456789abcdefULL;
+    id.lo = 0xfedcba9876543210ULL;
+
+    REQUIRE(Uuid::from_string("01234567-89AB-CDEF-FEDC-BA9876543210") == id);
+    REQUIRE(Uuid::from_string("0123456789ABCDEFFEDCBA9876543210") == id);
+}
+
+TEST_CASE("Uuid ordering sorts by high word before low word",
+          "[runtime][identity][issue-641]") {
+    Uuid low{1, 999};
+    Uuid middle{2, 1};
+    Uuid high{2, 2};
+
+    REQUIRE(low < middle);
+    REQUIRE(middle < high);
+    REQUIRE_FALSE(high < middle);
+}
+
 TEST_CASE("Typed identity wrappers", "[runtime][identity]") {
     SECTION("SessionId") {
         auto sid = SessionId::generate();
@@ -121,6 +142,19 @@ TEST_CASE("Typed identity wrappers", "[runtime][identity]") {
         REQUIRE(sessions.size() == 1);
         REQUIRE(objects.size() == 1);
     }
+}
+
+TEST_CASE("Typed identity nil and hashing are stable", "[runtime][identity][issue-641]") {
+    REQUIRE(SessionId::nil() == SessionId::nil());
+    REQUIRE(RunId::nil() == RunId::nil());
+    REQUIRE(ObjectId::nil() == ObjectId::from_string("00000000000000000000000000000000"));
+    REQUIRE(CorrelationId::nil() == CorrelationId::nil());
+
+    auto object = ObjectId::generate();
+    std::unordered_set<ObjectId> objects;
+    objects.insert(object);
+    objects.insert(object);
+    REQUIRE(objects.size() == 1);
 }
 
 TEST_CASE("EventEnvelope", "[runtime][identity]") {

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -119,6 +119,25 @@ TEST_CASE("LicenseValidator validate_and_parse extracts info", "[crypto][license
     REQUIRE(info->edition == "pro");
 }
 
+TEST_CASE("LicenseValidator validate_and_parse extracts optional machine and expiry",
+          "[crypto][license][issue-641]") {
+    LicenseValidator validator;
+
+    std::string payload =
+        "{\"product_id\":\"PulpSynth\",\"email\":\"user@example.com\","
+        "\"machine_id\":\"machine-1\",\"edition\":\"studio\","
+        "\"issued\":1700000000,\"expiry\":1800000000}";
+    auto info = validator.validate_and_parse(base64_encode(payload) + ".sig");
+
+    REQUIRE(info.has_value());
+    REQUIRE(info->product_id == "PulpSynth");
+    REQUIRE(info->user_email == "user@example.com");
+    REQUIRE(info->machine_id == "machine-1");
+    REQUIRE(info->edition == "studio");
+    REQUIRE(info->issued_timestamp == 1700000000);
+    REQUIRE(info->expiry_timestamp == 1800000000);
+}
+
 TEST_CASE("LicenseValidator validate_and_parse rejects malformed payloads", "[crypto][license]") {
     LicenseValidator validator;
 
@@ -166,6 +185,28 @@ TEST_CASE("LicenseValidator validate_file trims line endings", "[crypto][license
 
     LicenseValidator validator;
     REQUIRE(validator.validate_file(tmp.path_string()) == LicenseStatus::InvalidSignature);
+}
+
+TEST_CASE("LicenseValidator validate_file accepts file without trailing newline",
+          "[crypto][license][issue-641]") {
+    TemporaryFile tmp(".license");
+    std::string payload = "{\"product_id\":\"PulpSynth\",\"issued\":1700000000}";
+    std::string key = base64_encode(payload) + "." + base64_encode("signature");
+
+    {
+        std::ofstream out(tmp.path());
+        REQUIRE(out.good());
+        out << key;
+    }
+
+    LicenseValidator validator;
+    REQUIRE(validator.validate_file(tmp.path_string()) == LicenseStatus::InvalidSignature);
+}
+
+TEST_CASE("LicenseValidator validate rejects empty payload section",
+          "[crypto][license][issue-641]") {
+    LicenseValidator validator;
+    REQUIRE(validator.validate(".sig") == LicenseStatus::InvalidSignature);
 }
 
 TEST_CASE("LicenseGenerator requires a usable private key", "[crypto][license]") {


### PR DESCRIPTION
## Summary
- add analytics service coverage for disabled flush behavior, empty flushes, deterministic property output, and widget tracker event details
- add i18n coverage for overwrites, missing-key argument substitution, duplicate entries, PO commit boundaries, JSON trailing comma handling, and global argument translation
- add identity coverage for uppercase UUID parsing, ordering, nil typed IDs, and hash stability
- add license coverage for optional parsed fields, newline-free license files, and empty-payload validation classification

## Local validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Library/Caches/Pulp/fetchcontent-src/mbedtls-v3.6.2-tar`
- `cmake --build build --target pulp-test-analytics pulp-test-i18n pulp-test-identity pulp-test-license -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-analytics "[issue-641]" -r compact` (13 assertions / 4 cases)
- `./build/test/pulp-test-i18n "[issue-641]" -r compact` (16 assertions / 6 cases)
- `./build/test/pulp-test-identity "[issue-641]" -r compact` (10 assertions / 3 cases)
- `./build/test/pulp-test-license "[issue-641]" -r compact` (10 assertions / 3 cases)
- `./build/test/pulp-test-analytics -r compact` (29 assertions / 13 cases)
- `./build/test/pulp-test-i18n -r compact` (65 assertions / 23 cases)
- `./build/test/pulp-test-identity -r compact` (41 assertions / 7 cases)
- `./build/test/pulp-test-license -r compact` (43 assertions / 23 cases)
- `ctest --test-dir build -R "Analytics|i18n|Uuid|Typed identity|EventEnvelope|LicenseValidator|LicenseGenerator|BigInteger" --output-on-failure` (64/64 passed)
- `git diff --check origin/main...HEAD && git diff --check`
- `python3 tools/scripts/skill_sync_check.py`
- `tools/scripts/cli_version_check.sh`
- `./tools/check-docs.sh` (passed with existing warnings)

## CI
GitHub-hosted pull-request checks only. Namespace and SSH targets were not used.
