### PR TITLE
test(runtime): cover communication edge cases

### DIFF
--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -291,3 +291,81 @@ TEST_CASE("JsonRpcPeer reports closed and failed sends", "[json_rpc]") {
     channel.deliver_text(R"json({"jsonrpc":"2.0","id":1,"result":true})json");
     REQUIRE_FALSE(callback_called);
 }
+
+TEST_CASE("JsonRpcPeer omits params for empty request payloads",
+          "[json_rpc][coverage][issue-641]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string outbound_request;
+    pair.second->on_message([&](const Message& message) {
+        outbound_request.assign(message.as_text());
+    });
+
+    JsonRpcPeer client(*pair.first);
+    std::atomic<int> callbacks{0};
+    std::string result;
+    REQUIRE(client.send_request("noParams", "", [&](const JsonRpcResult& response) {
+        result = response.result_json;
+        callbacks.fetch_add(1);
+    }));
+
+    REQUIRE(outbound_request.find(R"("method":"noParams")") != std::string::npos);
+    REQUIRE(outbound_request.find(R"("params")") == std::string::npos);
+
+    pair.second->send_text(R"json({"jsonrpc":"2.0","id":1,"result":{"ok":true}})json");
+    REQUIRE(wait_until([&] { return callbacks.load() == 1; }));
+    REQUIRE(result.find(R"("ok")") != std::string::npos);
+    REQUIRE(result.find("true") != std::string::npos);
+}
+
+TEST_CASE("JsonRpcPeer preserves string request ids in responses",
+          "[json_rpc][coverage][issue-641]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string reply;
+    pair.first->on_message([&](const Message& message) {
+        reply.assign(message.as_text());
+    });
+
+    JsonRpcPeer server(*pair.second);
+    server.register_method("echo", [](std::string_view params) {
+        return JsonRpcResult::ok(std::string(params));
+    });
+
+    pair.first->send_text(
+        R"json({"jsonrpc":"2.0","id":"abc-123","method":"echo","params":{"value":7}})json");
+
+    REQUIRE(reply.find(R"("id":"abc-123")") != std::string::npos);
+    REQUIRE(reply.find(R"("value")") != std::string::npos);
+    REQUIRE(reply.find("7") != std::string::npos);
+}
+
+TEST_CASE("JsonRpcPeer dispatches incoming error responses with data",
+          "[json_rpc][coverage][issue-641]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string outbound_request;
+    pair.second->on_message([&](const Message& message) {
+        outbound_request.assign(message.as_text());
+    });
+
+    JsonRpcPeer client(*pair.first);
+    std::atomic<bool> done{false};
+    std::optional<JsonRpcError> error;
+
+    REQUIRE(client.send_request("willFail", "[]", [&](const JsonRpcResult& response) {
+        error = response.error;
+        done.store(true);
+    }));
+    REQUIRE(outbound_request.find(R"("id":1)") != std::string::npos);
+
+    pair.second->send_text(
+        R"json({"jsonrpc":"2.0","id":1,"error":{"code":-32099,"message":"custom","data":{"retry":false}}})json");
+
+    REQUIRE(wait_until([&] { return done.load(); }));
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == -32099);
+    REQUIRE(error->message == "custom");
+    REQUIRE(error->data_json.find(R"("retry")") != std::string::npos);
+    REQUIRE(error->data_json.find("false") != std::string::npos);
+}

--- a/test/test_memory_message_channel.cpp
+++ b/test/test_memory_message_channel.cpp
@@ -68,6 +68,64 @@ TEST_CASE("MemoryMessageChannel send succeeds without peer callback",
     REQUIRE(left->send_text("nobody-listens"));
 }
 
