### PR TITLE
test: cover format state io edges

### DIFF
--- a/test/test_headless.cpp
+++ b/test/test_headless.cpp
@@ -34,15 +34,27 @@ public:
         });
     }
 
-    void prepare(const pulp::format::PrepareContext&) override {}
+    void prepare(const pulp::format::PrepareContext& context) override {
+        ++prepare_calls;
+        last_prepare_context = context;
+    }
+
+    void release() override { ++release_calls; }
 
     void process(
         pulp::audio::BufferView<float>& output,
         const pulp::audio::BufferView<const float>& input,
-        pulp::midi::MidiBuffer&, pulp::midi::MidiBuffer&,
+        pulp::midi::MidiBuffer& midi_in, pulp::midi::MidiBuffer&,
         const pulp::format::ProcessContext& context) override
     {
         last_context = context;
+        ++process_calls;
+        midi_in_events = 0;
+        for (const auto& event : midi_in) {
+            if (event.is_note_on()) ++midi_note_ons;
+            ++midi_in_events;
+        }
+
         float db = state().get_value(1);
         float gain = std::pow(10.0f, db / 20.0f);
         for (std::size_t ch = 0; ch < output.num_channels() && ch < input.num_channels(); ++ch) {
@@ -63,6 +75,12 @@ public:
     }
 
     std::string plugin_state;
+    pulp::format::PrepareContext last_prepare_context{};
+    int prepare_calls = 0;
+    int release_calls = 0;
+    int process_calls = 0;
+    int midi_in_events = 0;
+    int midi_note_ons = 0;
 };
 
 std::unique_ptr<pulp::format::Processor> create_test_gain() {
@@ -100,6 +118,41 @@ TEST_CASE("HeadlessHost processes audio at unity gain", "[headless]") {
 
     // 0 dB = unity gain
     REQUIRE_THAT(out.channel(0)[0], WithinAbs(0.5, 0.001));
+}
+
+TEST_CASE("HeadlessHost forwards prepare context and release",
+          "[headless][coverage][issue-647]") {
+    pulp::format::HeadlessHost host(create_test_gain);
+    REQUIRE(last_processor != nullptr);
+    auto* processor = last_processor;
+
+    host.prepare(96000.0, 1024, 1, 4);
+    REQUIRE(processor->prepare_calls == 1);
+    REQUIRE_THAT(processor->last_prepare_context.sample_rate,
+                 WithinAbs(96000.0, 0.001));
+    REQUIRE(processor->last_prepare_context.max_buffer_size == 1024);
+    REQUIRE(processor->last_prepare_context.input_channels == 1);
+    REQUIRE(processor->last_prepare_context.output_channels == 4);
+
+    host.release();
+    REQUIRE(processor->release_calls == 1);
+}
+
+TEST_CASE("HeadlessHost fills default process context",
+          "[headless][coverage][issue-647]") {
+    pulp::format::HeadlessHost host(create_test_gain);
+    host.prepare(44100.0, 512);
+
+    pulp::audio::Buffer<float> in(2, 32), out(2, 32);
+    const float* in_ptrs[2] = {in.channel(0).data(), in.channel(1).data()};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 2, 32);
+    auto out_view = out.view();
+
+    last_context = {};
+    host.process(out_view, in_view);
+
+    REQUIRE_THAT(last_context.sample_rate, WithinAbs(44100.0, 0.001));
+    REQUIRE(last_context.num_samples == 32);
 }
 
 TEST_CASE("HeadlessHost applies parameter changes", "[headless]") {
@@ -152,6 +205,47 @@ TEST_CASE("HeadlessHost accepts explicit transport context for offline stepping"
     REQUIRE(last_context.position_samples == 2048);
     REQUIRE(last_context.time_sig_numerator == 7);
     REQUIRE(last_context.time_sig_denominator == 8);
+}
+
+TEST_CASE("HeadlessHost forwards explicit MIDI buffers",
+          "[headless][coverage][issue-647]") {
+    pulp::format::HeadlessHost host(create_test_gain);
+    host.prepare(48000.0, 256);
+    REQUIRE(last_processor != nullptr);
+    auto* processor = last_processor;
+
+    pulp::audio::Buffer<float> in(2, 16), out(2, 16);
+    const float* in_ptrs[2] = {in.channel(0).data(), in.channel(1).data()};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 2, 16);
+    auto out_view = out.view();
+    pulp::midi::MidiBuffer midi_in;
+    pulp::midi::MidiBuffer midi_out;
+    midi_in.add(pulp::midi::MidiEvent::note_on(0, 64, 100));
+
+    host.process(out_view, in_view, midi_in, midi_out);
+
+    REQUIRE(processor->process_calls == 1);
+    REQUIRE(processor->midi_in_events == 1);
+    REQUIRE(processor->midi_note_ons == 1);
+}
+
+TEST_CASE("HeadlessHost null processor process and release are no-ops",
+          "[headless][coverage][issue-647]") {
+    pulp::format::HeadlessHost host(create_null_processor);
+    host.prepare(48000.0, 64);
+
+    pulp::audio::Buffer<float> in(1, 4), out(1, 4);
+    for (std::size_t i = 0; i < 4; ++i) out.channel(0)[i] = 7.0f;
+    const float* in_ptrs[1] = {in.channel(0).data()};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 1, 4);
+    auto out_view = out.view();
+
+    host.process(out_view, in_view);
+    host.release();
+
+    for (std::size_t i = 0; i < 4; ++i) {
+        REQUIRE_THAT(out.channel(0)[i], WithinAbs(7.0, 0.001));
+    }
 }
 
 TEST_CASE("HeadlessHost state round-trip", "[headless]") {

--- a/test/test_plugin_state_io.cpp
+++ b/test/test_plugin_state_io.cpp
@@ -213,6 +213,26 @@ TEST_CASE("plugin_state_io preserves legacy raw StateStore blobs and resets plug
     REQUIRE(restored.processor.last_payload.empty());
 }
 
+TEST_CASE("plugin_state_io envelope with empty plugin payload resets plugin state",
+          "[format][plugin-state][coverage][issue-647]") {
+    TestRig source;
+    source.store.set_value(1, -15.0f);
+    auto store_blob = source.store.serialize();
+    auto envelope = make_envelope(store_blob, {});
+
+    TestRig restored;
+    restored.store.set_value(1, 6.0f);
+    restored.processor.plugin_state = "stale";
+
+    REQUIRE(pulp::format::plugin_state_io::deserialize(envelope,
+                                                       restored.store,
+                                                       restored.processor));
+    REQUIRE_THAT(restored.store.get_value(1), WithinAbs(-15.0, 0.01));
+    REQUIRE(restored.processor.plugin_state.empty());
+    REQUIRE(restored.processor.deserialize_calls == 1);
+    REQUIRE(restored.processor.last_payload.empty());
+}
+
 TEST_CASE("plugin_state_io serialize falls back to raw StateStore blobs when plugin payload is empty",
           "[format][plugin-state]") {
     TestRig source;
@@ -345,6 +365,44 @@ TEST_CASE("plugin_state_io rejects malformed blobs without touching live state",
         REQUIRE(restored.processor.plugin_state == "keep");
         REQUIRE(restored.processor.deserialize_calls == 0);
     }
+
+    SECTION("empty inner StateStore payload") {
+        const std::array<uint8_t, 4> plugin_blob = {'K', 'E', 'E', 'P'};
+        auto blob = make_envelope({}, plugin_blob);
+
+        TestRig restored;
+        restored.store.set_value(1, 3.0f);
+        restored.processor.plugin_state = "keep";
+
+        REQUIRE_FALSE(pulp::format::plugin_state_io::deserialize(blob,
+                                                                 restored.store,
+                                                                 restored.processor));
+        REQUIRE_THAT(restored.store.get_value(1), WithinAbs(3.0, 0.01));
+        REQUIRE(restored.processor.plugin_state == "keep");
+        REQUIRE(restored.processor.deserialize_calls == 0);
+    }
+}
+
+TEST_CASE("plugin_state_io rejects envelope CRC mismatch without plugin callback",
+          "[format][plugin-state][coverage][issue-647]") {
+    TestRig source;
+    source.store.set_value(1, -21.0f);
+    source.processor.plugin_state = "snapshot-c";
+    auto store_blob = source.store.serialize();
+    auto plugin_blob = source.processor.serialize_plugin_state();
+    auto blob = make_envelope(store_blob, plugin_blob);
+    blob[8] ^= 0x01; // mutate store size after CRC calculation
+
+    TestRig restored;
+    restored.store.set_value(1, 2.0f);
+    restored.processor.plugin_state = "keep";
+
+    REQUIRE_FALSE(pulp::format::plugin_state_io::deserialize(blob,
+                                                             restored.store,
+                                                             restored.processor));
+    REQUIRE_THAT(restored.store.get_value(1), WithinAbs(2.0, 0.01));
+    REQUIRE(restored.processor.plugin_state == "keep");
+    REQUIRE(restored.processor.deserialize_calls == 0);
 }
 
 TEST_CASE("plugin_state_io rolls back StateStore when plugin payload restore fails",

--- a/test/test_preset_manager.cpp
+++ b/test/test_preset_manager.cpp
@@ -223,6 +223,23 @@ TEST_CASE("PresetManager load skips malformed parameter values", "[state][preset
     REQUIRE(load_callbacks == 1);
 }
 
+TEST_CASE("PresetManager load clamps out-of-range parameter values",
+          "[state][preset][coverage][issue-647]") {
+    pulp::test::PresetTestSandbox sandbox("pulp-preset-load-clamp");
+    StateStore store;
+    setup_test_store(store);
+    PresetManager pm(store, "TestCo", "TestPlugin");
+
+    const auto preset_path = sandbox.root / "Clamped.json";
+    write_text_file(preset_path,
+                    R"json({"parameters":{"Gain":999,"Mix":-50}})json");
+
+    REQUIRE(pm.load(preset_path));
+    REQUIRE(store.get_value(1) == Catch::Approx(12.0f));
+    REQUIRE(store.get_value(2) == Catch::Approx(0.0f));
+    REQUIRE(pm.current_preset_name() == "Clamped");
+}
+
 TEST_CASE("PresetManager save scans subfolders and reports list changes", "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-save-subfolder");
     StateStore store;
@@ -247,6 +264,29 @@ TEST_CASE("PresetManager save scans subfolders and reports list changes", "[stat
     REQUIRE(presets.size() == 2);
     REQUIRE(presets[0].name == "Alpha");
     REQUIRE(presets[1].name == "Beta");
+}
+
+TEST_CASE("PresetManager user preset scan ignores non-json files and records nested folders",
+          "[state][preset][coverage][issue-647]") {
+    pulp::test::PresetTestSandbox sandbox("pulp-preset-scan-filter");
+    StateStore store;
+    setup_test_store(store);
+    PresetManager pm(store, "TestCo", "TestPlugin");
+
+    REQUIRE(pm.save("Root"));
+    write_text_file(pm.user_presets_dir() / "Bank" / "Lead.json",
+                    R"json({"parameters":{"Gain":-6}})json");
+    write_text_file(pm.user_presets_dir() / "Bank" / "Ignore.txt", "not a preset");
+    std::error_code ec;
+    fs::create_directories(pm.user_presets_dir() / "EmptyDir", ec);
+    REQUIRE_FALSE(ec);
+
+    auto presets = pm.user_presets();
+    REQUIRE(presets.size() == 2);
+    REQUIRE(presets[0].name == "Lead");
+    REQUIRE(presets[0].folder == "Bank");
+    REQUIRE(presets[1].name == "Root");
+    REQUIRE(presets[1].folder.empty());
 }
 
 TEST_CASE("PresetManager rename and delete update current preset and callbacks", "[state][preset]") {
@@ -277,6 +317,25 @@ TEST_CASE("PresetManager rename and delete update current preset and callbacks",
     REQUIRE_FALSE(pm.rename(new_preset, "Again"));
     REQUIRE_FALSE(pm.delete_preset(new_preset));
     REQUIRE(list_changes == 2);
+}
+
+TEST_CASE("PresetManager delete missing user preset is inert",
+          "[state][preset][coverage][issue-647]") {
+    pulp::test::PresetTestSandbox sandbox("pulp-preset-delete-missing");
+    StateStore store;
+    setup_test_store(store);
+    PresetManager pm(store, "TestCo", "TestPlugin");
+
+    int list_changes = 0;
+    pm.on_list_changed = [&] { ++list_changes; };
+
+    PresetInfo missing;
+    missing.name = "Missing";
+    missing.path = sandbox.root / "missing.json";
+    missing.is_factory = false;
+
+    REQUIRE_FALSE(pm.delete_preset(missing));
+    REQUIRE(list_changes == 0);
 }
 
 TEST_CASE("PresetManager import copies external presets into the user directory", "[state][preset]") {
@@ -327,4 +386,16 @@ TEST_CASE("PresetManager navigation wraps sorted presets and handles missing cur
 
     REQUIRE(pm.load_next());
     REQUIRE(pm.current_preset_name() == "Alpha");
+}
+
+TEST_CASE("PresetManager navigation on empty preset list returns false",
+          "[state][preset][coverage][issue-647]") {
+    pulp::test::PresetTestSandbox sandbox("pulp-preset-navigation-empty");
+    StateStore store;
+    setup_test_store(store);
+    PresetManager pm(store, "TestCo", "TestPlugin");
+
+    REQUIRE_FALSE(pm.load_next());
+    REQUIRE_FALSE(pm.load_previous());
+    REQUIRE(pm.current_preset_name().empty());
 }


### PR DESCRIPTION
## Summary
- cover HeadlessHost prepare/release forwarding, default process context, explicit MIDI buffers, and null-processor no-op processing
- cover plugin_state_io envelopes with empty plugin payloads, empty inner StateStore payloads, and CRC mismatch rejection before plugin callbacks
- cover PresetManager out-of-range load clamping, user preset scan filtering/folder metadata, missing delete no-op behavior, and empty navigation

## Local validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-test-headless pulp-test-plugin-state-io pulp-test-preset-manager -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-headless "[coverage][issue-647]" -r compact`
- `./build/test/pulp-test-plugin-state-io "[coverage][issue-647]" -r compact`
- `./build/test/pulp-test-preset-manager "[coverage][issue-647]" -r compact`
- `./build/test/pulp-test-headless && ./build/test/pulp-test-plugin-state-io && ./build/test/pulp-test-preset-manager`
- `ctest --test-dir build -R '(plugin_state_io rejects malformed blobs|HeadlessHost forwards|HeadlessHost fills|HeadlessHost null|plugin_state_io envelope with empty|plugin_state_io rejects envelope CRC|PresetManager load clamps|PresetManager user preset scan|PresetManager delete missing|PresetManager navigation on empty)' --output-on-failure`
- `git diff --check`
- `./tools/check-docs.sh` (passed with existing warnings)