### PR TITLE
test(view): cover theme asset edge paths

### DIFF
--- a/test/test_asset_manager.cpp
+++ b/test/test_asset_manager.cpp
@@ -69,6 +69,31 @@ TEST_CASE("AssetManager cache clear", "[view][assets]") {
     REQUIRE(mgr.cache_count() == 0);
 }
 
+TEST_CASE("Asset data wrappers report validity and byte size",
+          "[view][assets][coverage][issue-651]") {
+    ImageData image;
+    image.pixels = {1, 2, 3, 4};
+    image.width = 1;
+    image.height = 1;
+    REQUIRE(image.valid());
+    REQUIRE(image.byte_size() == 4);
+
+    FontData font;
+    font.data = {0, 1};
+    REQUIRE(font.valid());
+    REQUIRE(font.byte_size() == 2);
+
+    ShaderData shader{"void main() {}", ""};
+    REQUIRE(shader.valid());
+    REQUIRE(shader.byte_size() == shader.source.size());
+    shader.error = "compile failed";
+    REQUIRE_FALSE(shader.valid());
+
+    BlobData blob{{5, 6, 7}};
+    REQUIRE(blob.valid());
+    REQUIRE(blob.byte_size() == 3);
+}
+
 TEST_CASE("AssetManager max cache size", "[view][assets]") {
     auto& mgr = AssetManager::instance();
     size_t old_max = mgr.max_cache_size();
@@ -246,6 +271,24 @@ TEST_CASE("AssetManager load image from memory with PNG header", "[view][assets]
     REQUIRE(img.height == 8);
 }
 
+TEST_CASE("AssetManager image memory loading handles invalid and short buffers",
+          "[view][assets][coverage][issue-651]") {
+    auto& mgr = AssetManager::instance();
+
+    static const uint8_t short_png[] = {0x89, 0x50, 0x4E};
+    auto too_short = mgr.load_image_from_memory(short_png, sizeof(short_png));
+    REQUIRE_FALSE(too_short.valid());
+    REQUIRE(too_short.byte_size() == 0);
+
+    static const uint8_t not_png[] = {
+        'n', 'o', 't', 'p', 'n', 'g', '!', '!',
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1,
+    };
+    auto decoded = mgr.load_image_from_memory(not_png, sizeof(not_png));
+    REQUIRE_FALSE(decoded.valid());
+    REQUIRE(decoded.byte_size() == sizeof(not_png));
+}
+
 TEST_CASE("AssetManager load image from embedded", "[view][assets]") {
     auto& mgr = AssetManager::instance();
 
@@ -335,6 +378,18 @@ TEST_CASE("AssetManager data URI base64 decode", "[view][assets]") {
     // Should decode the base64 and attempt PNG parse
     // Won't be a valid image but should not crash
     // The decoded bytes would be the PNG signature (8 bytes)
+}
+
+TEST_CASE("AssetManager data URI decodes PNG dimensions with ignored characters",
+          "[view][assets][coverage][issue-651]") {
+    auto& mgr = AssetManager::instance();
+
+    auto img = mgr.load_image_from_data_uri(
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAAFCAYAAAA=\n!?");
+
+    REQUIRE(img.valid());
+    REQUIRE(img.width == 3);
+    REQUIRE(img.height == 5);
 }
 
 TEST_CASE("AssetManager rejects malformed data URIs", "[view][assets]") {
@@ -433,6 +488,38 @@ TEST_CASE("AssetManager blob file cache and misses", "[view][assets]") {
     REQUIRE_FALSE(missing_embedded.valid());
 
     mgr.clear_cache();
+    mgr.set_max_cache_size(old_max);
+}
+
+TEST_CASE("AssetManager font file loading derives family names and uses cache",
+          "[view][assets][coverage][issue-651]") {
+    auto& mgr = AssetManager::instance();
+    const auto old_max = mgr.max_cache_size();
+    mgr.clear_cache();
+    mgr.set_max_cache_size(1024 * 1024);
+
+    auto path = make_temp_asset_path("Pulp Test Font", ".ttf");
+    const std::vector<uint8_t> bytes = {0x00, 0x01, 0x00, 0x00, 0x66};
+    write_bytes(path, bytes);
+
+    auto font = mgr.load_font(path.string());
+    REQUIRE(font.valid());
+    REQUIRE(font.data == bytes);
+    REQUIRE(font.family_name == path.stem().string());
+    REQUIRE(mgr.cache_count() == 1);
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+
+    auto cached = mgr.load_font(path.string());
+    REQUIRE(cached.valid());
+    REQUIRE(cached.data == bytes);
+    REQUIRE(cached.family_name == font.family_name);
+
+    mgr.clear_cache();
+    auto missing = mgr.load_font(path.string());
+    REQUIRE_FALSE(missing.valid());
+
     mgr.set_max_cache_size(old_max);
 }
 

--- a/test/test_theme.cpp
+++ b/test/test_theme.cpp
@@ -232,6 +232,32 @@ TEST_CASE("Theme from_json maps malformed color strings to default color",
     REQUIRE(theme.color("bad.short").value() == Color{});
 }
 
+TEST_CASE("Theme JSON parser covers optional sections and alpha colors",
+          "[view][theme][coverage][issue-651]") {
+    auto theme = Theme::from_json(R"({
+        "colors": {
+            "overlay.tint": "#10203040",
+            "missing.hash": "102030"
+        },
+        "strings": {
+            "font.family": "Mono"
+        }
+    })");
+
+    auto tint = theme.color("overlay.tint").value();
+    REQUIRE(tint.r8() == 0x10);
+    REQUIRE(tint.g8() == 0x20);
+    REQUIRE(tint.b8() == 0x30);
+    REQUIRE(tint.a8() == 0x40);
+
+    REQUIRE(theme.color("missing.hash").value() == Color{});
+    REQUIRE_FALSE(theme.dimension("spacing.md").has_value());
+    REQUIRE(theme.string_token("font.family").value() == "Mono");
+
+    auto json = theme.to_json();
+    REQUIRE(json.find("#10203040") != std::string::npos);
+}
+
 TEST_CASE("Theme load and save handle file edge cases",
           "[view][theme][issue-493]") {
     const auto path = std::filesystem::temp_directory_path() /
@@ -261,6 +287,26 @@ TEST_CASE("Theme load and save handle file edge cases",
         loaded.dimension("spacing.md").value(),
         WithinAbs(theme.dimension("spacing.md").value(), 0.001));
     REQUIRE(loaded.string_token("font.family") == theme.string_token("font.family"));
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("Theme file IO rejects invalid JSON and unwritable targets",
+          "[view][theme][coverage][issue-651]") {
+    const auto path = std::filesystem::temp_directory_path() /
+        "pulp-theme-invalid-json-test.json";
+
+    {
+        std::ofstream invalid(path);
+        invalid << "{ invalid json";
+    }
+
+    auto invalid = Theme::load_from_file(path.string());
+    REQUIRE(invalid.colors.empty());
+    REQUIRE(invalid.dimensions.empty());
+    REQUIRE(invalid.strings.empty());
+
+    REQUIRE_FALSE(Theme::dark().save_to_file(std::filesystem::temp_directory_path().string()));
 
     std::filesystem::remove(path);
 }

--- a/test/test_theme_contrast.cpp
+++ b/test/test_theme_contrast.cpp
@@ -61,6 +61,16 @@ TEST_CASE("Min contrast thresholds are correct", "[view][contrast]") {
     REQUIRE_THAT(min_contrast_for_level(ContrastLevel::aaa_large), WithinAbs(4.5, 0.01));
 }
 
+TEST_CASE("Contrast helpers clamp channel inputs",
+          "[view][contrast][coverage][issue-651]") {
+    auto below_black = Color::rgba(-1.0f, -0.5f, -0.25f);
+    auto above_white = Color::rgba(2.0f, 1.5f, 1.25f);
+
+    REQUIRE_THAT(relative_luminance(below_black), WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(relative_luminance(above_white), WithinAbs(1.0, 0.001));
+    REQUIRE_THAT(contrast_ratio(below_black, above_white), WithinAbs(21.0, 0.1));
+}
+
 // ── Auto Contrast ───────────────────────────────────────────────────────────
 
 TEST_CASE("Auto contrast picks white on dark background", "[view][contrast]") {
@@ -114,6 +124,16 @@ TEST_CASE("Shift hue wraps around", "[view][contrast][hsl]") {
     auto shifted = shift_hue(red, 120.0f); // Should be green-ish
     auto hsl = rgb_to_hsl(shifted);
     REQUIRE_THAT(hsl.h, WithinAbs(120.0, 2.0));
+}
+
+TEST_CASE("Shift hue wraps negative and alpha is preserved",
+          "[view][contrast][hsl][coverage][issue-651]") {
+    auto color = Color::rgba8(0, 255, 0, 96);
+    auto shifted = shift_hue(color, -240.0f);
+    auto hsl = rgb_to_hsl(shifted);
+
+    REQUIRE_THAT(hsl.h, WithinAbs(240.0, 2.0));
+    REQUIRE_THAT(shifted.a, WithinAbs(color.a, 0.001));
 }
 
 TEST_CASE("Adjust lightness clamps at range bounds", "[view][contrast][hsl]") {
@@ -202,4 +222,23 @@ TEST_CASE("Auto-fix contrast produces valid theme", "[view][contrast][theme]") {
     if (tp && bp) {
         REQUIRE(contrast_ratio(*tp, *bp) >= 4.5f);
     }
+}
+
+TEST_CASE("Theme contrast validation skips missing pairs and reports failures",
+          "[view][contrast][theme][coverage][issue-651]") {
+    Theme partial;
+    partial.colors["bg.primary"] = Color::rgba8(255, 255, 255);
+    partial.colors["text.primary"] = Color::rgba8(200, 200, 200);
+
+    auto issues = validate_theme_contrast(partial, ContrastLevel::aa_normal);
+    REQUIRE(issues.size() == 1);
+    REQUIRE(issues.front().foreground_token == "text.primary");
+    REQUIRE(issues.front().background_token == "bg.primary");
+    REQUIRE(issues.front().ratio < min_contrast_for_level(ContrastLevel::aa_normal));
+    REQUIRE(issues.front().required_level == ContrastLevel::aa_normal);
+
+    auto fixed = auto_fix_contrast(partial, ContrastLevel::aa_normal);
+    REQUIRE(meets_contrast(*fixed.color("text.primary"),
+                           *fixed.color("bg.primary"),
+                           ContrastLevel::aa_normal));
 }

--- a/test/test_theme_presets.cpp
+++ b/test/test_theme_presets.cpp
@@ -37,6 +37,17 @@ TEST_CASE("find_preset returns nullptr for unknown", "[view][presets]") {
     REQUIRE(find_preset("nonexistent") == nullptr);
 }
 
+TEST_CASE("preset_ids preserves library order and exact size",
+          "[view][presets][coverage][issue-651]") {
+    const auto& presets = all_presets();
+    auto ids = preset_ids();
+
+    REQUIRE(ids.size() == presets.size());
+    REQUIRE_FALSE(ids.empty());
+    REQUIRE(ids.front() == presets.front().id);
+    REQUIRE(ids.back() == presets.back().id);
+}
+
 // ── Derivation Layer ────────────────────────────────────────────────────────
 
 TEST_CASE("Derived theme has all required tokens", "[view][presets][derive]") {
@@ -106,6 +117,36 @@ TEST_CASE("Derived theme JSON round-trip", "[view][presets][derive]") {
     auto orig_knob = original.color("knob.arc").value();
     auto rest_knob = restored.color("knob.arc").value();
     REQUIRE(orig_knob == rest_knob);
+}
+
+TEST_CASE("theme_from_preset applies variant-specific overrides",
+          "[view][presets][derive][coverage][issue-651]") {
+    ThemePreset preset;
+    preset.id = "custom";
+    preset.name = "Custom";
+    preset.light = all_presets().front().light;
+    preset.dark = all_presets().front().dark;
+    preset.light_overrides.colors["accent.primary"] = color_from_hex(0x010203);
+    preset.light_overrides.dimensions["spacing.md"] = 11.0f;
+    preset.light_overrides.strings["font.family"] = "LightFace";
+    preset.dark_overrides.colors["accent.primary"] = color_from_hex(0xA0B0C0);
+    preset.dark_overrides.dimensions["spacing.md"] = 7.0f;
+    preset.dark_overrides.strings["font.family"] = "DarkFace";
+
+    auto light = theme_from_preset(preset, false);
+    auto dark = theme_from_preset(preset, true);
+
+    REQUIRE(light.color("accent.primary")->r8() == 0x01);
+    REQUIRE(light.color("accent.primary")->g8() == 0x02);
+    REQUIRE(light.color("accent.primary")->b8() == 0x03);
+    REQUIRE_THAT(light.dimension("spacing.md").value(), Catch::Matchers::WithinAbs(11.0, 0.001));
+    REQUIRE(light.string_token("font.family").value() == "LightFace");
+
+    REQUIRE(dark.color("accent.primary")->r8() == 0xA0);
+    REQUIRE(dark.color("accent.primary")->g8() == 0xB0);
+    REQUIRE(dark.color("accent.primary")->b8() == 0xC0);
+    REQUIRE_THAT(dark.dimension("spacing.md").value(), Catch::Matchers::WithinAbs(7.0, 0.001));
+    REQUIRE(dark.string_token("font.family").value() == "DarkFace");
 }
 
 // ── Specific Presets ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds focused coverage for view theme JSON edge paths, including optional sections, alpha colors, invalid file input, and unwritable save targets.
- Extends AssetManager tests for data wrapper validity, invalid/short image buffers, data URI dimension decode with ignored characters, and font file cache behavior.
- Covers theme contrast clamp/negative hue/validation branches and preset id ordering plus variant override application.

## Local validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-test-theme pulp-test-asset-manager pulp-test-theme-contrast pulp-test-theme-presets -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-theme "[coverage][issue-651]" -r compact`
- `./build/test/pulp-test-asset-manager "[coverage][issue-651]" -r compact`
- `./build/test/pulp-test-theme-contrast "[coverage][issue-651]" -r compact`
- `./build/test/pulp-test-theme-presets "[coverage][issue-651]" -r compact`
- `./build/test/pulp-test-theme -r compact`
- `./build/test/pulp-test-asset-manager -r compact`
- `./build/test/pulp-test-theme-contrast -r compact`
- `./build/test/pulp-test-theme-presets -r compact`
- `ctest --test-dir build -R "(Theme JSON parser covers optional|Theme file IO rejects|Asset data wrappers report|AssetManager image memory loading|AssetManager data URI decodes|AssetManager font file loading|Contrast helpers clamp|Shift hue wraps negative|Theme contrast validation skips|preset_ids preserves|theme_from_preset applies)" --output-on-failure`
- `git diff --check`