### PR TITLE
test(runtime): cover codec and expression edge cases

### DIFF
--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/runtime/crypto.hpp>
+#include <algorithm>
+#include <cctype>
 #include <cstring>
 #include <vector>
 
@@ -23,6 +25,20 @@ TEST_CASE("SHA-256 binary data", "[crypto][sha256]") {
     REQUIRE(digest.size() == 32);
 }
 
+TEST_CASE("SHA-256 pointer overload preserves embedded NUL bytes",
+          "[crypto][sha256][coverage][issue-641]") {
+    const std::vector<uint8_t> data = {'a', 'b', 'c', 0x00, 'd', 'e', 'f'};
+
+    auto digest = sha256(data.data(), data.size());
+    auto hex = sha256_hex(data.data(), data.size());
+
+    REQUIRE(digest.size() == 32);
+    REQUIRE(hex == "516a5e926ce20c5f4d80f00e1a01abdf14986def6588d6abeed9fce090bc660c");
+    REQUIRE(std::all_of(hex.begin(), hex.end(), [](unsigned char c) {
+        return std::isdigit(c) || (c >= 'a' && c <= 'f');
+    }));
+}
+
 // ── SHA-1 ───────────────────────────────────────────────────────────────
 
 TEST_CASE("SHA-1 known value", "[crypto][sha1]") {
@@ -35,6 +51,17 @@ TEST_CASE("SHA-1 known value", "[crypto][sha1]") {
     REQUIRE(digest == expected);
 }
 
+TEST_CASE("SHA-1 pointer overload preserves embedded NUL bytes",
+          "[crypto][sha1][coverage][issue-641]") {
+    const std::vector<uint8_t> data = {'w', 's', 0x00, 'k', 'e', 'y'};
+    const std::vector<uint8_t> expected = {
+        0xb1, 0x24, 0x2e, 0x4b, 0x0c, 0x53, 0x4d, 0x49, 0x0f, 0x5e,
+        0xf7, 0xee, 0x67, 0xb8, 0x80, 0xf0, 0xa2, 0xb8, 0x8a, 0x6b,
+    };
+
+    REQUIRE(sha1(data.data(), data.size()) == expected);
+}
+
 // ── MD5 ─────────────────────────────────────────────────────────────────
 
 TEST_CASE("MD5 empty string", "[crypto][md5]") {
@@ -45,6 +72,17 @@ TEST_CASE("MD5 empty string", "[crypto][md5]") {
 TEST_CASE("MD5 known value", "[crypto][md5]") {
     auto hex = md5_hex("hello");
     REQUIRE(hex == "5d41402abc4b2a76b9719d911017c592");
+}
+
+TEST_CASE("MD5 binary data returns raw digest bytes",
+          "[crypto][md5][coverage][issue-641]") {
+    const std::vector<uint8_t> data = {0x00, 0xff, 0x10, 0x20, 0x00};
+    const std::vector<uint8_t> expected = {
+        0x96, 0x26, 0x6b, 0xae, 0xb1, 0xeb, 0x57, 0x35,
+        0xd5, 0x51, 0xca, 0xc2, 0xd9, 0xa8, 0x27, 0x75,
+    };
+
+    REQUIRE(md5(data.data(), data.size()) == expected);
 }
 
 // ── AES-256-CBC ─────────────────────────────────────────────────────────
@@ -86,6 +124,27 @@ TEST_CASE("AES empty plaintext", "[crypto][aes]") {
     REQUIRE(decrypted->empty());
 }
 
+TEST_CASE("AES exact block plaintext adds and removes full padding block",
+          "[crypto][aes][coverage][issue-641]") {
+    uint8_t key[32] = {};
+    uint8_t iv[16] = {};
+    std::memset(key, 0x21, 32);
+    std::memset(iv, 0x43, 16);
+
+    std::string plaintext = "sixteen byte txt";
+    REQUIRE(plaintext.size() == 16);
+
+    auto encrypted = aes_encrypt(
+        reinterpret_cast<const uint8_t*>(plaintext.data()),
+        plaintext.size(), key, iv);
+    REQUIRE(encrypted.has_value());
+    REQUIRE(encrypted->size() == 32);
+
+    auto decrypted = aes_decrypt(encrypted->data(), encrypted->size(), key, iv);
+    REQUIRE(decrypted.has_value());
+    REQUIRE(std::string(decrypted->begin(), decrypted->end()) == plaintext);
+}
+
 TEST_CASE("AES decrypt invalid data", "[crypto][aes]") {
     uint8_t key[32] = {};
     uint8_t iv[16] = {};
@@ -103,6 +162,24 @@ TEST_CASE("AES decrypt rejects non-block-aligned ciphertext", "[crypto][aes]") {
     uint8_t ciphertext[15] = {};
 
     auto result = aes_decrypt(ciphertext, sizeof(ciphertext), key, iv);
+    REQUIRE_FALSE(result.has_value());
+}
+
+TEST_CASE("AES decrypt rejects invalid PKCS7 padding bytes",
+          "[crypto][aes][coverage][issue-641]") {
+    uint8_t key[32] = {};
+    uint8_t iv[16] = {};
+    std::memset(key, 0x5c, 32);
+    std::memset(iv, 0xa7, 16);
+
+    std::string plaintext = "padding check";
+    auto encrypted = aes_encrypt(
+        reinterpret_cast<const uint8_t*>(plaintext.data()),
+        plaintext.size(), key, iv);
+    REQUIRE(encrypted.has_value());
+
+    encrypted->back() ^= 0x01;
+    auto result = aes_decrypt(encrypted->data(), encrypted->size(), key, iv);
     REQUIRE_FALSE(result.has_value());
 }
 

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -5,9 +5,12 @@
 #include <pulp/runtime/inter_process_lock.hpp>
 #include <pulp/runtime/child_process.hpp>
 #include <pulp/runtime/base64.hpp>
+#include <pulp/runtime/expression.hpp>
 #include <pulp/runtime/http.hpp>
 #include <pulp/runtime/range.hpp>
 #include <pulp/runtime/text_diff.hpp>
+#include <catch2/catch_approx.hpp>
+#include <cmath>
 #include <fstream>
 #include <filesystem>
 
@@ -237,6 +240,82 @@ TEST_CASE("base64 binary round-trip", "[runtime][base64]") {
     auto decoded = base64_decode(encoded);
     REQUIRE(decoded.has_value());
     REQUIRE(*decoded == data);
+}
+
+// ── Expression ─────────────────────────────────────────────────────────
+
+TEST_CASE("Expression evaluator handles precedence and exponent edge cases",
+          "[runtime][expression][coverage][issue-641]") {
+    auto value = evaluate("2 + 3 * 4 ^ 2");
+    REQUIRE(value.has_value());
+    REQUIRE(*value == Catch::Approx(50.0));
+
+    auto signed_power = evaluate("-2^2");
+    REQUIRE(signed_power.has_value());
+    REQUIRE(*signed_power == Catch::Approx(4.0));
+
+    auto grouped = evaluate("(-2)^2");
+    REQUIRE(grouped.has_value());
+    REQUIRE(*grouped == Catch::Approx(4.0));
+}
+
+TEST_CASE("Expression evaluator handles constants, functions, and scientific notation",
+          "[runtime][expression][coverage][issue-641]") {
+    auto trig = evaluate("sin(pi / 2) + cos(0)");
+    REQUIRE(trig.has_value());
+    REQUIRE(*trig == Catch::Approx(2.0));
+
+    auto clamped = evaluate("clamp(12, 10)");
+    REQUIRE(clamped.has_value());
+    REQUIRE(*clamped == Catch::Approx(10.0));
+
+    auto scientific = evaluate("1.5e2 + 2E-1");
+    REQUIRE(scientific.has_value());
+    REQUIRE(*scientific == Catch::Approx(150.2));
+}
+
+TEST_CASE("Expression evaluator resolves variables and rejects malformed inputs",
+          "[runtime][expression][coverage][issue-641]") {
+    auto variable = evaluate("gain * 2 + offset", {{"gain", 0.75}, {"offset", 0.25}});
+    REQUIRE(variable.has_value());
+    REQUIRE(*variable == Catch::Approx(1.75));
+
+    REQUIRE_FALSE(evaluate("missing + 1").has_value());
+    REQUIRE_FALSE(evaluate("min(1)").has_value());
+    REQUIRE_FALSE(evaluate("(1 + 2").has_value());
+    REQUIRE_FALSE(evaluate("").has_value());
+}
+
+TEST_CASE("ExpressionEvaluator stores variables and clears them",
+          "[runtime][expression][coverage][issue-641]") {
+    ExpressionEvaluator evaluator;
+    evaluator.set("x", 4.0);
+    evaluator.set("y", 2.5);
+
+    REQUIRE(evaluator.get("x").has_value());
+    REQUIRE(*evaluator.get("x") == Catch::Approx(4.0));
+
+    auto value = evaluator.evaluate("x * y");
+    REQUIRE(value.has_value());
+    REQUIRE(*value == Catch::Approx(10.0));
+
+    evaluator.clear_variables();
+    REQUIRE_FALSE(evaluator.get("x").has_value());
+    REQUIRE_FALSE(evaluator.evaluate("x").has_value());
+}
+
+TEST_CASE("ExpressionEvaluator dispatches registered unary functions",
+          "[runtime][expression][coverage][issue-641]") {
+    ExpressionEvaluator evaluator;
+    evaluator.register_function("db_to_gain", [](double db) {
+        return std::pow(10.0, db / 20.0);
+    });
+
+    auto unity = evaluator.evaluate("db_to_gain(0)");
+    REQUIRE(unity.has_value());
+    REQUIRE(*unity == Catch::Approx(1.0));
+
+    REQUIRE_FALSE(evaluator.evaluate("missing_fn(1)").has_value());
 }
 
 // ── HTTP URL parsing ───────────────────────────────────────────────────

--- a/test/test_xml_zip.cpp
+++ b/test/test_xml_zip.cpp
@@ -111,6 +111,46 @@ TEST_CASE("XmlDocument invalid XML", "[runtime][xml]") {
     REQUIRE_FALSE(doc.error().empty());
 }
 
+TEST_CASE("XmlDocument empty document queries are inert",
+          "[runtime][xml][coverage][issue-641]") {
+    XmlDocument doc;
+
+    REQUIRE_FALSE(doc.is_valid());
+    REQUIRE(doc.root_name().empty());
+    REQUIRE_FALSE(doc.root_attribute("missing").has_value());
+    REQUIRE_FALSE(doc.xpath_string("//missing").has_value());
+    REQUIRE(doc.xpath_strings("//missing").empty());
+
+    int walk_count = 0;
+    doc.walk([&](std::string_view, std::string_view) {
+        ++walk_count;
+    });
+    REQUIRE(walk_count == 0);
+}
+
+TEST_CASE("XmlDocument move construction and assignment preserve parsed state",
+          "[runtime][xml][coverage][issue-641]") {
+    XmlDocument original;
+    REQUIRE(original.parse(R"(<root name="first"><child>value</child></root>)"));
+
+    XmlDocument moved(std::move(original));
+    REQUIRE(moved.is_valid());
+    REQUIRE(moved.root_name() == "root");
+    REQUIRE(moved.root_attribute("name") == std::optional<std::string>{"first"});
+    REQUIRE_FALSE(original.is_valid());
+    REQUIRE(original.root_name().empty());
+
+    XmlDocument replacement;
+    REQUIRE(replacement.parse(R"(<replacement><leaf>next</leaf></replacement>)"));
+
+    moved = std::move(replacement);
+    REQUIRE(moved.is_valid());
+    REQUIRE(moved.root_name() == "replacement");
+    REQUIRE(moved.xpath_string("//leaf") == std::optional<std::string>{"next"});
+    REQUIRE_FALSE(replacement.is_valid());
+    REQUIRE(replacement.root_name().empty());
+}
+
 TEST_CASE("xml_generate creates document", "[runtime][xml]") {
     auto xml = xml_generate("preset", {
         {"name", "Default"},
@@ -124,6 +164,28 @@ TEST_CASE("xml_generate creates document", "[runtime][xml]") {
     auto name = doc.xpath_string("//name");
     REQUIRE(name.has_value());
     REQUIRE(*name == "Default");
+}
+
+TEST_CASE("xml_generate handles empty and repeated elements",
+          "[runtime][xml][coverage][issue-641]") {
+    auto xml = xml_generate("metadata", {
+        {"tag", "alpha"},
+        {"tag", "beta"},
+        {"empty", ""}
+    });
+
+    XmlDocument doc;
+    REQUIRE(doc.parse(xml));
+    REQUIRE(doc.root_name() == "metadata");
+
+    auto tags = doc.xpath_strings("//tag");
+    REQUIRE(tags.size() == 2);
+    REQUIRE(tags[0] == "alpha");
+    REQUIRE(tags[1] == "beta");
+
+    auto empty = doc.xpath_string("//empty");
+    REQUIRE(empty.has_value());
+    REQUIRE(empty->empty());
 }
 
 TEST_CASE("xml_generate escapes text content", "[runtime][xml]") {


### PR DESCRIPTION
## Summary
- cover binary hash overloads and AES padding edge cases
- add runtime expression evaluator coverage for precedence, functions, variables, and custom functions
- add XML document empty/move and repeated-element generation coverage

## Local validation
- cmake --build build --target pulp-test-crypto pulp-test-runtime-utils pulp-test-xml-zip -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-crypto "[coverage][issue-641]" -r compact && ./build/test/pulp-test-crypto -r compact
- ./build/test/pulp-test-runtime-utils "[coverage][issue-641]" -r compact && ./build/test/pulp-test-runtime-utils -r compact
- ./build/test/pulp-test-xml-zip "[coverage][issue-641]" -r compact && ./build/test/pulp-test-xml-zip -r compact
- ctest --test-dir build -R "(SHA-256 pointer|SHA-1 pointer|MD5 binary|AES exact|AES decrypt rejects invalid|Expression evaluator|ExpressionEvaluator|XmlDocument empty|XmlDocument move|xml_generate handles)" --output-on-failure
- git diff --check
- ./tools/check-docs.sh (passed with existing warnings)