### PR TITLE
test(view): cover panel and editor edge paths

### DIFF
--- a/core/view/include/pulp/view/preset_browser.hpp
+++ b/core/view/include/pulp/view/preset_browser.hpp
@@ -213,6 +213,8 @@ public:
 
         // Click in list area
         float list_y = header_h + (filter_text_.empty() ? 4.0f : 22.0f);
+        if (event.position.y < list_y)
+            return;
         float click_y = event.position.y - list_y + scroll_offset_;
         int index = static_cast<int>(click_y / row_height_);
 

--- a/test/test_code_editor.cpp
+++ b/test/test_code_editor.cpp
@@ -94,6 +94,20 @@ TEST_CASE("CodeEditor insert text", "[gui][code-editor]") {
     REQUIRE(editor.text() == "hello world");
 }
 
+TEST_CASE("CodeEditor insert appends in read-only fallback mode",
+          "[gui][code-editor][coverage][issue-655]") {
+    CodeEditor editor;
+    editor.set_read_only(true);
+    editor.set_text("alpha");
+    editor.insert_text("\nbeta");
+    editor.go_to_line(99);
+
+    REQUIRE(editor.text() == "alpha\nbeta");
+    REQUIRE(editor.cursor_line() == 99);
+    REQUIRE(editor.cursor_column() == 1);
+    REQUIRE(editor.selected_text().empty());
+}
+
 TEST_CASE("CodeEditor go to line", "[gui][code-editor]") {
     CodeEditor editor;
     editor.set_text("line1\nline2\nline3");
@@ -258,4 +272,26 @@ TEST_CASE("RecentlyOpenedFilesList persists trims and handles I/O misses",
     REQUIRE(reloaded.files()[1] == "/saved/a.txt");
 
     std::filesystem::remove_all(dir);
+}
+
+TEST_CASE("RecentlyOpenedFilesList remove and max-entry edge paths",
+          "[gui][code-editor][coverage][issue-655]") {
+    RecentlyOpenedFilesList mru;
+    mru.add("/a.txt");
+    mru.add("/b.txt");
+    mru.add("/c.txt");
+
+    mru.remove("/b.txt");
+    REQUIRE(mru.files().size() == 2);
+    REQUIRE(mru.files()[0] == "/c.txt");
+    REQUIRE(mru.files()[1] == "/a.txt");
+
+    mru.remove("/missing.txt");
+    REQUIRE(mru.files().size() == 2);
+
+    mru.set_max_entries(0);
+    REQUIRE(mru.files().empty());
+
+    mru.add("/d.txt");
+    REQUIRE(mru.files().empty());
 }

--- a/test/test_file_browser.cpp
+++ b/test/test_file_browser.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/canvas/canvas.hpp>
 #include <pulp/view/file_browser.hpp>
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -56,6 +57,10 @@ int index_containing(const std::vector<std::string>& texts, const std::string& n
 
 bool contains_text(const std::vector<std::string>& texts, const std::string& needle) {
     return index_containing(texts, needle) >= 0;
+}
+
+int exact_text_count(const std::vector<std::string>& texts, const std::string& text) {
+    return static_cast<int>(std::count(texts.begin(), texts.end(), text));
 }
 
 float x_for_exact_text(const RecordingCanvas& canvas, const std::string& text) {
@@ -120,6 +125,29 @@ TEST_CASE("FileBrowser filters hidden files and sorts directories before files",
     browser.paint(canvas);
     texts = fill_texts(canvas);
     REQUIRE(contains_text(texts, ".hidden.wav"));
+}
+
+TEST_CASE("FileBrowser paint clips rows and keeps directories through filters",
+          "[view][file-browser][coverage][issue-655]") {
+    TempDir tmp("filter-clip");
+    std::filesystem::create_directory(tmp.path / "Samples");
+    write_file(tmp.path / "alpha.wav");
+    write_file(tmp.path / "beta.txt");
+    write_file(tmp.path / "gamma.wav");
+
+    FileBrowser browser;
+    browser.set_bounds({0, 0, 320, 40});
+    browser.set_filters({"*.wav"});
+    browser.set_root(tmp.path);
+
+    RecordingCanvas clipped;
+    browser.paint(clipped);
+    auto texts = fill_texts(clipped);
+
+    REQUIRE(contains_text(texts, "Samples"));
+    REQUIRE(contains_text(texts, "alpha.wav"));
+    REQUIRE_FALSE(contains_text(texts, "beta.txt"));
+    REQUIRE_FALSE(contains_text(texts, "gamma.wav"));
 }
 
 TEST_CASE("FileTree skips hidden nodes and paints one expanded directory level",
@@ -221,4 +249,29 @@ TEST_CASE("MultiDocumentPanel remove_document preserves active document callback
         REQUIRE(closed == std::vector<int>({0, 1, 0}));
         REQUIRE(active_changes == std::vector<int>({0, 2, 1, 0, -1}));
     }
+}
+
+TEST_CASE("MultiDocumentPanel paint reflects active tab and empty state",
+          "[view][multi-document][coverage][issue-655]") {
+    MultiDocumentPanel empty;
+    empty.set_bounds({0, 0, 200, 80});
+    RecordingCanvas empty_canvas;
+    empty.paint(empty_canvas);
+    REQUIRE(empty_canvas.count(DrawCommand::Type::fill_text) == 0);
+    REQUIRE(empty_canvas.count(DrawCommand::Type::fill_rect) == 0);
+
+    MultiDocumentPanel panel;
+    panel.set_bounds({0, 0, 260, 100});
+    panel.add_document("Main", std::make_unique<View>());
+    panel.add_document("Aux", std::make_unique<View>());
+    panel.set_active(1);
+
+    RecordingCanvas canvas;
+    panel.paint(canvas);
+    auto texts = fill_texts(canvas);
+
+    REQUIRE(panel.active_index() == 1);
+    REQUIRE(exact_text_count(texts, "Main") == 1);
+    REQUIRE(exact_text_count(texts, "Aux") == 1);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rect) == 2);
 }

--- a/test/test_graph_editor_view.cpp
+++ b/test/test_graph_editor_view.cpp
@@ -32,6 +32,14 @@ MouseEvent modifier_event(uint16_t modifiers) {
     return event;
 }
 
+bool has_text(const RecordingCanvas& canvas, const std::string& text) {
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == DrawCommand::Type::fill_text && cmd.text == text)
+            return true;
+    }
+    return false;
+}
+
 } // namespace
 
 TEST_CASE("GraphEditorView paints graph nodes connections and drag ghost",
@@ -122,6 +130,35 @@ TEST_CASE("GraphEditorView modifier drags create feedback and midi edges",
     REQUIRE_FALSE(midi_graph.connections()[0].feedback);
 }
 
+TEST_CASE("GraphEditorView reverse modifier drags create feedback and midi edges",
+          "[view][graph_editor][coverage][issue-655]") {
+    SignalGraph feedback_graph;
+    const auto feedback_input = feedback_graph.add_input_node(1, "Input");
+    const auto feedback_output = feedback_graph.add_output_node(1, "Output");
+    GraphEditorView feedback(feedback_graph);
+    feedback.set_node_position(feedback_input, 10.0f, 10.0f);
+    feedback.set_node_position(feedback_output, 240.0f, 10.0f);
+
+    feedback.on_mouse_down(input_port(240.0f));
+    feedback.on_mouse_event(modifier_event(kModShift));
+    feedback.on_mouse_up(output_port(10.0f));
+    REQUIRE(feedback_graph.connections().size() == 1);
+    REQUIRE(feedback_graph.connections()[0].feedback);
+
+    SignalGraph midi_graph;
+    const auto midi_in = midi_graph.add_midi_input_node("Keys");
+    const auto midi_out = midi_graph.add_midi_output_node("Sink");
+    GraphEditorView midi(midi_graph);
+    midi.set_node_position(midi_in, 10.0f, 10.0f);
+    midi.set_node_position(midi_out, 240.0f, 10.0f);
+
+    midi.on_mouse_down(input_port(240.0f));
+    midi.on_mouse_event(modifier_event(kModAlt));
+    midi.on_mouse_up(output_port(10.0f));
+    REQUIRE(midi_graph.connections().size() == 1);
+    REQUIRE(midi_graph.connections()[0].midi);
+}
+
 TEST_CASE("GraphEditorView selection and miss handling are stable",
           "[view][graph_editor][issue-493]") {
     SignalGraph graph;
@@ -141,4 +178,32 @@ TEST_CASE("GraphEditorView selection and miss handling are stable",
     editor.on_mouse_drag({1000.0f, 1000.0f});
     editor.on_mouse_up({1000.0f, 1000.0f});
     REQUIRE(graph.connections().empty());
+}
+
+TEST_CASE("GraphEditorView paints unnamed nodes and clears drag ghost after miss",
+          "[view][graph_editor][coverage][issue-655]") {
+    SignalGraph graph;
+    const auto input = graph.add_input_node(1, "");
+    const auto output = graph.add_output_node(1, "Output");
+
+    GraphEditorView editor(graph);
+    editor.set_node_position(input, 10.0f, 10.0f);
+    editor.set_node_position(output, 240.0f, 10.0f);
+
+    RecordingCanvas initial;
+    editor.paint(initial);
+    REQUIRE(has_text(initial, "(unnamed)"));
+
+    editor.on_mouse_down(output_port(10.0f));
+    editor.on_mouse_drag({180.0f, 90.0f});
+    RecordingCanvas dragging;
+    editor.paint(dragging);
+    REQUIRE(dragging.count(DrawCommand::Type::cubic_to) == 1);
+
+    editor.on_mouse_up({900.0f, 900.0f});
+    REQUIRE(graph.connections().empty());
+
+    RecordingCanvas released;
+    editor.paint(released);
+    REQUIRE(released.count(DrawCommand::Type::cubic_to) == 0);
 }

--- a/test/test_preset_browser.cpp
+++ b/test/test_preset_browser.cpp
@@ -327,6 +327,29 @@ TEST_CASE("PresetBrowser mouse list selects and double-click activates", "[view]
     REQUIRE(browser.selected_index() == 2);
 }
 
+TEST_CASE("PresetBrowser filtered list click uses filter offset and row height",
+          "[view][preset_browser][coverage][issue-655]") {
+    TestPresetFixture f;
+    PresetBrowser browser(*f.pm);
+    browser.set_bounds({0, 0, 180, 180});
+    browser.set_row_height(30.0f);
+    browser.set_filter("clean");
+
+    std::string selected_name;
+    browser.on_preset_selected = [&](const PresetInfo& p) {
+        selected_name = p.name;
+    };
+
+    browser.on_mouse_event(mouse_down(40.0f, 40.0f));
+    REQUIRE(browser.selected_index() == -1);
+    REQUIRE(selected_name.empty());
+
+    browser.on_mouse_event(mouse_down(40.0f, 58.0f));
+    REQUIRE(browser.selected_index() == 0);
+    REQUIRE(selected_name == "Clean");
+    REQUIRE(browser.row_height() == 30.0f);
+}
+
 TEST_CASE("PresetBrowser paint produces draw commands", "[view][preset_browser]") {
     TestPresetFixture f;
     PresetBrowser browser(*f.pm);


### PR DESCRIPTION
## Summary
- Add coverage for FileBrowser filtered/height-clipped painting and MultiDocumentPanel empty/active-tab paint paths.
- Add GraphEditorView reverse modifier drag coverage plus unnamed-node and drag-miss ghost cleanup coverage.
- Add PresetBrowser filtered-list row geometry coverage and guard clicks in the filter gap so they do not select row 0.
- Add CodeEditor fallback/read-only insert state coverage and RecentlyOpenedFilesList remove/max-entry edge coverage.

## Local validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-test-file-browser pulp-test-graph-editor-view pulp-test-preset-browser pulp-test-code-editor -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-file-browser "[coverage][issue-655]" -r compact`
- `./build/test/pulp-test-graph-editor-view "[coverage][issue-655]" -r compact`
- `./build/test/pulp-test-preset-browser "[coverage][issue-655]" -r compact`
- `./build/test/pulp-test-code-editor "[coverage][issue-655]" -r compact`
- `./build/test/pulp-test-file-browser -r compact`
- `./build/test/pulp-test-graph-editor-view -r compact`
- `./build/test/pulp-test-preset-browser -r compact`
- `./build/test/pulp-test-code-editor -r compact`
- `ctest --test-dir build -R "(FileBrowser paint clips|MultiDocumentPanel paint reflects|GraphEditorView reverse modifier|GraphEditorView paints unnamed|PresetBrowser filtered list click|CodeEditor insert appends|RecentlyOpenedFilesList remove)" --output-on-failure`
- `git diff --check`

Note: local pre-push diff coverage was demoted by `PULP_DISABLE_PREPUSH_DIFF_COVER=1` because the fresh coverage configure failed to checkout pinned Highway tree `457c891775a7397bdb0376bb1031e6e027af1c48` from FetchContent in this worktree. The targeted and full affected macOS test binaries above passed before push.