### PR TITLE
test(runtime): cover primitive edge cases

### DIFF
--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -87,6 +87,24 @@ TEST_CASE("EnvironmentChange: any reflects individual flags",
     REQUIRE(change.any());
 }
 
+TEST_CASE("SafeAreaInsets zero detection checks all edges",
+          "[environment][coverage][issue-640]") {
+    SafeAreaInsets insets;
+    REQUIRE(insets.is_zero());
+
+    insets.top = 1.0f;
+    REQUIRE_FALSE(insets.is_zero());
+    insets = {};
+    insets.bottom = 1.0f;
+    REQUIRE_FALSE(insets.is_zero());
+    insets = {};
+    insets.left = 1.0f;
+    REQUIRE_FALSE(insets.is_zero());
+    insets = {};
+    insets.right = 1.0f;
+    REQUIRE_FALSE(insets.is_zero());
+}
+
 TEST_CASE("Environment: subscribe receives publish + correct change mask",
           "[environment]") {
     Environment::reset_for_test();
@@ -149,6 +167,32 @@ TEST_CASE("Environment: reset clears listeners held by live tokens",
 
     Environment::inject_for_test(make_state(ColorScheme::light));
     REQUIRE(calls == 0);
+}
+
+TEST_CASE("Environment: token reset is idempotent and preserves other listeners",
+          "[environment][coverage][issue-640]") {
+    Environment::reset_for_test();
+    int first_calls = 0;
+    int second_calls = 0;
+
+    auto first = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++first_calls; });
+    auto second = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++second_calls; });
+
+    first.reset();
+    first.reset();
+    REQUIRE_FALSE(first.valid());
+    REQUIRE(second.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(first_calls == 0);
+    REQUIRE(second_calls == 1);
+
+    second.reset();
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(first_calls == 0);
+    REQUIRE(second_calls == 1);
 }
 
 TEST_CASE("Environment: token move transfers ownership", "[environment]") {

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -49,6 +49,29 @@ TEST_CASE("SpscQueue basic operations", "[runtime][spsc]") {
     }
 }
 
