### PR TITLE
test(view): cover tree and accessibility edge paths

### DIFF
--- a/test/test_accessibility_tree.cpp
+++ b/test/test_accessibility_tree.cpp
@@ -7,6 +7,9 @@
 #include <pulp/view/accessibility_tree.hpp>
 #include <pulp/view/view.hpp>
 
+#include <string>
+#include <utility>
+
 using namespace pulp::view;
 
 namespace {
@@ -24,6 +27,46 @@ public:
 
 private:
     double current_ = 0.0;
+};
+
+class DegenerateRangeProbe : public View, public AccessibilityValueInterface {
+public:
+    explicit DegenerateRangeProbe(double current) : current_(current) {}
+
+    double get_current_value() const override { return current_; }
+    void set_current_value(double value) override { current_ = value; }
+    double get_minimum_value() const override { return 5.0; }
+    double get_maximum_value() const override { return 5.0; }
+
+private:
+    double current_ = 0.0;
+};
+
+class TextProbe : public AccessibilityTextInterface {
+public:
+    explicit TextProbe(std::string text) : text_(std::move(text)) {}
+
+    std::string get_text() const override { return text_; }
+    void set_text(std::string_view text) override { text_ = std::string(text); }
+
+private:
+    std::string text_;
+};
+
+class TableProbe : public AccessibilityTableInterface {
+public:
+    int get_row_count() const override { return 3; }
+    int get_column_count() const override { return 2; }
+    std::string get_column_header(int column) const override {
+        return column == 0 ? "Name" : "Value";
+    }
+};
+
+class CellProbe : public AccessibilityCellInterface {
+public:
+    std::string get_cell_text(int row, int column) const override {
+        return std::to_string(row) + ":" + std::to_string(column);
+    }
 };
 
 } // namespace
@@ -205,4 +248,58 @@ TEST_CASE("Accessibility snapshot surfaces ARIA state attributes",
 
     REQUIRE(nodes[2].label == "Decorative icon");
     REQUIRE(nodes[2].hidden == "true");
+}
+
+TEST_CASE("Accessibility value interface default strings clamp and fall back",
+          "[a11y][coverage][issue-654]") {
+    Probe root;
+
+    auto high = std::make_unique<RangeProbe>(30.0);
+    high->set_access_role(View::AccessRole::slider);
+    high->set_access_label("High");
+    root.add_child(std::move(high));
+
+    auto low = std::make_unique<RangeProbe>(-30.0);
+    low->set_access_role(View::AccessRole::slider);
+    low->set_access_label("Low");
+    root.add_child(std::move(low));
+
+    auto flat = std::make_unique<DegenerateRangeProbe>(7.25);
+    flat->set_access_role(View::AccessRole::meter);
+    flat->set_access_label("Flat");
+    root.add_child(std::move(flat));
+
+    auto nodes = snapshot_accessibility_tree(root);
+    REQUIRE(nodes.size() == 3);
+    REQUIRE(nodes[0].has_value);
+    REQUIRE(nodes[0].value_string == "100%");
+    REQUIRE(nodes[1].value_string == "0%");
+    REQUIRE(nodes[2].value_string == "7.25");
+}
+
+TEST_CASE("Accessibility helper interfaces expose default selection behavior",
+          "[a11y][coverage][issue-654]") {
+    TextProbe text("abcdef");
+    REQUIRE(text.get_character_count() == 6);
+    REQUIRE(text.get_selection() == std::pair<int, int>{0, 0});
+    REQUIRE_FALSE(text.is_editable());
+    REQUIRE(text.get_text_range(-5, 3) == "abc");
+    REQUIRE(text.get_text_range(2, 99) == "cdef");
+    REQUIRE(text.get_text_range(4, 2).empty());
+    text.set_selection(1, 4);
+    REQUIRE(text.get_selection() == std::pair<int, int>{0, 0});
+    text.set_text("xy");
+    REQUIRE(text.get_character_count() == 2);
+
+    TableProbe table;
+    REQUIRE(table.get_selected_row() == -1);
+    REQUIRE(table.get_selected_rows().empty());
+    REQUIRE_FALSE(table.supports_multi_selection());
+    table.select_row(1);
+    REQUIRE(table.get_selected_row() == -1);
+
+    CellProbe cell;
+    REQUIRE(cell.get_cell_text(2, 1) == "2:1");
+    REQUIRE_FALSE(cell.is_cell_editable(0, 0));
+    REQUIRE(cell.get_cell_span(0, 0) == std::pair<int, int>{1, 1});
 }

