### PR TITLE
test(format): cover adapter metadata edges

### DIFF
--- a/test/test_aax_model.cpp
+++ b/test/test_aax_model.cpp
@@ -392,10 +392,16 @@ TEST_CASE("AAX model validates fourcc and native plugin id derivation helpers", 
     REQUIRE(pulp::format::aax::fourcc("abc") == 0);
     REQUIRE(pulp::format::aax::fourcc("abcde") == 0);
     REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::fourcc("Pulp")) == "Pulp");
+    REQUIRE(pulp::format::aax::parameter_id_string(0) == "p00000000");
+    REQUIRE(pulp::format::aax::parameter_id_string(42) == "p0000002A");
+    REQUIRE(pulp::format::aax::parameter_id_string(0xffffffffu) == "pFFFFFFFF");
 
     const auto base = pulp::format::aax::fourcc("ABCD");
     REQUIRE(pulp::format::aax::derive_native_plugin_id(base, 0) == base);
     REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::derive_native_plugin_id(base, 1)) == "ABC1");
+    REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::derive_native_plugin_id(base, 10)) == "ABCA");
+    REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::derive_native_plugin_id(base, 35)) == "ABCZ");
+    REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::derive_native_plugin_id(base, 36)) == "ABCa");
     REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::derive_native_plugin_id(base, 61)) == "ABCz");
 
     const auto hashed = pulp::format::aax::derive_native_plugin_id(base, 62);