+TEST_CASE("SpscQueue reuses slots after wrap-around",
+          "[runtime][spsc][coverage][issue-641]") {
+    SpscQueue<int, 4> q;
+    REQUIRE(q.capacity() == 4);
+
+    for (int cycle = 0; cycle < 3; ++cycle) {
+        REQUIRE(q.empty());
+        for (int i = 0; i < 4; ++i) {
+            REQUIRE(q.try_push(cycle * 10 + i));
+        }
+        REQUIRE_FALSE(q.try_push(999));
+        REQUIRE(q.size_approx() == 4);
+        for (int i = 0; i < 4; ++i) {
+            auto value = q.try_pop();
+            REQUIRE(value.has_value());
+            REQUIRE(*value == cycle * 10 + i);
+        }
+    }
+
+    REQUIRE(q.empty());
+    REQUIRE_FALSE(q.try_pop().has_value());
+}
+
 TEST_CASE("SpscQueue cross-thread", "[runtime][spsc]") {
     SpscQueue<int, 1024> q;
     constexpr int count = 10000;
@@ -106,6 +129,16 @@ TEST_CASE("ScopeGuard move transfers cleanup ownership", "[runtime][scope_guard]
         auto guard = make_scope_guard([&] { ++calls; });
         auto moved = std::move(guard);
         static_cast<void>(moved);
+    }
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("PULP_ON_SCOPE_EXIT runs at block exit",
+          "[runtime][scope_guard][coverage][issue-641]") {
+    int calls = 0;
+    {
+        PULP_ON_SCOPE_EXIT(++calls);
+        REQUIRE(calls == 0);
     }
     REQUIRE(calls == 1);
 }

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -8,8 +8,10 @@
 #include <pulp/runtime/http.hpp>
 #include <pulp/runtime/range.hpp>
 #include <pulp/runtime/text_diff.hpp>
+#include <algorithm>
 #include <fstream>
 #include <filesystem>
+#include <iterator>
 
 using namespace pulp::runtime;
 
@@ -87,6 +89,52 @@ TEST_CASE("MemoryMappedFile move semantics", "[runtime][mmap]") {
     REQUIRE_FALSE(a.is_open());
 }
 
+TEST_CASE("MemoryMappedFile ReadWrite mode persists byte edits",
+          "[runtime][mmap][coverage][issue-641]") {
+    TemporaryFile tmp(".bin");
+    {
+        std::ofstream f(tmp.path(), std::ios::binary);
+        f << "abcde";
+    }
+
+    MemoryMappedFile mmap;
+    REQUIRE(mmap.open(tmp.path_string(), MapMode::ReadWrite));
+    REQUIRE(mmap.is_open());
+    REQUIRE(mmap.size() == 5);
+    REQUIRE(mmap.mutable_data() != nullptr);
+
+    mmap.mutable_data()[1] = static_cast<uint8_t>('A');
+    mmap.mutable_data()[3] = static_cast<uint8_t>('D');
+    mmap.close();
+    REQUIRE_FALSE(mmap.is_open());
+
+    std::ifstream f(tmp.path(), std::ios::binary);
+    std::string contents((std::istreambuf_iterator<char>(f)),
+                         std::istreambuf_iterator<char>());
+    REQUIRE(contents == "aAcDe");
+}
+
+TEST_CASE("MemoryMappedFile open failure clears an existing mapping",
+          "[runtime][mmap][coverage][issue-641]") {
+    TemporaryFile mapped(".bin");
+    {
+        std::ofstream f(mapped.path(), std::ios::binary);
+        f << "mapped";
+    }
+
+    TemporaryFile empty(".bin");
+
+    MemoryMappedFile mmap;
+    REQUIRE(mmap.open(mapped.path_string()));
+    REQUIRE(mmap.is_open());
+    REQUIRE(mmap.size() == 6);
+
+    REQUIRE_FALSE(mmap.open(empty.path_string()));
+    REQUIRE_FALSE(mmap.is_open());
+    REQUIRE(mmap.data() == nullptr);
+    REQUIRE(mmap.size() == 0);
+}
+
 // ── DynamicLibrary ──────────────────────────────────────────────────────
 
 TEST_CASE("DynamicLibrary loads system library", "[runtime][dynlib]") {
@@ -128,6 +176,25 @@ TEST_CASE("InterProcessLock double lock succeeds", "[runtime][ipc_lock]") {
     InterProcessLock lock("test_lock_double");
     REQUIRE(lock.try_lock());
     REQUIRE(lock.try_lock());  // Already locked, should still return true
+}
+
+TEST_CASE("InterProcessLock unlock is idempotent and permits reacquire",
+          "[runtime][ipc_lock][coverage][issue-641]") {
+    InterProcessLock lock("test_lock_reacquire");
+    REQUIRE_FALSE(lock.is_locked());
+
+    lock.unlock();
+    REQUIRE_FALSE(lock.is_locked());
+
+    REQUIRE(lock.try_lock());
+    REQUIRE(lock.is_locked());
+    lock.unlock();
+    REQUIRE_FALSE(lock.is_locked());
+    lock.unlock();
+    REQUIRE_FALSE(lock.is_locked());
+
+    REQUIRE(lock.try_lock());
+    REQUIRE(lock.is_locked());
 }
 
 // ── ChildProcess ────────────────────────────────────────────────────────
@@ -239,6 +306,24 @@ TEST_CASE("base64 binary round-trip", "[runtime][base64]") {
     REQUIRE(*decoded == data);
 }
 
+TEST_CASE("base64 handles explicit byte pointers and exact quartet decoding",
+          "[runtime][base64][coverage][issue-641]") {
+    REQUIRE(base64_encode(nullptr, 0) == "");
+
+    const uint8_t bytes[] = {0x00, 0x10, 0x20, 0x30, 0xff};
+    auto encoded = base64_encode(bytes, sizeof(bytes));
+    REQUIRE(encoded == "ABAgMP8=");
+
+    auto decoded = base64_decode("ABAgMP8=");
+    REQUIRE(decoded.has_value());
+    REQUIRE(decoded->size() == sizeof(bytes));
+    REQUIRE(std::equal(decoded->begin(), decoded->end(), std::begin(bytes)));
+
+    auto quartet = base64_decode("////");
+    REQUIRE(quartet.has_value());
+    REQUIRE(*quartet == std::vector<uint8_t>{0xff, 0xff, 0xff});
+}
+
 // ── HTTP URL parsing ───────────────────────────────────────────────────
 
 TEST_CASE("HTTP helpers reject malformed URLs without transport work",
@@ -317,6 +402,26 @@ TEST_CASE("text_diff preserves equal lines across replacements and appends",
             "+ delta\n"
             "  gamma\n"
             "+ omega\n");
+}
+
+TEST_CASE("text_diff keeps repeated-line matches stable",
+          "[runtime][text-diff][coverage][issue-641]") {
+    auto diff = text_diff("same\nkeep\nsame\nremove\nsame",
+                          "same\nkeep\nsame\ninsert\nsame");
+
+    REQUIRE(diff.size() == 6);
+    REQUIRE(diff[0].op == DiffOp::Equal);
+    REQUIRE(diff[0].text == "same");
+    REQUIRE(diff[1].op == DiffOp::Equal);
+    REQUIRE(diff[1].text == "keep");
+    REQUIRE(diff[2].op == DiffOp::Equal);
+    REQUIRE(diff[2].text == "same");
+    REQUIRE(diff[3].op == DiffOp::Delete);
+    REQUIRE(diff[3].text == "remove");
+    REQUIRE(diff[4].op == DiffOp::Insert);
+    REQUIRE(diff[4].text == "insert");
+    REQUIRE(diff[5].op == DiffOp::Equal);
+    REQUIRE(diff[5].text == "same");
 }
 
 // ── Range ───────────────────────────────────────────────────────────────
@@ -401,4 +506,15 @@ TEST_CASE("FloatRange", "[runtime][range]") {
     FloatRange r(0.0f, 1.0f);
     REQUIRE(r.contains(0.5f));
     REQUIRE_FALSE(r.contains(1.0f));
+}
+
+TEST_CASE("Range boundary touch points remain non-intersections",
+          "[runtime][range][coverage][issue-641]") {
+    REQUIRE_FALSE(IntRange(0, 10).intersects(IntRange(10, 20)));
+    REQUIRE(IntRange(0, 10).intersection(IntRange(10, 20)).empty());
+    REQUIRE(IntRange(10, 20).intersection(IntRange(0, 10)).empty());
+
+    REQUIRE(IntRange(5, 5).empty());
+    REQUIRE(IntRange(5, 4).empty());
+    REQUIRE(IntRange(5, 5).constrain(100) == 5);
 }


### PR DESCRIPTION
## Summary
- add runtime primitive coverage for MemoryMappedFile write persistence/failure reset, InterProcessLock reacquire behavior, SPSC queue wrap-around, and scope-exit macro cleanup
- add runtime utility coverage for explicit byte-pointer base64, repeated-line text diffs, and range boundary intersections
- add platform environment coverage for safe-area zero checks and idempotent token reset behavior

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF
- cmake --build build --target pulp-test-runtime-utils pulp-test-runtime pulp-test-environment -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-runtime-utils "[coverage][issue-641]" -r compact
- ./build/test/pulp-test-runtime "[coverage][issue-641]" -r compact
- ./build/test/pulp-test-environment "[coverage][issue-640]" -r compact
- ./build/test/pulp-test-runtime-utils -r compact
- ./build/test/pulp-test-runtime -r compact
- ./build/test/pulp-test-environment -r compact
- ctest --test-dir build -R "(MemoryMappedFile ReadWrite|MemoryMappedFile open failure|InterProcessLock unlock|base64 handles explicit|text_diff keeps repeated|Range boundary|SpscQueue reuses|PULP_ON_SCOPE_EXIT|SafeAreaInsets zero|token reset is idempotent)" --output-on-failure
- git diff --check
- ./tools/check-docs.sh (passes with existing warnings)