--- a/test/test_tree_view.cpp
+++ b/test/test_tree_view.cpp
@@ -2,6 +2,9 @@
 #include <pulp/view/tree_view.hpp>
 #include <pulp/canvas/canvas.hpp>
 
+#include <algorithm>
+#include <string>
+
 using namespace pulp::view;
 using namespace pulp::canvas;
 
@@ -20,6 +23,25 @@ KeyEvent key_down(KeyCode key) {
     e.key = key;
     e.is_down = true;
     return e;
+}
+
+bool has_text(const RecordingCanvas& canvas, const std::string& text) {
+    return std::any_of(canvas.commands().begin(),
+                       canvas.commands().end(),
+                       [&](const DrawCommand& cmd) {
+                           return cmd.type == DrawCommand::Type::fill_text &&
+                                  cmd.text == text;
+                       });
+}
+
+int text_count(const RecordingCanvas& canvas, const std::string& text) {
+    return static_cast<int>(std::count_if(
+        canvas.commands().begin(),
+        canvas.commands().end(),
+        [&](const DrawCommand& cmd) {
+            return cmd.type == DrawCommand::Type::fill_text &&
+                   cmd.text == text;
+        }));
 }
 
 } // namespace
@@ -215,4 +237,65 @@ TEST_CASE("TreeView row_height and indent configurable", "[view][tree]") {
 
     REQUIRE(tree.row_height() == 30.0f);
     REQUIRE(tree.indent() == 24.0f);
+}
+
+TEST_CASE("TreeView collapsed children are hidden from paint and hit testing",
+          "[view][tree][coverage][issue-654]") {
+    TreeView tree;
+    auto& group = tree.root().add_child("Group");
+    group.add_child("Hidden child");
+    auto& visible = tree.root().add_child("Visible");
+    tree.set_bounds({0, 0, 240, 120});
+
+    std::string selected;
+    tree.on_select = [&](TreeNode& node) { selected = node.label; };
+
+    RecordingCanvas collapsed;
+    tree.paint(collapsed);
+    REQUIRE(has_text(collapsed, "Group"));
+    REQUIRE_FALSE(has_text(collapsed, "Hidden child"));
+    REQUIRE(has_text(collapsed, "Visible"));
+
+    tree.on_mouse_event(mouse_down(40, 28));
+    REQUIRE(selected == "Visible");
+    REQUIRE(tree.selected_node() == &visible);
+}
+
+TEST_CASE("TreeView expanded child activation and selected paint paths",
+          "[view][tree][coverage][issue-654]") {
+    TreeView tree;
+    tree.set_bounds({0, 0, 240, 160});
+    tree.set_row_height(20.0f);
+    tree.set_indent(24.0f);
+    auto& group = tree.root().add_child("Group");
+    auto& child = group.add_child("Child");
+    group.expanded = true;
+
+    std::string activated;
+    tree.on_activate = [&](TreeNode& node) { activated = node.label; };
+
+    tree.on_mouse_event(mouse_down(54, 25, 2));
+    REQUIRE(activated == "Child");
+
+    tree.set_selected_node(&child);
+    RecordingCanvas selected;
+    tree.paint(selected);
+    REQUIRE(selected.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(text_count(selected, "\xe2\x96\xbc") == 1);
+    REQUIRE(has_text(selected, "Child"));
+}
+
+TEST_CASE("TreeView left key on collapsed parent is handled without toggling",
+          "[view][tree][coverage][issue-654]") {
+    TreeView tree;
+    auto& group = tree.root().add_child("Group");
+    group.add_child("Child");
+    tree.set_selected_node(&group);
+
+    int toggles = 0;
+    tree.on_toggle = [&](TreeNode&, bool) { ++toggles; };
+
+    REQUIRE(tree.on_key_event(key_down(KeyCode::left)));
+    REQUIRE_FALSE(group.expanded);
+    REQUIRE(toggles == 0);
 }


### PR DESCRIPTION
## Summary
- Add TreeView coverage for collapsed-child paint/hit-testing, expanded child double-click activation, selected-row paint, and left-key behavior on collapsed parents.
- Add accessibility coverage for default value-string clamping/fallback plus default text, table, and cell helper interface behavior.

## Local validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-test-tree-view pulp-test-accessibility-tree -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-tree-view "[coverage][issue-654]" -r compact`
- `./build/test/pulp-test-accessibility-tree "[coverage][issue-654]" -r compact`
- `./build/test/pulp-test-tree-view -r compact`
- `./build/test/pulp-test-accessibility-tree -r compact`
- `ctest --test-dir build -R "(TreeView collapsed children|TreeView expanded child|TreeView left key|Accessibility value interface|Accessibility helper interfaces)" --output-on-failure`
- `git diff --check`