### PR TITLE
test: cover state and validation harness edges

### DIFF
--- a/test/test_binding.cpp
+++ b/test/test_binding.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/state/binding.hpp>
+#include <vector>
 
 using namespace pulp::state;
 using Catch::Matchers::WithinAbs;
@@ -61,6 +62,41 @@ TEST_CASE("Binding normalized", "[binding]") {
     REQUIRE_THAT(b.get(), WithinAbs(24.0, 0.1));
 }
 
+TEST_CASE("Binding unknown parameter operations stay inert",
+          "[binding][coverage][issue-646]") {
+    auto store = make_store();
+    Binding b(*store,999);
+    int call_count = 0;
+    b.on_change([&](float) { ++call_count; });
+
+    REQUIRE(b.is_bound());
+    REQUIRE(b.id() == 999);
+    REQUIRE(b.info() == nullptr);
+    REQUIRE_THAT(b.get(), WithinAbs(0.0, 0.01));
+    REQUIRE_THAT(b.get_normalized(), WithinAbs(0.0, 0.01));
+
+    b.set(12.0f);
+    b.set_normalized(0.75f);
+    REQUIRE_FALSE(b.poll());
+    REQUIRE(call_count == 0);
+}
+
+TEST_CASE("Binding set_normalized clamps and quantizes through store",
+          "[binding][coverage][issue-646]") {
+    auto store = make_store();
+    Binding b(*store,1); // range -60..24, step 0.1
+
+    b.set_normalized(-0.25f);
+    REQUIRE_THAT(b.get(), WithinAbs(-60.0, 0.01));
+
+    b.set_normalized(1.25f);
+    REQUIRE_THAT(b.get(), WithinAbs(24.0, 0.01));
+
+    b.set_normalized(0.1234f);
+    REQUIRE_THAT(b.get(), WithinAbs(-49.6, 0.01));
+    REQUIRE_THAT(b.get_normalized(), WithinAbs(0.1238, 0.001));
+}
+
 TEST_CASE("Binding set_normalized only notifies when value changes", "[binding]") {
     auto store = make_store();
     Binding b(*store,2); // range 0..100, default 50
@@ -85,6 +121,29 @@ TEST_CASE("Binding on_change fires", "[binding]") {
 
     b.set(6.0f);
     REQUIRE_THAT(received, WithinAbs(6.0, 0.01));
+}
+
+TEST_CASE("Binding on_change callbacks fire in registration order",
+          "[binding][coverage][issue-646]") {
+    auto store = make_store();
+    Binding b(*store,1);
+    std::vector<int> calls;
+    std::vector<float> values;
+
+    b.on_change([&](float v) {
+        calls.push_back(1);
+        values.push_back(v);
+    });
+    b.on_change([&](float v) {
+        calls.push_back(2);
+        values.push_back(v);
+    });
+
+    b.set(3.5f);
+    REQUIRE(calls == std::vector<int>{1, 2});
+    REQUIRE(values.size() == 2);
+    REQUIRE_THAT(values[0], WithinAbs(3.5, 0.01));
+    REQUIRE_THAT(values[1], WithinAbs(3.5, 0.01));
 }
 
 TEST_CASE("Binding on_change does not fire for same value", "[binding]") {

--- a/test/test_descriptor_validation.cpp
+++ b/test/test_descriptor_validation.cpp
@@ -35,6 +35,16 @@ bool has_warning_on(const std::vector<DescriptorIssue>& issues,
     return false;
 }
 
+std::size_t warning_count_on(const std::vector<DescriptorIssue>& issues,
+                             const std::string& field) {
+    std::size_t count = 0;
+    for (const auto& i : issues) {
+        if (i.severity == DescriptorIssueSeverity::Warning && i.field == field)
+            ++count;
+    }
+    return count;
+}
+
 } // namespace
 
 TEST_CASE("DescriptorValidation: well-formed effect passes with no issues",
@@ -221,6 +231,19 @@ TEST_CASE("DescriptorValidation: supports_ump follows the accepts_midi sidecar w
         REQUIRE_FALSE(has_warning_on(issues, "accepts_midi"));
         REQUIRE(descriptor_is_valid(issues));
     }
+}
+
+TEST_CASE("DescriptorValidation: MIDI capability warnings accumulate without invalidating descriptor",
+          "[format][descriptor-validation][coverage][issue-646]") {
+    auto d = well_formed_effect();
+    d.category = PluginCategory::MidiEffect;
+    d.accepts_midi = false;
+    d.supports_mpe = true;
+    d.supports_ump = true;
+
+    auto issues = validate_descriptor(d);
+    REQUIRE(warning_count_on(issues, "accepts_midi") == 2);
+    REQUIRE(descriptor_is_valid(issues));
 }
 
 TEST_CASE("DescriptorValidation: MidiEffect without audio output is valid",

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/state/state.hpp>
+#include <cstring>
 #include <vector>
 
 using namespace pulp::state;
@@ -13,6 +14,33 @@ static ParamInfo make_param_info(ParamID id, const char* name, const char* unit,
     info.unit = unit;
     info.range = range;
     return info;
+}
+
+static uint32_t read_u32_le(const std::vector<uint8_t>& data, std::size_t offset) {
+    return static_cast<uint32_t>(data[offset])
+        | (static_cast<uint32_t>(data[offset + 1]) << 8)
+        | (static_cast<uint32_t>(data[offset + 2]) << 16)
+        | (static_cast<uint32_t>(data[offset + 3]) << 24);
+}
+
+static void write_u32_le(std::vector<uint8_t>& data, std::size_t offset, uint32_t value) {
+    data[offset] = static_cast<uint8_t>(value & 0xffu);
+    data[offset + 1] = static_cast<uint8_t>((value >> 8) & 0xffu);
+    data[offset + 2] = static_cast<uint8_t>((value >> 16) & 0xffu);
+    data[offset + 3] = static_cast<uint8_t>((value >> 24) & 0xffu);
+}
+
+static uint32_t crc32_simple_for_test(const std::vector<uint8_t>& data,
+                                      std::size_t len) {
+    uint32_t crc = 0xFFFFFFFFu;
+    for (std::size_t i = 0; i < len; ++i) {
+        crc ^= data[i];
+        for (int j = 0; j < 8; ++j) {
+            const uint32_t mask = (crc & 1u) ? 0xFFFFFFFFu : 0u;
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+    return ~crc;
 }
 
 TEST_CASE("ParamRange normalization", "[state][range]") {
@@ -32,6 +60,26 @@ TEST_CASE("ParamRange with step", "[state][range]") {
 
     REQUIRE_THAT(range.denormalize(0.33f), WithinAbs(3.0, 0.5));
     REQUIRE_THAT(range.denormalize(0.77f), WithinAbs(8.0, 0.5));
+}
+
+TEST_CASE("ParamRange clamps normalized conversions at range boundaries",
+          "[state][range][coverage][issue-646]") {
+    ParamRange range{-10.0f, 30.0f, 5.0f, 0.0f};
+
+    REQUIRE_THAT(range.normalize(-100.0f), WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(range.normalize(100.0f), WithinAbs(1.0, 0.001));
+    REQUIRE_THAT(range.denormalize(-0.5f), WithinAbs(-10.0, 0.001));
+    REQUIRE_THAT(range.denormalize(1.5f), WithinAbs(30.0, 0.001));
+}
+
+TEST_CASE("ParamRange zero-width ranges normalize safely",
+          "[state][range][coverage][issue-646]") {
+    ParamRange range{7.0f, 7.0f, 7.0f, 0.0f};
+
+    REQUIRE_THAT(range.normalize(7.0f), WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(range.normalize(100.0f), WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(range.denormalize(0.25f), WithinAbs(7.0, 0.001));
+    REQUIRE_THAT(range.denormalize(2.0f), WithinAbs(7.0, 0.001));
 }
 
 TEST_CASE("StateStore basic operations", "[state][store]") {
@@ -158,6 +206,53 @@ TEST_CASE("StateStore serialization", "[state][serialize]") {
     SECTION("Too-short data rejected") {
         REQUIRE_FALSE(store.deserialize(std::span<const uint8_t>{}));
     }
+}
+
+TEST_CASE("StateStore serialization records header fields and rejects future versions",
+          "[state][serialize][coverage][issue-646]") {
+    StateStore store;
+    auto p1 = make_param_info(10, "Drive", "", {0.0f, 1.0f, 0.25f});
+    auto p2 = make_param_info(20, "Tone", "", {-1.0f, 1.0f, 0.0f});
+    store.add_parameter(p1);
+    store.add_parameter(p2);
+    store.set_value(10, 0.75f);
+
+    auto data = store.serialize();
+    REQUIRE(data.size() == 32);
+    REQUIRE(std::memcmp(data.data(), "PULP", 4) == 0);
+    REQUIRE(read_u32_le(data, 4) == 1);
+    REQUIRE(read_u32_le(data, 8) == 2);
+    REQUIRE(read_u32_le(data, 12) == 10);
+    REQUIRE(read_u32_le(data, 20) == 20);
+
+    auto future = data;
+    write_u32_le(future, 4, 999u);
+    const auto payload_size = future.size() - 4;
+    write_u32_le(future, payload_size, crc32_simple_for_test(future, payload_size));
+
+    StateStore target;
+    target.add_parameter(p1);
+    target.set_value(10, 0.1f);
+    REQUIRE_FALSE(target.deserialize(future));
+    REQUIRE_THAT(target.get_value(10), WithinAbs(0.1, 0.001));
+}
+
+TEST_CASE("StateStore set_normalized clamps and quantizes via ParamRange",
+          "[state][store][coverage][issue-646]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "Steps", "", {0.0f, 10.0f, 5.0f, 2.0f}));
+
+    store.set_normalized(1, -1.0f);
+    REQUIRE_THAT(store.get_value(1), WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(store.get_normalized(1), WithinAbs(0.0, 0.001));
+
+    store.set_normalized(1, 0.34f);
+    REQUIRE_THAT(store.get_value(1), WithinAbs(4.0, 0.001));
+    REQUIRE_THAT(store.get_normalized(1), WithinAbs(0.4, 0.001));
+
+    store.set_normalized(1, 4.0f);
+    REQUIRE_THAT(store.get_value(1), WithinAbs(10.0, 0.001));
+    REQUIRE_THAT(store.get_normalized(1), WithinAbs(1.0, 0.001));
 }
 
 TEST_CASE("StateStore change listener", "[state][listener]") {

--- a/test/test_validation_harness.cpp
+++ b/test/test_validation_harness.cpp
@@ -99,6 +99,12 @@ std::filesystem::path make_temp_path(const char* stem) {
     return std::filesystem::temp_directory_path() / (std::string(stem) + "-" + unique + ".json");
 }
 
+std::filesystem::path make_temp_dir(const char* stem) {
+    auto unique = std::to_string(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+    return std::filesystem::temp_directory_path() / (std::string(stem) + "-" + unique);
+}
+
 } // anonymous namespace
 
 using Catch::Matchers::WithinAbs;
@@ -122,6 +128,20 @@ TEST_CASE("ValidationHarness set/get param", "[harness][phase2]") {
     REQUIRE_THAT(harness.get_param(2), WithinAbs(0.5, 0.01));
 }
 
+TEST_CASE("ValidationHarness configure creates artifact directory",
+          "[harness][phase2][coverage][issue-646]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    auto out_dir = make_temp_dir("pulp-harness-output-dir");
+    REQUIRE_FALSE(std::filesystem::exists(out_dir));
+
+    harness.configure({.output_dir = out_dir});
+
+    REQUIRE(std::filesystem::is_directory(out_dir));
+    std::error_code ec;
+    std::filesystem::remove_all(out_dir, ec);
+    REQUIRE_FALSE(ec);
+}
+
 TEST_CASE("ValidationHarness processes silence blocks", "[harness][phase2]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({.buffer_size = 64});
@@ -132,6 +152,18 @@ TEST_CASE("ValidationHarness processes silence blocks", "[harness][phase2]") {
     REQUIRE(output.size() == 128);
 
     // All zeros (silence in, unity gain)
+    for (float s : output) {
+        REQUIRE_THAT(static_cast<double>(s), WithinAbs(0.0, 0.0001));
+    }
+}
+
+TEST_CASE("ValidationHarness process_blocks zero blocks returns one silent buffer",
+          "[harness][phase2][coverage][issue-646]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    harness.configure({.buffer_size = 8, .output_channels = 2});
+
+    auto output = harness.process_blocks(0);
+    REQUIRE(output.size() == 16);
     for (float s : output) {
         REQUIRE_THAT(static_cast<double>(s), WithinAbs(0.0, 0.0001));
     }
@@ -253,6 +285,29 @@ TEST_CASE("ValidationHarness generates valid report JSON", "[harness][phase2]") 
     REQUIRE_THAT(report, ContainsSubstring("\"total\": 50"));
 }
 
+TEST_CASE("ValidationHarness report escapes JSON metadata and entry strings",
+          "[harness][phase2][coverage][issue-646]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    harness.configure({
+        .git_ref = "branch/quote\"slash\\",
+        .run_id = "run\nwith\ttabs",
+    });
+
+    pulp::format::ReportEntry entry;
+    entry.type = "validator";
+    entry.status = pulp::format::ValidationStatus::error;
+    entry.target = "Plugin \"A\"";
+    entry.error_message = "line1\nline2\\done";
+    entry.payload_json = "{\"tool\":\"fake\"}";
+    harness.add_entry(entry);
+
+    auto report = harness.generate_report();
+    REQUIRE_THAT(report, ContainsSubstring("branch/quote\\\"slash\\\\"));
+    REQUIRE_THAT(report, ContainsSubstring("run\\nwith\\ttabs"));
+    REQUIRE_THAT(report, ContainsSubstring("Plugin \\\"A\\\""));
+    REQUIRE_THAT(report, ContainsSubstring("line1\\nline2\\\\done"));
+}
+
 TEST_CASE("ValidationHarness empty report is valid", "[harness][phase2]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
@@ -291,6 +346,21 @@ TEST_CASE("ValidationHarness write_report creates file", "[harness][phase2]") {
     REQUIRE_FALSE(ec);
 }
 
+TEST_CASE("ValidationHarness write_report creates nested directories",
+          "[harness][phase2][coverage][issue-646]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    harness.configure({});
+
+    auto dir = make_temp_dir("pulp-harness-nested-report");
+    auto report_path = dir / "a" / "b" / "report.json";
+    REQUIRE(harness.write_report(report_path));
+    REQUIRE(std::filesystem::is_regular_file(report_path));
+
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+    REQUIRE_FALSE(ec);
+}
+
 // ── Validator graceful degradation ──────────────────────────────────────────
 
 TEST_CASE("ValidationHarness run_validator skips missing tool", "[harness][phase2]") {
@@ -319,6 +389,23 @@ TEST_CASE("ValidationHarness run_validator errors on missing plugin", "[harness]
 
     REQUIRE(entry.status == pulp::format::ValidationStatus::error);
     REQUIRE_THAT(entry.error_message, ContainsSubstring("not found"));
+}
+
+TEST_CASE("ValidationHarness run_validator errors on unknown installed tool",
+          "[harness][phase2][coverage][issue-646]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    harness.configure({});
+
+    auto tmp_plugin = make_temp_path("fake-plugin-for-unknown-validator");
+    { std::ofstream f(tmp_plugin); f << "dummy"; }
+
+    auto entry = harness.run_validator("sh", tmp_plugin);
+    REQUIRE(entry.status == pulp::format::ValidationStatus::error);
+    REQUIRE_THAT(entry.error_message, ContainsSubstring("Unknown validator tool: sh"));
+
+    std::error_code ec;
+    std::filesystem::remove(tmp_plugin, ec);
+    REQUIRE_FALSE(ec);
 }
 
 // ── Screenshot / inspector providers (#298) ─────────────────────────────────


### PR DESCRIPTION
## Summary
- add ParamRange boundary and zero-width normalization coverage
- cover StateStore serialized headers, future-version rejection, and normalized quantization
- cover Binding unknown IDs, normalized clamping/quantization, and callback ordering
- cover ValidationHarness artifact directory creation, zero-block processing, JSON escaping, nested report writes, and unknown installed validator handling
- cover descriptor MIDI capability warning aggregation

## Local validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-test-state pulp-test-binding pulp-test-validation-harness pulp-test-descriptor-validation -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-state "[coverage][issue-646]" -r compact`
- `./build/test/pulp-test-binding "[coverage][issue-646]" -r compact`
- `./build/test/pulp-test-validation-harness "[coverage][issue-646]" -r compact`
- `./build/test/pulp-test-descriptor-validation "[coverage][issue-646]" -r compact`
- `./build/test/pulp-test-state && ./build/test/pulp-test-binding && ./build/test/pulp-test-validation-harness && ./build/test/pulp-test-descriptor-validation`
- `ctest --test-dir build -R '(ParamRange clamps|ParamRange zero-width|StateStore serialization records|StateStore set_normalized|Binding unknown|Binding set_normalized|Binding on_change callbacks|ValidationHarness configure creates|ValidationHarness process_blocks zero|ValidationHarness report escapes|ValidationHarness write_report creates nested|ValidationHarness run_validator errors on unknown|DescriptorValidation: MIDI capability warnings)' --output-on-failure`
- `git diff --check`
- `./tools/check-docs.sh` (passed with existing warnings)