+TEST_CASE("MemoryMessageChannel delivers zero-length binary and text payloads",
+          "[runtime][message_channel][coverage][issue-641]") {
+    auto [left, right] = MemoryMessageChannel::make_pair();
+
+    std::vector<Message> received;
+    right->on_message([&](const Message& message) {
+        received.push_back(message);
+    });
+
+    std::uint8_t empty = 0;
+    REQUIRE(left->send(&empty, 0));
+    REQUIRE(left->send_text(""));
+
+    REQUIRE(received.size() == 2);
+    REQUIRE(received[0].kind == MessageKind::Binary);
+    REQUIRE(received[0].payload.empty());
+    REQUIRE(received[1].kind == MessageKind::Text);
+    REQUIRE(received[1].payload.empty());
+    REQUIRE(received[1].as_text().empty());
+}
+
+TEST_CASE("MemoryMessageChannel can clear callbacks while remaining open",
+          "[runtime][message_channel][coverage][issue-641]") {
+    auto [left, right] = MemoryMessageChannel::make_pair();
+
+    int calls = 0;
+    right->on_message([&](const Message&) { ++calls; });
+    REQUIRE(left->send_text("before-clear"));
+    REQUIRE(calls == 1);
+
+    right->on_message({});
+    REQUIRE(left->send_text("after-clear"));
+    REQUIRE(calls == 1);
+    REQUIRE(left->is_open());
+    REQUIRE(right->is_open());
+}
+
+TEST_CASE("MemoryMessageChannel text views preserve embedded NUL bytes",
+          "[runtime][message_channel][coverage][issue-641]") {
+    auto [left, right] = MemoryMessageChannel::make_pair();
+
+    std::string text = "prefix";
+    text.push_back('\0');
+    text += "suffix";
+
+    std::string_view view;
+    Message received;
+    right->on_message([&](const Message& message) {
+        received = message;
+        view = received.as_text();
+    });
+
+    REQUIRE(left->send_text(text));
+    REQUIRE(received.kind == MessageKind::Text);
+    REQUIRE(view.size() == text.size());
+    REQUIRE(std::string(view) == text);
+}
+
 TEST_CASE("MemoryMessageChannel close is peer-wide and idempotent",
           "[runtime][message_channel]") {
     auto [left, right] = MemoryMessageChannel::make_pair();

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <pulp/runtime/named_pipe.hpp>
+#include <pulp/runtime/network_stream.hpp>
 #include <pulp/runtime/stream.hpp>
 
 #include <array>
@@ -11,11 +12,13 @@
 #include <string>
 
 using pulp::runtime::FileStream;
+using pulp::runtime::HttpStream;
 using pulp::runtime::MemoryStream;
 using pulp::runtime::NamedPipe;
 using pulp::runtime::Stream;
 using pulp::runtime::StreamError;
 using pulp::runtime::StreamResult;
+using pulp::runtime::TcpStream;
 
 namespace {
 
@@ -209,6 +212,92 @@ TEST_CASE("Stream polymorphic usage", "[stream]") {
     REQUIRE(r.ok());
     REQUIRE(r.bytes == std::strlen(msg));
     REQUIRE(std::memcmp(buf.data(), msg, std::strlen(msg)) == 0);
+}
+
+TEST_CASE("FileStream ReadWrite mode tracks position and truncates on open",
+          "[stream][file][coverage][issue-641]") {
+    auto path = make_temp_path("pulp_stream_readwrite");
+    const std::uint8_t first[] = {'o', 'l', 'd'};
+    const std::uint8_t second[] = {'n', 'e', 'w', '!'};
+
+    {
+        FileStream seed(path.string(), FileStream::Mode::Write);
+        REQUIRE(seed.write(first, sizeof(first)).bytes == sizeof(first));
+        REQUIRE(seed.flush());
+    }
+
+    {
+        FileStream stream(path.string(), FileStream::Mode::ReadWrite);
+        REQUIRE(stream.is_open());
+        REQUIRE(stream.position() == 0);
+        REQUIRE(stream.write(second, sizeof(second)).bytes == sizeof(second));
+        REQUIRE(stream.position() == sizeof(second));
+        REQUIRE(stream.flush());
+    }
+
+    {
+        FileStream readback(path.string(), FileStream::Mode::Read);
+        std::array<std::uint8_t, sizeof(second)> out{};
+        auto got = readback.read(out.data(), out.size());
+        REQUIRE(got.ok());
+        REQUIRE(got.bytes == out.size());
+        REQUIRE(std::memcmp(out.data(), second, sizeof(second)) == 0);
+        REQUIRE(readback.read(out.data(), out.size()).closed());
+    }
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("MemoryStream clear keeps closed streams closed",
+          "[stream][memory][coverage][issue-641]") {
+    MemoryStream stream(std::vector<std::uint8_t>{1, 2, 3});
+    stream.close();
+    stream.clear();
+
+    REQUIRE_FALSE(stream.is_open());
+    REQUIRE(stream.size() == 0);
+    REQUIRE(stream.read_position() == 0);
+
+    std::uint8_t byte = 0;
+    REQUIRE(stream.read(&byte, 1).closed());
+    REQUIRE(stream.write(&byte, 1).closed());
+}
+
+TEST_CASE("TcpStream closed state rejects I/O and survives move assignment",
+          "[stream][tcp][coverage][issue-641]") {
+    TcpStream first;
+    TcpStream second;
+    std::uint8_t byte = 0;
+
+    REQUIRE_FALSE(first.is_open());
+    REQUIRE(first.read(&byte, 1).closed());
+    REQUIRE(first.write(&byte, 1).closed());
+
+    second = std::move(first);
+    REQUIRE_FALSE(second.is_open());
+    REQUIRE(second.read(&byte, 1).closed());
+    REQUIRE(second.write(&byte, 1).closed());
+}
+
+TEST_CASE("HttpStream invalid URLs fail without external transport",
+          "[stream][http][coverage][issue-641]") {
+    HttpStream stream;
+    HttpStream::Request request;
+    request.url = "not-a-url";
+    request.timeout_seconds = 1;
+
+    REQUIRE_FALSE(stream.fetch(request));
+    REQUIRE_FALSE(stream.is_open());
+    REQUIRE(stream.status_code() == 0);
+    REQUIRE(stream.transport_error() == "Invalid URL");
+
+    std::array<std::uint8_t, 8> out{};
+    REQUIRE(stream.read(out.data(), out.size()).error == StreamError::IoError);
+    REQUIRE(stream.write(out.data(), out.size()).error == StreamError::Invalid);
+    REQUIRE(stream.eof());
+
+    stream.close();
+    REQUIRE(stream.read(out.data(), out.size()).closed());
 }
 
 TEST_CASE("NamedPipe closed and missing endpoints fail closed", "[stream][named_pipe][issue-641]") {


### PR DESCRIPTION
## Summary
- add MemoryMessageChannel edge coverage for empty payloads, callback clearing, and embedded NUL text
- add JsonRpcPeer coverage for omitted params, string request ids, and error response data
- add stream coverage for FileStream ReadWrite truncation, closed Memory/TCP behavior, and invalid HttpStream fetches

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF
- cmake --build build --target pulp-test-memory-message-channel pulp-test-json-rpc pulp-test-stream pulp-test-websocket-channel -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-memory-message-channel "[coverage][issue-641]" -r compact
- ./build/test/pulp-test-json-rpc "[coverage][issue-641]" -r compact
- ./build/test/pulp-test-stream "[coverage][issue-641]" -r compact
- ./build/test/pulp-test-memory-message-channel -r compact
- ./build/test/pulp-test-json-rpc -r compact
- ./build/test/pulp-test-stream -r compact
- ./build/test/pulp-test-websocket-channel -r compact
- ctest --test-dir build -R "(zero-length binary|clear callbacks|embedded NUL|omits params|string request ids|incoming error responses|ReadWrite mode|clear keeps closed|TcpStream closed|HttpStream invalid)" --output-on-failure
- git diff --check
- ./tools/check-docs.sh (passes with existing warnings)