### PR TITLE
test(view): cover control edge paths

### DIFF
--- a/core/view/src/table.cpp
+++ b/core/view/src/table.cpp
@@ -104,6 +104,11 @@ void TableListBox::paint(canvas::Canvas& canvas) {
 void TableListBox::on_mouse_down(Point pos) {
     float header_h = header_height_;
 
+    if (pos.x < 0.0f || pos.y < 0.0f || pos.x >= bounds().width ||
+        pos.y >= bounds().height) {
+        return;
+    }
+
     if (pos.y < header_h) {
         // Click on header — sort by column
         float col_x = 0;

--- a/test/test_gui_components.cpp
+++ b/test/test_gui_components.cpp
@@ -126,6 +126,9 @@ TEST_CASE("Toolbar enable/disable", "[gui][toolbar]") {
 
     toolbar.set_enabled("save", false);
     // Disabled items shouldn't trigger (tested via on_mouse_down in real usage)
+    toolbar.set_enabled("missing", false);
+    toolbar.on_mouse_down({10, 10});
+    REQUIRE_FALSE(clicked);
 }
 
 TEST_CASE("Toolbar remove item", "[gui][toolbar]") {
@@ -134,8 +137,34 @@ TEST_CASE("Toolbar remove item", "[gui][toolbar]") {
     toolbar.add_button("b", "B", []() {});
     REQUIRE(toolbar.item_count() == 2);
 
+    toolbar.remove_item("missing");
+    REQUIRE(toolbar.item_count() == 2);
+
     toolbar.remove_item("a");
     REQUIRE(toolbar.item_count() == 1);
+}
+
+TEST_CASE("Toolbar missing ids and sizing fallbacks are stable",
+          "[gui][toolbar][coverage][issue-653]") {
+    Toolbar toolbar;
+    toolbar.add_toggle("solo", "Solo", [](bool) {});
+
+    toolbar.set_toggled("missing", true);
+    toolbar.set_enabled("missing", false);
+    REQUIRE_FALSE(toolbar.is_toggled("missing"));
+    REQUIRE_FALSE(toolbar.is_toggled("solo"));
+
+    toolbar.set_item_size(18.0f);
+    toolbar.set_spacing(2.0f);
+    REQUIRE(toolbar.intrinsic_height() == 26.0f);
+
+    toolbar.set_orientation(Toolbar::Orientation::vertical);
+    REQUIRE(toolbar.intrinsic_height() == 0.0f);
+
+    int clicks = 0;
+    toolbar.add_button("go", "Go", [&] { ++clicks; });
+    toolbar.on_mouse_down({40, 40});
+    REQUIRE(clicks == 0);
 }
 
 TEST_CASE("Toolbar mouse interaction skips separators and disabled items",

--- a/test/test_modal.cpp
+++ b/test/test_modal.cpp
@@ -2,6 +2,8 @@
 #include <pulp/view/modal.hpp>
 #include <pulp/canvas/canvas.hpp>
 
+#include <memory>
+
 using namespace pulp::view;
 using namespace pulp::canvas;
 
@@ -51,4 +53,49 @@ TEST_CASE("ModalOverlay non-Escape key not handled", "[view][modal]") {
     enter.is_down = true;
     REQUIRE_FALSE(modal.on_key_event(enter));
     REQUIRE_FALSE(dismissed);
+}
+
+TEST_CASE("ModalOverlay backdrop click dismisses only outside children",
+          "[view][modal][coverage][issue-653]") {
+    ModalOverlay modal;
+    modal.set_bounds({0, 0, 200, 100});
+    auto child = std::make_unique<View>();
+    child->set_bounds({25, 20, 50, 40});
+    modal.add_child(std::move(child));
+
+    int dismiss_count = 0;
+    modal.on_dismiss = [&] { ++dismiss_count; };
+
+    MouseEvent child_click;
+    child_click.position = {30, 25};
+    child_click.is_down = true;
+    modal.on_mouse_event(child_click);
+    REQUIRE(dismiss_count == 0);
+
+    MouseEvent backdrop_click;
+    backdrop_click.position = {150, 80};
+    backdrop_click.is_down = true;
+    modal.on_mouse_event(backdrop_click);
+    REQUIRE(dismiss_count == 1);
+
+    modal.dismiss_on_backdrop_click = false;
+    modal.on_mouse_event(backdrop_click);
+    REQUIRE(dismiss_count == 1);
+}
+
+TEST_CASE("ModalOverlay ignores mouse-up and missing dismiss callback",
+          "[view][modal][coverage][issue-653]") {
+    ModalOverlay modal;
+    modal.set_bounds({0, 0, 80, 40});
+
+    MouseEvent up;
+    up.position = {10, 10};
+    up.is_down = false;
+    modal.on_mouse_event(up);
+
+    MouseEvent down;
+    down.position = {10, 10};
+    down.is_down = true;
+    modal.on_mouse_event(down);
+    SUCCEED("modal mouse paths tolerate missing callbacks");
 }

--- a/test/test_property_list.cpp
+++ b/test/test_property_list.cpp
@@ -124,3 +124,60 @@ TEST_CASE("PropertyList set_value only mutates existing keys", "[view][property_
     REQUIRE(gain != nullptr);
     REQUIRE(std::get<float>(gain->value) == 0.75f);
 }
+
+TEST_CASE("PropertyList category visibility and label fallback paint paths",
+          "[view][property_list][coverage][issue-653]") {
+    PropertyList list;
+    list.set_bounds({0, 0, 220, 100});
+    list.set_row_height(20.0f);
+    list.set_label_width_fraction(0.25f);
+    list.set_show_categories(false);
+    list.set_properties({
+        {"key_only", "", std::string("value"), false, "Hidden"},
+        {"readonly", "Read Only", true, true, "Hidden"},
+    });
+
+    RecordingCanvas canvas;
+    list.paint(canvas);
+
+    REQUIRE_FALSE(has_text(canvas, "Hidden"));
+    REQUIRE(has_text(canvas, "key_only"));
+    REQUIRE(has_text(canvas, "value"));
+    REQUIRE(has_text(canvas, "Read Only"));
+    REQUIRE(has_text(canvas, "true"));
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_line) == 2);
+    REQUIRE(list.intrinsic_height() == 40.0f);
+}
+
+TEST_CASE("PropertyList selection highlight covers non-bool rows and misses",
+          "[view][property_list][coverage][issue-653]") {
+    PropertyList list;
+    list.set_bounds({0, 0, 180, 100});
+    list.set_row_height(20.0f);
+    list.set_properties({
+        {"name", "Name", std::string("Main"), false, ""},
+        {"bypass", "Bypass", false, false, ""},
+    });
+
+    int changes = 0;
+    list.on_change = [&](const std::string&, PropertyList::PropertyValue) {
+        ++changes;
+    };
+
+    list.on_mouse_down({5.0f, 5.0f});
+    RecordingCanvas selected_text;
+    list.paint(selected_text);
+    REQUIRE(selected_text.count(DrawCommand::Type::fill_rect) == 2);
+    REQUIRE(changes == 0);
+
+    list.on_mouse_down({5.0f, 200.0f});
+    RecordingCanvas after_miss;
+    list.paint(after_miss);
+    REQUIRE(after_miss.count(DrawCommand::Type::fill_rect) == 1);
+
+    list.on_mouse_down({5.0f, 25.0f});
+    REQUIRE(changes == 1);
+    auto* bypass = list.find_property("bypass");
+    REQUIRE(bypass != nullptr);
+    REQUIRE(std::get<bool>(bypass->value));
+}

--- a/test/test_table_list_box.cpp
+++ b/test/test_table_list_box.cpp
@@ -173,3 +173,51 @@ TEST_CASE("SimpleTableModel handles negative sort columns and sparse rows",
     REQUIRE(model.cell_text(0, 1).empty());
     REQUIRE(model.cell_text(1, 1) == "two");
 }
+
+TEST_CASE("TableListBox clear columns and model-less clicks are stable",
+          "[gui][table][coverage][issue-653]") {
+    TableListBox table;
+    table.set_bounds({0, 0, 160, 80});
+    table.set_header_height(20.0f);
+    table.add_column({"Name", 80.0f});
+    table.add_column({"Value", 80.0f});
+    REQUIRE(table.column_count() == 2);
+
+    table.on_mouse_down({10.0f, 5.0f});
+    table.on_mouse_down({10.0f, 35.0f});
+    REQUIRE(table.selected_row() == -1);
+
+    table.clear_columns();
+    REQUIRE(table.column_count() == 0);
+
+    RecordingCanvas canvas;
+    table.paint(canvas);
+    REQUIRE(canvas.command_count() == 0);
+}
+
+TEST_CASE("TableListBox paints selected row and ignores negative body clicks",
+          "[gui][table][coverage][issue-653]") {
+    RecordingTableModel model({
+        {"First", "A"},
+        {"Second", "B"},
+    });
+
+    TableListBox table;
+    table.set_bounds({0, 0, 180, 80});
+    table.set_header_height(20.0f);
+    table.set_row_height(20.0f);
+    table.set_model(&model);
+    table.add_column({"Name", 90.0f});
+    table.add_column({"Value", 90.0f});
+    table.set_selected_row(1);
+
+    table.on_mouse_down({10.0f, -5.0f});
+    REQUIRE(model.sort_calls.empty());
+    REQUIRE(table.selected_row() == 1);
+
+    RecordingCanvas canvas;
+    table.paint(canvas);
+    REQUIRE(has_text(canvas, "First"));
+    REQUIRE(has_text(canvas, "Second"));
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rect) >= 3);
+}


### PR DESCRIPTION
## Summary
- cover modal, toolbar, property-list, and table-list edge paths in one view-controls batch
- fix TableListBox to ignore clicks outside its bounds before header/row handling
- keep the batch small enough for focused local validation but broad enough to amortize one GitHub-hosted CI run

## Local validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-test-modal pulp-test-gui-components pulp-test-property-list pulp-test-table-list-box -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-modal "[coverage][issue-653]" -r compact`
- `./build/test/pulp-test-gui-components "[coverage][issue-653]" -r compact`
- `./build/test/pulp-test-property-list "[coverage][issue-653]" -r compact`
- `./build/test/pulp-test-table-list-box "[coverage][issue-653]" -r compact`
- `./build/test/pulp-test-modal -r compact`
- `./build/test/pulp-test-gui-components -r compact`
- `./build/test/pulp-test-property-list -r compact`
- `./build/test/pulp-test-table-list-box -r compact`
- `ctest --test-dir build -R "(ModalOverlay backdrop click|ModalOverlay ignores mouse-up|Toolbar missing ids|PropertyList category visibility|PropertyList selection highlight|TableListBox clear columns|TableListBox paints selected row)" --output-on-failure`
- `git diff --check`

Note: pre-push local diff-cover was demoted by `PULP_DISABLE_PREPUSH_DIFF_COVER=1` after a local FetchContent checkout failed to read the pinned Highway tree. The focused and full macOS test binaries above passed.