### PR TITLE
test(midi): cover mpe ci primitive edges

### DIFF
--- a/test/test_midi_buffer_ump.cpp
+++ b/test/test_midi_buffer_ump.cpp
@@ -41,3 +41,26 @@ TEST_CASE("plugin-side consumer can iterate UMP packets via the sidecar",
     REQUIRE(buf.ump()->size() == 2);     // UMP sidecar visible
     REQUIRE((*buf.ump())[0].packet.message_type() == UmpMessageType::Midi2ChannelVoice);
 }
+
+TEST_CASE("attached UMP sidecar remains externally owned across MidiBuffer edits",
+          "[midi][buffer][ump][issue-645]") {
+    MidiBuffer buf;
+    UmpBuffer first;
+    UmpBuffer second;
+    first.add(UmpPacket::note_on_2(0, 1, 60, 0x8000), 32);
+    second.add(UmpPacket::note_on_2(0, 2, 67, 0x4000), 64);
+
+    buf.attach_ump(&first);
+    buf.add(MidiEvent::note_on(0, 60, 100));
+    REQUIRE(buf.ump() == &first);
+    REQUIRE(buf.ump()->size() == 1);
+
+    buf.clear();
+    REQUIRE(buf.empty());
+    REQUIRE(buf.ump() == &first);
+    REQUIRE(buf.ump()->size() == 1);
+
+    buf.attach_ump(&second);
+    REQUIRE(buf.ump() == &second);
+    REQUIRE((*buf.ump())[0].packet.channel() == 2);
+}

--- a/test/test_midi_ci.cpp
+++ b/test/test_midi_ci.cpp
@@ -21,6 +21,13 @@ uint32_t read_muid_at(const std::vector<uint8_t>& msg, std::size_t offset) {
         | (static_cast<uint32_t>(msg[offset + 3]) << 21);
 }
 
