### PR TITLE
test(platform): cover helper edge cases

### DIFF
--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -166,6 +166,46 @@ TEST_CASE("Environment: token move transfers ownership", "[environment]") {
     REQUIRE(calls == 1);
 }
 
+TEST_CASE("Environment: publish without listeners still updates snapshot",
+          "[environment][coverage][issue-649]") {
+    Environment::reset_for_test();
+
+    auto state = make_state(ColorScheme::light, 1.25f, 48.0f);
+    state.safe_area.bottom = 12.0f;
+    state.memory_pressure = MemoryPressure::moderate;
+    Environment::instance().publish(state);
+
+    auto got = Environment::instance().snapshot();
+    REQUIRE(got.color_scheme == ColorScheme::light);
+    REQUIRE(got.display.scale == 1.25f);
+    REQUIRE(got.keyboard.bottom == 48.0f);
+    REQUIRE(got.safe_area.bottom == 12.0f);
+    REQUIRE(got.memory_pressure == MemoryPressure::moderate);
+}
+
+TEST_CASE("Environment: token reset and self-move assignment are idempotent",
+          "[environment][coverage][issue-649]") {
+    Environment::reset_for_test();
+    int calls = 0;
+
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+    REQUIRE(token.valid());
+
+    auto* same_token = &token;
+    token = std::move(*same_token);
+    REQUIRE(token.valid());
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(calls == 1);
+
+    token.reset();
+    REQUIRE_FALSE(token.valid());
+    token.reset();
+    REQUIRE_FALSE(token.valid());
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(calls == 1);
+}
+
 TEST_CASE("Environment: token move assignment replaces prior subscription",
           "[environment][issue-640]") {
     Environment::reset_for_test();

--- a/test/test_permissions.cpp
+++ b/test/test_permissions.cpp
@@ -162,6 +162,35 @@ TEST_CASE("nested PermissionsOverride clear exposes backend then restores outer 
     REQUIRE(query(Permission::Microphone) == outer_state);
 }
 
+TEST_CASE("PermissionsOverride clear on missing entries is a no-op",
+          "[platform][permissions][override][coverage][issue-649]") {
+    const auto backend_microphone = query(Permission::Microphone);
+    const auto backend_camera = query(Permission::Camera);
+
+    PermissionsOverride guard;
+    guard.clear(Permission::Microphone);
+    REQUIRE(query(Permission::Microphone) == backend_microphone);
+
+    guard.set(Permission::Camera, state_different_from(backend_camera));
+    guard.clear(Permission::Microphone);
+    REQUIRE(query(Permission::Microphone) == backend_microphone);
+    REQUIRE(query(Permission::Camera) == state_different_from(backend_camera));
+}
+
+TEST_CASE("empty nested PermissionsOverride preserves outer entries",
+          "[platform][permissions][override][coverage][issue-649]") {
+    const auto backend_microphone = query(Permission::Microphone);
+    const auto outer_state = state_different_from(backend_microphone);
+
+    PermissionsOverride outer;
+    outer.set(Permission::Microphone, outer_state);
+    {
+        PermissionsOverride inner;
+        REQUIRE(query(Permission::Microphone) == outer_state);
+    }
+    REQUIRE(query(Permission::Microphone) == outer_state);
+}
+
 TEST_CASE("has_platform_backend reports truthfully for the current target",
           "[platform][permissions]") {
 #if defined(PULP_PERMISSIONS_HAS_BACKEND)

--- a/test/test_platform.cpp
+++ b/test/test_platform.cpp
@@ -1,7 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/platform/platform.hpp>
 #include <pulp/platform/popup_menu.hpp>
+#include <pulp/platform/progress_parser.hpp>
 #include <pulp/platform/win/registry.hpp>
+
+#include <vector>
 
 using namespace pulp::platform;
 
@@ -71,6 +74,46 @@ TEST_CASE("PopupMenu records items and separators",
     REQUIRE_FALSE(items[2].enabled);
     REQUIRE(items[2].checked);
     REQUIRE_FALSE(items[2].is_separator);
+}
+
+TEST_CASE("ProgressParser accepts payloads, empty payloads, and type-only lines",
+          "[platform][progress][coverage][issue-649]") {
+    std::vector<ProgressEvent> events;
+    ProgressParser parser([&](const ProgressEvent& e) {
+        events.push_back(e);
+    });
+
+    parser.feed_line("PROGRESS:DOWNLOAD_START:https://example.test/file.zip");
+    parser.feed_line("PROGRESS:OVERALL:42");
+    parser.feed_line("PROGRESS:EMPTY:");
+    parser.feed_line("PROGRESS:TYPE_ONLY");
+
+    REQUIRE(events.size() == 4);
+    REQUIRE(events[0].type == "DOWNLOAD_START");
+    REQUIRE(events[0].payload == "https://example.test/file.zip");
+    REQUIRE(events[1].type == "OVERALL");
+    REQUIRE(events[1].payload == "42");
+    REQUIRE(events[2].type == "EMPTY");
+    REQUIRE(events[2].payload.empty());
+    REQUIRE(events[3].type == "TYPE_ONLY");
+    REQUIRE(events[3].payload.empty());
+}
+
+TEST_CASE("ProgressParser ignores non-progress lines and tolerates empty callbacks",
+          "[platform][progress][coverage][issue-649]") {
+    int calls = 0;
+    ProgressParser parser([&](const ProgressEvent&) { ++calls; });
+
+    parser.feed_line("");
+    parser.feed_line("progress:LOWERCASE:ignored");
+    parser.feed_line("INFO:PROGRESS:OVERALL:1");
+    parser.feed_line("PROGRESSISH:OVERALL:1");
+    REQUIRE(calls == 0);
+
+    ProgressParser empty_callback({});
+    empty_callback.feed_line("PROGRESS:OVERALL:100");
+    empty_callback.feed_line("PROGRESS:TYPE_ONLY");
+    SUCCEED("empty callbacks are inert");
 }
 
 #if !defined(__APPLE__)


### PR DESCRIPTION
## Summary
- add ProgressParser coverage for payload, empty payload, type-only, ignored-line, and empty-callback cases
- add Environment coverage for listener-free publishes, snapshot updates, token self-move/reset idempotency
- add PermissionsOverride coverage for clearing missing entries and preserving outer override state through empty nested guards

## Validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-test-platform pulp-test-environment pulp-test-permissions -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-platform "[coverage][issue-649]" -r compact`
- `./build/test/pulp-test-environment "[coverage][issue-649]" -r compact`
- `./build/test/pulp-test-permissions "[coverage][issue-649]" -r compact`
- `./build/test/pulp-test-platform -r compact`
- `./build/test/pulp-test-environment -r compact`
- `./build/test/pulp-test-permissions -r compact`
- `ctest --test-dir build -R "(ProgressParser accepts|ProgressParser ignores|Environment: publish without listeners|Environment: token reset|PermissionsOverride clear on missing|empty nested PermissionsOverride)" --output-on-failure`
- `git diff --check`
- `./tools/check-docs.sh` (passes with existing warnings)