### PR TITLE
test: consolidate runtime platform codecov queue

### DIFF
--- a/core/runtime/src/analytics.cpp
+++ b/core/runtime/src/analytics.cpp
@@ -4,6 +4,26 @@
 
 namespace pulp::runtime {
 
+namespace {
+
+std::string json_escape(std::string_view value) {
+    std::string escaped;
+    escaped.reserve(value.size());
+    for (char c : value) {
+        switch (c) {
+            case '\\': escaped += "\\\\"; break;
+            case '"': escaped += "\\\""; break;
+            case '\n': escaped += "\\n"; break;
+            case '\r': escaped += "\\r"; break;
+            case '\t': escaped += "\\t"; break;
+            default: escaped += c; break;
+        }
+    }
+    return escaped;
+}
+
+}  // namespace
+
 // ── FileAnalyticsDestination ────────────────────────────────────────────
 
 FileAnalyticsDestination::FileAnalyticsDestination(std::string_view path)
@@ -28,13 +48,13 @@ void FileAnalyticsDestination::flush() {
     if (!file) return;
 
     for (auto& event : buffer_) {
-        file << "{\"event\":\"" << event.name << "\",\"time\":" << event.timestamp;
+        file << "{\"event\":\"" << json_escape(event.name) << "\",\"time\":" << event.timestamp;
         if (!event.properties.empty()) {
             file << ",\"props\":{";
             bool first = true;
             for (auto& [k, v] : event.properties) {
                 if (!first) file << ",";
-                file << "\"" << k << "\":\"" << v << "\"";
+                file << "\"" << json_escape(k) << "\":\"" << json_escape(v) << "\"";
                 first = false;
             }
             file << "}";

--- a/core/runtime/src/analytics.cpp
+++ b/core/runtime/src/analytics.cpp
@@ -10,13 +10,18 @@ std::string json_escape(std::string_view value) {
     std::string escaped;
     escaped.reserve(value.size());
     for (char c : value) {
-        switch (c) {
-            case '\\': escaped += "\\\\"; break;
-            case '"': escaped += "\\\""; break;
-            case '\n': escaped += "\\n"; break;
-            case '\r': escaped += "\\r"; break;
-            case '\t': escaped += "\\t"; break;
-            default: escaped += c; break;
+        if (c == '\\') {
+            escaped += "\\\\";
+        } else if (c == '"') {
+            escaped += "\\\"";
+        } else if (c == '\n') {
+            escaped += "\\n";
+        } else if (c == '\r') {
+            escaped += "\\r";
+        } else if (c == '\t') {
+            escaped += "\\t";
+        } else {
+            escaped += c;
         }
     }
     return escaped;

--- a/core/runtime/src/identity.cpp
+++ b/core/runtime/src/identity.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <iomanip>
 #include <charconv>
+#include <cctype>
 
 namespace pulp::runtime {
 
@@ -40,12 +41,21 @@ Uuid Uuid::from_string(std::string_view str) {
     // Parse "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" (36 chars)
     // or compact "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" (32 chars)
     Uuid id;
+    if (str.size() != 32 && str.size() != 36) return id;
+    if (str.size() == 36 &&
+        (str[8] != '-' || str[13] != '-' || str[18] != '-' || str[23] != '-')) {
+        return id;
+    }
+
     std::string hex;
     hex.reserve(32);
     for (char c : str) {
         if (c != '-') hex += c;
     }
     if (hex.size() != 32) return id; // nil on parse failure
+    for (char c : hex) {
+        if (!std::isxdigit(static_cast<unsigned char>(c))) return id;
+    }
 
     for (int i = 0; i < 8; ++i) {
         id.hi = (id.hi << 8) | (hex_digit(hex[i * 2]) << 4 | hex_digit(hex[i * 2 + 1]));

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -187,10 +187,32 @@ find "${PROFRAW_DIR}" -name '*.profraw' -print0 \
 # they're built from third-party sources not instrumented by our flags.
 BINARIES=()
 
-# Test executables — first, these drive the actual coverage hits. On
-# Windows/MSYS, CTest can run `.exe` files whose Unix executable bit is
-# not visible to `find -perm -u+x`; include `.exe` explicitly so their
-# coverage maps reach llvm-cov.
+# First-party static libraries — expose every instrumented TU regardless
+# of whether a test links it. Pattern is `libpulp-*.a` on macOS/Linux
+# and `pulp-*.lib` on Windows (clang-cl's MSVC-style driver emits `.lib`
+# archives, not `.a`). Without the `.lib` branch the Windows coverage
+# matrix leg silently skips the full-surface expansion, so the Windows
+# Codecov upload has only test-linked TUs — same narrow view this fix
+# was meant to close everywhere. Deliberately does not pick up
+# libausdk.a / libvst3-sdk.a (external SDKs, not our code); the
+# `pulp-*.lib` prefix is narrow enough to skip third-party .lib files
+# that also appear under the build tree.
+#
+# Keep archives before executables. Files compiled into both a static
+# archive and a test binary need the executed test binary's coverage map
+# to win; adding archives after tests can leave diff-cover with the
+# archive's zero-hit record for source that tests did exercise.
+while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
+    find "${BUILD_DIR}" -type f \
+         \( -name 'libpulp-*.a' -o -name 'pulp-*.lib' \) \
+         ! -path "${BUILD_DIR}/test/*" \
+         2>/dev/null || true
+)
+
+# Test executables — these drive the actual coverage hits. On Windows/MSYS,
+# CTest can run `.exe` files whose Unix executable bit is not visible to
+# `find -perm -u+x`; include `.exe` explicitly so their coverage maps reach
+# llvm-cov.
 while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
     find "${BUILD_DIR}/test" -maxdepth 2 -type f \
          \( -perm -u+x -o -name '*.exe' \) \
@@ -216,23 +238,6 @@ if [[ ${#BINARIES[@]} -eq 0 ]]; then
     echo "run_coverage.sh: no test binaries found under ${BUILD_DIR}/test" >&2
     exit 1
 fi
-
-# First-party static libraries — expose every instrumented TU regardless
-# of whether a test links it. Pattern is `libpulp-*.a` on macOS/Linux
-# and `pulp-*.lib` on Windows (clang-cl's MSVC-style driver emits `.lib`
-# archives, not `.a`). Without the `.lib` branch the Windows coverage
-# matrix leg silently skips the full-surface expansion, so the Windows
-# Codecov upload has only test-linked TUs — same narrow view this fix
-# was meant to close everywhere. Deliberately does not pick up
-# libausdk.a / libvst3-sdk.a (external SDKs, not our code); the
-# `pulp-*.lib` prefix is narrow enough to skip third-party .lib files
-# that also appear under the build tree.
-while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
-    find "${BUILD_DIR}" -type f \
-         \( -name 'libpulp-*.a' -o -name 'pulp-*.lib' \) \
-         ! -path "${BUILD_DIR}/test/*" \
-         2>/dev/null || true
-)
 
 # First-party non-test executables — CLI, standalone host, inspector.
 # Test binaries under build/test/ are already included above; exclude

--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -148,6 +148,62 @@ TEST_CASE("FileAnalyticsDestination escapes JSON strings", "[runtime][analytics]
     REQUIRE(line.find("\",\"return\"") != std::string::npos);
 }
 
+TEST_CASE("FileAnalyticsDestination escapes each special JSON character",
+          "[runtime][analytics][coverage][issue-656]") {
+    struct Case {
+        std::string input;
+        std::string expected;
+    };
+
+    const Case cases[] = {
+        {"back\\slash", "back\\\\slash"},
+        {"double\"quote", "double\\\"quote"},
+        {"new\nline", "new\\nline"},
+        {"carriage\rreturn", "carriage\\rreturn"},
+        {"tab\tchar", "tab\\tchar"},
+    };
+
+    for (const auto& c : cases) {
+        TemporaryFile tmp(".jsonl");
+        FileAnalyticsDestination dest(tmp.path_string());
+
+        AnalyticsEvent event;
+        event.name = c.input;
+        event.timestamp = 1.0;
+        dest.log_event(event);
+        dest.flush();
+
+        std::ifstream f(tmp.path());
+        std::string line;
+        REQUIRE(std::getline(f, line));
+        REQUIRE(line.find("\"event\":\"" + c.expected + "\"") != std::string::npos);
+    }
+}
+
+TEST_CASE("FileAnalyticsDestination escapes special JSON property keys and values",
+          "[runtime][analytics][coverage][issue-656]") {
+    TemporaryFile tmp(".jsonl");
+    FileAnalyticsDestination dest(tmp.path_string());
+
+    AnalyticsEvent event;
+    event.name = "props";
+    event.timestamp = 1.0;
+    event.properties = {
+        {"slash\\key", "quote\"value"},
+        {"line\nkey", "return\rvalue"},
+        {"tab\tkey", "tab\tvalue"},
+    };
+    dest.log_event(event);
+    dest.flush();
+
+    std::ifstream f(tmp.path());
+    std::string line;
+    REQUIRE(std::getline(f, line));
+    REQUIRE(line.find("\"slash\\\\key\":\"quote\\\"value\"") != std::string::npos);
+    REQUIRE(line.find("\"line\\nkey\":\"return\\rvalue\"") != std::string::npos);
+    REQUIRE(line.find("\"tab\\tkey\":\"tab\\tvalue\"") != std::string::npos);
+}
+
 TEST_CASE("FileAnalyticsDestination empty flush does not create output", "[runtime][analytics][coverage][issue-656]") {
     TemporaryFile tmp(".jsonl");
     auto path = tmp.path();

--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -2,6 +2,7 @@
 #include <pulp/runtime/analytics.hpp>
 #include <pulp/runtime/temporary_file.hpp>
 #include <fstream>
+#include <filesystem>
 #include <memory>
 #include <vector>
 
@@ -73,6 +74,21 @@ TEST_CASE("Analytics forwards event details and flushes destinations", "[runtime
 
     a.flush();
     REQUIRE(*flushes == 1);
+}
+
+TEST_CASE("Analytics flush reaches destinations even when disabled", "[runtime][analytics][issue-641]") {
+    auto events = std::make_shared<std::vector<AnalyticsEvent>>();
+    auto flushes = std::make_shared<int>(0);
+
+    auto& a = Analytics::instance();
+    a.add_destination(std::make_unique<RecordingDestination>(events, flushes));
+
+    a.set_enabled(false);
+    a.flush();
+    REQUIRE(*flushes == 1);
+    REQUIRE(events->empty());
+
+    a.set_enabled(true);
 }
 
 TEST_CASE("Analytics disabled skips destinations", "[runtime][analytics]") {
@@ -148,6 +164,33 @@ TEST_CASE("FileAnalyticsDestination appends multiple flushes", "[runtime][analyt
     REQUIRE(content.find("\"event\":\"second\"") != std::string::npos);
 }
 
+TEST_CASE("FileAnalyticsDestination empty flush does not create output", "[runtime][analytics][issue-641]") {
+    TemporaryFile tmp(".jsonl");
+    auto path = tmp.path();
+    std::filesystem::remove(path);
+
+    FileAnalyticsDestination dest(tmp.path_string());
+    dest.flush();
+
+    REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
+TEST_CASE("FileAnalyticsDestination writes property map in key order", "[runtime][analytics][issue-641]") {
+    TemporaryFile tmp(".jsonl");
+    FileAnalyticsDestination dest(tmp.path_string());
+
+    AnalyticsEvent event;
+    event.name = "ordered";
+    event.properties = {{"z", "last"}, {"a", "first"}};
+    dest.log_event(event);
+    dest.flush();
+
+    std::ifstream f(tmp.path());
+    std::string line;
+    REQUIRE(std::getline(f, line));
+    REQUIRE(line.find("\"a\":\"first\"") < line.find("\"z\":\"last\""));
+}
+
 TEST_CASE("WidgetTracker logs events", "[runtime][analytics]") {
     auto& a = Analytics::instance();
     a.set_enabled(true);
@@ -158,4 +201,27 @@ TEST_CASE("WidgetTracker logs events", "[runtime][analytics]") {
     WidgetTracker::track_preset_select("Default");
 
     REQUIRE(a.event_count() == before + 3);
+}
+
+TEST_CASE("WidgetTracker forwards expected event names and properties",
+          "[runtime][analytics][issue-641]") {
+    auto events = std::make_shared<std::vector<AnalyticsEvent>>();
+    auto flushes = std::make_shared<int>(0);
+
+    auto& a = Analytics::instance();
+    a.set_enabled(true);
+    a.add_destination(std::make_unique<RecordingDestination>(events, flushes));
+
+    WidgetTracker::track_click("bypass");
+    WidgetTracker::track_value_change("gain", "-6");
+    WidgetTracker::track_preset_select("Init");
+
+    REQUIRE(events->size() == 3);
+    REQUIRE((*events)[0].name == "widget_click");
+    REQUIRE((*events)[0].properties.at("widget") == "bypass");
+    REQUIRE((*events)[1].name == "value_change");
+    REQUIRE((*events)[1].properties.at("widget") == "gain");
+    REQUIRE((*events)[1].properties.at("value") == "-6");
+    REQUIRE((*events)[2].name == "preset_select");
+    REQUIRE((*events)[2].properties.at("preset") == "Init");
 }

--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -132,7 +132,10 @@ TEST_CASE("FileAnalyticsDestination escapes JSON strings", "[runtime][analytics]
     AnalyticsEvent event;
     event.name = "quote\"and\nline";
     event.timestamp = 1.0;
-    event.properties = {{"key\"name", "value\\path\tend"}};
+    event.properties = {
+        {"key\"name", "value\\path\tend"},
+        {"return", "line\rend"},
+    };
     dest.log_event(event);
     dest.flush();
 
@@ -141,6 +144,8 @@ TEST_CASE("FileAnalyticsDestination escapes JSON strings", "[runtime][analytics]
     REQUIRE(std::getline(f, line));
     REQUIRE(line.find("\"event\":\"quote\\\"and\\nline\"") != std::string::npos);
     REQUIRE(line.find("\"key\\\"name\":\"value\\\\path\\tend\"") != std::string::npos);
+    REQUIRE(line.find("\"return\":\"line\\rend\"") != std::string::npos);
+    REQUIRE(line.find("\",\"return\"") != std::string::npos);
 }
 
 TEST_CASE("FileAnalyticsDestination empty flush does not create output", "[runtime][analytics][coverage][issue-656]") {

--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -2,6 +2,7 @@
 #include <pulp/runtime/analytics.hpp>
 #include <pulp/runtime/temporary_file.hpp>
 #include <fstream>
+#include <filesystem>
 #include <memory>
 #include <vector>
 
@@ -107,6 +108,35 @@ TEST_CASE("FileAnalyticsDestination writes JSON", "[runtime][analytics]") {
     REQUIRE(std::getline(f, line));
     REQUIRE(line.find("\"event\":\"test\"") != std::string::npos);
     REQUIRE(line.find("\"key\":\"value\"") != std::string::npos);
+}
+
+TEST_CASE("FileAnalyticsDestination escapes JSON strings", "[runtime][analytics][coverage][issue-656]") {
+    TemporaryFile tmp(".jsonl");
+    FileAnalyticsDestination dest(tmp.path_string());
+
+    AnalyticsEvent event;
+    event.name = "quote\"and\nline";
+    event.timestamp = 1.0;
+    event.properties = {{"key\"name", "value\\path\tend"}};
+    dest.log_event(event);
+    dest.flush();
+
+    std::ifstream f(tmp.path());
+    std::string line;
+    REQUIRE(std::getline(f, line));
+    REQUIRE(line.find("\"event\":\"quote\\\"and\\nline\"") != std::string::npos);
+    REQUIRE(line.find("\"key\\\"name\":\"value\\\\path\\tend\"") != std::string::npos);
+}
+
+TEST_CASE("FileAnalyticsDestination empty flush does not create output", "[runtime][analytics][coverage][issue-656]") {
+    TemporaryFile tmp(".jsonl");
+    auto path = tmp.path();
+    tmp.release();
+    std::filesystem::remove(path);
+
+    FileAnalyticsDestination dest(path.string());
+    dest.flush();
+    REQUIRE_FALSE(std::filesystem::exists(path));
 }
 
 TEST_CASE("FileAnalyticsDestination auto flushes at batch threshold", "[runtime][analytics]") {

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/runtime/crypto.hpp>
+#include <algorithm>
+#include <cctype>
 #include <cstring>
 #include <vector>
 
@@ -23,6 +25,20 @@ TEST_CASE("SHA-256 binary data", "[crypto][sha256]") {
     REQUIRE(digest.size() == 32);
 }
 
+TEST_CASE("SHA-256 pointer overload preserves embedded NUL bytes",
+          "[crypto][sha256][coverage][issue-641]") {
+    const std::vector<uint8_t> data = {'a', 'b', 'c', 0x00, 'd', 'e', 'f'};
+
+    auto digest = sha256(data.data(), data.size());
+    auto hex = sha256_hex(data.data(), data.size());
+
+    REQUIRE(digest.size() == 32);
+    REQUIRE(hex == "516a5e926ce20c5f4d80f00e1a01abdf14986def6588d6abeed9fce090bc660c");
+    REQUIRE(std::all_of(hex.begin(), hex.end(), [](unsigned char c) {
+        return std::isdigit(c) || (c >= 'a' && c <= 'f');
+    }));
+}
+
 // ── SHA-1 ───────────────────────────────────────────────────────────────
 
 TEST_CASE("SHA-1 known value", "[crypto][sha1]") {
@@ -35,6 +51,17 @@ TEST_CASE("SHA-1 known value", "[crypto][sha1]") {
     REQUIRE(digest == expected);
 }
 
+TEST_CASE("SHA-1 pointer overload preserves embedded NUL bytes",
+          "[crypto][sha1][coverage][issue-641]") {
+    const std::vector<uint8_t> data = {'w', 's', 0x00, 'k', 'e', 'y'};
+    const std::vector<uint8_t> expected = {
+        0xb1, 0x24, 0x2e, 0x4b, 0x0c, 0x53, 0x4d, 0x49, 0x0f, 0x5e,
+        0xf7, 0xee, 0x67, 0xb8, 0x80, 0xf0, 0xa2, 0xb8, 0x8a, 0x6b,
+    };
+
+    REQUIRE(sha1(data.data(), data.size()) == expected);
+}
+
 // ── MD5 ─────────────────────────────────────────────────────────────────
 
 TEST_CASE("MD5 empty string", "[crypto][md5]") {
@@ -45,6 +72,17 @@ TEST_CASE("MD5 empty string", "[crypto][md5]") {
 TEST_CASE("MD5 known value", "[crypto][md5]") {
     auto hex = md5_hex("hello");
     REQUIRE(hex == "5d41402abc4b2a76b9719d911017c592");
+}
+
+TEST_CASE("MD5 binary data returns raw digest bytes",
+          "[crypto][md5][coverage][issue-641]") {
+    const std::vector<uint8_t> data = {0x00, 0xff, 0x10, 0x20, 0x00};
+    const std::vector<uint8_t> expected = {
+        0x96, 0x26, 0x6b, 0xae, 0xb1, 0xeb, 0x57, 0x35,
+        0xd5, 0x51, 0xca, 0xc2, 0xd9, 0xa8, 0x27, 0x75,
+    };
+
+    REQUIRE(md5(data.data(), data.size()) == expected);
 }
 
 // ── AES-256-CBC ─────────────────────────────────────────────────────────
@@ -86,6 +124,27 @@ TEST_CASE("AES empty plaintext", "[crypto][aes]") {
     REQUIRE(decrypted->empty());
 }
 
+TEST_CASE("AES exact block plaintext adds and removes full padding block",
+          "[crypto][aes][coverage][issue-641]") {
+    uint8_t key[32] = {};
+    uint8_t iv[16] = {};
+    std::memset(key, 0x21, 32);
+    std::memset(iv, 0x43, 16);
+
+    std::string plaintext = "sixteen byte txt";
+    REQUIRE(plaintext.size() == 16);
+
+    auto encrypted = aes_encrypt(
+        reinterpret_cast<const uint8_t*>(plaintext.data()),
+        plaintext.size(), key, iv);
+    REQUIRE(encrypted.has_value());
+    REQUIRE(encrypted->size() == 32);
+
+    auto decrypted = aes_decrypt(encrypted->data(), encrypted->size(), key, iv);
+    REQUIRE(decrypted.has_value());
+    REQUIRE(std::string(decrypted->begin(), decrypted->end()) == plaintext);
+}
+
 TEST_CASE("AES decrypt invalid data", "[crypto][aes]") {
     uint8_t key[32] = {};
     uint8_t iv[16] = {};
@@ -103,6 +162,24 @@ TEST_CASE("AES decrypt rejects non-block-aligned ciphertext", "[crypto][aes]") {
     uint8_t ciphertext[15] = {};
 
     auto result = aes_decrypt(ciphertext, sizeof(ciphertext), key, iv);
+    REQUIRE_FALSE(result.has_value());
+}
+
+TEST_CASE("AES decrypt rejects invalid PKCS7 padding bytes",
+          "[crypto][aes][coverage][issue-641]") {
+    uint8_t key[32] = {};
+    uint8_t iv[16] = {};
+    std::memset(key, 0x5c, 32);
+    std::memset(iv, 0xa7, 16);
+
+    std::string plaintext = "padding check";
+    auto encrypted = aes_encrypt(
+        reinterpret_cast<const uint8_t*>(plaintext.data()),
+        plaintext.size(), key, iv);
+    REQUIRE(encrypted.has_value());
+
+    encrypted->back() ^= 0x01;
+    auto result = aes_decrypt(encrypted->data(), encrypted->size(), key, iv);
     REQUIRE_FALSE(result.has_value());
 }
 

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -87,6 +87,24 @@ TEST_CASE("EnvironmentChange: any reflects individual flags",
     REQUIRE(change.any());
 }
 
+TEST_CASE("SafeAreaInsets zero detection checks all edges",
+          "[environment][coverage][issue-640]") {
+    SafeAreaInsets insets;
+    REQUIRE(insets.is_zero());
+
+    insets.top = 1.0f;
+    REQUIRE_FALSE(insets.is_zero());
+    insets = {};
+    insets.bottom = 1.0f;
+    REQUIRE_FALSE(insets.is_zero());
+    insets = {};
+    insets.left = 1.0f;
+    REQUIRE_FALSE(insets.is_zero());
+    insets = {};
+    insets.right = 1.0f;
+    REQUIRE_FALSE(insets.is_zero());
+}
+
 TEST_CASE("Environment: subscribe receives publish + correct change mask",
           "[environment]") {
     Environment::reset_for_test();
@@ -149,6 +167,32 @@ TEST_CASE("Environment: reset clears listeners held by live tokens",
 
     Environment::inject_for_test(make_state(ColorScheme::light));
     REQUIRE(calls == 0);
+}
+
+TEST_CASE("Environment: token reset is idempotent and preserves other listeners",
+          "[environment][coverage][issue-640]") {
+    Environment::reset_for_test();
+    int first_calls = 0;
+    int second_calls = 0;
+
+    auto first = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++first_calls; });
+    auto second = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++second_calls; });
+
+    first.reset();
+    first.reset();
+    REQUIRE_FALSE(first.valid());
+    REQUIRE(second.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(first_calls == 0);
+    REQUIRE(second_calls == 1);
+
+    second.reset();
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(first_calls == 0);
+    REQUIRE(second_calls == 1);
 }
 
 TEST_CASE("Environment: token move transfers ownership", "[environment]") {

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -166,6 +166,46 @@ TEST_CASE("Environment: token move transfers ownership", "[environment]") {
     REQUIRE(calls == 1);
 }
 
+TEST_CASE("Environment: publish without listeners still updates snapshot",
+          "[environment][coverage][issue-649]") {
+    Environment::reset_for_test();
+
+    auto state = make_state(ColorScheme::light, 1.25f, 48.0f);
+    state.safe_area.bottom = 12.0f;
+    state.memory_pressure = MemoryPressure::moderate;
+    Environment::instance().publish(state);
+
+    auto got = Environment::instance().snapshot();
+    REQUIRE(got.color_scheme == ColorScheme::light);
+    REQUIRE(got.display.scale == 1.25f);
+    REQUIRE(got.keyboard.bottom == 48.0f);
+    REQUIRE(got.safe_area.bottom == 12.0f);
+    REQUIRE(got.memory_pressure == MemoryPressure::moderate);
+}
+
+TEST_CASE("Environment: token reset and self-move assignment are idempotent",
+          "[environment][coverage][issue-649]") {
+    Environment::reset_for_test();
+    int calls = 0;
+
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+    REQUIRE(token.valid());
+
+    auto* same_token = &token;
+    token = std::move(*same_token);
+    REQUIRE(token.valid());
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(calls == 1);
+
+    token.reset();
+    REQUIRE_FALSE(token.valid());
+    token.reset();
+    REQUIRE_FALSE(token.valid());
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(calls == 1);
+}
+
 TEST_CASE("Environment: token move assignment replaces prior subscription",
           "[environment][issue-640]") {
     Environment::reset_for_test();

--- a/test/test_events_async_helpers.cpp
+++ b/test/test_events_async_helpers.cpp
@@ -140,6 +140,26 @@ TEST_CASE("ActionBroadcaster ignores missing listener removals",
     REQUIRE(seen.size() == 3);
 }
 
+TEST_CASE("ActionBroadcaster handles empty actions and no-listener sends",
+          "[events][async_updater][action_broadcaster][issue-642]") {
+    ActionBroadcaster broadcaster;
+
+    broadcaster.send_action("");
+    broadcaster.remove_listener(123);
+
+    std::vector<std::string> seen;
+    auto listener = broadcaster.add_listener(
+        [&](std::string_view action) { seen.emplace_back(action); });
+
+    broadcaster.send_action("");
+    broadcaster.send_action("named");
+    REQUIRE(seen == std::vector<std::string>{"", "named"});
+
+    broadcaster.remove_listener(listener);
+    broadcaster.send_action("ignored");
+    REQUIRE(seen.size() == 2);
+}
+
 TEST_CASE("MultiTimer stop all permits selective restart",
           "[events][async_updater][multi_timer][issue-642]") {
     RecordingMultiTimer timers;
@@ -161,6 +181,26 @@ TEST_CASE("MultiTimer stop all permits selective restart",
     timers.stop_timer(42);
     REQUIRE_FALSE(timers.is_timer_running(1));
     REQUIRE_FALSE(timers.is_timer_running(2));
+}
+
+TEST_CASE("MultiTimer restart keeps one running entry per id",
+          "[events][async_updater][multi_timer][issue-642]") {
+    RecordingMultiTimer timers;
+
+    timers.start_timer(7, 20);
+    timers.start_timer(7, 10);
+    timers.start_timer(7, 5);
+    REQUIRE(timers.is_timer_running(7));
+
+    timers.stop_timer(7);
+    REQUIRE_FALSE(timers.is_timer_running(7));
+
+    timers.start_timer(7, 1);
+    REQUIRE(timers.is_timer_running(7));
+
+    timers.stop_all_timers();
+    timers.stop_all_timers();
+    REQUIRE_FALSE(timers.is_timer_running(7));
 }
 
 TEST_CASE("ScopedLowPowerModeDisabler has no observable test-lane side effects",

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -15,6 +15,15 @@ TEST_CASE("i18n add and translate", "[runtime][i18n]") {
     REQUIRE(strings.count() == 1);
 }
 
+TEST_CASE("i18n add overwrites existing translation", "[runtime][i18n][issue-641]") {
+    LocalisedStrings strings;
+    strings.add("mode", "Old");
+    strings.add("mode", "New");
+
+    REQUIRE(strings.count() == 1);
+    REQUIRE(strings.translate("mode") == "New");
+}
+
 TEST_CASE("i18n translate missing key returns key", "[runtime][i18n]") {
     LocalisedStrings strings;
     REQUIRE(strings.translate("missing_key") == "missing_key");
@@ -40,6 +49,12 @@ TEST_CASE("i18n argument substitution leaves unmatched placeholders", "[runtime]
 
     REQUIRE(strings.translate("mixed", {"left", "right"}) == "left/{2}/right/left");
     REQUIRE(strings.translate("empty", {""}) == "beforeafter");
+}
+
+TEST_CASE("i18n argument substitution also applies to missing-key fallback",
+          "[runtime][i18n][issue-641]") {
+    LocalisedStrings strings;
+    REQUIRE(strings.translate("missing {0}/{1}/{2}", {"a", "b"}) == "missing a/b/{2}");
 }
 
 TEST_CASE("i18n clear removes all translations", "[runtime][i18n]") {
@@ -96,6 +111,22 @@ TEST_CASE("i18n .strings parser ignores malformed lines", "[runtime][i18n]") {
     REQUIRE_FALSE(strings.has("missing_value"));
 }
 
+TEST_CASE("i18n .strings parser overwrites duplicate keys", "[runtime][i18n][issue-641]") {
+    TemporaryFile tmp(".strings");
+    {
+        std::ofstream f(tmp.path());
+        f << "\"name\" = \"Old\";\n";
+        f << "\"other\" = \"Kept\";\n";
+        f << "\"name\" = \"New\";\n";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_strings_file(tmp.path_string()));
+    REQUIRE(strings.count() == 2);
+    REQUIRE(strings.translate("name") == "New");
+    REQUIRE(strings.translate("other") == "Kept");
+}
+
 // ── .po file format ─────────────────────────────────────────────────────
 
 TEST_CASE("i18n load .po file", "[runtime][i18n]") {
@@ -139,6 +170,24 @@ TEST_CASE("i18n .po parser handles continuations and empty entries", "[runtime][
     REQUIRE(strings.count() == 1);
     REQUIRE(strings.translate("long_key") == "lange_wert");
     REQUIRE_FALSE(strings.has("empty_translation"));
+}
+
+TEST_CASE("i18n .po parser commits previous entry when new msgid starts",
+          "[runtime][i18n][issue-641]") {
+    TemporaryFile tmp(".po");
+    {
+        std::ofstream f(tmp.path());
+        f << "msgid \"first\"\n";
+        f << "msgstr \"one\"\n";
+        f << "msgid \"second\"\n";
+        f << "msgstr \"two\"\n";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_po_file(tmp.path_string()));
+    REQUIRE(strings.count() == 2);
+    REQUIRE(strings.translate("first") == "one");
+    REQUIRE(strings.translate("second") == "two");
 }
 
 // ── JSON file format ────────────────────────────────────────────────────
@@ -205,6 +254,25 @@ TEST_CASE("i18n JSON parser rejects missing object opener", "[runtime][i18n]") {
     REQUIRE(strings.count() == 0);
 }
 
+TEST_CASE("i18n JSON parser allows duplicate keys and trailing comma",
+          "[runtime][i18n][issue-641]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << "{\n";
+        f << "  \"name\": \"Old\",\n";
+        f << "  \"name\": \"New\",\n";
+        f << "  \"last\": \"value\",\n";
+        f << "}\n";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_json_file(tmp.path_string()));
+    REQUIRE(strings.count() == 2);
+    REQUIRE(strings.translate("name") == "New");
+    REQUIRE(strings.translate("last") == "value");
+}
+
 // ── File load failures ──────────────────────────────────────────────────
 
 TEST_CASE("i18n load nonexistent file returns false", "[runtime][i18n]") {
@@ -220,6 +288,16 @@ TEST_CASE("i18n global instance", "[runtime][i18n]") {
     auto& inst = LocalisedStrings::instance();
     inst.add("test_global", "works");
     REQUIRE(tr("test_global") == "works");
+    inst.clear();
+}
+
+TEST_CASE("i18n global tr supports argument substitution", "[runtime][i18n][issue-641]") {
+    auto& inst = LocalisedStrings::instance();
+    inst.clear();
+    inst.add("global_args", "{0}:{1}");
+
+    REQUIRE(tr("global_args", {"left", "right"}) == "left:right");
+
     inst.clear();
 }
 

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -11,8 +11,17 @@ TEST_CASE("i18n add and translate", "[runtime][i18n]") {
     LocalisedStrings strings;
     strings.add("greeting", "Hello");
     REQUIRE(strings.translate("greeting") == "Hello");
+    REQUIRE(strings.t("greeting") == "Hello");
     REQUIRE(strings.has("greeting"));
     REQUIRE(strings.count() == 1);
+}
+
+TEST_CASE("i18n duplicate keys overwrite previous values", "[runtime][i18n][coverage][issue-656]") {
+    LocalisedStrings strings;
+    strings.add("mode", "old");
+    strings.add("mode", "new");
+    REQUIRE(strings.count() == 1);
+    REQUIRE(strings.translate("mode") == "new");
 }
 
 TEST_CASE("i18n translate missing key returns key", "[runtime][i18n]") {
@@ -94,6 +103,22 @@ TEST_CASE("i18n .strings parser ignores malformed lines", "[runtime][i18n]") {
     REQUIRE(strings.count() == 1);
     REQUIRE(strings.translate("valid") == "kept");
     REQUIRE_FALSE(strings.has("missing_value"));
+}
+
+TEST_CASE("i18n .strings parser lets later entries replace earlier ones",
+          "[runtime][i18n][coverage][issue-656]") {
+    TemporaryFile tmp(".strings");
+    {
+        std::ofstream f(tmp.path());
+        f << "\"label\" = \"First\";\n";
+        f << "\"label\" = \"Second\";\n";
+        f << "\"other\" = \"Value\";\n";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_strings_file(tmp.path_string()));
+    REQUIRE(strings.count() == 2);
+    REQUIRE(strings.translate("label") == "Second");
 }
 
 // ── .po file format ─────────────────────────────────────────────────────
@@ -184,6 +209,24 @@ TEST_CASE("i18n JSON parser handles escapes and keyless entries", "[runtime][i18
     REQUIRE(strings.translate("slash") == "path\\file");
 }
 
+TEST_CASE("i18n JSON parser accepts commas and duplicate keys", "[runtime][i18n][coverage][issue-656]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << "{\n";
+        f << "  \"mode\": \"old\",\n";
+        f << "  \"mode\": \"new\",\n";
+        f << "  \"tail\": \"kept\",\n";
+        f << "}\n";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_json_file(tmp.path_string()));
+    REQUIRE(strings.count() == 2);
+    REQUIRE(strings.translate("mode") == "new");
+    REQUIRE(strings.translate("tail") == "kept");
+}
+
 TEST_CASE("i18n JSON parser rejects missing object opener", "[runtime][i18n]") {
     TemporaryFile tmp(".json");
 
@@ -220,6 +263,8 @@ TEST_CASE("i18n global instance", "[runtime][i18n]") {
     auto& inst = LocalisedStrings::instance();
     inst.add("test_global", "works");
     REQUIRE(tr("test_global") == "works");
+    inst.add("test_global_args", "{0} works");
+    REQUIRE(tr("test_global_args", {"also"}) == "also works");
     inst.clear();
 }
 

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -116,12 +116,9 @@ TEST_CASE("i18n .strings parser lets later entries replace earlier ones",
     TemporaryFile tmp(".strings");
     {
         std::ofstream f(tmp.path());
-        f << ""label" = "First";
-";
-        f << ""label" = "Second";
-";
-        f << ""other" = "Value";
-";
+        f << "\"label\" = \"First\";\n";
+        f << "\"label\" = \"Second\";\n";
+        f << "\"other\" = \"Value\";\n";
     }
 
     LocalisedStrings strings;

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -88,6 +88,7 @@ TEST_CASE("Uuid string round-trip", "[runtime][identity]") {
         REQUIRE(Uuid::from_string("00112233-4455-6677-8899-aabbccddeefg").is_nil());
         REQUIRE(Uuid::from_string("00112233445566778899aabb-ccddeeff").is_nil());
         REQUIRE(Uuid::from_string("001122334455-6677-8899-aabbccddeeff").is_nil());
+        REQUIRE(Uuid::from_string("0011223344556677-8899-aabb-ccdd-eeff").is_nil());
         REQUIRE(Uuid::from_string("00112233445566778899aabbccddeeff00").is_nil());
     }
 }

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -107,6 +107,12 @@ TEST_CASE("Uuid ordering and hashing cover deterministic values", "[runtime][ide
     REQUIRE(ids.size() == 2);
 }
 
+TEST_CASE("Uuid parsing rejects malformed dashed layout",
+          "[runtime][identity][coverage][issue-656]") {
+    auto parsed = Uuid::from_string("0011223344556677-8899-aabb-ccdd-eeff");
+    REQUIRE(parsed.is_nil());
+}
+
 TEST_CASE("Uuid parsing accepts uppercase dashed and compact hex",
           "[runtime][identity][issue-641]") {
     Uuid id;

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -67,6 +67,12 @@ TEST_CASE("Uuid string round-trip", "[runtime][identity]") {
         REQUIRE(parsed == original);
     }
 
+    SECTION("from_string accepts uppercase hex") {
+        auto parsed = Uuid::from_string("00112233-4455-6677-8899-AABBCCDDEEFF");
+        REQUIRE_FALSE(parsed.is_nil());
+        REQUIRE(parsed.to_string() == "00112233-4455-6677-8899-aabbccddeeff");
+    }
+
     SECTION("Nil UUID") {
         Uuid nil;
         REQUIRE(nil.is_nil());
@@ -77,6 +83,26 @@ TEST_CASE("Uuid string round-trip", "[runtime][identity]") {
         auto parsed = Uuid::from_string("not-a-uuid");
         REQUIRE(parsed.is_nil());
     }
+
+    SECTION("Invalid hex digits and misplaced dashes return nil") {
+        REQUIRE(Uuid::from_string("00112233-4455-6677-8899-aabbccddeefg").is_nil());
+        REQUIRE(Uuid::from_string("001122334455-6677-8899-aabbccddeeff").is_nil());
+        REQUIRE(Uuid::from_string("00112233445566778899aabbccddeeff00").is_nil());
+    }
+}
+
+TEST_CASE("Uuid ordering and hashing cover deterministic values", "[runtime][identity][coverage][issue-656]") {
+    auto low = Uuid::from_string("00000000-0000-0000-0000-000000000001");
+    auto high = Uuid::from_string("00000000-0000-0000-0000-000000000002");
+
+    REQUIRE(low < high);
+    REQUIRE_FALSE(high < low);
+
+    std::unordered_set<Uuid> ids;
+    ids.insert(low);
+    ids.insert(high);
+    ids.insert(Uuid::from_string(low.to_hex()));
+    REQUIRE(ids.size() == 2);
 }
 
 TEST_CASE("Typed identity wrappers", "[runtime][identity]") {

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -86,6 +86,7 @@ TEST_CASE("Uuid string round-trip", "[runtime][identity]") {
 
     SECTION("Invalid hex digits and misplaced dashes return nil") {
         REQUIRE(Uuid::from_string("00112233-4455-6677-8899-aabbccddeefg").is_nil());
+        REQUIRE(Uuid::from_string("00112233445566778899aabb-ccddeeff").is_nil());
         REQUIRE(Uuid::from_string("001122334455-6677-8899-aabbccddeeff").is_nil());
         REQUIRE(Uuid::from_string("00112233445566778899aabbccddeeff00").is_nil());
     }

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -79,6 +79,27 @@ TEST_CASE("Uuid string round-trip", "[runtime][identity]") {
     }
 }
 
+TEST_CASE("Uuid parsing accepts uppercase dashed and compact hex",
+          "[runtime][identity][issue-641]") {
+    Uuid id;
+    id.hi = 0x0123456789abcdefULL;
+    id.lo = 0xfedcba9876543210ULL;
+
+    REQUIRE(Uuid::from_string("01234567-89AB-CDEF-FEDC-BA9876543210") == id);
+    REQUIRE(Uuid::from_string("0123456789ABCDEFFEDCBA9876543210") == id);
+}
+
+TEST_CASE("Uuid ordering sorts by high word before low word",
+          "[runtime][identity][issue-641]") {
+    Uuid low{1, 999};
+    Uuid middle{2, 1};
+    Uuid high{2, 2};
+
+    REQUIRE(low < middle);
+    REQUIRE(middle < high);
+    REQUIRE_FALSE(high < middle);
+}
+
 TEST_CASE("Typed identity wrappers", "[runtime][identity]") {
     SECTION("SessionId") {
         auto sid = SessionId::generate();
@@ -121,6 +142,19 @@ TEST_CASE("Typed identity wrappers", "[runtime][identity]") {
         REQUIRE(sessions.size() == 1);
         REQUIRE(objects.size() == 1);
     }
+}
+
+TEST_CASE("Typed identity nil and hashing are stable", "[runtime][identity][issue-641]") {
+    REQUIRE(SessionId::nil() == SessionId::nil());
+    REQUIRE(RunId::nil() == RunId::nil());
+    REQUIRE(ObjectId::nil() == ObjectId::from_string("00000000000000000000000000000000"));
+    REQUIRE(CorrelationId::nil() == CorrelationId::nil());
+
+    auto object = ObjectId::generate();
+    std::unordered_set<ObjectId> objects;
+    objects.insert(object);
+    objects.insert(object);
+    REQUIRE(objects.size() == 1);
 }
 
 TEST_CASE("EventEnvelope", "[runtime][identity]") {

--- a/test/test_ipc_endpoints.cpp
+++ b/test/test_ipc_endpoints.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/events/interprocess_connection.hpp>
 
+#include <string_view>
+#include <vector>
+
 using namespace pulp::events;
 
 TEST_CASE("IPC socket endpoints reject empty ports without opening connections",
@@ -31,4 +34,92 @@ TEST_CASE("IPC socket listener rejects empty endpoint strings",
 
     server.stop();
     REQUIRE_FALSE(server.is_running());
+}
+
+TEST_CASE("IPC socket client rejects malformed port strings without connecting",
+          "[events][ipc][endpoint][issue-642]") {
+    const std::vector<std::string_view> endpoints = {
+        "127.0.0.1:not-a-port",
+        "127.0.0.1:12x",
+        "127.0.0.1:+12",
+        "127.0.0.1:-1",
+        "127.0.0.1: 12",
+        "127.0.0.1:12 ",
+        "127.0.0.1:65536",
+        "127.0.0.1:999999999999",
+    };
+
+    for (auto endpoint : endpoints) {
+        InterprocessConnection client;
+        REQUIRE_FALSE(client.connect(endpoint, IpcTransport::Socket));
+        REQUIRE(client.state() == IpcState::Error);
+        REQUIRE_FALSE(client.is_connected());
+    }
+}
+
+TEST_CASE("IPC socket connection-server rejects malformed port strings",
+          "[events][ipc][endpoint][issue-642]") {
+    const std::vector<std::string_view> endpoints = {
+        "127.0.0.1:not-a-port",
+        "127.0.0.1:12x",
+        "127.0.0.1:+12",
+        "127.0.0.1:-1",
+        "127.0.0.1: 12",
+        "127.0.0.1:12 ",
+        "127.0.0.1:65536",
+        "127.0.0.1:999999999999",
+    };
+
+    for (auto endpoint : endpoints) {
+        InterprocessConnection connection;
+        REQUIRE_FALSE(connection.create_server(endpoint, IpcTransport::Socket));
+        REQUIRE(connection.state() == IpcState::Error);
+        REQUIRE_FALSE(connection.is_connected());
+    }
+}
+
+TEST_CASE("IPC socket listener rejects malformed port strings without staying running",
+          "[events][ipc][endpoint][issue-642]") {
+    const std::vector<std::string_view> endpoints = {
+        "not-a-port",
+        "12x",
+        "+12",
+        "-1",
+        " 12",
+        "12 ",
+        "127.0.0.1:not-a-port",
+        "127.0.0.1:12x",
+        "127.0.0.1:+12",
+        "127.0.0.1:-1",
+        "127.0.0.1: 12",
+        "127.0.0.1:12 ",
+        "127.0.0.1:65536",
+        "127.0.0.1:999999999999",
+    };
+
+    for (auto endpoint : endpoints) {
+        InterprocessConnectionServer server;
+        REQUIRE_FALSE(server.start(endpoint, IpcTransport::Socket));
+        REQUIRE_FALSE(server.is_running());
+        server.stop();
+        REQUIRE_FALSE(server.is_running());
+    }
+}
+
+TEST_CASE("IPC socket endpoint failure can be reset with disconnect",
+          "[events][ipc][endpoint][issue-642]") {
+    InterprocessConnection connection;
+
+    REQUIRE_FALSE(connection.connect("127.0.0.1:bad", IpcTransport::Socket));
+    REQUIRE(connection.state() == IpcState::Error);
+
+    connection.disconnect();
+    REQUIRE(connection.state() == IpcState::Disconnected);
+    REQUIRE_FALSE(connection.is_connected());
+
+    REQUIRE_FALSE(connection.create_server("127.0.0.1:bad", IpcTransport::Socket));
+    REQUIRE(connection.state() == IpcState::Error);
+
+    connection.disconnect();
+    REQUIRE(connection.state() == IpcState::Disconnected);
 }

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -291,3 +291,81 @@ TEST_CASE("JsonRpcPeer reports closed and failed sends", "[json_rpc]") {
     channel.deliver_text(R"json({"jsonrpc":"2.0","id":1,"result":true})json");
     REQUIRE_FALSE(callback_called);
 }
+
+TEST_CASE("JsonRpcPeer omits params for empty request payloads",
+          "[json_rpc][coverage][issue-641]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string outbound_request;
+    pair.second->on_message([&](const Message& message) {
+        outbound_request.assign(message.as_text());
+    });
+
+    JsonRpcPeer client(*pair.first);
+    std::atomic<int> callbacks{0};
+    std::string result;
+    REQUIRE(client.send_request("noParams", "", [&](const JsonRpcResult& response) {
+        result = response.result_json;
+        callbacks.fetch_add(1);
+    }));
+
+    REQUIRE(outbound_request.find(R"("method":"noParams")") != std::string::npos);
+    REQUIRE(outbound_request.find(R"("params")") == std::string::npos);
+
+    pair.second->send_text(R"json({"jsonrpc":"2.0","id":1,"result":{"ok":true}})json");
+    REQUIRE(wait_until([&] { return callbacks.load() == 1; }));
+    REQUIRE(result.find(R"("ok")") != std::string::npos);
+    REQUIRE(result.find("true") != std::string::npos);
+}
+
+TEST_CASE("JsonRpcPeer preserves string request ids in responses",
+          "[json_rpc][coverage][issue-641]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string reply;
+    pair.first->on_message([&](const Message& message) {
+        reply.assign(message.as_text());
+    });
+
+    JsonRpcPeer server(*pair.second);
+    server.register_method("echo", [](std::string_view params) {
+        return JsonRpcResult::ok(std::string(params));
+    });
+
+    pair.first->send_text(
+        R"json({"jsonrpc":"2.0","id":"abc-123","method":"echo","params":{"value":7}})json");
+
+    REQUIRE(reply.find(R"("id":"abc-123")") != std::string::npos);
+    REQUIRE(reply.find(R"("value")") != std::string::npos);
+    REQUIRE(reply.find("7") != std::string::npos);
+}
+
+TEST_CASE("JsonRpcPeer dispatches incoming error responses with data",
+          "[json_rpc][coverage][issue-641]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string outbound_request;
+    pair.second->on_message([&](const Message& message) {
+        outbound_request.assign(message.as_text());
+    });
+
+    JsonRpcPeer client(*pair.first);
+    std::atomic<bool> done{false};
+    std::optional<JsonRpcError> error;
+
+    REQUIRE(client.send_request("willFail", "[]", [&](const JsonRpcResult& response) {
+        error = response.error;
+        done.store(true);
+    }));
+    REQUIRE(outbound_request.find(R"("id":1)") != std::string::npos);
+
+    pair.second->send_text(
+        R"json({"jsonrpc":"2.0","id":1,"error":{"code":-32099,"message":"custom","data":{"retry":false}}})json");
+
+    REQUIRE(wait_until([&] { return done.load(); }));
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == -32099);
+    REQUIRE(error->message == "custom");
+    REQUIRE(error->data_json.find(R"("retry")") != std::string::npos);
+    REQUIRE(error->data_json.find("false") != std::string::npos);
+}

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -144,9 +144,9 @@ TEST_CASE("LicenseValidator validate_and_parse includes optional machine and exp
           "[crypto][license][coverage][issue-656]") {
     LicenseValidator validator;
 
-    std::string payload = "{"product_id":"PulpSuite","email":"user@example.com","
-                          ""machine_id":"machine-1","edition":"team","
-                          ""issued":1700000000,"expiry":1800000000}";
+    std::string payload = "{\"product_id\":\"PulpSuite\",\"email\":\"user@example.com\","
+                          "\"machine_id\":\"machine-1\",\"edition\":\"team\","
+                          "\"issued\":1700000000,\"expiry\":1800000000}";
     auto info = validator.validate_and_parse(base64_encode(payload) + ".sig");
     REQUIRE(info.has_value());
     REQUIRE(info->product_id == "PulpSuite");

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -119,6 +119,25 @@ TEST_CASE("LicenseValidator validate_and_parse extracts info", "[crypto][license
     REQUIRE(info->edition == "pro");
 }
 
+TEST_CASE("LicenseValidator validate_and_parse extracts optional machine and expiry",
+          "[crypto][license][issue-641]") {
+    LicenseValidator validator;
+
+    std::string payload =
+        "{\"product_id\":\"PulpSynth\",\"email\":\"user@example.com\","
+        "\"machine_id\":\"machine-1\",\"edition\":\"studio\","
+        "\"issued\":1700000000,\"expiry\":1800000000}";
+    auto info = validator.validate_and_parse(base64_encode(payload) + ".sig");
+
+    REQUIRE(info.has_value());
+    REQUIRE(info->product_id == "PulpSynth");
+    REQUIRE(info->user_email == "user@example.com");
+    REQUIRE(info->machine_id == "machine-1");
+    REQUIRE(info->edition == "studio");
+    REQUIRE(info->issued_timestamp == 1700000000);
+    REQUIRE(info->expiry_timestamp == 1800000000);
+}
+
 TEST_CASE("LicenseValidator validate_and_parse rejects malformed payloads", "[crypto][license]") {
     LicenseValidator validator;
 
@@ -166,6 +185,28 @@ TEST_CASE("LicenseValidator validate_file trims line endings", "[crypto][license
 
     LicenseValidator validator;
     REQUIRE(validator.validate_file(tmp.path_string()) == LicenseStatus::InvalidSignature);
+}
+
+TEST_CASE("LicenseValidator validate_file accepts file without trailing newline",
+          "[crypto][license][issue-641]") {
+    TemporaryFile tmp(".license");
+    std::string payload = "{\"product_id\":\"PulpSynth\",\"issued\":1700000000}";
+    std::string key = base64_encode(payload) + "." + base64_encode("signature");
+
+    {
+        std::ofstream out(tmp.path());
+        REQUIRE(out.good());
+        out << key;
+    }
+
+    LicenseValidator validator;
+    REQUIRE(validator.validate_file(tmp.path_string()) == LicenseStatus::InvalidSignature);
+}
+
+TEST_CASE("LicenseValidator validate rejects empty payload section",
+          "[crypto][license][issue-641]") {
+    LicenseValidator validator;
+    REQUIRE(validator.validate(".sig") == LicenseStatus::InvalidSignature);
 }
 
 TEST_CASE("LicenseGenerator requires a usable private key", "[crypto][license]") {

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -77,6 +77,27 @@ TEST_CASE("BigInteger large numbers", "[crypto][bigint]") {
     REQUIRE(c.to_string() == "1000000000000000000");
 }
 
+TEST_CASE("BigInteger copy move hex and bit-count helpers", "[crypto][bigint][coverage][issue-656]") {
+    auto value = BigInteger::from_hex("0100");
+    REQUIRE(value.to_string() == "256");
+    REQUIRE(value.to_hex() == "0100");
+    REQUIRE(value.bit_count() == 9);
+
+    BigInteger copied(value);
+    REQUIRE(copied == value);
+
+    BigInteger assigned;
+    assigned = copied;
+    REQUIRE(assigned == value);
+
+    BigInteger moved(std::move(assigned));
+    REQUIRE(moved == value);
+
+    BigInteger move_assigned;
+    move_assigned = std::move(moved);
+    REQUIRE(move_assigned.to_string() == "256");
+}
+
 // ── License ─────────────────────────────────────────────────────────────
 
 TEST_CASE("LicenseValidator invalid format", "[crypto][license]") {
@@ -117,6 +138,23 @@ TEST_CASE("LicenseValidator validate_and_parse extracts info", "[crypto][license
     REQUIRE(info->product_id == "PulpGain");
     REQUIRE(info->user_email == "user@example.com");
     REQUIRE(info->edition == "pro");
+}
+
+TEST_CASE("LicenseValidator validate_and_parse includes optional machine and expiry fields",
+          "[crypto][license][coverage][issue-656]") {
+    LicenseValidator validator;
+
+    std::string payload = "{\"product_id\":\"PulpSuite\",\"email\":\"user@example.com\","
+                          "\"machine_id\":\"machine-1\",\"edition\":\"team\","
+                          "\"issued\":1700000000,\"expiry\":1800000000}";
+    auto info = validator.validate_and_parse(base64_encode(payload) + ".sig");
+    REQUIRE(info.has_value());
+    REQUIRE(info->product_id == "PulpSuite");
+    REQUIRE(info->user_email == "user@example.com");
+    REQUIRE(info->machine_id == "machine-1");
+    REQUIRE(info->edition == "team");
+    REQUIRE(info->issued_timestamp == 1700000000);
+    REQUIRE(info->expiry_timestamp == 1800000000);
 }
 
 TEST_CASE("LicenseValidator validate_and_parse rejects malformed payloads", "[crypto][license]") {
@@ -179,4 +217,10 @@ TEST_CASE("LicenseGenerator requires a usable private key", "[crypto][license]")
 
     generator.set_private_key("not a pem key");
     REQUIRE_FALSE(generator.generate(info).has_value());
+}
+
+TEST_CASE("OnlineActivation rejects malformed server URLs without network", "[crypto][license][coverage][issue-656]") {
+    REQUIRE_FALSE(OnlineActivation::activate("not-a-url", "serial", "product").has_value());
+    REQUIRE_FALSE(OnlineActivation::deactivate("not-a-url", "license"));
+    REQUIRE(OnlineActivation::check_status("not-a-url", "license") == LicenseStatus::NotFound);
 }

--- a/test/test_memory_message_channel.cpp
+++ b/test/test_memory_message_channel.cpp
@@ -68,6 +68,64 @@ TEST_CASE("MemoryMessageChannel send succeeds without peer callback",
     REQUIRE(left->send_text("nobody-listens"));
 }
 
+TEST_CASE("MemoryMessageChannel delivers zero-length binary and text payloads",
+          "[runtime][message_channel][coverage][issue-641]") {
+    auto [left, right] = MemoryMessageChannel::make_pair();
+
+    std::vector<Message> received;
+    right->on_message([&](const Message& message) {
+        received.push_back(message);
+    });
+
+    std::uint8_t empty = 0;
+    REQUIRE(left->send(&empty, 0));
+    REQUIRE(left->send_text(""));
+
+    REQUIRE(received.size() == 2);
+    REQUIRE(received[0].kind == MessageKind::Binary);
+    REQUIRE(received[0].payload.empty());
+    REQUIRE(received[1].kind == MessageKind::Text);
+    REQUIRE(received[1].payload.empty());
+    REQUIRE(received[1].as_text().empty());
+}
+
+TEST_CASE("MemoryMessageChannel can clear callbacks while remaining open",
+          "[runtime][message_channel][coverage][issue-641]") {
+    auto [left, right] = MemoryMessageChannel::make_pair();
+
+    int calls = 0;
+    right->on_message([&](const Message&) { ++calls; });
+    REQUIRE(left->send_text("before-clear"));
+    REQUIRE(calls == 1);
+
+    right->on_message({});
+    REQUIRE(left->send_text("after-clear"));
+    REQUIRE(calls == 1);
+    REQUIRE(left->is_open());
+    REQUIRE(right->is_open());
+}
+
+TEST_CASE("MemoryMessageChannel text views preserve embedded NUL bytes",
+          "[runtime][message_channel][coverage][issue-641]") {
+    auto [left, right] = MemoryMessageChannel::make_pair();
+
+    std::string text = "prefix";
+    text.push_back('\0');
+    text += "suffix";
+
+    std::string_view view;
+    Message received;
+    right->on_message([&](const Message& message) {
+        received = message;
+        view = received.as_text();
+    });
+
+    REQUIRE(left->send_text(text));
+    REQUIRE(received.kind == MessageKind::Text);
+    REQUIRE(view.size() == text.size());
+    REQUIRE(std::string(view) == text);
+}
+
 TEST_CASE("MemoryMessageChannel close is peer-wide and idempotent",
           "[runtime][message_channel]") {
     auto [left, right] = MemoryMessageChannel::make_pair();

--- a/test/test_network_service_discovery.cpp
+++ b/test/test_network_service_discovery.cpp
@@ -318,6 +318,96 @@ TEST_CASE("NSD removing backend stops old backend and evicts discoveries",
     REQUIRE_FALSE(nsd.register_service("svc", "_pulp._tcp", 1234));
 }
 
+TEST_CASE("NSD caches same-name services separately by type",
+          "[events][service-discovery][issue-642]") {
+    NetworkServiceDiscovery nsd;
+    nsd.install_backend(std::make_unique<FakeBackend>());
+
+    NetworkServiceDiscovery::Service http;
+    http.name = "pulpd";
+    http.type = "_http._tcp";
+    http.hostname = "http.local";
+    http.port = 80;
+
+    NetworkServiceDiscovery::Service pulp = http;
+    pulp.type = "_pulp._tcp";
+    pulp.hostname = "pulp.local";
+    pulp.port = 4321;
+
+    nsd.notify_service_found(http);
+    nsd.notify_service_found(pulp);
+    REQUIRE(nsd.discovered().size() == 2);
+
+    nsd.notify_service_lost(http);
+    REQUIRE(nsd.discovered().size() == 1);
+    REQUIRE(nsd.discovered().front().type == "_pulp._tcp");
+    REQUIRE(nsd.discovered().front().hostname == "pulp.local");
+}
+
+TEST_CASE("NSD install_backend nullptr without discoveries only stops old backend",
+          "[events][service-discovery][issue-642]") {
+    NetworkServiceDiscovery nsd;
+    auto backend = std::make_unique<FakeBackend>();
+    auto log = backend->log;
+    nsd.install_backend(std::move(backend));
+
+    int lost_count = 0;
+    nsd.on_service_lost = [&](const NetworkServiceDiscovery::Service&) {
+        ++lost_count;
+    };
+
+    nsd.install_backend(nullptr);
+    REQUIRE_FALSE(nsd.has_backend());
+    REQUIRE(nsd.discovered().empty());
+    REQUIRE(lost_count == 0);
+    REQUIRE(log->stopped == 1);
+    REQUIRE_FALSE(nsd.register_service("svc", "_pulp._tcp", 1234));
+}
+
+TEST_CASE("NSD stop forwards to backend even before browsing",
+          "[events][service-discovery][issue-642]") {
+    NetworkServiceDiscovery nsd;
+    auto backend = std::make_unique<FakeBackend>();
+    auto log = backend->log;
+    nsd.install_backend(std::move(backend));
+
+    nsd.stop();
+    nsd.stop();
+
+    REQUIRE(log->stopped == 2);
+    REQUIRE(nsd.has_backend());
+}
+
+TEST_CASE("NSD discovery stores entries when callbacks are absent",
+          "[events][service-discovery][issue-642]") {
+    NetworkServiceDiscovery nsd;
+    nsd.install_backend(std::make_unique<FakeBackend>());
+
+    NetworkServiceDiscovery::Service svc;
+    svc.name = "pulpd";
+    svc.type = "_pulp._tcp";
+    svc.hostname = "pulpd.local";
+    svc.address = "127.0.0.1";
+    svc.port = 4321;
+
+    nsd.notify_service_found(svc);
+    REQUIRE(nsd.discovered().size() == 1);
+
+    nsd.notify_service_lost(svc);
+    REQUIRE(nsd.discovered().empty());
+}
+
+TEST_CASE("LockingAsyncUpdater trigger_and_wait handles every call synchronously",
+          "[events][service-discovery][locking-updater][issue-642]") {
+    RecordingLockingUpdater updater;
+
+    updater.trigger_and_wait();
+    updater.trigger_and_wait();
+    updater.trigger_and_wait();
+
+    REQUIRE(updater.handles.load() == 3);
+}
+
 TEST_CASE("NSD backend swap clears discoveries without lost callback",
           "[events][service-discovery][issue-642]") {
     NetworkServiceDiscovery nsd;

--- a/test/test_permissions.cpp
+++ b/test/test_permissions.cpp
@@ -162,6 +162,35 @@ TEST_CASE("nested PermissionsOverride clear exposes backend then restores outer 
     REQUIRE(query(Permission::Microphone) == outer_state);
 }
 
+TEST_CASE("PermissionsOverride clear on missing entries is a no-op",
+          "[platform][permissions][override][coverage][issue-649]") {
+    const auto backend_microphone = query(Permission::Microphone);
+    const auto backend_camera = query(Permission::Camera);
+
+    PermissionsOverride guard;
+    guard.clear(Permission::Microphone);
+    REQUIRE(query(Permission::Microphone) == backend_microphone);
+
+    guard.set(Permission::Camera, state_different_from(backend_camera));
+    guard.clear(Permission::Microphone);
+    REQUIRE(query(Permission::Microphone) == backend_microphone);
+    REQUIRE(query(Permission::Camera) == state_different_from(backend_camera));
+}
+
+TEST_CASE("empty nested PermissionsOverride preserves outer entries",
+          "[platform][permissions][override][coverage][issue-649]") {
+    const auto backend_microphone = query(Permission::Microphone);
+    const auto outer_state = state_different_from(backend_microphone);
+
+    PermissionsOverride outer;
+    outer.set(Permission::Microphone, outer_state);
+    {
+        PermissionsOverride inner;
+        REQUIRE(query(Permission::Microphone) == outer_state);
+    }
+    REQUIRE(query(Permission::Microphone) == outer_state);
+}
+
 TEST_CASE("has_platform_backend reports truthfully for the current target",
           "[platform][permissions]") {
 #if defined(PULP_PERMISSIONS_HAS_BACKEND)

--- a/test/test_platform.cpp
+++ b/test/test_platform.cpp
@@ -1,7 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/platform/platform.hpp>
 #include <pulp/platform/popup_menu.hpp>
+#include <pulp/platform/progress_parser.hpp>
 #include <pulp/platform/win/registry.hpp>
+
+#include <vector>
 
 using namespace pulp::platform;
 
@@ -71,6 +74,46 @@ TEST_CASE("PopupMenu records items and separators",
     REQUIRE_FALSE(items[2].enabled);
     REQUIRE(items[2].checked);
     REQUIRE_FALSE(items[2].is_separator);
+}
+
+TEST_CASE("ProgressParser accepts payloads, empty payloads, and type-only lines",
+          "[platform][progress][coverage][issue-649]") {
+    std::vector<ProgressEvent> events;
+    ProgressParser parser([&](const ProgressEvent& e) {
+        events.push_back(e);
+    });
+
+    parser.feed_line("PROGRESS:DOWNLOAD_START:https://example.test/file.zip");
+    parser.feed_line("PROGRESS:OVERALL:42");
+    parser.feed_line("PROGRESS:EMPTY:");
+    parser.feed_line("PROGRESS:TYPE_ONLY");
+
+    REQUIRE(events.size() == 4);
+    REQUIRE(events[0].type == "DOWNLOAD_START");
+    REQUIRE(events[0].payload == "https://example.test/file.zip");
+    REQUIRE(events[1].type == "OVERALL");
+    REQUIRE(events[1].payload == "42");
+    REQUIRE(events[2].type == "EMPTY");
+    REQUIRE(events[2].payload.empty());
+    REQUIRE(events[3].type == "TYPE_ONLY");
+    REQUIRE(events[3].payload.empty());
+}
+
+TEST_CASE("ProgressParser ignores non-progress lines and tolerates empty callbacks",
+          "[platform][progress][coverage][issue-649]") {
+    int calls = 0;
+    ProgressParser parser([&](const ProgressEvent&) { ++calls; });
+
+    parser.feed_line("");
+    parser.feed_line("progress:LOWERCASE:ignored");
+    parser.feed_line("INFO:PROGRESS:OVERALL:1");
+    parser.feed_line("PROGRESSISH:OVERALL:1");
+    REQUIRE(calls == 0);
+
+    ProgressParser empty_callback({});
+    empty_callback.feed_line("PROGRESS:OVERALL:100");
+    empty_callback.feed_line("PROGRESS:TYPE_ONLY");
+    SUCCEED("empty callbacks are inert");
 }
 
 #if !defined(__APPLE__)

--- a/test/test_properties_file.cpp
+++ b/test/test_properties_file.cpp
@@ -4,6 +4,7 @@
 #include <pulp/runtime/temporary_file.hpp>
 #include <filesystem>
 #include <fstream>
+#include <random>
 
 using namespace pulp::state;
 using namespace pulp::runtime;
@@ -35,6 +36,21 @@ TEST_CASE("PropertiesFile numeric getters reject invalid stored strings", "[stat
 
     REQUIRE_FALSE(props.get_int("count").has_value());
     REQUIRE_FALSE(props.get_double("gain").has_value());
+}
+
+TEST_CASE("PropertiesFile bool getter treats stored false-like values as false",
+          "[state][properties][issue-641]") {
+    PropertiesFile props;
+    props.set_string("word_false", "false");
+    props.set_string("zero", "0");
+    props.set_string("garbage", "not-a-bool");
+
+    REQUIRE(props.get_bool("word_false").has_value());
+    REQUIRE_FALSE(*props.get_bool("word_false"));
+    REQUIRE(props.get_bool("zero").has_value());
+    REQUIRE_FALSE(*props.get_bool("zero"));
+    REQUIRE(props.get_bool("garbage").has_value());
+    REQUIRE_FALSE(*props.get_bool("garbage"));
 }
 
 TEST_CASE("PropertiesFile set and get int", "[state][properties]") {
@@ -157,6 +173,21 @@ TEST_CASE("PropertiesFile load invalid JSON returns false", "[state][properties]
     REQUIRE_FALSE(props.load(tmp.path_string()));
 }
 
+TEST_CASE("PropertiesFile load non-object JSON leaves existing values intact",
+          "[state][properties][issue-641]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << "[\"not\", \"an\", \"object\"]";
+    }
+
+    PropertiesFile props;
+    props.set_string("stale", "value");
+    REQUIRE_FALSE(props.load(tmp.path_string()));
+    REQUIRE(props.get_string("stale").value_or("") == "value");
+    REQUIRE(props.path() == tmp.path_string());
+}
+
 TEST_CASE("PropertiesFile load empty file clears existing values", "[state][properties]") {
     TemporaryFile tmp(".json");
     {
@@ -171,11 +202,53 @@ TEST_CASE("PropertiesFile load empty file clears existing values", "[state][prop
     REQUIRE(props.size() == 0);
 }
 
+TEST_CASE("PropertiesFile load skips unsupported JSON member types",
+          "[state][properties][json][issue-641]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << R"JSON({
+            "name": "Pulp",
+            "enabled": true,
+            "count": 7,
+            "gain": 0.5,
+            "ignored_null": null,
+            "ignored_array": [1, 2],
+            "ignored_object": {"nested": true}
+        })JSON";
+    }
+
+    PropertiesFile props;
+    REQUIRE(props.load(tmp.path_string()));
+    REQUIRE(props.size() == 4);
+    REQUIRE(props.get_string("name").value_or("") == "Pulp");
+    REQUIRE(props.get_bool("enabled").value_or(false));
+    REQUIRE(props.get_int("count").value_or(0) == 7);
+    REQUIRE_THAT(props.get_double("gain").value_or(0.0), WithinAbs(0.5, 1e-9));
+    REQUIRE_FALSE(props.contains("ignored_null"));
+    REQUIRE_FALSE(props.contains("ignored_array"));
+    REQUIRE_FALSE(props.contains("ignored_object"));
+}
+
 TEST_CASE("PropertiesFile save without path returns false", "[state][properties]") {
     PropertiesFile props;
     props.set_string("key", "value");
 
     REQUIRE_FALSE(props.save());
+}
+
+TEST_CASE("PropertiesFile save fails when destination is a directory",
+          "[state][properties][issue-641]") {
+    auto dir = std::filesystem::temp_directory_path() /
+               ("pulp_props_dir_dest_" + std::to_string(std::random_device{}()));
+    std::filesystem::create_directories(dir);
+
+    PropertiesFile props;
+    props.set_string("key", "value");
+    REQUIRE_FALSE(props.save(dir.string()));
+    REQUIRE(props.path() == dir.string());
+
+    std::filesystem::remove_all(dir);
 }
 
 TEST_CASE("PropertiesFile save creates parent directories", "[state][properties]") {
@@ -207,6 +280,21 @@ TEST_CASE("PropertiesFile save and reload preserves path", "[state][properties]"
     PropertiesFile props2;
     REQUIRE(props2.load(tmp.path_string()));
     REQUIRE(props2.get_string("key2").value_or("") == "val2");
+}
+
+TEST_CASE("PropertiesFile remove missing key and clear empty file are no-ops",
+          "[state][properties][issue-641]") {
+    PropertiesFile props;
+    props.remove("missing");
+    REQUIRE(props.size() == 0);
+
+    props.clear();
+    REQUIRE(props.keys().empty());
+
+    props.set_string("present", "yes");
+    props.remove("missing");
+    REQUIRE(props.size() == 1);
+    REQUIRE(props.contains("present"));
 }
 
 // ── ApplicationProperties ───────────────────────────────────────────────

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -49,6 +49,29 @@ TEST_CASE("SpscQueue basic operations", "[runtime][spsc]") {
     }
 }
 
+TEST_CASE("SpscQueue reuses slots after wrap-around",
+          "[runtime][spsc][coverage][issue-641]") {
+    SpscQueue<int, 4> q;
+    REQUIRE(q.capacity() == 4);
+
+    for (int cycle = 0; cycle < 3; ++cycle) {
+        REQUIRE(q.empty());
+        for (int i = 0; i < 4; ++i) {
+            REQUIRE(q.try_push(cycle * 10 + i));
+        }
+        REQUIRE_FALSE(q.try_push(999));
+        REQUIRE(q.size_approx() == 4);
+        for (int i = 0; i < 4; ++i) {
+            auto value = q.try_pop();
+            REQUIRE(value.has_value());
+            REQUIRE(*value == cycle * 10 + i);
+        }
+    }
+
+    REQUIRE(q.empty());
+    REQUIRE_FALSE(q.try_pop().has_value());
+}
+
 TEST_CASE("SpscQueue cross-thread", "[runtime][spsc]") {
     SpscQueue<int, 1024> q;
     constexpr int count = 10000;
@@ -106,6 +129,16 @@ TEST_CASE("ScopeGuard move transfers cleanup ownership", "[runtime][scope_guard]
         auto guard = make_scope_guard([&] { ++calls; });
         auto moved = std::move(guard);
         static_cast<void>(moved);
+    }
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("PULP_ON_SCOPE_EXIT runs at block exit",
+          "[runtime][scope_guard][coverage][issue-641]") {
+    int calls = 0;
+    {
+        PULP_ON_SCOPE_EXIT(++calls);
+        REQUIRE(calls == 0);
     }
     REQUIRE(calls == 1);
 }

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -8,8 +8,10 @@
 #include <pulp/runtime/http.hpp>
 #include <pulp/runtime/range.hpp>
 #include <pulp/runtime/text_diff.hpp>
+#include <algorithm>
 #include <fstream>
 #include <filesystem>
+#include <iterator>
 
 using namespace pulp::runtime;
 
@@ -87,6 +89,52 @@ TEST_CASE("MemoryMappedFile move semantics", "[runtime][mmap]") {
     REQUIRE_FALSE(a.is_open());
 }
 
+TEST_CASE("MemoryMappedFile ReadWrite mode persists byte edits",
+          "[runtime][mmap][coverage][issue-641]") {
+    TemporaryFile tmp(".bin");
+    {
+        std::ofstream f(tmp.path(), std::ios::binary);
+        f << "abcde";
+    }
+
+    MemoryMappedFile mmap;
+    REQUIRE(mmap.open(tmp.path_string(), MapMode::ReadWrite));
+    REQUIRE(mmap.is_open());
+    REQUIRE(mmap.size() == 5);
+    REQUIRE(mmap.mutable_data() != nullptr);
+
+    mmap.mutable_data()[1] = static_cast<uint8_t>('A');
+    mmap.mutable_data()[3] = static_cast<uint8_t>('D');
+    mmap.close();
+    REQUIRE_FALSE(mmap.is_open());
+
+    std::ifstream f(tmp.path(), std::ios::binary);
+    std::string contents((std::istreambuf_iterator<char>(f)),
+                         std::istreambuf_iterator<char>());
+    REQUIRE(contents == "aAcDe");
+}
+
+TEST_CASE("MemoryMappedFile open failure clears an existing mapping",
+          "[runtime][mmap][coverage][issue-641]") {
+    TemporaryFile mapped(".bin");
+    {
+        std::ofstream f(mapped.path(), std::ios::binary);
+        f << "mapped";
+    }
+
+    TemporaryFile empty(".bin");
+
+    MemoryMappedFile mmap;
+    REQUIRE(mmap.open(mapped.path_string()));
+    REQUIRE(mmap.is_open());
+    REQUIRE(mmap.size() == 6);
+
+    REQUIRE_FALSE(mmap.open(empty.path_string()));
+    REQUIRE_FALSE(mmap.is_open());
+    REQUIRE(mmap.data() == nullptr);
+    REQUIRE(mmap.size() == 0);
+}
+
 // ── DynamicLibrary ──────────────────────────────────────────────────────
 
 TEST_CASE("DynamicLibrary loads system library", "[runtime][dynlib]") {
@@ -128,6 +176,25 @@ TEST_CASE("InterProcessLock double lock succeeds", "[runtime][ipc_lock]") {
     InterProcessLock lock("test_lock_double");
     REQUIRE(lock.try_lock());
     REQUIRE(lock.try_lock());  // Already locked, should still return true
+}
+
+TEST_CASE("InterProcessLock unlock is idempotent and permits reacquire",
+          "[runtime][ipc_lock][coverage][issue-641]") {
+    InterProcessLock lock("test_lock_reacquire");
+    REQUIRE_FALSE(lock.is_locked());
+
+    lock.unlock();
+    REQUIRE_FALSE(lock.is_locked());
+
+    REQUIRE(lock.try_lock());
+    REQUIRE(lock.is_locked());
+    lock.unlock();
+    REQUIRE_FALSE(lock.is_locked());
+    lock.unlock();
+    REQUIRE_FALSE(lock.is_locked());
+
+    REQUIRE(lock.try_lock());
+    REQUIRE(lock.is_locked());
 }
 
 // ── ChildProcess ────────────────────────────────────────────────────────
@@ -239,6 +306,24 @@ TEST_CASE("base64 binary round-trip", "[runtime][base64]") {
     REQUIRE(*decoded == data);
 }
 
+TEST_CASE("base64 handles explicit byte pointers and exact quartet decoding",
+          "[runtime][base64][coverage][issue-641]") {
+    REQUIRE(base64_encode(nullptr, 0) == "");
+
+    const uint8_t bytes[] = {0x00, 0x10, 0x20, 0x30, 0xff};
+    auto encoded = base64_encode(bytes, sizeof(bytes));
+    REQUIRE(encoded == "ABAgMP8=");
+
+    auto decoded = base64_decode("ABAgMP8=");
+    REQUIRE(decoded.has_value());
+    REQUIRE(decoded->size() == sizeof(bytes));
+    REQUIRE(std::equal(decoded->begin(), decoded->end(), std::begin(bytes)));
+
+    auto quartet = base64_decode("////");
+    REQUIRE(quartet.has_value());
+    REQUIRE(*quartet == std::vector<uint8_t>{0xff, 0xff, 0xff});
+}
+
 // ── HTTP URL parsing ───────────────────────────────────────────────────
 
 TEST_CASE("HTTP helpers reject malformed URLs without transport work",
@@ -317,6 +402,26 @@ TEST_CASE("text_diff preserves equal lines across replacements and appends",
             "+ delta\n"
             "  gamma\n"
             "+ omega\n");
+}
+
+TEST_CASE("text_diff keeps repeated-line matches stable",
+          "[runtime][text-diff][coverage][issue-641]") {
+    auto diff = text_diff("same\nkeep\nsame\nremove\nsame",
+                          "same\nkeep\nsame\ninsert\nsame");
+
+    REQUIRE(diff.size() == 6);
+    REQUIRE(diff[0].op == DiffOp::Equal);
+    REQUIRE(diff[0].text == "same");
+    REQUIRE(diff[1].op == DiffOp::Equal);
+    REQUIRE(diff[1].text == "keep");
+    REQUIRE(diff[2].op == DiffOp::Equal);
+    REQUIRE(diff[2].text == "same");
+    REQUIRE(diff[3].op == DiffOp::Delete);
+    REQUIRE(diff[3].text == "remove");
+    REQUIRE(diff[4].op == DiffOp::Insert);
+    REQUIRE(diff[4].text == "insert");
+    REQUIRE(diff[5].op == DiffOp::Equal);
+    REQUIRE(diff[5].text == "same");
 }
 
 // ── Range ───────────────────────────────────────────────────────────────
@@ -401,4 +506,15 @@ TEST_CASE("FloatRange", "[runtime][range]") {
     FloatRange r(0.0f, 1.0f);
     REQUIRE(r.contains(0.5f));
     REQUIRE_FALSE(r.contains(1.0f));
+}
+
+TEST_CASE("Range boundary touch points remain non-intersections",
+          "[runtime][range][coverage][issue-641]") {
+    REQUIRE_FALSE(IntRange(0, 10).intersects(IntRange(10, 20)));
+    REQUIRE(IntRange(0, 10).intersection(IntRange(10, 20)).empty());
+    REQUIRE(IntRange(10, 20).intersection(IntRange(0, 10)).empty());
+
+    REQUIRE(IntRange(5, 5).empty());
+    REQUIRE(IntRange(5, 4).empty());
+    REQUIRE(IntRange(5, 5).constrain(100) == 5);
 }

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -87,6 +87,55 @@ TEST_CASE("MemoryMappedFile move semantics", "[runtime][mmap]") {
     REQUIRE_FALSE(a.is_open());
 }
 
+TEST_CASE("MemoryMappedFile read-write maps persist and move assignment closes old map",
+          "[runtime][mmap][coverage][issue-656]") {
+    TemporaryFile first(".bin");
+    TemporaryFile second(".bin");
+    {
+        std::ofstream f(first.path(), std::ios::binary);
+        f << "abcd";
+    }
+    {
+        std::ofstream f(second.path(), std::ios::binary);
+        f << "wxyz";
+    }
+
+    MemoryMappedFile old_map;
+    REQUIRE(old_map.open(first.path_string(), MapMode::ReadOnly));
+    REQUIRE(old_map.is_open());
+
+    MemoryMappedFile writable;
+    REQUIRE(writable.open(second.path_string(), MapMode::ReadWrite));
+    REQUIRE(writable.is_open());
+    REQUIRE(writable.size() == 4);
+    writable.mutable_data()[1] = static_cast<uint8_t>('!');
+
+    old_map = std::move(writable);
+    REQUIRE(old_map.is_open());
+    REQUIRE_FALSE(writable.is_open());
+    REQUIRE(old_map.size() == 4);
+    REQUIRE(std::string(reinterpret_cast<const char*>(old_map.data()), old_map.size()) == "w!yz");
+
+    old_map.close();
+    std::ifstream f(second.path(), std::ios::binary);
+    std::string saved((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    REQUIRE(saved == "w!yz");
+}
+
+TEST_CASE("MemoryMappedFile rejects empty files and close is idempotent",
+          "[runtime][mmap][coverage][issue-656]") {
+    TemporaryFile tmp(".bin");
+
+    MemoryMappedFile mmap;
+    REQUIRE_FALSE(mmap.open(tmp.path_string()));
+    REQUIRE_FALSE(mmap.is_open());
+    REQUIRE(mmap.size() == 0);
+    REQUIRE(mmap.data() == nullptr);
+    mmap.close();
+    mmap.close();
+    REQUIRE_FALSE(mmap.is_open());
+}
+
 // ── DynamicLibrary ──────────────────────────────────────────────────────
 
 TEST_CASE("DynamicLibrary loads system library", "[runtime][dynlib]") {
@@ -267,6 +316,26 @@ TEST_CASE("HTTP helpers reject invalid numeric URL ports",
     const auto too_large_port = http_post("http://example.com:65536/path", "body", "text/plain", 1);
     REQUIRE(too_large_port.status_code == 0);
     REQUIRE(too_large_port.error == "Invalid URL");
+}
+
+TEST_CASE("HttpResponse ok covers status code boundaries", "[runtime][http][url][coverage][issue-656]") {
+    HttpResponse response;
+    response.status_code = 199;
+    REQUIRE_FALSE(response.ok());
+    response.status_code = 200;
+    REQUIRE(response.ok());
+    response.status_code = 299;
+    REQUIRE(response.ok());
+    response.status_code = 300;
+    REQUIRE_FALSE(response.ok());
+}
+
+TEST_CASE("HTTP helpers reject malformed URL hosts and schemes",
+          "[runtime][http][url][coverage][issue-656]") {
+    REQUIRE(http_get("https://:443/path", 1).error == "Invalid URL");
+    REQUIRE(http_get("http://example.com:not-a-port/path", 1).error == "Invalid URL");
+    REQUIRE(http_post("file://example.com/path", "body", "text/plain", 1).error == "Invalid URL");
+    REQUIRE_FALSE(http_download("http://", "/tmp/pulp-url-invalid-download-656", 1));
 }
 
 // ── Text Diff ────────────────────────────────────────────────────────────

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/runtime/memory_mapped_file.hpp>
 #include <pulp/runtime/temporary_file.hpp>
 #include <pulp/runtime/dynamic_library.hpp>
@@ -46,6 +47,47 @@ TEST_CASE("TemporaryFile move semantics", "[runtime][temp_file]") {
     REQUIRE(std::filesystem::exists(path));
 }
 
+TEST_CASE("TemporaryFile normalizes extensions without leading dots",
+          "[runtime][temp_file][issue-641]") {
+    TemporaryFile tmp("raw");
+    REQUIRE(tmp.path().extension() == ".raw");
+    REQUIRE(std::filesystem::exists(tmp.path()));
+}
+
+TEST_CASE("TemporaryFile move assignment removes the previous active file",
+          "[runtime][temp_file][issue-641]") {
+    std::filesystem::path old_path;
+    std::filesystem::path new_path;
+    {
+        TemporaryFile old_file(".old");
+        TemporaryFile new_file(".new");
+        old_path = old_file.path();
+        new_path = new_file.path();
+
+        old_file = std::move(new_file);
+        REQUIRE(old_file.path() == new_path);
+        REQUIRE_FALSE(std::filesystem::exists(old_path));
+        REQUIRE(std::filesystem::exists(new_path));
+    }
+
+    REQUIRE_FALSE(std::filesystem::exists(new_path));
+}
+
+TEST_CASE("TemporaryFile self move assignment preserves ownership",
+          "[runtime][temp_file][issue-641]") {
+    std::filesystem::path path;
+    {
+        TemporaryFile tmp(".self");
+        path = tmp.path();
+        auto& ref = tmp;
+        tmp = std::move(ref);
+        REQUIRE(tmp.path() == path);
+        REQUIRE(std::filesystem::exists(path));
+    }
+
+    REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
 // ── MemoryMappedFile ────────────────────────────────────────────────────
 
 TEST_CASE("MemoryMappedFile maps a file", "[runtime][mmap]") {
@@ -85,6 +127,28 @@ TEST_CASE("MemoryMappedFile move semantics", "[runtime][mmap]") {
     MemoryMappedFile b = std::move(a);
     REQUIRE(b.is_open());
     REQUIRE_FALSE(a.is_open());
+}
+
+TEST_CASE("MemoryMappedFile reopen closes the previous mapping",
+          "[runtime][mmap][issue-641]") {
+    TemporaryFile first(".bin");
+    TemporaryFile second(".bin");
+    {
+        std::ofstream f(first.path(), std::ios::binary);
+        f << "first";
+    }
+    {
+        std::ofstream f(second.path(), std::ios::binary);
+        f << "second-file";
+    }
+
+    MemoryMappedFile mmap;
+    REQUIRE(mmap.open(first.path_string()));
+    REQUIRE(mmap.size() == 5);
+    REQUIRE(mmap.open(second.path_string()));
+    REQUIRE(mmap.is_open());
+    REQUIRE(mmap.size() == 11);
+    REQUIRE(std::string(reinterpret_cast<const char*>(mmap.data()), mmap.size()) == "second-file");
 }
 
 // ── DynamicLibrary ──────────────────────────────────────────────────────
@@ -361,6 +425,13 @@ TEST_CASE("Range constrain", "[runtime][range]") {
     REQUIRE(r.constrain(200) == 99);
 }
 
+TEST_CASE("Range constrain handles empty and reversed integer ranges",
+          "[runtime][range][coverage][issue-641]") {
+    REQUIRE(IntRange(5, 5).constrain(100) == 5);
+    REQUIRE(IntRange(10, 5).constrain(-100) == 10);
+    REQUIRE(IntRange(-3, -1).constrain(9) == -2);
+}
+
 TEST_CASE("Range from_start_length", "[runtime][range]") {
     auto r = IntRange::from_start_length(5, 10);
     REQUIRE(r.start == 5);
@@ -401,4 +472,18 @@ TEST_CASE("FloatRange", "[runtime][range]") {
     FloatRange r(0.0f, 1.0f);
     REQUIRE(r.contains(0.5f));
     REQUIRE_FALSE(r.contains(1.0f));
+}
+
+TEST_CASE("DoubleRange intersections and unions preserve fractional bounds",
+          "[runtime][range][coverage][issue-641]") {
+    DoubleRange a(0.25, 2.75);
+    DoubleRange b(1.5, 4.0);
+
+    auto intersection = a.intersection(b);
+    REQUIRE_THAT(intersection.start, Catch::Matchers::WithinAbs(1.5, 1e-12));
+    REQUIRE_THAT(intersection.end, Catch::Matchers::WithinAbs(2.75, 1e-12));
+
+    auto combined = a.enclosing_union(b);
+    REQUIRE_THAT(combined.start, Catch::Matchers::WithinAbs(0.25, 1e-12));
+    REQUIRE_THAT(combined.end, Catch::Matchers::WithinAbs(4.0, 1e-12));
 }

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -5,9 +5,12 @@
 #include <pulp/runtime/inter_process_lock.hpp>
 #include <pulp/runtime/child_process.hpp>
 #include <pulp/runtime/base64.hpp>
+#include <pulp/runtime/expression.hpp>
 #include <pulp/runtime/http.hpp>
 #include <pulp/runtime/range.hpp>
 #include <pulp/runtime/text_diff.hpp>
+#include <catch2/catch_approx.hpp>
+#include <cmath>
 #include <fstream>
 #include <filesystem>
 
@@ -237,6 +240,82 @@ TEST_CASE("base64 binary round-trip", "[runtime][base64]") {
     auto decoded = base64_decode(encoded);
     REQUIRE(decoded.has_value());
     REQUIRE(*decoded == data);
+}
+
+// ── Expression ─────────────────────────────────────────────────────────
+
+TEST_CASE("Expression evaluator handles precedence and exponent edge cases",
+          "[runtime][expression][coverage][issue-641]") {
+    auto value = evaluate("2 + 3 * 4 ^ 2");
+    REQUIRE(value.has_value());
+    REQUIRE(*value == Catch::Approx(50.0));
+
+    auto signed_power = evaluate("-2^2");
+    REQUIRE(signed_power.has_value());
+    REQUIRE(*signed_power == Catch::Approx(4.0));
+
+    auto grouped = evaluate("(-2)^2");
+    REQUIRE(grouped.has_value());
+    REQUIRE(*grouped == Catch::Approx(4.0));
+}
+
+TEST_CASE("Expression evaluator handles constants, functions, and scientific notation",
+          "[runtime][expression][coverage][issue-641]") {
+    auto trig = evaluate("sin(pi / 2) + cos(0)");
+    REQUIRE(trig.has_value());
+    REQUIRE(*trig == Catch::Approx(2.0));
+
+    auto clamped = evaluate("clamp(12, 10)");
+    REQUIRE(clamped.has_value());
+    REQUIRE(*clamped == Catch::Approx(10.0));
+
+    auto scientific = evaluate("1.5e2 + 2E-1");
+    REQUIRE(scientific.has_value());
+    REQUIRE(*scientific == Catch::Approx(150.2));
+}
+
+TEST_CASE("Expression evaluator resolves variables and rejects malformed inputs",
+          "[runtime][expression][coverage][issue-641]") {
+    auto variable = evaluate("gain * 2 + offset", {{"gain", 0.75}, {"offset", 0.25}});
+    REQUIRE(variable.has_value());
+    REQUIRE(*variable == Catch::Approx(1.75));
+
+    REQUIRE_FALSE(evaluate("missing + 1").has_value());
+    REQUIRE_FALSE(evaluate("min(1)").has_value());
+    REQUIRE_FALSE(evaluate("(1 + 2").has_value());
+    REQUIRE_FALSE(evaluate("").has_value());
+}
+
+TEST_CASE("ExpressionEvaluator stores variables and clears them",
+          "[runtime][expression][coverage][issue-641]") {
+    ExpressionEvaluator evaluator;
+    evaluator.set("x", 4.0);
+    evaluator.set("y", 2.5);
+
+    REQUIRE(evaluator.get("x").has_value());
+    REQUIRE(*evaluator.get("x") == Catch::Approx(4.0));
+
+    auto value = evaluator.evaluate("x * y");
+    REQUIRE(value.has_value());
+    REQUIRE(*value == Catch::Approx(10.0));
+
+    evaluator.clear_variables();
+    REQUIRE_FALSE(evaluator.get("x").has_value());
+    REQUIRE_FALSE(evaluator.evaluate("x").has_value());
+}
+
+TEST_CASE("ExpressionEvaluator dispatches registered unary functions",
+          "[runtime][expression][coverage][issue-641]") {
+    ExpressionEvaluator evaluator;
+    evaluator.register_function("db_to_gain", [](double db) {
+        return std::pow(10.0, db / 20.0);
+    });
+
+    auto unity = evaluator.evaluate("db_to_gain(0)");
+    REQUIRE(unity.has_value());
+    REQUIRE(*unity == Catch::Approx(1.0));
+
+    REQUIRE_FALSE(evaluator.evaluate("missing_fn(1)").has_value());
 }
 
 // ── HTTP URL parsing ───────────────────────────────────────────────────

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -37,6 +37,23 @@ TEST_CASE("StateTree get with defaults", "[state][tree]") {
     REQUIRE(tree->get_bool("missing", true) == true);
 }
 
+TEST_CASE("StateTree typed getters keep defaults for mismatched property types",
+          "[state][tree][issue-641]") {
+    auto tree = StateTree::create("test");
+    tree->set("as_string", std::string("123"));
+    tree->set("as_bool", true);
+    tree->set("as_int", int64_t(9));
+    tree->set("as_double", 1.25);
+
+    REQUIRE(tree->get_int("as_string", 77) == 77);
+    REQUIRE(tree->get_bool("as_string", true));
+    REQUIRE(tree->get_string("as_int", "fallback") == "fallback");
+    REQUIRE_THAT(tree->get_double("as_int", 0.0), WithinAbs(9.0, 1e-9));
+    REQUIRE(tree->get_int("as_double", 44) == 44);
+    REQUIRE(tree->get_bool("as_int", false) == false);
+    REQUIRE(tree->get_bool("as_bool", false) == true);
+}
+
 TEST_CASE("StateTree has and remove", "[state][tree]") {
     auto tree = StateTree::create("test");
     tree->set("key", std::string("value"));
@@ -104,6 +121,23 @@ TEST_CASE("StateTree remove child by index", "[state][tree]") {
     REQUIRE(root->child(1)->type_name() == "c");
 }
 
+TEST_CASE("StateTree child access and removal ignore invalid indexes",
+          "[state][tree][issue-641]") {
+    auto root = StateTree::create("root");
+    root->add_child(StateTree::create("a"));
+
+    int removed_count = 0;
+    root->add_child_removed_listener(
+        [&](StateTree&, StateTree&, int) { removed_count++; });
+
+    REQUIRE(root->child(-1) == nullptr);
+    REQUIRE(root->child(1) == nullptr);
+    root->remove_child(-1);
+    root->remove_child(99);
+    REQUIRE(root->child_count() == 1);
+    REQUIRE(removed_count == 0);
+}
+
 TEST_CASE("StateTree insert child at index", "[state][tree]") {
     auto root = StateTree::create("root");
     root->add_child(StateTree::create("a"));
@@ -112,6 +146,21 @@ TEST_CASE("StateTree insert child at index", "[state][tree]") {
     root->insert_child(1, StateTree::create("b"));
     REQUIRE(root->child_count() == 3);
     REQUIRE(root->child(1)->type_name() == "b");
+}
+
+TEST_CASE("StateTree insert at end and missing child pointer removal are stable",
+          "[state][tree][issue-641]") {
+    auto root = StateTree::create("root");
+    auto missing = StateTree::create("missing");
+
+    root->add_child(StateTree::create("a"));
+    root->insert_child(root->child_count(), StateTree::create("b"));
+    root->remove_child(missing.get());
+
+    REQUIRE(root->child_count() == 2);
+    REQUIRE(root->child(0)->type_name() == "a");
+    REQUIRE(root->child(1)->type_name() == "b");
+    REQUIRE(missing->parent() == nullptr);
 }
 
 // ── Listeners ───────────────────────────────────────────────────────────
@@ -126,6 +175,44 @@ TEST_CASE("StateTree property change listener", "[state][tree]") {
 
     tree->set("volume", 0.5);
     REQUIRE(changed_prop == "volume");
+}
+
+TEST_CASE("StateTree property listener receives old and new values",
+          "[state][tree][issue-641]") {
+    auto tree = StateTree::create("test");
+    std::vector<PropertyValue> old_values;
+    std::vector<PropertyValue> new_values;
+
+    tree->add_listener(
+        [&](StateTree&, std::string_view, const PropertyValue& old_val,
+            const PropertyValue& new_val) {
+            old_values.push_back(old_val);
+            new_values.push_back(new_val);
+        });
+
+    tree->set("gain", 0.25);
+    tree->set("gain", 0.5);
+
+    REQUIRE(old_values.size() == 2);
+    REQUIRE(std::holds_alternative<std::monostate>(old_values[0]));
+    REQUIRE_THAT(std::get<double>(new_values[0]), WithinAbs(0.25, 1e-9));
+    REQUIRE_THAT(std::get<double>(old_values[1]), WithinAbs(0.25, 1e-9));
+    REQUIRE_THAT(std::get<double>(new_values[1]), WithinAbs(0.5, 1e-9));
+}
+
+TEST_CASE("StateTree remove does not emit property callbacks",
+          "[state][tree][issue-641]") {
+    auto tree = StateTree::create("test");
+    tree->set("name", std::string("before"));
+
+    int count = 0;
+    tree->add_listener([&](StateTree&, std::string_view, const PropertyValue&,
+                           const PropertyValue&) { count++; });
+
+    tree->remove("name");
+    tree->remove("missing");
+    REQUIRE(count == 0);
+    REQUIRE_FALSE(tree->has("name"));
 }
 
 TEST_CASE("StateTree child added listener", "[state][tree]") {
@@ -258,6 +345,42 @@ TEST_CASE("StateTree from_json with empty object", "[state][tree][json]") {
     REQUIRE(result->type_name() == "node");  // Default type
 }
 
+TEST_CASE("StateTree from_json skips unsupported properties and child values",
+          "[state][tree][json][issue-641]") {
+    auto result = StateTree::from_json(R"JSON({
+        "type": 123,
+        "properties": {
+            "name": "Patch",
+            "enabled": false,
+            "voice_count": 8,
+            "gain": 0.25,
+            "ignored_null": null,
+            "ignored_array": [1, 2],
+            "ignored_object": {"nested": true}
+        },
+        "children": [
+            {"type": "osc", "properties": {"wave": "sine"}},
+            null,
+            42,
+            {"properties": {"default_type": true}}
+        ]
+    })JSON");
+
+    REQUIRE(result != nullptr);
+    REQUIRE(result->type_name() == "node");
+    REQUIRE(result->get_string("name") == "Patch");
+    REQUIRE_FALSE(result->get_bool("enabled", true));
+    REQUIRE(result->get_int("voice_count") == 8);
+    REQUIRE_THAT(result->get_double("gain"), WithinAbs(0.25, 1e-9));
+    REQUIRE_FALSE(result->has("ignored_null"));
+    REQUIRE_FALSE(result->has("ignored_array"));
+    REQUIRE_FALSE(result->has("ignored_object"));
+    REQUIRE(result->child_count() == 2);
+    REQUIRE(result->child(0)->type_name() == "osc");
+    REQUIRE(result->child(1)->type_name() == "node");
+    REQUIRE(result->child(1)->get_bool("default_type"));
+}
+
 // ── Deep copy ───────────────────────────────────────────────────────────
 
 TEST_CASE("StateTree deep copy", "[state][tree]") {
@@ -273,6 +396,19 @@ TEST_CASE("StateTree deep copy", "[state][tree]") {
     // Modifying copy doesn't affect original
     copy->set("name", std::string("modified"));
     REQUIRE(root->get_string("name") == "original");
+}
+
+TEST_CASE("StateTree deep copy rewires child parent pointers",
+          "[state][tree][issue-641]") {
+    auto root = StateTree::create("root");
+    auto child = StateTree::create("child");
+    root->add_child(child);
+
+    auto copy = root->deep_copy();
+    REQUIRE(copy->child_count() == 1);
+    REQUIRE(copy->child(0).get() != child.get());
+    REQUIRE(copy->child(0)->parent() == copy.get());
+    REQUIRE(child->parent() == root.get());
 }
 
 // ── ObservableValue ─────────────────────────────────────────────────────
@@ -322,6 +458,27 @@ TEST_CASE("ObservableValue remove listener", "[state][observable]") {
     val.remove_listener(id);
     val.set(2);
     REQUIRE(count == 1);  // Listener removed
+}
+
+TEST_CASE("ObservableValue assignment operator emits one change",
+          "[state][observable][issue-641]") {
+    ObservableValue<int> val(1);
+    int old_value = 0;
+    int new_value = 0;
+    int count = 0;
+    val.add_listener([&](const int& old_val, const int& next_val) {
+        old_value = old_val;
+        new_value = next_val;
+        count++;
+    });
+
+    val = 5;
+    val = 5;
+
+    REQUIRE(val.get() == 5);
+    REQUIRE(old_value == 1);
+    REQUIRE(new_value == 5);
+    REQUIRE(count == 1);
 }
 
 // ── CachedProperty ──────────────────────────────────────────────────────
@@ -380,6 +537,19 @@ TEST_CASE("CachedProperty unbound set only updates local cache", "[state][cached
     REQUIRE(size.get() == 512);
 }
 
+TEST_CASE("CachedProperty ignores mismatched external updates",
+          "[state][cached][issue-641]") {
+    auto tree = StateTree::create("params");
+    tree->set("name", std::string("Initial"));
+    CachedProperty<std::string> name(tree, "name", "Default");
+
+    tree->set("name", int64_t(123));
+    REQUIRE(name.get() == "Initial");
+
+    name.set("Restored");
+    REQUIRE(tree->get_string("name") == "Restored");
+}
+
 // ── StateTreeSynchroniser ───────────────────────────────────────────────
 
 TEST_CASE("StateTreeSynchroniser records property and child deltas", "[state][sync]") {
@@ -409,6 +579,25 @@ TEST_CASE("StateTreeSynchroniser records property and child deltas", "[state][sy
     REQUIRE(deltas[2].child_index == 0);
 
     REQUIRE(sync.take_deltas().empty());
+}
+
+TEST_CASE("StateTreeSynchroniser attach replaces the previous tree",
+          "[state][sync][issue-641]") {
+    auto first = StateTree::create("first");
+    auto second = StateTree::create("second");
+    StateTreeSynchroniser sync;
+
+    sync.attach(first);
+    first->set("name", std::string("before"));
+    sync.attach(second);
+    first->set("name", std::string("ignored"));
+    second->set("name", std::string("recorded"));
+
+    auto deltas = sync.take_deltas();
+    REQUIRE(deltas.size() == 1);
+    REQUIRE(deltas[0].path == "second");
+    REQUIRE(deltas[0].key == "name");
+    REQUIRE(std::get<std::string>(deltas[0].value) == "recorded");
 }
 
 TEST_CASE("StateTreeSynchroniser detach clears pending and stops recording", "[state][sync]") {
@@ -465,6 +654,32 @@ TEST_CASE("StateTreeSynchroniser decode rejects undersized buffers", "[state][sy
 
     decoded = StateTreeSynchroniser::decode(nullptr, 0);
     REQUIRE(decoded.empty());
+}
+
+TEST_CASE("StateTreeSynchroniser encodes and decodes empty delta batches",
+          "[state][sync][issue-641]") {
+    auto encoded = StateTreeSynchroniser::encode({});
+    REQUIRE(encoded.size() == 2);
+
+    auto decoded = StateTreeSynchroniser::decode(encoded.data(), encoded.size());
+    REQUIRE(decoded.empty());
+}
+
+TEST_CASE("StateTreeSynchroniser decode keeps complete prefix on truncated batches",
+          "[state][sync][issue-641]") {
+    std::vector<SyncDelta> deltas = {
+        {SyncDeltaType::PropertySet, "root", "name", std::string("Lead"), 0},
+        {SyncDeltaType::PropertySet, "root", "count", int64_t(3), 0},
+    };
+    auto encoded = StateTreeSynchroniser::encode(deltas);
+    auto first_only = StateTreeSynchroniser::encode({deltas[0]});
+    encoded.resize(first_only.size() + 1);
+
+    auto decoded = StateTreeSynchroniser::decode(encoded.data(), encoded.size());
+    REQUIRE(decoded.size() == 1);
+    REQUIRE(decoded[0].type == SyncDeltaType::PropertySet);
+    REQUIRE(decoded[0].key == "name");
+    REQUIRE(std::get<std::string>(decoded[0].value) == "Lead");
 }
 
 TEST_CASE("StateTreeSynchroniser apply mutates properties and children", "[state][sync]") {

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <pulp/runtime/named_pipe.hpp>
+#include <pulp/runtime/network_stream.hpp>
 #include <pulp/runtime/stream.hpp>
 
 #include <array>
@@ -11,11 +12,13 @@
 #include <string>
 
 using pulp::runtime::FileStream;
+using pulp::runtime::HttpStream;
 using pulp::runtime::MemoryStream;
 using pulp::runtime::NamedPipe;
 using pulp::runtime::Stream;
 using pulp::runtime::StreamError;
 using pulp::runtime::StreamResult;
+using pulp::runtime::TcpStream;
 
 namespace {
 
@@ -209,6 +212,92 @@ TEST_CASE("Stream polymorphic usage", "[stream]") {
     REQUIRE(r.ok());
     REQUIRE(r.bytes == std::strlen(msg));
     REQUIRE(std::memcmp(buf.data(), msg, std::strlen(msg)) == 0);
+}
+
+TEST_CASE("FileStream ReadWrite mode tracks position and truncates on open",
+          "[stream][file][coverage][issue-641]") {
+    auto path = make_temp_path("pulp_stream_readwrite");
+    const std::uint8_t first[] = {'o', 'l', 'd'};
+    const std::uint8_t second[] = {'n', 'e', 'w', '!'};
+
+    {
+        FileStream seed(path.string(), FileStream::Mode::Write);
+        REQUIRE(seed.write(first, sizeof(first)).bytes == sizeof(first));
+        REQUIRE(seed.flush());
+    }
+
+    {
+        FileStream stream(path.string(), FileStream::Mode::ReadWrite);
+        REQUIRE(stream.is_open());
+        REQUIRE(stream.position() == 0);
+        REQUIRE(stream.write(second, sizeof(second)).bytes == sizeof(second));
+        REQUIRE(stream.position() == sizeof(second));
+        REQUIRE(stream.flush());
+    }
+
+    {
+        FileStream readback(path.string(), FileStream::Mode::Read);
+        std::array<std::uint8_t, sizeof(second)> out{};
+        auto got = readback.read(out.data(), out.size());
+        REQUIRE(got.ok());
+        REQUIRE(got.bytes == out.size());
+        REQUIRE(std::memcmp(out.data(), second, sizeof(second)) == 0);
+        REQUIRE(readback.read(out.data(), out.size()).closed());
+    }
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("MemoryStream clear keeps closed streams closed",
+          "[stream][memory][coverage][issue-641]") {
+    MemoryStream stream(std::vector<std::uint8_t>{1, 2, 3});
+    stream.close();
+    stream.clear();
+
+    REQUIRE_FALSE(stream.is_open());
+    REQUIRE(stream.size() == 0);
+    REQUIRE(stream.read_position() == 0);
+
+    std::uint8_t byte = 0;
+    REQUIRE(stream.read(&byte, 1).closed());
+    REQUIRE(stream.write(&byte, 1).closed());
+}
+
+TEST_CASE("TcpStream closed state rejects I/O and survives move assignment",
+          "[stream][tcp][coverage][issue-641]") {
+    TcpStream first;
+    TcpStream second;
+    std::uint8_t byte = 0;
+
+    REQUIRE_FALSE(first.is_open());
+    REQUIRE(first.read(&byte, 1).closed());
+    REQUIRE(first.write(&byte, 1).closed());
+
+    second = std::move(first);
+    REQUIRE_FALSE(second.is_open());
+    REQUIRE(second.read(&byte, 1).closed());
+    REQUIRE(second.write(&byte, 1).closed());
+}
+
+TEST_CASE("HttpStream invalid URLs fail without external transport",
+          "[stream][http][coverage][issue-641]") {
+    HttpStream stream;
+    HttpStream::Request request;
+    request.url = "not-a-url";
+    request.timeout_seconds = 1;
+
+    REQUIRE_FALSE(stream.fetch(request));
+    REQUIRE_FALSE(stream.is_open());
+    REQUIRE(stream.status_code() == 0);
+    REQUIRE(stream.transport_error() == "Invalid URL");
+
+    std::array<std::uint8_t, 8> out{};
+    REQUIRE(stream.read(out.data(), out.size()).error == StreamError::IoError);
+    REQUIRE(stream.write(out.data(), out.size()).error == StreamError::Invalid);
+    REQUIRE(stream.eof());
+
+    stream.close();
+    REQUIRE(stream.read(out.data(), out.size()).closed());
 }
 
 TEST_CASE("NamedPipe closed and missing endpoints fail closed", "[stream][named_pipe][issue-641]") {

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -117,6 +117,23 @@ TEST_CASE("MemoryStream zero-size, rewind, and clear edge paths", "[stream]") {
     REQUIRE(eof.closed());
 }
 
+TEST_CASE("StreamResult helpers classify non-ok states", "[stream][coverage][issue-656]") {
+    auto ok = StreamResult::make(3);
+    REQUIRE(ok.ok());
+    REQUIRE(ok.bytes == 3);
+    REQUIRE_FALSE(ok.closed());
+    REQUIRE_FALSE(ok.would_block());
+
+    auto blocked = StreamResult::fail(StreamError::WouldBlock);
+    REQUIRE_FALSE(blocked.ok());
+    REQUIRE(blocked.would_block());
+    REQUIRE_FALSE(blocked.closed());
+
+    auto invalid = StreamResult::fail(StreamError::Invalid);
+    REQUIRE_FALSE(invalid.ok());
+    REQUIRE_FALSE(invalid.closed());
+}
+
 TEST_CASE("FileStream round-trip via filesystem", "[stream]") {
     auto path = make_temp_path("pulp_stream");
     const std::uint8_t payload[] = {'p', 'u', 'l', 'p', 0, 1, 2, 3};
@@ -193,6 +210,45 @@ TEST_CASE("FileStream open failure leaves stream closed", "[stream]") {
     auto r = s.read(buf, sizeof(buf));
     REQUIRE_FALSE(r.ok());
     REQUIRE(r.closed());
+}
+
+TEST_CASE("FileStream zero-size operations and positions are stable", "[stream][coverage][issue-656]") {
+    auto path = make_temp_path("pulp_stream_position");
+    const std::uint8_t payload[] = {'x', 'y', 'z'};
+
+    {
+        FileStream stream(path.string(), FileStream::Mode::ReadWrite);
+        REQUIRE(stream.is_open());
+        REQUIRE(stream.position() == 0);
+
+        auto zero_write = stream.write(payload, 0);
+        REQUIRE(zero_write.ok());
+        REQUIRE(zero_write.bytes == 0);
+        REQUIRE(stream.position() == 0);
+
+        auto wrote = stream.write(payload, sizeof(payload));
+        REQUIRE(wrote.ok());
+        REQUIRE(wrote.bytes == sizeof(payload));
+        REQUIRE(stream.position() == sizeof(payload));
+        REQUIRE(stream.flush());
+    }
+
+    {
+        FileStream stream(path.string(), FileStream::Mode::Read);
+        std::uint8_t out[3]{};
+        auto zero_read = stream.read(out, 0);
+        REQUIRE(zero_read.ok());
+        REQUIRE(zero_read.bytes == 0);
+        REQUIRE(stream.position() == 0);
+    }
+
+    FileStream closed;
+    REQUIRE(closed.position() == static_cast<std::size_t>(-1));
+    REQUIRE_FALSE(closed.flush());
+    closed.close();
+    REQUIRE_FALSE(closed.is_open());
+
+    std::filesystem::remove(path);
 }
 
 TEST_CASE("Stream polymorphic usage", "[stream]") {

--- a/test/test_xml_zip.cpp
+++ b/test/test_xml_zip.cpp
@@ -111,6 +111,46 @@ TEST_CASE("XmlDocument invalid XML", "[runtime][xml]") {
     REQUIRE_FALSE(doc.error().empty());
 }
 
+TEST_CASE("XmlDocument empty document queries are inert",
+          "[runtime][xml][coverage][issue-641]") {
+    XmlDocument doc;
+
+    REQUIRE_FALSE(doc.is_valid());
+    REQUIRE(doc.root_name().empty());
+    REQUIRE_FALSE(doc.root_attribute("missing").has_value());
+    REQUIRE_FALSE(doc.xpath_string("//missing").has_value());
+    REQUIRE(doc.xpath_strings("//missing").empty());
+
+    int walk_count = 0;
+    doc.walk([&](std::string_view, std::string_view) {
+        ++walk_count;
+    });
+    REQUIRE(walk_count == 0);
+}
+
+TEST_CASE("XmlDocument move construction and assignment preserve parsed state",
+          "[runtime][xml][coverage][issue-641]") {
+    XmlDocument original;
+    REQUIRE(original.parse(R"(<root name="first"><child>value</child></root>)"));
+
+    XmlDocument moved(std::move(original));
+    REQUIRE(moved.is_valid());
+    REQUIRE(moved.root_name() == "root");
+    REQUIRE(moved.root_attribute("name") == std::optional<std::string>{"first"});
+    REQUIRE_FALSE(original.is_valid());
+    REQUIRE(original.root_name().empty());
+
+    XmlDocument replacement;
+    REQUIRE(replacement.parse(R"(<replacement><leaf>next</leaf></replacement>)"));
+
+    moved = std::move(replacement);
+    REQUIRE(moved.is_valid());
+    REQUIRE(moved.root_name() == "replacement");
+    REQUIRE(moved.xpath_string("//leaf") == std::optional<std::string>{"next"});
+    REQUIRE_FALSE(replacement.is_valid());
+    REQUIRE(replacement.root_name().empty());
+}
+
 TEST_CASE("xml_generate creates document", "[runtime][xml]") {
     auto xml = xml_generate("preset", {
         {"name", "Default"},
@@ -124,6 +164,28 @@ TEST_CASE("xml_generate creates document", "[runtime][xml]") {
     auto name = doc.xpath_string("//name");
     REQUIRE(name.has_value());
     REQUIRE(*name == "Default");
+}
+
+TEST_CASE("xml_generate handles empty and repeated elements",
+          "[runtime][xml][coverage][issue-641]") {
+    auto xml = xml_generate("metadata", {
+        {"tag", "alpha"},
+        {"tag", "beta"},
+        {"empty", ""}
+    });
+
+    XmlDocument doc;
+    REQUIRE(doc.parse(xml));
+    REQUIRE(doc.root_name() == "metadata");
+
+    auto tags = doc.xpath_strings("//tag");
+    REQUIRE(tags.size() == 2);
+    REQUIRE(tags[0] == "alpha");
+    REQUIRE(tags[1] == "beta");
+
+    auto empty = doc.xpath_string("//empty");
+    REQUIRE(empty.has_value());
+    REQUIRE(empty->empty());
 }
 
 TEST_CASE("xml_generate escapes text content", "[runtime][xml]") {

--- a/tools/scripts/local_diff_cover.sh
+++ b/tools/scripts/local_diff_cover.sh
@@ -221,19 +221,21 @@ find "${PROFRAW_DIR}" -name '*.profraw' -print0 \
 # the diff-cover gate. See issue #919 (Codex review on PR #919).
 BINARIES=()
 
-# 1. Test executables — primary coverage drivers.
-while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
-    find "${BUILD_DIR}/test" -maxdepth 2 -type f -perm -u+x \
-        ! -name '*.cmake' ! -name '*.txt' 2>/dev/null || true
-)
-
-# 2. First-party static archives — expose every instrumented TU even
+# 1. First-party static archives — expose every instrumented TU even
 #    when no test transitively links it. `pulp-*.lib` covers Windows
-#    where clang-cl emits MSVC-style archives.
+#    where clang-cl emits MSVC-style archives. Keep these before test
+#    executables so duplicate source coverage maps from actually-run
+#    tests win over archive-only zero-hit records.
 while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
     find "${BUILD_DIR}" -type f \
         \( -name 'libpulp-*.a' -o -name 'pulp-*.lib' \) \
         2>/dev/null || true
+)
+
+# 2. Test executables — primary coverage drivers.
+while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
+    find "${BUILD_DIR}/test" -maxdepth 2 -type f -perm -u+x \
+        ! -name '*.cmake' ! -name '*.txt' 2>/dev/null || true
 )
 
 # 3. First-party non-test executables — CLI, standalone host, inspector.

--- a/tools/scripts/test_local_diff_cover.py
+++ b/tools/scripts/test_local_diff_cover.py
@@ -388,6 +388,25 @@ class ObjectDiscoveryParityTests(unittest.TestCase):
                 f"surface set, so dropping it here desyncs both lanes.",
             )
 
+    def test_static_archives_are_discovered_before_test_binaries(self) -> None:
+        """Duplicate maps must let executed test binaries win.
+
+        Production files linked into both libpulp-*.a and a test executable
+        can otherwise report the archive's zero-hit map even when CTest
+        exercised the code. The CI and local scripts should keep archives
+        first, then test binaries.
+        """
+
+        for path in (SCRIPT, CI_SCRIPT):
+            text = path.read_text()
+            archive_idx = text.index("libpulp-*.a")
+            tests_idx = text.index('"${BUILD_DIR}/test"')
+            self.assertLess(
+                archive_idx,
+                tests_idx,
+                f"{path} must discover static archives before test binaries",
+            )
+
 
 class TargetedCtestTests(unittest.TestCase):
     """Targeted local diff-cover runs must also limit the ctest pass."""


### PR DESCRIPTION
Consolidated codecov coverage batch to reduce GitHub macOS CI fan-out.

Supersedes small PRs: #2025, #2026, #2030, #2031, #2032, #2033, #2040. Also includes the locally held runtime helper batch.

Local macOS validation:
- CMake configure with `PULP_ENABLE_GPU=OFF`, examples off
- Built affected runtime/platform/event/state targets
- Ran affected C++ test binaries directly; all passed

Note: pre-push diff-cover attempted its own coverage configure and hit a transient Highway FetchContent checkout failure, then demoted under `PULP_DISABLE_PREPUSH_DIFF_COVER=1`; focused local validation above is green.