+uint32_t read_uint7_at(const std::vector<uint8_t>& msg, std::size_t offset, std::size_t bytes) {
+    uint32_t value = 0;
+    for (std::size_t i = 0; i < bytes; ++i)
+        value |= static_cast<uint32_t>(msg[offset + i]) << (7 * i);
+    return value;
+}
+
 std::vector<uint8_t> make_ci_header(CiMessageType type, MUID source, MUID destination) {
     std::vector<uint8_t> msg{0xF0, 0x7E, 0x7F, 0x0D,
                              static_cast<uint8_t>(type), 0x02};
@@ -56,6 +63,34 @@ TEST_CASE("CiDiscovery creates valid inquiry", "[midi][ci]") {
     REQUIRE(msg[4] == 0x70);       // Discovery inquiry
 }
 
+TEST_CASE("CiDiscovery discovery inquiry encodes local identity fields",
+          "[midi][ci][issue-645]") {
+    CiDiscovery ci;
+    CiDeviceInfo info;
+    info.muid = MUID{0x01234567};
+    info.manufacturer_id = 0x00123456;
+    info.family_id = 0x2345;
+    info.model_id = 0x3456;
+    info.software_version = 0x01234567;
+    info.ci_version = 3;
+    info.max_sysex_size = 96;
+    ci.set_device_info(info);
+
+    auto msg = ci.create_discovery_inquiry();
+
+    REQUIRE(msg.size() == 31);
+    REQUIRE(msg[4] == static_cast<uint8_t>(CiMessageType::DiscoveryInquiry));
+    REQUIRE(msg[5] == 3);
+    REQUIRE(read_muid_at(msg, 6) == info.muid.value);
+    REQUIRE(read_muid_at(msg, 10) == MUID::broadcast().value);
+    REQUIRE(read_uint7_at(msg, 14, 3) == info.manufacturer_id);
+    REQUIRE(read_uint7_at(msg, 17, 2) == info.family_id);
+    REQUIRE(read_uint7_at(msg, 19, 2) == info.model_id);
+    REQUIRE(read_uint7_at(msg, 21, 4) == info.software_version);
+    REQUIRE(msg[25] == 0x07);
+    REQUIRE(read_uint7_at(msg, 26, 4) == info.max_sysex_size);
+}
+
 TEST_CASE("CiDiscovery profile inquiry encodes destination",
           "[midi][ci][issue-645]") {
     CiDiscovery ci;
@@ -81,6 +116,39 @@ TEST_CASE("CiDiscovery responds to inquiry", "[midi][ci]") {
     REQUIRE_FALSE(reply.empty());
     REQUIRE(reply.front() == 0xF0);
     REQUIRE(reply[4] == 0x71);  // Discovery reply
+}
+
+TEST_CASE("CiDiscovery discovery reply addresses source and encodes responder identity",
+          "[midi][ci][issue-645]") {
+    CiDiscovery responder;
+    CiDeviceInfo info;
+    info.muid = MUID{0x0002468A};
+    info.manufacturer_id = 0x00010203;
+    info.family_id = 0x0203;
+    info.model_id = 0x0304;
+    info.software_version = 0x00040506;
+    info.ci_version = 4;
+    info.max_sysex_size = 120;
+    responder.set_device_info(info);
+
+    MUID peer{0x00013579};
+    auto inquiry = make_ci_header(CiMessageType::DiscoveryInquiry,
+                                  peer, MUID::broadcast());
+    inquiry.push_back(0xF7);
+
+    auto reply = responder.process_message(inquiry.data(), inquiry.size());
+
+    REQUIRE(reply.size() == 31);
+    REQUIRE(reply[4] == static_cast<uint8_t>(CiMessageType::DiscoveryReply));
+    REQUIRE(reply[5] == info.ci_version);
+    REQUIRE(read_muid_at(reply, 6) == info.muid.value);
+    REQUIRE(read_muid_at(reply, 10) == peer.value);
+    REQUIRE(read_uint7_at(reply, 14, 3) == info.manufacturer_id);
+    REQUIRE(read_uint7_at(reply, 17, 2) == info.family_id);
+    REQUIRE(read_uint7_at(reply, 19, 2) == info.model_id);
+    REQUIRE(read_uint7_at(reply, 21, 4) == info.software_version);
+    REQUIRE(read_uint7_at(reply, 26, 4) == info.max_sysex_size);
+    REQUIRE(reply.back() == 0xF7);
 }
 
 TEST_CASE("CiDiscovery ignores malformed and unhandled messages",
@@ -194,6 +262,21 @@ TEST_CASE("CiDiscovery property exchange", "[midi][ci]") {
     REQUIRE(*val == "PulpSynth");
 
     REQUIRE_FALSE(ci.get_property("nonexistent").has_value());
+}
+
+TEST_CASE("CiDiscovery properties accept empty and overwritten values",
+          "[midi][ci][issue-645]") {
+    CiDiscovery ci;
+
+    ci.set_property("", "");
+    REQUIRE(ci.get_property("").has_value());
+    REQUIRE(*ci.get_property("") == "");
+
+    ci.set_property("DeviceName", "First");
+    ci.set_property("DeviceName", "Second");
+    auto value = ci.get_property("DeviceName");
+    REQUIRE(value.has_value());
+    REQUIRE(*value == "Second");
 }
 
 TEST_CASE("CiDiscovery profile inquiry response", "[midi][ci]") {

--- a/test/test_mpe_buffer.cpp
+++ b/test/test_mpe_buffer.cpp
@@ -3,6 +3,7 @@
 
 #include <pulp/format/processor.hpp>
 #include <pulp/midi/mpe_buffer.hpp>
+#include <vector>
 
 using namespace pulp::midi;
 using Kind = MpeExpressionEvent::Kind;
@@ -12,6 +13,16 @@ namespace {
 MidiEvent channel_pressure(uint8_t channel, uint8_t value) {
     return {choc::midi::ShortMessage(
         static_cast<uint8_t>(0xD0 | (channel & 0x0F)), value, 0), 0, 0.0};
+}
+
+UmpPacket channel_pressure_ump(uint8_t group, uint8_t channel, uint32_t value) {
+    UmpPacket p;
+    p.word_count = 2;
+    p.words[0] = (0x4u << 28)
+        | (static_cast<uint32_t>(group & 0x0F) << 24)
+        | (static_cast<uint32_t>(0xD0 | (channel & 0x0F)) << 16);
+    p.words[1] = value;
+    return p;
 }
 } // namespace
 
@@ -60,6 +71,104 @@ TEST_CASE("MpeBuffer clear and sort", "[midi][mpe]") {
 
     buffer.clear();
     REQUIRE(buffer.empty());
+}
+
+TEST_CASE("MpeConfig identifies lower and upper zone member boundaries",
+          "[midi][mpe][issue-645]") {
+    auto cfg = MpeConfig::dual(3, 2);
+
+    REQUIRE(cfg.lower_zone.is_lower());
+    REQUIRE(cfg.upper_zone.is_upper());
+    REQUIRE(cfg.is_manager_channel(0));
+    REQUIRE(cfg.is_manager_channel(15));
+
+    REQUIRE(cfg.zone_for_channel(1) == &cfg.lower_zone);
+    REQUIRE(cfg.zone_for_channel(3) == &cfg.lower_zone);
+    REQUIRE(cfg.zone_for_channel(4) == nullptr);
+    REQUIRE(cfg.zone_for_channel(13) == &cfg.upper_zone);
+    REQUIRE(cfg.zone_for_channel(14) == &cfg.upper_zone);
+    REQUIRE(cfg.zone_for_channel(12) == nullptr);
+}
+
+TEST_CASE("MpeVoiceTracker seeds new notes from cached member expression",
+          "[midi][mpe][issue-645]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+
+    REQUIRE(tracker.process(MidiEvent::pitch_bend(2, 16383)));
+    REQUIRE(tracker.process(channel_pressure(2, 64)));
+    REQUIRE(tracker.process(MidiEvent::cc(2, 74, 100)));
+    REQUIRE(tracker.process(MidiEvent::note_on(2, 61, 90)));
+
+    const auto* note = tracker.find(2, 61);
+    REQUIRE(note != nullptr);
+    REQUIRE(note->pitch_bend_semitones == Approx(48.0f).margin(0.01f));
+    REQUIRE(note->pressure == Approx(64.0f / 127.0f).margin(1e-6f));
+    REQUIRE(note->timbre == Approx(100.0f / 127.0f).margin(1e-6f));
+}
+
+TEST_CASE("MpeVoiceTracker manager messages update zone state without notes",
+          "[midi][mpe][issue-645]") {
+    MpeVoiceTracker tracker{MpeConfig::dual(4, 3)};
+    tracker.set_manager_bend_range(2.0f);
+
+    REQUIRE(tracker.process(MidiEvent::pitch_bend(0, 16383)));
+    REQUIRE(tracker.process(channel_pressure(15, 127)));
+    REQUIRE(tracker.process(MidiEvent::cc(15, 74, 64)));
+
+    REQUIRE(tracker.active_count() == 0);
+    REQUIRE(tracker.lower_zone_state().pitch_bend_semitones == Approx(2.0f).margin(0.01f));
+    REQUIRE(tracker.upper_zone_state().pressure == Approx(1.0f).margin(1e-6f));
+    REQUIRE(tracker.upper_zone_state().timbre == Approx(64.0f / 127.0f).margin(1e-6f));
+}
+
+TEST_CASE("MpeVoiceTracker UMP manager and member events feed callbacks",
+          "[midi][mpe][issue-645]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    MpeBuffer buffer;
+    int32_t offset = 0;
+    bind_tracker_to_buffer(tracker, buffer, offset);
+
+    offset = 5;
+    REQUIRE(tracker.process(UmpPacket::pitch_bend_2(0, 0, 0xFFFFFFFFu)));
+    REQUIRE(buffer.empty());
+    REQUIRE(tracker.lower_zone_state().pitch_bend_semitones > 1.9f);
+
+    offset = 10;
+    REQUIRE(tracker.process(UmpPacket::note_on_2(0, 3, 67, 0xFFFF)));
+    offset = 20;
+    REQUIRE(tracker.process(channel_pressure_ump(0, 3, 0xFFFFFFFFu)));
+    offset = 30;
+    REQUIRE(tracker.process(UmpPacket::registered_per_note_cc(0, 3, 67, 74,
+                                                              0xFFFFFFFFu)));
+
+    REQUIRE(buffer.size() == 3);
+    REQUIRE(buffer[0].kind == Kind::NoteOn);
+    REQUIRE(buffer[0].sample_offset == 10);
+    REQUIRE(buffer[0].state.velocity == 127);
+    REQUIRE(buffer[1].kind == Kind::Pressure);
+    REQUIRE(buffer[1].state.pressure == Approx(1.0f).margin(1e-6f));
+    REQUIRE(buffer[2].kind == Kind::Timbre);
+    REQUIRE(buffer[2].state.timbre == Approx(1.0f).margin(1e-6f));
+}
+
+TEST_CASE("MpeVoiceTracker reset and config changes clear active state",
+          "[midi][mpe][issue-645]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.process(MidiEvent::note_on(1, 60, 100));
+    tracker.process(MidiEvent::pitch_bend(1, 16383));
+    REQUIRE(tracker.active_count() == 1);
+    REQUIRE(tracker.member_bend_range() == Approx(48.0f));
+
+    tracker.set_member_bend_range(-1.0f);
+    tracker.set_manager_bend_range(0.0f);
+    REQUIRE(tracker.member_bend_range() == Approx(48.0f));
+    REQUIRE(tracker.manager_bend_range() == Approx(2.0f));
+
+    tracker.set_config(MpeConfig::dual(2, 2));
+    REQUIRE(tracker.active_count() == 0);
+    REQUIRE(tracker.find(1, 60) == nullptr);
+    REQUIRE(tracker.config().upper_zone.member_channels == 2);
+    REQUIRE(tracker.lower_zone_state().pitch_bend_semitones == Approx(0.0f));
 }
 
 TEST_CASE("Processor::supports_mpe defaults to false", "[midi][mpe]") {


### PR DESCRIPTION
## Summary
- add MPE tracker/buffer coverage for zone boundaries, cached member expression, manager-zone state, UMP member callbacks, and reset/config changes
- add MIDI-CI discovery wire encoding coverage for identity fields, responder replies, and property overwrites
- add UMP sidecar ownership coverage across MidiBuffer edits

## Local validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-test-mpe-buffer pulp-test-midi-ci pulp-test-midi-buffer-ump -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-mpe-buffer "[issue-645]"`
- `./build/test/pulp-test-midi-ci "[issue-645]"`
- `./build/test/pulp-test-midi-buffer-ump "[issue-645]"`
- `./build/test/pulp-test-mpe-buffer && ./build/test/pulp-test-midi-ci && ./build/test/pulp-test-midi-buffer-ump`
- `ctest --test-dir build -R '(MpeConfig|MpeVoiceTracker|CiDiscovery discovery|CiDiscovery properties|attached UMP sidecar)' --output-on-failure`
- `git diff --check`
- `./tools/check-docs.sh` (passes with existing warnings)