@@ -415,9 +421,67 @@ TEST_CASE("AAX model exposes stem mapping helpers for supported and unknown layo
     REQUIRE(pulp::format::aax::stem_kind_for_channels(9) == pulp::format::aax::StemKind::none);
 
     REQUIRE(pulp::format::aax::stem_channel_count(pulp::format::aax::StemKind::stereo) == 2);
+    REQUIRE(pulp::format::aax::stem_channel_count(pulp::format::aax::StemKind::surround_7_1) == 8);
     REQUIRE(std::string(pulp::format::aax::stem_signature(pulp::format::aax::StemKind::surround_5_1)) == "5.1");
+    REQUIRE(std::string(pulp::format::aax::stem_signature(pulp::format::aax::StemKind::surround_7_1)) == "7.1");
     REQUIRE(pulp::format::aax::stem_channel_count(pulp::format::aax::StemKind::lcrs) == 0);
     REQUIRE(std::string(pulp::format::aax::stem_signature(pulp::format::aax::StemKind::lcrs)) == "unknown");
+    REQUIRE(pulp::format::aax::stem_channel_count(pulp::format::aax::StemKind::surround_6_0) == 0);
+    REQUIRE(std::string(pulp::format::aax::stem_signature(pulp::format::aax::StemKind::surround_6_0)) == "unknown");
+}
+
+TEST_CASE("AAX model carries descriptor and parameter metadata into definitions", "[aax][model][coverage][issue-648]") {
+    auto codes = valid_codes();
+    auto descriptor = descriptor_with_buses(
+        {{"Main In", 2, false}},
+        {{"Main Out", 2, false}},
+        pulp::format::PluginCategory::Effect,
+        true,
+        true);
+    descriptor.name = "MetadataEffect";
+
+    ConfigurableProcessor::configure(
+        std::move(descriptor),
+        {
+            {
+                .id = 7,
+                .name = "Blend",
+                .unit = "%",
+                .range = {0.0f, 100.0f, 25.0f, 0.0f},
+                .to_string = [](float value) { return std::to_string(static_cast<int>(value)) + "%"; },
+                .from_string = [](const std::string& text) { return std::stof(text); },
+            },
+            {
+                .id = 8,
+                .name = "Shape",
+                .unit = "",
+                .range = {0.0f, 1.0f, 0.0f, 0.25f},
+            },
+        },
+        128);
+
+    auto result = pulp::format::aax::build_plugin_definition(make_configured_processor, codes);
+    REQUIRE(result.ok);
+    REQUIRE(result.definition.codes.manufacturer_id == codes.manufacturer_id);
+    REQUIRE(result.definition.supports_midi_input);
+    REQUIRE(result.definition.supports_midi_output);
+    REQUIRE(result.definition.uses_transport);
+    REQUIRE(result.definition.latency_samples == 128);
+    REQUIRE(result.definition.packet_float_count == 3);
+    REQUIRE(result.definition.parameters.size() == 2);
+    REQUIRE(result.definition.parameters[0].id == 7);
+    REQUIRE(result.definition.parameters[0].aax_id == "p00000007");
+    REQUIRE(result.definition.parameters[0].name == "Blend");
+    REQUIRE(result.definition.parameters[0].unit == "%");
+    REQUIRE(result.definition.parameters[0].range.default_value == 25.0f);
+    REQUIRE(result.definition.parameters[0].to_string(42.0f) == "42%");
+    REQUIRE(result.definition.parameters[0].from_string("64") == 64.0f);
+    REQUIRE_FALSE(result.definition.parameters[0].discrete);
+    REQUIRE(result.definition.parameters[1].discrete);
+    REQUIRE(result.definition.parameters[1].step_count == 5);
+    REQUIRE(result.definition.components.size() == 1);
+    REQUIRE(result.definition.components[0].native_plugin_id == codes.native_id_base);
+    REQUIRE(result.definition.components[0].description == "MetadataEffect stereo -> stereo");
 }
 
 TEST_CASE("AAX model truncates long labels and falls back for empty parameter names", "[aax][model]") {

--- a/test/test_ara.cpp
+++ b/test/test_ara.cpp
@@ -38,6 +38,29 @@ TEST_CASE("AraDocumentController subclass overrides work", "[ara]") {
     REQUIRE((c.supported_roles() & static_cast<int>(AraRole::EditorView)) != 0);
 }
 
+TEST_CASE("AraDocumentController defaults are inert and non-ARA", "[ara][coverage][issue-648]") {
+    AraDocumentController controller;
+    controller.begin_editing();
+    controller.notify_audio_source_content_changed(123);
+    controller.end_editing();
+    REQUIRE(controller.supported_roles() == static_cast<int>(AraRole::None));
+    REQUIRE(controller.is_ara_supported() == false);
+    REQUIRE(controller.ara_factory_name().empty());
+}
+
+TEST_CASE("AraRole bit values remain stable for adapter metadata", "[ara][coverage][issue-648]") {
+    REQUIRE(static_cast<int>(AraRole::None) == 0);
+    REQUIRE(static_cast<int>(AraRole::PlaybackRenderer) == 1);
+    REQUIRE(static_cast<int>(AraRole::EditorRenderer) == 2);
+    REQUIRE(static_cast<int>(AraRole::EditorView) == 4);
+
+    const auto render_and_view =
+        static_cast<int>(AraRole::PlaybackRenderer)
+        | static_cast<int>(AraRole::EditorRenderer)
+        | static_cast<int>(AraRole::EditorView);
+    REQUIRE(render_and_view == 7);
+}
+
 TEST_CASE("ara_sdk_generation reflects SDK headers", "[ara]") {
 #ifdef PULP_HAS_ARA
     // Compiled with the Celemony SDK — generation constant is at least

--- a/test/test_ios_audio_session.cpp
+++ b/test/test_ios_audio_session.cpp
@@ -88,6 +88,54 @@ TEST_CASE("C ABI entry routes to the C++ listener",
     pulp_ios_audio_session_set_callback(nullptr, nullptr);
 }
 
+TEST_CASE("C ABI ignores null events and prefers C++ listeners over raw callbacks",
+          "[ios][audio-session][c-abi][coverage][issue-648]") {
+    int c_calls = 0;
+    pulp_ios_audio_session_set_callback(
+        [](const PulpIosAudioSessionEvent*, void* ud) {
+            ++(*static_cast<int*>(ud));
+        },
+        &c_calls);
+    pulp_ios_audio_session_emit(nullptr);
+    REQUIRE(c_calls == 0);
+
+    int cpp_calls = 0;
+    set_ios_audio_session_listener(
+        [&](const PulpIosAudioSessionEvent&) { ++cpp_calls; });
+
+    PulpIosAudioSessionEvent e{};
+    e.event = PULP_IOS_AUDIO_EVENT_ROUTE_CHANGED;
+    e.reason = PULP_IOS_ROUTE_CHANGE_CATEGORY_CHANGE;
+    pulp_ios_audio_session_emit(&e);
+    REQUIRE(cpp_calls == 1);
+    REQUIRE(c_calls == 0);
+
+    set_ios_audio_session_listener({});
+    pulp_ios_audio_session_emit(&e);
+    REQUIRE(c_calls == 1);
+
+    pulp_ios_audio_session_set_callback(nullptr, nullptr);
+}
+
+TEST_CASE("audio session listener replacement detaches the previous sink",
+          "[ios][audio-session][coverage][issue-648]") {
+    int first_calls = 0;
+    int second_calls = 0;
+    set_ios_audio_session_listener(
+        [&](const PulpIosAudioSessionEvent&) { ++first_calls; });
+    set_ios_audio_session_listener(
+        [&](const PulpIosAudioSessionEvent&) { ++second_calls; });
+
+    PulpIosAudioSessionEvent e{};
+    e.event = PULP_IOS_AUDIO_EVENT_INTERRUPTION_ENDED;
+    REQUIRE(emit_ios_audio_session_event(e));
+    REQUIRE(first_calls == 0);
+    REQUIRE(second_calls == 1);
+
+    set_ios_audio_session_listener({});
+    REQUIRE_FALSE(emit_ios_audio_session_event(e));
+}
+
 TEST_CASE("to_string covers every event code",
           "[ios][audio-session]") {
     REQUIRE(to_string(PULP_IOS_AUDIO_EVENT_NONE) == "none");


### PR DESCRIPTION
## Summary
- add AAX metadata edge coverage for parameter ids, variant suffixes, stem mappings, latency, MIDI flags, packet sizing, and parameter converters
- add ARA default-controller and role-bit stability coverage
- add iOS audio-session C ABI coverage for null events, C++ listener precedence, fallback callbacks, and listener replacement

## Validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-test-aax-model pulp-test-ara pulp-test-ios-audio-session -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-aax-model "[coverage][issue-648]" -r compact`
- `./build/test/pulp-test-ara "[coverage][issue-648]" -r compact`
- `./build/test/pulp-test-ios-audio-session "[coverage][issue-648]" -r compact`
- `./build/test/pulp-test-aax-model -r compact`
- `./build/test/pulp-test-ara -r compact`
- `./build/test/pulp-test-ios-audio-session -r compact`
- `ctest --test-dir build -R "(AAX model carries descriptor|AraDocumentController defaults|AraRole bit values|C ABI ignores null events|audio session listener replacement)" --output-on-failure`
- `git diff --check`
- `./tools/check-docs.sh` (passes with existing warnings)