### PR TITLE
test(canvas): cover text SDF atlas edge paths

### DIFF
--- a/test/test_msdf_atlas.cpp
+++ b/test/test_msdf_atlas.cpp
@@ -23,6 +23,26 @@ TEST_CASE("MsdfAtlas default state is empty", "[canvas][msdf][issue-641]") {
     REQUIRE(atlas.glyph(U'A') == nullptr);
 }
 
+TEST_CASE("MsdfAtlas move operations preserve channel mode and glyph lookup",
+          "[canvas][msdf][coverage][issue-650]") {
+    MsdfAtlas original;
+    REQUIRE(original.build("stub", {U'A', U'B'}, 18, 3, 128,
+                           /*include_alpha*/ true));
+    REQUIRE(original.channels() == 4);
+
+    MsdfAtlas moved(std::move(original));
+    REQUIRE(moved.channels() == 4);
+    REQUIRE(moved.glyph_count() == 2);
+    REQUIRE(moved.glyph(U'A') != nullptr);
+    REQUIRE(moved.pixels() != nullptr);
+
+    MsdfAtlas assigned;
+    assigned = std::move(moved);
+    REQUIRE(assigned.channels() == 4);
+    REQUIRE(assigned.glyph(U'B') != nullptr);
+    REQUIRE(assigned.glyph(U'Z') == nullptr);
+}
+
 TEST_CASE("MsdfAtlas packs the requested glyphs", "[canvas][msdf]") {
     MsdfAtlas atlas;
     std::vector<char32_t> chars = {U'A', U'B', U'C', U'D'};
@@ -52,6 +72,29 @@ TEST_CASE("MsdfAtlas empty build records base size and channel mode",
     REQUIRE(atlas.channels() == 4);
     REQUIRE(atlas.width() == 0);
     REQUIRE(atlas.height() == 0);
+}
+
+TEST_CASE("MsdfAtlas rebuild resets channels and overflow failure clears glyphs",
+          "[canvas][msdf][coverage][issue-650]") {
+    MsdfAtlas atlas;
+    REQUIRE(atlas.build("stub", {U'A'}, 20, 2, 128,
+                        /*include_alpha*/ true));
+    REQUIRE(atlas.channels() == 4);
+    REQUIRE(atlas.glyph_count() == 1);
+
+    REQUIRE(atlas.build("stub", {}, 12, 1, 128,
+                        /*include_alpha*/ false));
+    REQUIRE(atlas.channels() == 3);
+    REQUIRE(atlas.glyph_count() == 0);
+    REQUIRE(atlas.pixels() == nullptr);
+
+    std::vector<char32_t> many;
+    for (char32_t c = 0; c < 100; ++c) many.push_back(c);
+    REQUIRE_FALSE(atlas.build("stub", many, 128, 8, 256,
+                              /*include_alpha*/ true));
+    REQUIRE(atlas.glyph_count() == 0);
+    REQUIRE(atlas.channels() == 3);
+    REQUIRE(atlas.pixels() == nullptr);
 }
 
 TEST_CASE("MsdfAtlas packs glyphs into deterministic tile coordinates",

--- a/test/test_path_to_sdf.cpp
+++ b/test/test_path_to_sdf.cpp
@@ -76,3 +76,18 @@ TEST_CASE("path_to_sdf: mask threshold treats 127 outside and 128 inside",
     REQUIRE(sdf[0] == 0);
     REQUIRE(sdf[1] == 255);
 }
+
+TEST_CASE("path_to_sdf: one-pixel islands saturate in both directions",
+          "[canvas][sdf][path][coverage][issue-650]") {
+    std::uint8_t mask[9] = {
+        0, 0, 0,
+        0, 255, 0,
+        0, 0, 0,
+    };
+
+    auto sdf = path_to_sdf(mask, 3, 3, 1);
+    REQUIRE(sdf.size() == 9);
+    REQUIRE(sdf[4] == 255);
+    REQUIRE(sdf[0] == 0);
+    REQUIRE(sdf[1] == 0);
+}

--- a/test/test_psdf_atlas.cpp
+++ b/test/test_psdf_atlas.cpp
@@ -18,6 +18,20 @@ TEST_CASE("PsdfAtlas builds with the requested glyphs", "[canvas][psdf]") {
     REQUIRE(atlas.pixels() != nullptr);
 }
 
+TEST_CASE("PsdfAtlas keeps the SdfAtlas lookup and move surface",
+          "[canvas][psdf][coverage][issue-650]") {
+    PsdfAtlas atlas;
+    REQUIRE(atlas.build("stub", {U'P', U'S'}, 24, 3, 256));
+    REQUIRE(atlas.base_size() == 24);
+    REQUIRE(atlas.glyph(U'P') != nullptr);
+    REQUIRE(atlas.glyph(U'X') == nullptr);
+
+    PsdfAtlas moved(std::move(atlas));
+    REQUIRE(moved.glyph_count() == 2);
+    REQUIRE(moved.pixels() != nullptr);
+    REQUIRE(moved.glyph(U'S') != nullptr);
+}
+
 TEST_CASE("vector_fallback threshold picks SDF vs path rendering",
           "[canvas][psdf][fallback]") {
     // base_size 48 → 1x at 48px, 4x at 192px, 10x at 480px.
@@ -34,4 +48,12 @@ TEST_CASE("vector_fallback threshold picks SDF vs path rendering",
     // Degenerate base_size is never a fallback trigger.
     REQUIRE_FALSE(should_use_vector_fallback(100.0f, 0.0f));
     REQUIRE_FALSE(should_use_vector_fallback(-100.0f, 48.0f));
+}
+
+TEST_CASE("vector_fallback equality and negative thresholds are strict",
+          "[canvas][psdf][fallback][coverage][issue-650]") {
+    REQUIRE_FALSE(should_use_vector_fallback(96.0f, 48.0f, 2.0f));
+    REQUIRE(should_use_vector_fallback(96.1f, 48.0f, 2.0f));
+    REQUIRE(should_use_vector_fallback(1.0f, 48.0f, -1.0f));
+    REQUIRE_FALSE(should_use_vector_fallback(1.0f, -48.0f, -1.0f));
 }

--- a/test/test_sdf_atlas.cpp
+++ b/test/test_sdf_atlas.cpp
@@ -28,6 +28,28 @@ TEST_CASE("SdfAtlas default state is empty", "[canvas][sdf][issue-641]") {
     REQUIRE(atlas.glyph(U'A') == nullptr);
 }
 
+TEST_CASE("SdfAtlas move operations transfer atlas storage",
+          "[canvas][sdf][coverage][issue-650]") {
+    SdfAtlas original;
+    REQUIRE(original.build("stub", {U'A', U'B'}, 20, 2, 128));
+    const auto* before = original.glyph(U'B');
+    REQUIRE(before != nullptr);
+
+    SdfAtlas moved(std::move(original));
+    REQUIRE(moved.glyph_count() == 2);
+    REQUIRE(moved.base_size() == 20);
+    REQUIRE(moved.pixels() != nullptr);
+    REQUIRE(moved.glyph(U'B') != nullptr);
+    REQUIRE(moved.glyph(U'B')->atlas_x == before->atlas_x);
+
+    SdfAtlas assigned;
+    assigned = std::move(moved);
+    REQUIRE(assigned.glyph_count() == 2);
+    REQUIRE(assigned.pixels() != nullptr);
+    REQUIRE(assigned.glyph(U'A') != nullptr);
+    REQUIRE(assigned.glyph(U'Z') == nullptr);
+}
+
 TEST_CASE("SdfAtlas builds with the requested glyphs", "[canvas][sdf]") {
     SdfAtlas atlas;
     std::vector<char32_t> chars = {U'A', U'B', U'C', U'D'};
@@ -64,6 +86,24 @@ TEST_CASE("SdfAtlas rejects invalid build arguments without allocation",
     REQUIRE_FALSE(invalid_padding.build("stub", {U'A'}, 32, -1, 256));
     REQUIRE(invalid_padding.glyph_count() == 0);
     REQUIRE(invalid_padding.pixels() == nullptr);
+}
+
+TEST_CASE("SdfAtlas invalid rebuild preserves prior atlas but overflow clears it",
+          "[canvas][sdf][coverage][issue-650]") {
+    SdfAtlas atlas;
+    REQUIRE(atlas.build("stub", {U'A'}, 16, 2, 128));
+    REQUIRE(atlas.glyph_count() == 1);
+    REQUIRE(atlas.glyph(U'A') != nullptr);
+
+    REQUIRE_FALSE(atlas.build("stub", {}, 16, 2, 128));
+    REQUIRE(atlas.glyph_count() == 1);
+    REQUIRE(atlas.glyph(U'A') != nullptr);
+
+    std::vector<char32_t> many;
+    for (char32_t c = 0; c < 100; ++c) many.push_back(c);
+    REQUIRE_FALSE(atlas.build("stub", many, 128, 8, 256));
+    REQUIRE(atlas.glyph_count() == 0);
+    REQUIRE(atlas.pixels() == nullptr);
 }
 
 TEST_CASE("SdfAtlas packs glyphs into deterministic tile coordinates",

--- a/test/test_sdf_atlas_cache.cpp
+++ b/test/test_sdf_atlas_cache.cpp
@@ -12,6 +12,15 @@ TEST_CASE("SdfAtlasCache initializes with a seed glyph set", "[canvas][cache]") 
     REQUIRE(cache.touch(U'Z') == nullptr);
 }
 
+TEST_CASE("SdfAtlasCache can initialize an empty resident set",
+          "[canvas][cache][coverage][issue-650]") {
+    SdfAtlasCache cache;
+    REQUIRE_FALSE(cache.initialize("", {}, 24, 4, 512));
+    REQUIRE(cache.size() == 0);
+    REQUIRE(cache.touch(U'A') == nullptr);
+    REQUIRE(cache.atlas().pixels() == nullptr);
+}
+
 TEST_CASE("SdfAtlasCache failed initialize clears prior resident glyphs",
           "[canvas][cache][issue-641]") {
     SdfAtlasCache cache;
@@ -40,6 +49,24 @@ TEST_CASE("SdfAtlasCache reinitialize stamps new glyphs at current frame",
     const auto* z = cache.touch(U'Z');
     REQUIRE(z != nullptr);
     REQUIRE(z->frame_last_used == cache.current_frame());
+}
+
+TEST_CASE("SdfAtlasCache touching resident glyph updates recency without clearing dirty",
+          "[canvas][cache][coverage][issue-650]") {
+    SdfAtlasCache cache;
+    REQUIRE(cache.initialize("", {U'A', U'B'}, 24, 4, 512));
+
+    cache.next_frame();
+    cache.next_frame();
+    const auto* a = cache.touch(U'A');
+    REQUIRE(a != nullptr);
+    REQUIRE(a->frame_last_used == 2);
+    REQUIRE(a->dirty);
+
+    cache.next_frame();
+    REQUIRE(cache.evict_older_than(2) == 1);
+    REQUIRE(cache.touch(U'B') == nullptr);
+    REQUIRE(cache.touch(U'A') != nullptr);
 }
 
 TEST_CASE("SdfAtlasCache advances frame counter and records recency",

--- a/test/test_sdf_effects.cpp
+++ b/test/test_sdf_effects.cpp
@@ -6,6 +6,20 @@
 
 using namespace pulp::canvas;
 
+TEST_CASE("SdfEffectParams default to inactive shader-safe values",
+          "[canvas][sdf][effects][coverage][issue-650]") {
+    SdfEffectParams p;
+    REQUIRE(p.active == 0);
+    REQUIRE_FALSE(has_effect(p.active, SdfEffect::Outline));
+    REQUIRE_FALSE(has_effect(p.active, SdfEffect::Glow));
+    REQUIRE_FALSE(has_effect(p.active, SdfEffect::Shadow));
+    REQUIRE_FALSE(has_effect(p.active, SdfEffect::Bevel));
+    REQUIRE(p.outline_color[3] == 1.0f);
+    REQUIRE(p.glow_color[3] == 1.0f);
+    REQUIRE(p.shadow_color[3] == 0.5f);
+    REQUIRE(p.bevel_mix == 0.0f);
+}
+
 TEST_CASE("SdfEffect bitmask composes with |", "[canvas][sdf][effects]") {
     const std::uint8_t mask = SdfEffect::Outline | SdfEffect::Shadow;
     REQUIRE(has_effect(mask, SdfEffect::Outline));
@@ -13,6 +27,17 @@ TEST_CASE("SdfEffect bitmask composes with |", "[canvas][sdf][effects]") {
     REQUIRE_FALSE(has_effect(mask, SdfEffect::Glow));
     REQUIRE_FALSE(has_effect(mask, SdfEffect::Bevel));
     REQUIRE_FALSE(has_effect(mask, SdfEffect::None));
+}
+
+TEST_CASE("SdfEffect bitmask accepts manually combined active masks",
+          "[canvas][sdf][effects][coverage][issue-650]") {
+    const auto mask = static_cast<std::uint8_t>(SdfEffect::Outline)
+                    | static_cast<std::uint8_t>(SdfEffect::Glow)
+                    | static_cast<std::uint8_t>(SdfEffect::Bevel);
+    REQUIRE(has_effect(mask, SdfEffect::Outline));
+    REQUIRE(has_effect(mask, SdfEffect::Glow));
+    REQUIRE(has_effect(mask, SdfEffect::Bevel));
+    REQUIRE_FALSE(has_effect(mask, SdfEffect::Shadow));
 }
 
 TEST_CASE("preset_subtle_shadow has only Shadow active",
@@ -29,6 +54,19 @@ TEST_CASE("preset_outline width is respected",
     auto p = preset_outline(3.0f);
     REQUIRE(has_effect(p.active, SdfEffect::Outline));
     REQUIRE(p.outline_width == 3.0f);
+}
+
+TEST_CASE("SDF effect presets preserve explicit zero dimensions",
+          "[canvas][sdf][effects][presets][coverage][issue-650]") {
+    auto outline = preset_outline(0.0f);
+    REQUIRE(has_effect(outline.active, SdfEffect::Outline));
+    REQUIRE(outline.outline_width == 0.0f);
+
+    auto glow = preset_glow(0.0f, {0.2f, 0.3f, 0.4f, 0.5f});
+    REQUIRE(has_effect(glow.active, SdfEffect::Glow));
+    REQUIRE(glow.glow_radius == 0.0f);
+    REQUIRE(glow.glow_color[2] == 0.4f);
+    REQUIRE(glow.glow_color[3] == 0.5f);
 }
 
 TEST_CASE("preset_glow carries the given color",

--- a/test/test_sdf_software_renderer.cpp
+++ b/test/test_sdf_software_renderer.cpp
@@ -68,6 +68,22 @@ TEST_CASE("software SDF render handles empty quad list",
     for (auto v : out) REQUIRE(v == 0);
 }
 
+TEST_CASE("software SDF render leaves output untouched for invalid output bounds",
+          "[canvas][sdf][render][coverage][issue-650]") {
+    TinyAtlas atlas{1, 1, {255}};
+    SdfTextQuad q;
+    q.dst_w = 1.0f;
+    q.dst_h = 1.0f;
+    q.src_w = 1.0f;
+    q.src_h = 1.0f;
+
+    std::uint8_t out[1] = {11};
+    render_sdf_text_software(atlas, {q}, out, 0, 1);
+    REQUIRE(out[0] == 11);
+    render_sdf_text_software(atlas, {q}, out, 1, 0);
+    REQUIRE(out[0] == 11);
+}
+
 TEST_CASE("software SDF render leaves output untouched for empty atlas",
           "[canvas][sdf][render][issue-641]") {
     TinyAtlas atlas;
@@ -160,4 +176,23 @@ TEST_CASE("software SDF render keeps maximum alpha for overlapping quads",
     std::uint8_t out[1] = {0};
     render_sdf_text_software(atlas, {low, high}, out, 1, 1);
     REQUIRE(out[0] == 255);
+}
+
+TEST_CASE("software SDF render honors custom edge thresholds",
+          "[canvas][sdf][render][coverage][issue-650]") {
+    TinyAtlas atlas{2, 1, {64, 255}};
+    SdfTextQuad q;
+    q.dst_w = 2.0f;
+    q.dst_h = 1.0f;
+    q.src_w = 2.0f;
+    q.src_h = 1.0f;
+
+    std::uint8_t out[2] = {0, 0};
+    SdfTextOptions opts;
+    opts.edge = 1.0f;
+    render_sdf_text_software(atlas, {q}, out, 2, 1, opts);
+
+    REQUIRE(out[0] == 0);
+    REQUIRE(out[1] > 0);
+    REQUIRE(out[1] < 255);
 }

--- a/test/test_sdf_text.cpp
+++ b/test/test_sdf_text.cpp
@@ -41,6 +41,16 @@ struct FakeAtlas {
 };
 }  // namespace
 
+TEST_CASE("SdfTextOptions default to shader contract values",
+          "[canvas][sdf][layout][coverage][issue-650]") {
+    SdfTextOptions opts;
+    REQUIRE(opts.edge == Catch::Approx(0.5f));
+    REQUIRE(opts.softness == 0.0f);
+    REQUIRE(opts.mip_bias == 0.0f);
+    REQUIRE(opts.gamma == Catch::Approx(2.2f));
+    REQUIRE(opts.snap == SdfPenSnap::Free);
+}
+
 TEST_CASE("snap_pen_x honours the pen-snap policy", "[canvas][sdf][snap]") {
     REQUIRE(snap_pen_x(3.7f, SdfPenSnap::Free)    == 3.7f);
     REQUIRE(snap_pen_x(3.7f, SdfPenSnap::Nearest) == 4.0f);
@@ -96,6 +106,20 @@ TEST_CASE("build_text_quads skips missing glyphs", "[canvas][sdf][layout]") {
     REQUIRE(quads.size() == 2);  // X is skipped.
 }
 
+TEST_CASE("build_text_quads handles empty text and zero render size",
+          "[canvas][sdf][layout][coverage][issue-650]") {
+    FakeAtlas atlas;
+    REQUIRE(build_text_quads(atlas, std::u32string(), 10.0f, 20.0f, 12.0f).empty());
+
+    auto zero = build_text_quads(atlas, std::u32string(U"A"),
+                                 10.0f, 20.0f, 0.0f);
+    REQUIRE(zero.size() == 1);
+    REQUIRE(zero[0].dst_x == 10.0f);
+    REQUIRE(zero[0].dst_y == 20.0f);
+    REQUIRE(zero[0].dst_w == 0.0f);
+    REQUIRE(zero[0].dst_h == 0.0f);
+}
+
 TEST_CASE("build_text_quads returns empty when atlas base size is invalid",
           "[canvas][sdf][layout][issue-641]") {
     FakeAtlas atlas;
@@ -139,6 +163,27 @@ TEST_CASE("named SDF text wrappers forward to shared quad builder",
     REQUIRE(sdf[0].codepoint == U'A');
     REQUIRE(msdf[0].codepoint == U'A');
     REQUIRE(psdf[0].codepoint == U'A');
+}
+
+TEST_CASE("named SDF text wrappers forward options consistently",
+          "[canvas][sdf][layout][coverage][issue-650]") {
+    FakeAtlas atlas;
+    SdfTextOptions opts;
+    opts.snap = SdfPenSnap::Nearest;
+
+    const auto sdf = fill_text_sdf(atlas, std::u32string(U"A"),
+                                   1.6f, 2.4f, 10.0f, opts);
+    const auto msdf = fill_text_msdf(atlas, std::u32string(U"A"),
+                                     1.6f, 2.4f, 10.0f, opts);
+    const auto psdf = fill_text_psdf(atlas, std::u32string(U"A"),
+                                     1.6f, 2.4f, 10.0f, opts);
+
+    REQUIRE(sdf.size() == 1);
+    REQUIRE(msdf.size() == 1);
+    REQUIRE(psdf.size() == 1);
+    REQUIRE(sdf[0].dst_x == msdf[0].dst_x);
+    REQUIRE(msdf[0].dst_x == psdf[0].dst_x);
+    REQUIRE(sdf[0].dst_y == psdf[0].dst_y);
 }
 
 TEST_CASE("build_text_quads works against MsdfAtlas (shared surface)",


### PR DESCRIPTION
## Summary
- add canvas text/SDF coverage for SdfAtlas move/rebuild failure paths
- cover MsdfAtlas move, channel reset, and overflow cleanup behavior
- cover PsdfAtlas lookup/move, vector fallback boundary behavior, SdfAtlasCache recency, and path_to_sdf one-pixel saturation
- extend the same batch across SDF effect presets, SDF text option/quad wrappers, and software renderer threshold/bounds behavior

## Local validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-test-sdf-atlas pulp-test-msdf-atlas pulp-test-psdf-atlas pulp-test-sdf-atlas-cache pulp-test-path-to-sdf -j$(sysctl -n hw.ncpu)`
- `cmake --build build --target pulp-test-sdf-effects pulp-test-sdf-text pulp-test-sdf-software-renderer -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-sdf-atlas "[coverage][issue-650]" -r compact`
- `./build/test/pulp-test-msdf-atlas "[coverage][issue-650]" -r compact`
- `./build/test/pulp-test-psdf-atlas "[coverage][issue-650]" -r compact`
- `./build/test/pulp-test-sdf-atlas-cache "[coverage][issue-650]" -r compact`
- `./build/test/pulp-test-path-to-sdf "[coverage][issue-650]" -r compact`
- `./build/test/pulp-test-sdf-effects "[coverage][issue-650]" -r compact`
- `./build/test/pulp-test-sdf-text "[coverage][issue-650]" -r compact`
- `./build/test/pulp-test-sdf-software-renderer "[coverage][issue-650]" -r compact`
- full binaries: `pulp-test-sdf-atlas`, `pulp-test-msdf-atlas`, `pulp-test-psdf-atlas`, `pulp-test-sdf-atlas-cache`, `pulp-test-path-to-sdf`, `pulp-test-sdf-effects`, `pulp-test-sdf-text`, `pulp-test-sdf-software-renderer`
- exact CTest selections for the new cases in both commits
- `git diff --check`
- `./tools/check-docs.sh` (passes with existing warnings)

GitHub-hosted CI only. No Namespace dispatch and no SSH targets.