### PR TITLE
test: consolidate media codecov queue

### DIFF
--- a/test/test_attributed_string.cpp
+++ b/test/test_attributed_string.cpp
@@ -116,6 +116,34 @@ TEST_CASE("AttributedString empty span has zero text length but remains a span",
     REQUIRE(str.spans().size() == 1);
 }
 
+TEST_CASE("AttributedString bulk style setters are no-ops on empty strings",
+          "[canvas][text][issue-644]") {
+    AttributedString str;
+    str.set_font("mono", 22.0f);
+    str.set_color(Color::rgba(1, 2, 3));
+
+    REQUIRE(str.empty());
+    REQUIRE(str.length() == 0);
+    REQUIRE(str.plain_text().empty());
+}
+
+TEST_CASE("AttributedString clear drops spans and accepts reuse",
+          "[canvas][text][issue-644]") {
+    AttributedString str("before");
+    str.append(" after", Color::rgba(9, 8, 7));
+    REQUIRE(str.spans().size() == 2);
+
+    str.clear();
+    REQUIRE(str.empty());
+
+    str.append("again", 18.0f, Color::rgba(1, 2, 3));
+    REQUIRE_FALSE(str.empty());
+    REQUIRE(str.plain_text() == "again");
+    REQUIRE(str.spans().size() == 1);
+    REQUIRE(str.spans()[0].font_size == 18.0f);
+    REQUIRE(str.spans()[0].color.g == 2);
+}
+
 // ── TextLayout word wrapping ────────────────────────────────────────────
 
 TEST_CASE("TextLayout empty string", "[canvas][layout]") {
@@ -221,6 +249,18 @@ TEST_CASE("TextLayout empty span creates blank line", "[canvas][layout]") {
     REQUIRE(layout.lines[0].width == 0);
     REQUIRE_THAT(layout.lines[0].height, WithinAbs(12.0f, 1e-5));
     REQUIRE_THAT(layout.total_height, WithinAbs(12.0f, 1e-5));
+}
+
+TEST_CASE("TextLayout skips the delimiter that triggered word wrapping",
+          "[canvas][layout][issue-644]") {
+    AttributedString str("alpha beta gamma");
+    auto layout = layout_attributed_string(str, 48.0f, 10.0f);
+
+    REQUIRE(layout.lines.size() == 3);
+    REQUIRE(layout.lines[0].spans[0].text == "alpha");
+    REQUIRE(layout.lines[1].spans[0].text == "beta");
+    REQUIRE(layout.lines[2].spans[0].text == "gamma");
+    REQUIRE_THAT(layout.total_height, WithinAbs(30.0f, 1e-5));
 }
 
 TEST_CASE("TextLayout narrow width forces word break", "[canvas][layout]") {

--- a/test/test_audio_file.cpp
+++ b/test/test_audio_file.cpp
@@ -425,6 +425,30 @@ TEST_CASE("Read nonexistent file returns nullopt", "[audio][file]") {
     REQUIRE_FALSE(info.has_value());
 }
 
+TEST_CASE("AudioFileData shape helpers and WAV writer reject first-channel empties",
+          "[audio][file][issue-640]") {
+    AudioFileData data;
+    REQUIRE(data.num_channels() == 0);
+    REQUIRE(data.num_frames() == 0);
+    REQUIRE(data.empty());
+
+    data.sample_rate = 44100;
+    data.channels = {{}, {0.25f, 0.5f}};
+    REQUIRE(data.num_channels() == 2);
+    REQUIRE(data.num_frames() == 0);
+    REQUIRE(data.empty());
+
+    auto path = unique_temp_audio_path("_empty_first_channel.wav");
+    std::filesystem::remove(path);
+    REQUIRE_FALSE(write_wav_file(path.string(), data));
+    REQUIRE_FALSE(std::filesystem::exists(path));
+
+    data.channels = {{0.0f, 0.5f, 1.0f}, {-0.5f}};
+    REQUIRE(data.num_channels() == 2);
+    REQUIRE(data.num_frames() == 3);
+    REQUIRE_FALSE(data.empty());
+}
+
 TEST_CASE("WAV helpers write deinterleaved channel data and reject malformed input",
           "[audio][file][issue-640]") {
     auto path = unique_temp_audio_path("_helper_edges.wav");
@@ -719,6 +743,31 @@ TEST_CASE("StreamingWriter rejects invalid opens and closed writes",
     REQUIRE(writer.frames_written() == 0);
 
     writer.close();
+    writer.close();
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("StreamingWriter finalizes the active file before a failed reopen",
+          "[audio][file][streaming][issue-640]") {
+    auto path = unique_temp_audio_path("_stream_reopen_fail.wav");
+    std::filesystem::remove(path);
+
+    StreamingWriter writer;
+    REQUIRE(writer.open(path.string(), 44100, 1, 16));
+
+    const float frames[] = {-0.25f, 0.25f};
+    REQUIRE(writer.write_frames(frames, 2) == 2);
+    REQUIRE(writer.frames_written() == 2);
+
+    REQUIRE_FALSE(writer.open(std::filesystem::temp_directory_path().string(), 44100, 1, 16));
+    REQUIRE_FALSE(writer.is_open());
+    REQUIRE(writer.frames_written() == 0);
+
+    auto bytes = read_binary_file(path);
+    require_wav_header(bytes, 1, 44100, 16, 4);
+    REQUIRE(static_cast<int16_t>(read_le16(bytes, 44)) == -8191);
+    REQUIRE(static_cast<int16_t>(read_le16(bytes, 46)) == 8191);
+
     writer.close();
     std::filesystem::remove(path);
 }
@@ -1147,4 +1196,58 @@ TEST_CASE("AIFF reader rejects truncated PCM payloads", "[audio][file][registry]
     REQUIRE_FALSE(registry.read(tmp_path.string()).has_value());
 
     std::filesystem::remove(tmp_path);
+}
+
+TEST_CASE("AIFF reader rejects invalid COMM metadata and unsupported PCM depths",
+          "[audio][file][registry][aiff][issue-640]") {
+    auto& registry = FormatRegistry::instance();
+
+    SECTION("zero sample rate") {
+        auto tmp_path = unique_temp_audio_path("_aiff_zero_rate.aiff");
+        auto comm = make_comm_chunk(1, 1, 16);
+        std::fill(comm.begin() + 8, comm.begin() + 18, 0);
+
+        write_aiff_fixture(tmp_path,
+                           "AIFF",
+                           {
+                               {"COMM", comm},
+                               {"SSND", make_ssnd_chunk({0x40, 0x00})},
+                           });
+
+        REQUIRE_FALSE(registry.read_info(tmp_path.string()).has_value());
+        REQUIRE_FALSE(registry.read(tmp_path.string()).has_value());
+        std::filesystem::remove(tmp_path);
+    }
+
+    SECTION("zero channels") {
+        auto tmp_path = unique_temp_audio_path("_aiff_zero_channels.aiff");
+
+        write_aiff_fixture(tmp_path,
+                           "AIFF",
+                           {
+                               {"COMM", make_comm_chunk(0, 1, 16)},
+                               {"SSND", make_ssnd_chunk({0x40, 0x00})},
+                           });
+
+        REQUIRE_FALSE(registry.read_info(tmp_path.string()).has_value());
+        REQUIRE_FALSE(registry.read(tmp_path.string()).has_value());
+        std::filesystem::remove(tmp_path);
+    }
+
+    SECTION("unsupported PCM bit depth") {
+        auto tmp_path = unique_temp_audio_path("_aiff_20bit.aiff");
+
+        write_aiff_fixture(tmp_path,
+                           "AIFF",
+                           {
+                               {"COMM", make_comm_chunk(1, 1, 20)},
+                               {"SSND", make_ssnd_chunk({0x40, 0x00})},
+                           });
+
+        auto info = registry.read_info(tmp_path.string());
+        REQUIRE(info.has_value());
+        REQUIRE(info->bits_per_sample == 20);
+        REQUIRE_FALSE(registry.read(tmp_path.string()).has_value());
+        std::filesystem::remove(tmp_path);
+    }
 }

--- a/test/test_descriptor_validation.cpp
+++ b/test/test_descriptor_validation.cpp
@@ -248,3 +248,44 @@ TEST_CASE("DescriptorValidation: reverse-DNS bundle_id passes",
         REQUIRE(i.field != "bundle_id");
     }
 }
+
+TEST_CASE("DescriptorValidation: mixed warnings and errors remain invalid",
+          "[format][descriptor-validation][issue-493]") {
+    auto d = well_formed_effect();
+    d.name.clear();
+    d.bundle_id = "Not Reverse DNS";
+    d.output_buses = {{"Broken Out", 0, false}};
+
+    auto issues = validate_descriptor(d);
+    REQUIRE(has_error_on(issues, "name"));
+    REQUIRE(has_warning_on(issues, "bundle_id"));
+    REQUIRE(has_error_on(issues, "output_buses"));
+    REQUIRE_FALSE(descriptor_is_valid(issues));
+}
+
+TEST_CASE("DescriptorValidation: optional zero-channel side inputs are accepted",
+          "[format][descriptor-validation][issue-493]") {
+    auto d = well_formed_effect();
+    d.input_buses = {
+        {"Main In", 2, false},
+        {"Sidechain", 0, true},
+    };
+    d.output_buses = {{"Main Out", 2, false}};
+
+    auto issues = validate_descriptor(d);
+    REQUIRE_FALSE(has_error_on(issues, "input_buses"));
+    REQUIRE(descriptor_is_valid(issues));
+}
+
+TEST_CASE("DescriptorValidation: MIDI sidecar capabilities are warning-only without MIDI input",
+          "[format][descriptor-validation][issue-493]") {
+    auto d = well_formed_effect();
+    d.accepts_midi = false;
+    d.produces_midi = true;
+    d.supports_mpe = true;
+    d.supports_ump = true;
+
+    auto issues = validate_descriptor(d);
+    REQUIRE(has_warning_on(issues, "accepts_midi"));
+    REQUIRE(descriptor_is_valid(issues));
+}

--- a/test/test_diagnostic_reporter.cpp
+++ b/test/test_diagnostic_reporter.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/format/diagnostic_reporter.hpp>
+#include <pulp/format/host_type.hpp>
 #include <pulp/state/store.hpp>
 
 using namespace pulp::format;
@@ -135,4 +136,60 @@ TEST_CASE("DiagnosticReporter instrument type", "[format][diagnostic]") {
 
     auto report = diag.generate_report();
     REQUIRE(report.find("Instrument") != std::string::npos);
+}
+
+TEST_CASE("DiagnosticReporter default report omits optional sections until set",
+          "[format][diagnostic][issue-493]") {
+    DiagnosticReporter diag;
+    auto report = diag.generate_report();
+    auto json = diag.generate_json();
+
+    REQUIRE(report.find("--- Plugin ---") != std::string::npos);
+    REQUIRE(report.find("Format:") == std::string::npos);
+    REQUIRE(report.find("Host:") == std::string::npos);
+    REQUIRE(report.find("CPU Load:") == std::string::npos);
+    REQUIRE(report.find("--- Custom ---") == std::string::npos);
+    REQUIRE(report.find("--- Parameters (0) ---") != std::string::npos);
+    REQUIRE(json.find("\"parameters\": [") != std::string::npos);
+    REQUIRE(json.find("\"name\": \"\"") != std::string::npos);
+}
+
+TEST_CASE("DiagnosticReporter JSON reflects instrument/effect type and parameter values",
+          "[format][diagnostic][issue-493]") {
+    DiagnosticReporter diag;
+    auto desc = make_desc();
+    desc.category = PluginCategory::Instrument;
+    StateStore store;
+    setup_store(store);
+    store.set_value(1, -18.0f);
+    store.set_value(2, 25.0f);
+
+    diag.set_plugin_info(desc, store);
+    diag.set_audio_config(96000, 128, 0, 2);
+
+    auto json = diag.generate_json();
+    REQUIRE(json.find("\"type\": \"instrument\"") != std::string::npos);
+    REQUIRE(json.find("\"sampleRate\": 96000") != std::string::npos);
+    REQUIRE(json.find("\"bufferSize\": 128") != std::string::npos);
+    REQUIRE(json.find("\"inputChannels\": 0") != std::string::npos);
+    REQUIRE(json.find("\"outputChannels\": 2") != std::string::npos);
+    REQUIRE(json.find("\"value\": -18.0000") != std::string::npos);
+    REQUIRE(json.find("\"value\": 25.0000") != std::string::npos);
+}
+
+TEST_CASE("HostType names and feature heuristics cover fixed-size and no-sidechain hosts",
+          "[format][host-type][issue-493]") {
+    REQUIRE(host_type_name(HostType::Unknown) == "Unknown");
+    REQUIRE(host_type_name(HostType::Other) == "Other");
+    REQUIRE(host_type_name(static_cast<HostType>(255)) == "Unknown");
+
+    REQUIRE_FALSE(host_supports_resize(HostType::ProTools));
+    REQUIRE_FALSE(host_supports_resize(HostType::GarageBand));
+    REQUIRE(host_supports_resize(HostType::LogicPro));
+    REQUIRE(host_supports_resize(HostType::Unknown));
+
+    REQUIRE_FALSE(host_supports_sidechain(HostType::GarageBand));
+    REQUIRE_FALSE(host_supports_sidechain(HostType::AudacityTenacity));
+    REQUIRE(host_supports_sidechain(HostType::Reaper));
+    REQUIRE(host_supports_sidechain(HostType::Unknown));
 }

--- a/test/test_dirty_tracker.cpp
+++ b/test/test_dirty_tracker.cpp
@@ -70,6 +70,24 @@ TEST_CASE("DirtyTracker invalidate_all forces full repaint", "[render][dirty]") 
     REQUIRE(dt.dirty_rects().empty());
 }
 
+TEST_CASE("DirtyTracker full repaint keeps empty partial bounds",
+          "[render][dirty][issue-644]") {
+    DirtyTracker dt;
+    dt.clear();
+    dt.invalidate(1, 2, 3, 4);
+    REQUIRE_FALSE(dt.dirty_rects().empty());
+
+    dt.invalidate_all();
+    REQUIRE(dt.is_dirty());
+    REQUIRE(dt.needs_full_repaint());
+    REQUIRE(dt.dirty_rects().empty());
+    auto b = dt.bounds();
+    REQUIRE(b.x == Catch::Approx(0.0f));
+    REQUIRE(b.y == Catch::Approx(0.0f));
+    REQUIRE(b.w == Catch::Approx(0.0f));
+    REQUIRE(b.h == Catch::Approx(0.0f));
+}
+
 TEST_CASE("DirtyTracker frame counter increments", "[render][dirty]") {
     DirtyTracker dt;
     REQUIRE(dt.frame_count() == 0);
@@ -129,6 +147,30 @@ TEST_CASE("DirtyTracker threshold sums partial dirty regions", "[render][dirty][
     dt.invalidate(50, 50, 30, 30);
     REQUIRE(dt.needs_full_repaint());
     REQUIRE(dt.dirty_rects().empty());
+}
+
+TEST_CASE("DirtyTracker threshold equality remains partial repaint",
+          "[render][dirty][issue-644]") {
+    DirtyTracker dt;
+    dt.set_viewport(100, 100, 0.25f);
+    dt.clear();
+
+    dt.invalidate(0, 0, 50, 50);
+    REQUIRE(dt.is_dirty());
+    REQUIRE_FALSE(dt.needs_full_repaint());
+    REQUIRE(dt.dirty_rects().size() == 1);
+}
+
+TEST_CASE("DirtyTracker ignores invalid viewport dimensions for promotion",
+          "[render][dirty][issue-644]") {
+    DirtyTracker dt;
+    dt.set_viewport(-100, 100, 0.01f);
+    dt.clear();
+    dt.invalidate(0, 0, 1000, 1000);
+
+    REQUIRE(dt.is_dirty());
+    REQUIRE_FALSE(dt.needs_full_repaint());
+    REQUIRE(dt.dirty_rects().size() == 1);
 }
 
 TEST_CASE("DirtyTracker does not promote to full repaint without viewport", "[render][dirty][issue-646]") {

--- a/test/test_dsp_expansion.cpp
+++ b/test/test_dsp_expansion.cpp
@@ -75,6 +75,23 @@ TEST_CASE("FirFilter order returns tap count", "[signal][fir]") {
     REQUIRE(fir.order() == 3);
 }
 
+TEST_CASE("FirFilter empty coefficients pass samples through and reset safely",
+          "[signal][fir][issue-645]") {
+    FirFilter fir;
+    REQUIRE(fir.order() == 0);
+    REQUIRE_THAT(fir.process(-0.25f), WithinAbs(-0.25f, 1e-6f));
+
+    float buffer[] = {0.25f, -0.5f, 0.75f};
+    fir.process(buffer, 3);
+    REQUIRE_THAT(buffer[0], WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(buffer[1], WithinAbs(-0.5f, 1e-6f));
+    REQUIRE_THAT(buffer[2], WithinAbs(0.75f, 1e-6f));
+
+    fir.reset();
+    REQUIRE(fir.order() == 0);
+    REQUIRE_THAT(fir.process(0.5f), WithinAbs(0.5f, 1e-6f));
+}
+
 // ── BallisticsFilter ─────────────────────────────────────────────────────
 
 TEST_CASE("BallisticsFilter tracks rising signal", "[signal][ballistics]") {
@@ -370,6 +387,28 @@ TEST_CASE("LookupTable buffer processing", "[signal][lookup]") {
     REQUIRE_THAT(buf[0], WithinAbs(0.0, 0.01));
     REQUIRE_THAT(buf[1], WithinAbs(1.0, 0.01));
     REQUIRE_THAT(buf[2], WithinAbs(1.0, 0.01));
+}
+
+TEST_CASE("LookupTable indexed access clamps and zero-length buffers are no-ops",
+          "[signal][lookup][issue-645]") {
+    LookupTable table(5, 0.0f, 1.0f, [](float x) { return 10.0f + x; });
+
+    REQUIRE_THAT(table[-100], WithinAbs(10.0f, 1e-6f));
+    REQUIRE_THAT(table[0], WithinAbs(10.0f, 1e-6f));
+    REQUIRE_THAT(table[2], WithinAbs(10.5f, 1e-6f));
+    REQUIRE_THAT(table[99], WithinAbs(11.0f, 1e-6f));
+
+    float samples[] = {-1.0f, 0.5f, 2.0f};
+    table.process(samples, 0);
+    table.process(samples, -3);
+    REQUIRE_THAT(samples[0], WithinAbs(-1.0f, 1e-6f));
+    REQUIRE_THAT(samples[1], WithinAbs(0.5f, 1e-6f));
+    REQUIRE_THAT(samples[2], WithinAbs(2.0f, 1e-6f));
+
+    table.process(samples, 3);
+    REQUIRE_THAT(samples[0], WithinAbs(10.0f, 1e-6f));
+    REQUIRE_THAT(samples[1], WithinAbs(10.5f, 1e-6f));
+    REQUIRE_THAT(samples[2], WithinAbs(11.0f, 1e-6f));
 }
 
 // ── TptFilter ────────────────────────────────────────────────────────────

--- a/test/test_midi_buffer_ump.cpp
+++ b/test/test_midi_buffer_ump.cpp
@@ -41,3 +41,26 @@ TEST_CASE("plugin-side consumer can iterate UMP packets via the sidecar",
     REQUIRE(buf.ump()->size() == 2);     // UMP sidecar visible
     REQUIRE((*buf.ump())[0].packet.message_type() == UmpMessageType::Midi2ChannelVoice);
 }
+
+TEST_CASE("attached UMP sidecar remains externally owned across MidiBuffer edits",
+          "[midi][buffer][ump][issue-645]") {
+    MidiBuffer buf;
+    UmpBuffer first;
+    UmpBuffer second;
+    first.add(UmpPacket::note_on_2(0, 1, 60, 0x8000), 32);
+    second.add(UmpPacket::note_on_2(0, 2, 67, 0x4000), 64);
+
+    buf.attach_ump(&first);
+    buf.add(MidiEvent::note_on(0, 60, 100));
+    REQUIRE(buf.ump() == &first);
+    REQUIRE(buf.ump()->size() == 1);
+
+    buf.clear();
+    REQUIRE(buf.empty());
+    REQUIRE(buf.ump() == &first);
+    REQUIRE(buf.ump()->size() == 1);
+
+    buf.attach_ump(&second);
+    REQUIRE(buf.ump() == &second);
+    REQUIRE((*buf.ump())[0].packet.channel() == 2);
+}

--- a/test/test_midi_ci.cpp
+++ b/test/test_midi_ci.cpp
@@ -21,6 +21,13 @@ uint32_t read_muid_at(const std::vector<uint8_t>& msg, std::size_t offset) {
         | (static_cast<uint32_t>(msg[offset + 3]) << 21);
 }
 
+uint32_t read_uint7_at(const std::vector<uint8_t>& msg, std::size_t offset, std::size_t bytes) {
+    uint32_t value = 0;
+    for (std::size_t i = 0; i < bytes; ++i)
+        value |= static_cast<uint32_t>(msg[offset + i]) << (7 * i);
+    return value;
+}
+
 std::vector<uint8_t> make_ci_header(CiMessageType type, MUID source, MUID destination) {
     std::vector<uint8_t> msg{0xF0, 0x7E, 0x7F, 0x0D,
                              static_cast<uint8_t>(type), 0x02};
@@ -56,6 +63,34 @@ TEST_CASE("CiDiscovery creates valid inquiry", "[midi][ci]") {
     REQUIRE(msg[4] == 0x70);       // Discovery inquiry
 }
 
+TEST_CASE("CiDiscovery discovery inquiry encodes local identity fields",
+          "[midi][ci][issue-645]") {
+    CiDiscovery ci;
+    CiDeviceInfo info;
+    info.muid = MUID{0x01234567};
+    info.manufacturer_id = 0x00123456;
+    info.family_id = 0x2345;
+    info.model_id = 0x3456;
+    info.software_version = 0x01234567;
+    info.ci_version = 3;
+    info.max_sysex_size = 96;
+    ci.set_device_info(info);
+
+    auto msg = ci.create_discovery_inquiry();
+
+    REQUIRE(msg.size() == 31);
+    REQUIRE(msg[4] == static_cast<uint8_t>(CiMessageType::DiscoveryInquiry));
+    REQUIRE(msg[5] == 3);
+    REQUIRE(read_muid_at(msg, 6) == info.muid.value);
+    REQUIRE(read_muid_at(msg, 10) == MUID::broadcast().value);
+    REQUIRE(read_uint7_at(msg, 14, 3) == info.manufacturer_id);
+    REQUIRE(read_uint7_at(msg, 17, 2) == info.family_id);
+    REQUIRE(read_uint7_at(msg, 19, 2) == info.model_id);
+    REQUIRE(read_uint7_at(msg, 21, 4) == info.software_version);
+    REQUIRE(msg[25] == 0x07);
+    REQUIRE(read_uint7_at(msg, 26, 4) == info.max_sysex_size);
+}
+
 TEST_CASE("CiDiscovery profile inquiry encodes destination",
           "[midi][ci][issue-645]") {
     CiDiscovery ci;
@@ -81,6 +116,39 @@ TEST_CASE("CiDiscovery responds to inquiry", "[midi][ci]") {
     REQUIRE_FALSE(reply.empty());
     REQUIRE(reply.front() == 0xF0);
     REQUIRE(reply[4] == 0x71);  // Discovery reply
+}
+
+TEST_CASE("CiDiscovery discovery reply addresses source and encodes responder identity",
+          "[midi][ci][issue-645]") {
+    CiDiscovery responder;
+    CiDeviceInfo info;
+    info.muid = MUID{0x0002468A};
+    info.manufacturer_id = 0x00010203;
+    info.family_id = 0x0203;
+    info.model_id = 0x0304;
+    info.software_version = 0x00040506;
+    info.ci_version = 4;
+    info.max_sysex_size = 120;
+    responder.set_device_info(info);
+
+    MUID peer{0x00013579};
+    auto inquiry = make_ci_header(CiMessageType::DiscoveryInquiry,
+                                  peer, MUID::broadcast());
+    inquiry.push_back(0xF7);
+
+    auto reply = responder.process_message(inquiry.data(), inquiry.size());
+
+    REQUIRE(reply.size() == 31);
+    REQUIRE(reply[4] == static_cast<uint8_t>(CiMessageType::DiscoveryReply));
+    REQUIRE(reply[5] == info.ci_version);
+    REQUIRE(read_muid_at(reply, 6) == info.muid.value);
+    REQUIRE(read_muid_at(reply, 10) == peer.value);
+    REQUIRE(read_uint7_at(reply, 14, 3) == info.manufacturer_id);
+    REQUIRE(read_uint7_at(reply, 17, 2) == info.family_id);
+    REQUIRE(read_uint7_at(reply, 19, 2) == info.model_id);
+    REQUIRE(read_uint7_at(reply, 21, 4) == info.software_version);
+    REQUIRE(read_uint7_at(reply, 26, 4) == info.max_sysex_size);
+    REQUIRE(reply.back() == 0xF7);
 }
 
 TEST_CASE("CiDiscovery ignores malformed and unhandled messages",
@@ -194,6 +262,21 @@ TEST_CASE("CiDiscovery property exchange", "[midi][ci]") {
     REQUIRE(*val == "PulpSynth");
 
     REQUIRE_FALSE(ci.get_property("nonexistent").has_value());
+}
+
+TEST_CASE("CiDiscovery properties accept empty and overwritten values",
+          "[midi][ci][issue-645]") {
+    CiDiscovery ci;
+
+    ci.set_property("", "");
+    REQUIRE(ci.get_property("").has_value());
+    REQUIRE(*ci.get_property("") == "");
+
+    ci.set_property("DeviceName", "First");
+    ci.set_property("DeviceName", "Second");
+    auto value = ci.get_property("DeviceName");
+    REQUIRE(value.has_value());
+    REQUIRE(*value == "Second");
 }
 
 TEST_CASE("CiDiscovery profile inquiry response", "[midi][ci]") {

--- a/test/test_midi_file.cpp
+++ b/test/test_midi_file.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -21,7 +22,9 @@ struct TempDir {
 
     TempDir() {
         const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
-        path = fs::temp_directory_path() / ("pulp-midi-file-test-" + std::to_string(stamp));
+        const auto entropy = std::random_device{}();
+        path = fs::temp_directory_path() / ("pulp-midi-file-test-"
+            + std::to_string(stamp) + "-" + std::to_string(entropy));
         fs::create_directories(path);
     }
 

--- a/test/test_mpe_buffer.cpp
+++ b/test/test_mpe_buffer.cpp
@@ -3,6 +3,7 @@
 
 #include <pulp/format/processor.hpp>
 #include <pulp/midi/mpe_buffer.hpp>
+#include <vector>
 
 using namespace pulp::midi;
 using Kind = MpeExpressionEvent::Kind;
@@ -12,6 +13,16 @@ namespace {
 MidiEvent channel_pressure(uint8_t channel, uint8_t value) {
     return {choc::midi::ShortMessage(
         static_cast<uint8_t>(0xD0 | (channel & 0x0F)), value, 0), 0, 0.0};
+}
+
+UmpPacket channel_pressure_ump(uint8_t group, uint8_t channel, uint32_t value) {
+    UmpPacket p;
+    p.word_count = 2;
+    p.words[0] = (0x4u << 28)
+        | (static_cast<uint32_t>(group & 0x0F) << 24)
+        | (static_cast<uint32_t>(0xD0 | (channel & 0x0F)) << 16);
+    p.words[1] = value;
+    return p;
 }
 } // namespace
 
@@ -60,6 +71,176 @@ TEST_CASE("MpeBuffer clear and sort", "[midi][mpe]") {
 
     buffer.clear();
     REQUIRE(buffer.empty());
+}
+
+TEST_CASE("MpeBuffer groups equal sample offsets without dropping events",
+          "[midi][mpe][issue-645]") {
+    MpeBuffer buffer;
+    MpeNoteState first;
+    first.note = 60;
+    MpeNoteState second;
+    second.note = 64;
+    MpeNoteState third;
+    third.note = 67;
+
+    buffer.add({12, Kind::NoteOn, first});
+    buffer.add({12, Kind::Pressure, second});
+    buffer.add({20, Kind::Timbre, third});
+    buffer.sort();
+
+    REQUIRE(buffer.size() == 3);
+    REQUIRE(buffer[0].sample_offset == 12);
+    REQUIRE(buffer[1].sample_offset == 12);
+    REQUIRE(buffer[2].sample_offset == 20);
+    const bool saw_first_equal_offset = buffer[0].state.note == 60
+                                     || buffer[1].state.note == 60;
+    const bool saw_second_equal_offset = buffer[0].state.note == 64
+                                      || buffer[1].state.note == 64;
+    REQUIRE(saw_first_equal_offset);
+    REQUIRE(saw_second_equal_offset);
+    REQUIRE(buffer[2].state.note == 67);
+}
+
+TEST_CASE("MpeBuffer accepts moved expression events and supports const iteration",
+          "[midi][mpe][issue-645]") {
+    MpeBuffer buffer;
+    MpeExpressionEvent event;
+    event.sample_offset = 7;
+    event.kind = Kind::NoteOn;
+    event.state.channel = 3;
+    event.state.note = 72;
+    event.state.velocity = 100;
+
+    buffer.add(std::move(event));
+
+    const MpeBuffer& const_buffer = buffer;
+    int seen = 0;
+    for (const auto& e : const_buffer) {
+        REQUIRE(e.sample_offset == 7);
+        REQUIRE(e.kind == Kind::NoteOn);
+        REQUIRE(e.state.channel == 3);
+        REQUIRE(e.state.note == 72);
+        REQUIRE(e.state.velocity == 100);
+        ++seen;
+    }
+    REQUIRE(seen == 1);
+}
+
+TEST_CASE("MpeConfig identifies lower and upper zone member boundaries",
+          "[midi][mpe][issue-645]") {
+    auto cfg = MpeConfig::dual(3, 2);
+
+    REQUIRE(cfg.lower_zone.is_lower());
+    REQUIRE(cfg.upper_zone.is_upper());
+    REQUIRE(cfg.is_manager_channel(0));
+    REQUIRE(cfg.is_manager_channel(15));
+
+    REQUIRE(cfg.zone_for_channel(1) == &cfg.lower_zone);
+    REQUIRE(cfg.zone_for_channel(3) == &cfg.lower_zone);
+    REQUIRE(cfg.zone_for_channel(4) == nullptr);
+    REQUIRE(cfg.zone_for_channel(13) == &cfg.upper_zone);
+    REQUIRE(cfg.zone_for_channel(14) == &cfg.upper_zone);
+    REQUIRE(cfg.zone_for_channel(12) == nullptr);
+}
+
+TEST_CASE("MpeVoiceTracker seeds new notes from cached member expression",
+          "[midi][mpe][issue-645]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+
+    REQUIRE(tracker.process(MidiEvent::pitch_bend(2, 16383)));
+    REQUIRE(tracker.process(channel_pressure(2, 64)));
+    REQUIRE(tracker.process(MidiEvent::cc(2, 74, 100)));
+    REQUIRE(tracker.process(MidiEvent::note_on(2, 61, 90)));
+
+    const auto* note = tracker.find(2, 61);
+    REQUIRE(note != nullptr);
+    REQUIRE(note->pitch_bend_semitones == Approx(48.0f).margin(0.01f));
+    REQUIRE(note->pressure == Approx(64.0f / 127.0f).margin(1e-6f));
+    REQUIRE(note->timbre == Approx(100.0f / 127.0f).margin(1e-6f));
+}
+
+TEST_CASE("MpeVoiceTracker manager messages update zone state without notes",
+          "[midi][mpe][issue-645]") {
+    MpeVoiceTracker tracker{MpeConfig::dual(4, 3)};
+    tracker.set_manager_bend_range(2.0f);
+
+    REQUIRE(tracker.process(MidiEvent::pitch_bend(0, 16383)));
+    REQUIRE(tracker.process(channel_pressure(15, 127)));
+    REQUIRE(tracker.process(MidiEvent::cc(15, 74, 64)));
+
+    REQUIRE(tracker.active_count() == 0);
+    REQUIRE(tracker.lower_zone_state().pitch_bend_semitones == Approx(2.0f).margin(0.01f));
+    REQUIRE(tracker.upper_zone_state().pressure == Approx(1.0f).margin(1e-6f));
+    REQUIRE(tracker.upper_zone_state().timbre == Approx(64.0f / 127.0f).margin(1e-6f));
+}
+
+TEST_CASE("bind_tracker_to_buffer uses the latest referenced sample offset",
+          "[midi][mpe][issue-645]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    MpeBuffer buffer;
+    int32_t offset = 0;
+    bind_tracker_to_buffer(tracker, buffer, offset);
+
+    offset = 3;
+    REQUIRE(tracker.process(MidiEvent::note_on(1, 60, 100)));
+    offset = 99;
+    REQUIRE(tracker.process(MidiEvent::note_off(1, 60)));
+
+    REQUIRE(buffer.size() == 2);
+    REQUIRE(buffer[0].sample_offset == 3);
+    REQUIRE(buffer[0].kind == Kind::NoteOn);
+    REQUIRE(buffer[1].sample_offset == 99);
+    REQUIRE(buffer[1].kind == Kind::NoteOff);
+}
+
+TEST_CASE("MpeVoiceTracker UMP manager and member events feed callbacks",
+          "[midi][mpe][issue-645]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    MpeBuffer buffer;
+    int32_t offset = 0;
+    bind_tracker_to_buffer(tracker, buffer, offset);
+
+    offset = 5;
+    REQUIRE(tracker.process(UmpPacket::pitch_bend_2(0, 0, 0xFFFFFFFFu)));
+    REQUIRE(buffer.empty());
+    REQUIRE(tracker.lower_zone_state().pitch_bend_semitones > 1.9f);
+
+    offset = 10;
+    REQUIRE(tracker.process(UmpPacket::note_on_2(0, 3, 67, 0xFFFF)));
+    offset = 20;
+    REQUIRE(tracker.process(channel_pressure_ump(0, 3, 0xFFFFFFFFu)));
+    offset = 30;
+    REQUIRE(tracker.process(UmpPacket::registered_per_note_cc(0, 3, 67, 74,
+                                                              0xFFFFFFFFu)));
+
+    REQUIRE(buffer.size() == 3);
+    REQUIRE(buffer[0].kind == Kind::NoteOn);
+    REQUIRE(buffer[0].sample_offset == 10);
+    REQUIRE(buffer[0].state.velocity == 127);
+    REQUIRE(buffer[1].kind == Kind::Pressure);
+    REQUIRE(buffer[1].state.pressure == Approx(1.0f).margin(1e-6f));
+    REQUIRE(buffer[2].kind == Kind::Timbre);
+    REQUIRE(buffer[2].state.timbre == Approx(1.0f).margin(1e-6f));
+}
+
+TEST_CASE("MpeVoiceTracker reset and config changes clear active state",
+          "[midi][mpe][issue-645]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.process(MidiEvent::note_on(1, 60, 100));
+    tracker.process(MidiEvent::pitch_bend(1, 16383));
+    REQUIRE(tracker.active_count() == 1);
+    REQUIRE(tracker.member_bend_range() == Approx(48.0f));
+
+    tracker.set_member_bend_range(-1.0f);
+    tracker.set_manager_bend_range(0.0f);
+    REQUIRE(tracker.member_bend_range() == Approx(48.0f));
+    REQUIRE(tracker.manager_bend_range() == Approx(2.0f));
+
+    tracker.set_config(MpeConfig::dual(2, 2));
+    REQUIRE(tracker.active_count() == 0);
+    REQUIRE(tracker.find(1, 60) == nullptr);
+    REQUIRE(tracker.config().upper_zone.member_channels == 2);
+    REQUIRE(tracker.lower_zone_state().pitch_bend_semitones == Approx(0.0f));
 }
 
 TEST_CASE("Processor::supports_mpe defaults to false", "[midi][mpe]") {

--- a/test/test_msdf_atlas.cpp
+++ b/test/test_msdf_atlas.cpp
@@ -23,6 +23,26 @@ TEST_CASE("MsdfAtlas default state is empty", "[canvas][msdf][issue-641]") {
     REQUIRE(atlas.glyph(U'A') == nullptr);
 }
 
+TEST_CASE("MsdfAtlas move operations preserve channel mode and glyph lookup",
+          "[canvas][msdf][coverage][issue-650]") {
+    MsdfAtlas original;
+    REQUIRE(original.build("stub", {U'A', U'B'}, 18, 3, 128,
+                           /*include_alpha*/ true));
+    REQUIRE(original.channels() == 4);
+
+    MsdfAtlas moved(std::move(original));
+    REQUIRE(moved.channels() == 4);
+    REQUIRE(moved.glyph_count() == 2);
+    REQUIRE(moved.glyph(U'A') != nullptr);
+    REQUIRE(moved.pixels() != nullptr);
+
+    MsdfAtlas assigned;
+    assigned = std::move(moved);
+    REQUIRE(assigned.channels() == 4);
+    REQUIRE(assigned.glyph(U'B') != nullptr);
+    REQUIRE(assigned.glyph(U'Z') == nullptr);
+}
+
 TEST_CASE("MsdfAtlas packs the requested glyphs", "[canvas][msdf]") {
     MsdfAtlas atlas;
     std::vector<char32_t> chars = {U'A', U'B', U'C', U'D'};
@@ -52,6 +72,29 @@ TEST_CASE("MsdfAtlas empty build records base size and channel mode",
     REQUIRE(atlas.channels() == 4);
     REQUIRE(atlas.width() == 0);
     REQUIRE(atlas.height() == 0);
+}
+
+TEST_CASE("MsdfAtlas rebuild resets channels and overflow failure clears glyphs",
+          "[canvas][msdf][coverage][issue-650]") {
+    MsdfAtlas atlas;
+    REQUIRE(atlas.build("stub", {U'A'}, 20, 2, 128,
+                        /*include_alpha*/ true));
+    REQUIRE(atlas.channels() == 4);
+    REQUIRE(atlas.glyph_count() == 1);
+
+    REQUIRE(atlas.build("stub", {}, 12, 1, 128,
+                        /*include_alpha*/ false));
+    REQUIRE(atlas.channels() == 3);
+    REQUIRE(atlas.glyph_count() == 0);
+    REQUIRE(atlas.pixels() == nullptr);
+
+    std::vector<char32_t> many;
+    for (char32_t c = 0; c < 100; ++c) many.push_back(c);
+    REQUIRE_FALSE(atlas.build("stub", many, 128, 8, 256,
+                              /*include_alpha*/ true));
+    REQUIRE(atlas.glyph_count() == 0);
+    REQUIRE(atlas.channels() == 3);
+    REQUIRE(atlas.pixels() == nullptr);
 }
 
 TEST_CASE("MsdfAtlas packs glyphs into deterministic tile coordinates",

--- a/test/test_osc.cpp
+++ b/test/test_osc.cpp
@@ -43,6 +43,18 @@ TEST_CASE("OSC Message get with defaults", "[osc][message]") {
     REQUIRE(msg.get_string(0, "nope") == "nope");
 }
 
+TEST_CASE("OSC Message typed defaults cover every wrong-type accessor", "[osc][message][issue-644]") {
+    Message msg("/defaults");
+    msg.add(std::string("label"));
+    msg.add(std::vector<uint8_t>{0x01, 0x02});
+    msg.add(1.5f);
+
+    REQUIRE(msg.get_int(0, -10) == -10);
+    REQUIRE(msg.get_float(1, -2.0f) == -2.0f);
+    REQUIRE(msg.get_string(2, "fallback") == "fallback");
+    REQUIRE(msg.get_string(99, "missing") == "missing");
+}
+
 // ── Encoding/Decoding ────────────────────────────────────────────────────────
 
 TEST_CASE("OSC encode/decode round-trip int+float", "[osc][codec]") {
@@ -418,4 +430,57 @@ TEST_CASE("OSC Sender::send without connect is rejected", "[osc][udp][sender]") 
     Message msg("/x");
     msg.add(1);
     REQUIRE_FALSE(tx.send(msg));
+}
+
+TEST_CASE("OSC decode preserves empty strings and padded string arguments", "[osc][codec][issue-644]") {
+    Message msg("/strings");
+    msg.add(std::string{});
+    msg.add(std::string{"abc"});
+    msg.add(std::string{"abcd"});
+
+    auto data = encode(msg);
+    REQUIRE(data.size() % 4 == 0);
+
+    auto decoded = decode(data.data(), data.size());
+    REQUIRE(decoded.address == "/strings");
+    REQUIRE(decoded.args.size() == 3);
+    REQUIRE(decoded.get_string(0, "fallback").empty());
+    REQUIRE(decoded.get_string(1) == "abc");
+    REQUIRE(decoded.get_string(2) == "abcd");
+}
+
+TEST_CASE("OSC decode of truncated string argument returns empty string", "[osc][codec][issue-644]") {
+    std::vector<uint8_t> buf;
+    const char addr[] = "/truncated";
+    buf.insert(buf.end(), addr, addr + sizeof(addr));
+    while (buf.size() % 4 != 0) buf.push_back(0);
+    const char tags[] = ",s";
+    buf.insert(buf.end(), tags, tags + sizeof(tags));
+    while (buf.size() % 4 != 0) buf.push_back(0);
+
+    auto decoded = decode(buf.data(), buf.size());
+    REQUIRE(decoded.address == "/truncated");
+    REQUIRE(decoded.args.size() == 1);
+    REQUIRE(decoded.get_string(0, "fallback").empty());
+}
+
+TEST_CASE("OSC decode tolerates extra trailing padding bytes", "[osc][codec][issue-644]") {
+    Message msg("/trail");
+    msg.add(123);
+    auto data = encode(msg);
+    data.insert(data.end(), {0, 0, 0, 0});
+
+    auto decoded = decode(data.data(), data.size());
+    REQUIRE(decoded.address == "/trail");
+    REQUIRE(decoded.args.size() == 1);
+    REQUIRE(decoded.get_int(0) == 123);
+}
+
+TEST_CASE("OSC Sender::send_raw without connect is rejected", "[osc][udp][sender][issue-644]") {
+    Sender tx;
+    uint8_t payload[] = {0, 1, 2, 3};
+    REQUIRE_FALSE(tx.is_connected());
+    REQUIRE_FALSE(tx.send_raw(payload, sizeof(payload)));
+    tx.disconnect();
+    REQUIRE_FALSE(tx.is_connected());
 }

--- a/test/test_osc_bundle.cpp
+++ b/test/test_osc_bundle.cpp
@@ -54,6 +54,13 @@ TEST_CASE("OSC TimeTag equality", "[osc][bundle]") {
     REQUIRE(a == b);
 }
 
+TEST_CASE("OSC TimeTag keeps fractional unix seconds near one-second boundary",
+          "[osc][bundle][issue-644]") {
+    auto tt = TimeTag::from_unix(12345.999);
+    REQUIRE_THAT(tt.to_unix(), WithinAbs(12345.999, 0.001));
+    REQUIRE_FALSE(tt == TimeTag::from_unix(12345.0));
+}
+
 // ── Bundle construction ─────────────────────────────────────────────────
 
 TEST_CASE("OSC Bundle add message", "[osc][bundle]") {
@@ -81,6 +88,15 @@ TEST_CASE("OSC Bundle add nested bundle", "[osc][bundle]") {
     REQUIRE(outer.elements.size() == 1);
     REQUIRE(outer.elements[0].is_bundle());
     REQUIRE(outer.elements[0].bundle().elements.size() == 1);
+}
+
+TEST_CASE("OSC default BundleElement is an empty message element",
+          "[osc][bundle][issue-644]") {
+    BundleElement elem;
+    REQUIRE(elem.is_message());
+    REQUIRE_FALSE(elem.is_bundle());
+    REQUIRE(elem.message().address.empty());
+    REQUIRE(elem.message().args.empty());
 }
 
 // ── Bundle serialization ────────────────────────────────────────────────
@@ -146,6 +162,13 @@ TEST_CASE("OSC address wildcard ?", "[osc][bundle]") {
     REQUIRE(address_matches("/foo/ba?", "/foo/bar"));
     REQUIRE(address_matches("/foo/ba?", "/foo/baz"));
     REQUIRE_FALSE(address_matches("/foo/ba?", "/foo/ba"));
+}
+
+TEST_CASE("OSC address wildcard question mark does not cross path separator",
+          "[osc][bundle][pattern][issue-644]") {
+    REQUIRE_FALSE(address_matches("/foo/?/bar", "/foo//bar"));
+    REQUIRE_FALSE(address_matches("/foo/?", "/foo//"));
+    REQUIRE(address_matches("/foo/?", "/foo/a"));
 }
 
 // ── TimeTag edges ──────────────────────────────────────────────────────
@@ -375,4 +398,17 @@ TEST_CASE("Malformed address patterns fail closed",
     REQUIRE_FALSE(address_matches("/note/[ab", "/note/a"));
     REQUIRE_FALSE(address_matches("/note/[!0-9", "/note/a"));
     REQUIRE_FALSE(address_matches("/{foo,bar/gain", "/foo/gain"));
+}
+
+TEST_CASE("Address pattern alternatives support first and later branches",
+          "[osc][bundle][pattern][issue-644]") {
+    REQUIRE(address_matches("/{foo,bar,baz}/gain", "/foo/gain"));
+    REQUIRE(address_matches("/{foo,bar,baz}/gain", "/baz/gain"));
+    REQUIRE_FALSE(address_matches("/{foo,bar,baz}/gain", "/ba/gain"));
+}
+
+TEST_CASE("Address pattern character class negated enumeration",
+          "[osc][bundle][pattern][issue-644]") {
+    REQUIRE(address_matches("/pad/[!abc]", "/pad/z"));
+    REQUIRE_FALSE(address_matches("/pad/[!abc]", "/pad/b"));
 }

--- a/test/test_path_to_sdf.cpp
+++ b/test/test_path_to_sdf.cpp
@@ -76,3 +76,18 @@ TEST_CASE("path_to_sdf: mask threshold treats 127 outside and 128 inside",
     REQUIRE(sdf[0] == 0);
     REQUIRE(sdf[1] == 255);
 }
+
+TEST_CASE("path_to_sdf: one-pixel islands saturate in both directions",
+          "[canvas][sdf][path][coverage][issue-650]") {
+    std::uint8_t mask[9] = {
+        0, 0, 0,
+        0, 255, 0,
+        0, 0, 0,
+    };
+
+    auto sdf = path_to_sdf(mask, 3, 3, 1);
+    REQUIRE(sdf.size() == 9);
+    REQUIRE(sdf[4] == 255);
+    REQUIRE(sdf[0] == 0);
+    REQUIRE(sdf[1] == 0);
+}

--- a/test/test_psdf_atlas.cpp
+++ b/test/test_psdf_atlas.cpp
@@ -18,6 +18,20 @@ TEST_CASE("PsdfAtlas builds with the requested glyphs", "[canvas][psdf]") {
     REQUIRE(atlas.pixels() != nullptr);
 }
 
+TEST_CASE("PsdfAtlas keeps the SdfAtlas lookup and move surface",
+          "[canvas][psdf][coverage][issue-650]") {
+    PsdfAtlas atlas;
+    REQUIRE(atlas.build("stub", {U'P', U'S'}, 24, 3, 256));
+    REQUIRE(atlas.base_size() == 24);
+    REQUIRE(atlas.glyph(U'P') != nullptr);
+    REQUIRE(atlas.glyph(U'X') == nullptr);
+
+    PsdfAtlas moved(std::move(atlas));
+    REQUIRE(moved.glyph_count() == 2);
+    REQUIRE(moved.pixels() != nullptr);
+    REQUIRE(moved.glyph(U'S') != nullptr);
+}
+
 TEST_CASE("vector_fallback threshold picks SDF vs path rendering",
           "[canvas][psdf][fallback]") {
     // base_size 48 → 1x at 48px, 4x at 192px, 10x at 480px.
@@ -34,4 +48,12 @@ TEST_CASE("vector_fallback threshold picks SDF vs path rendering",
     // Degenerate base_size is never a fallback trigger.
     REQUIRE_FALSE(should_use_vector_fallback(100.0f, 0.0f));
     REQUIRE_FALSE(should_use_vector_fallback(-100.0f, 48.0f));
+}
+
+TEST_CASE("vector_fallback equality and negative thresholds are strict",
+          "[canvas][psdf][fallback][coverage][issue-650]") {
+    REQUIRE_FALSE(should_use_vector_fallback(96.0f, 48.0f, 2.0f));
+    REQUIRE(should_use_vector_fallback(96.1f, 48.0f, 2.0f));
+    REQUIRE(should_use_vector_fallback(1.0f, 48.0f, -1.0f));
+    REQUIRE_FALSE(should_use_vector_fallback(1.0f, -48.0f, -1.0f));
 }

--- a/test/test_scan_blacklist.cpp
+++ b/test/test_scan_blacklist.cpp
@@ -143,3 +143,41 @@ TEST_CASE("load_from and save_to report unavailable paths",
     fs::create_directories(f.path);
     REQUIRE_FALSE(bl.save_to(f.path.string()));
 }
+
+TEST_CASE("from_text accepts empty/comment-only files and clears previous entries",
+          "[host][blacklist][issue-493]") {
+    ScanBlacklist bl;
+    REQUIRE(bl.from_text("/old|1|2|stale\n"));
+    REQUIRE(bl.size() == 1);
+
+    REQUIRE(bl.from_text("# only comments\n\n   \n"));
+    REQUIRE(bl.size() == 0);
+    REQUIRE_FALSE(bl.is_blacklisted("/old"));
+}
+
+TEST_CASE("from_text preserves reasons containing delimiter-like escaped data",
+          "[host][blacklist][issue-493]") {
+    ScanBlacklist bl;
+    REQUIRE(bl.from_text("/plugin.vst3|10|20|first%7Csecond%25third\n"));
+
+    auto entry = bl.entries().find("/plugin.vst3");
+    REQUIRE(entry != bl.entries().end());
+    REQUIRE(entry->second.mtime == 10);
+    REQUIRE(entry->second.size == 20);
+    REQUIRE(entry->second.reason == "first|second%third");
+
+    const auto text = bl.to_text();
+    REQUIRE(text.find("first%7Csecond%25third") != std::string::npos);
+}
+
+TEST_CASE("from_text tolerates signed stamp values from old blacklist files",
+          "[host][blacklist][issue-493]") {
+    ScanBlacklist bl;
+    REQUIRE(bl.from_text("/plugin.vst3|-1|-2|old stamp\n"));
+
+    auto entry = bl.entries().find("/plugin.vst3");
+    REQUIRE(entry != bl.entries().end());
+    REQUIRE(entry->second.mtime == -1);
+    REQUIRE(entry->second.size == -2);
+    REQUIRE(entry->second.reason == "old stamp");
+}

--- a/test/test_sdf_atlas.cpp
+++ b/test/test_sdf_atlas.cpp
@@ -28,6 +28,28 @@ TEST_CASE("SdfAtlas default state is empty", "[canvas][sdf][issue-641]") {
     REQUIRE(atlas.glyph(U'A') == nullptr);
 }
 
+TEST_CASE("SdfAtlas move operations transfer atlas storage",
+          "[canvas][sdf][coverage][issue-650]") {
+    SdfAtlas original;
+    REQUIRE(original.build("stub", {U'A', U'B'}, 20, 2, 128));
+    const auto* before = original.glyph(U'B');
+    REQUIRE(before != nullptr);
+
+    SdfAtlas moved(std::move(original));
+    REQUIRE(moved.glyph_count() == 2);
+    REQUIRE(moved.base_size() == 20);
+    REQUIRE(moved.pixels() != nullptr);
+    REQUIRE(moved.glyph(U'B') != nullptr);
+    REQUIRE(moved.glyph(U'B')->atlas_x == before->atlas_x);
+
+    SdfAtlas assigned;
+    assigned = std::move(moved);
+    REQUIRE(assigned.glyph_count() == 2);
+    REQUIRE(assigned.pixels() != nullptr);
+    REQUIRE(assigned.glyph(U'A') != nullptr);
+    REQUIRE(assigned.glyph(U'Z') == nullptr);
+}
+
 TEST_CASE("SdfAtlas builds with the requested glyphs", "[canvas][sdf]") {
     SdfAtlas atlas;
     std::vector<char32_t> chars = {U'A', U'B', U'C', U'D'};
@@ -64,6 +86,24 @@ TEST_CASE("SdfAtlas rejects invalid build arguments without allocation",
     REQUIRE_FALSE(invalid_padding.build("stub", {U'A'}, 32, -1, 256));
     REQUIRE(invalid_padding.glyph_count() == 0);
     REQUIRE(invalid_padding.pixels() == nullptr);
+}
+
+TEST_CASE("SdfAtlas invalid rebuild preserves prior atlas but overflow clears it",
+          "[canvas][sdf][coverage][issue-650]") {
+    SdfAtlas atlas;
+    REQUIRE(atlas.build("stub", {U'A'}, 16, 2, 128));
+    REQUIRE(atlas.glyph_count() == 1);
+    REQUIRE(atlas.glyph(U'A') != nullptr);
+
+    REQUIRE_FALSE(atlas.build("stub", {}, 16, 2, 128));
+    REQUIRE(atlas.glyph_count() == 1);
+    REQUIRE(atlas.glyph(U'A') != nullptr);
+
+    std::vector<char32_t> many;
+    for (char32_t c = 0; c < 100; ++c) many.push_back(c);
+    REQUIRE_FALSE(atlas.build("stub", many, 128, 8, 256));
+    REQUIRE(atlas.glyph_count() == 0);
+    REQUIRE(atlas.pixels() == nullptr);
 }
 
 TEST_CASE("SdfAtlas packs glyphs into deterministic tile coordinates",

--- a/test/test_sdf_atlas_cache.cpp
+++ b/test/test_sdf_atlas_cache.cpp
@@ -12,6 +12,15 @@ TEST_CASE("SdfAtlasCache initializes with a seed glyph set", "[canvas][cache]") 
     REQUIRE(cache.touch(U'Z') == nullptr);
 }
 
+TEST_CASE("SdfAtlasCache can initialize an empty resident set",
+          "[canvas][cache][coverage][issue-650]") {
+    SdfAtlasCache cache;
+    REQUIRE_FALSE(cache.initialize("", {}, 24, 4, 512));
+    REQUIRE(cache.size() == 0);
+    REQUIRE(cache.touch(U'A') == nullptr);
+    REQUIRE(cache.atlas().pixels() == nullptr);
+}
+
 TEST_CASE("SdfAtlasCache failed initialize clears prior resident glyphs",
           "[canvas][cache][issue-641]") {
     SdfAtlasCache cache;
@@ -40,6 +49,24 @@ TEST_CASE("SdfAtlasCache reinitialize stamps new glyphs at current frame",
     const auto* z = cache.touch(U'Z');
     REQUIRE(z != nullptr);
     REQUIRE(z->frame_last_used == cache.current_frame());
+}
+
+TEST_CASE("SdfAtlasCache touching resident glyph updates recency without clearing dirty",
+          "[canvas][cache][coverage][issue-650]") {
+    SdfAtlasCache cache;
+    REQUIRE(cache.initialize("", {U'A', U'B'}, 24, 4, 512));
+
+    cache.next_frame();
+    cache.next_frame();
+    const auto* a = cache.touch(U'A');
+    REQUIRE(a != nullptr);
+    REQUIRE(a->frame_last_used == 2);
+    REQUIRE(a->dirty);
+
+    cache.next_frame();
+    REQUIRE(cache.evict_older_than(2) == 1);
+    REQUIRE(cache.touch(U'B') == nullptr);
+    REQUIRE(cache.touch(U'A') != nullptr);
 }
 
 TEST_CASE("SdfAtlasCache advances frame counter and records recency",

--- a/test/test_sdf_effects.cpp
+++ b/test/test_sdf_effects.cpp
@@ -6,6 +6,20 @@
 
 using namespace pulp::canvas;
 
+TEST_CASE("SdfEffectParams default to inactive shader-safe values",
+          "[canvas][sdf][effects][coverage][issue-650]") {
+    SdfEffectParams p;
+    REQUIRE(p.active == 0);
+    REQUIRE_FALSE(has_effect(p.active, SdfEffect::Outline));
+    REQUIRE_FALSE(has_effect(p.active, SdfEffect::Glow));
+    REQUIRE_FALSE(has_effect(p.active, SdfEffect::Shadow));
+    REQUIRE_FALSE(has_effect(p.active, SdfEffect::Bevel));
+    REQUIRE(p.outline_color[3] == 1.0f);
+    REQUIRE(p.glow_color[3] == 1.0f);
+    REQUIRE(p.shadow_color[3] == 0.5f);
+    REQUIRE(p.bevel_mix == 0.0f);
+}
+
 TEST_CASE("SdfEffect bitmask composes with |", "[canvas][sdf][effects]") {
     const std::uint8_t mask = SdfEffect::Outline | SdfEffect::Shadow;
     REQUIRE(has_effect(mask, SdfEffect::Outline));
@@ -13,6 +27,17 @@ TEST_CASE("SdfEffect bitmask composes with |", "[canvas][sdf][effects]") {
     REQUIRE_FALSE(has_effect(mask, SdfEffect::Glow));
     REQUIRE_FALSE(has_effect(mask, SdfEffect::Bevel));
     REQUIRE_FALSE(has_effect(mask, SdfEffect::None));
+}
+
+TEST_CASE("SdfEffect bitmask accepts manually combined active masks",
+          "[canvas][sdf][effects][coverage][issue-650]") {
+    const auto mask = static_cast<std::uint8_t>(SdfEffect::Outline)
+                    | static_cast<std::uint8_t>(SdfEffect::Glow)
+                    | static_cast<std::uint8_t>(SdfEffect::Bevel);
+    REQUIRE(has_effect(mask, SdfEffect::Outline));
+    REQUIRE(has_effect(mask, SdfEffect::Glow));
+    REQUIRE(has_effect(mask, SdfEffect::Bevel));
+    REQUIRE_FALSE(has_effect(mask, SdfEffect::Shadow));
 }
 
 TEST_CASE("preset_subtle_shadow has only Shadow active",
@@ -29,6 +54,19 @@ TEST_CASE("preset_outline width is respected",
     auto p = preset_outline(3.0f);
     REQUIRE(has_effect(p.active, SdfEffect::Outline));
     REQUIRE(p.outline_width == 3.0f);
+}
+
+TEST_CASE("SDF effect presets preserve explicit zero dimensions",
+          "[canvas][sdf][effects][presets][coverage][issue-650]") {
+    auto outline = preset_outline(0.0f);
+    REQUIRE(has_effect(outline.active, SdfEffect::Outline));
+    REQUIRE(outline.outline_width == 0.0f);
+
+    auto glow = preset_glow(0.0f, {0.2f, 0.3f, 0.4f, 0.5f});
+    REQUIRE(has_effect(glow.active, SdfEffect::Glow));
+    REQUIRE(glow.glow_radius == 0.0f);
+    REQUIRE(glow.glow_color[2] == 0.4f);
+    REQUIRE(glow.glow_color[3] == 0.5f);
 }
 
 TEST_CASE("preset_glow carries the given color",

--- a/test/test_sdf_software_renderer.cpp
+++ b/test/test_sdf_software_renderer.cpp
@@ -68,6 +68,22 @@ TEST_CASE("software SDF render handles empty quad list",
     for (auto v : out) REQUIRE(v == 0);
 }
 
+TEST_CASE("software SDF render leaves output untouched for invalid output bounds",
+          "[canvas][sdf][render][coverage][issue-650]") {
+    TinyAtlas atlas{1, 1, {255}};
+    SdfTextQuad q;
+    q.dst_w = 1.0f;
+    q.dst_h = 1.0f;
+    q.src_w = 1.0f;
+    q.src_h = 1.0f;
+
+    std::uint8_t out[1] = {11};
+    render_sdf_text_software(atlas, {q}, out, 0, 1);
+    REQUIRE(out[0] == 11);
+    render_sdf_text_software(atlas, {q}, out, 1, 0);
+    REQUIRE(out[0] == 11);
+}
+
 TEST_CASE("software SDF render leaves output untouched for empty atlas",
           "[canvas][sdf][render][issue-641]") {
     TinyAtlas atlas;
@@ -160,4 +176,23 @@ TEST_CASE("software SDF render keeps maximum alpha for overlapping quads",
     std::uint8_t out[1] = {0};
     render_sdf_text_software(atlas, {low, high}, out, 1, 1);
     REQUIRE(out[0] == 255);
+}
+
+TEST_CASE("software SDF render honors custom edge thresholds",
+          "[canvas][sdf][render][coverage][issue-650]") {
+    TinyAtlas atlas{2, 1, {64, 255}};
+    SdfTextQuad q;
+    q.dst_w = 2.0f;
+    q.dst_h = 1.0f;
+    q.src_w = 2.0f;
+    q.src_h = 1.0f;
+
+    std::uint8_t out[2] = {0, 0};
+    SdfTextOptions opts;
+    opts.edge = 1.0f;
+    render_sdf_text_software(atlas, {q}, out, 2, 1, opts);
+
+    REQUIRE(out[0] == 0);
+    REQUIRE(out[1] > 0);
+    REQUIRE(out[1] < 255);
 }

--- a/test/test_sdf_text.cpp
+++ b/test/test_sdf_text.cpp
@@ -41,6 +41,16 @@ struct FakeAtlas {
 };
 }  // namespace
 
+TEST_CASE("SdfTextOptions default to shader contract values",
+          "[canvas][sdf][layout][coverage][issue-650]") {
+    SdfTextOptions opts;
+    REQUIRE(opts.edge == Catch::Approx(0.5f));
+    REQUIRE(opts.softness == 0.0f);
+    REQUIRE(opts.mip_bias == 0.0f);
+    REQUIRE(opts.gamma == Catch::Approx(2.2f));
+    REQUIRE(opts.snap == SdfPenSnap::Free);
+}
+
 TEST_CASE("snap_pen_x honours the pen-snap policy", "[canvas][sdf][snap]") {
     REQUIRE(snap_pen_x(3.7f, SdfPenSnap::Free)    == 3.7f);
     REQUIRE(snap_pen_x(3.7f, SdfPenSnap::Nearest) == 4.0f);
@@ -96,6 +106,20 @@ TEST_CASE("build_text_quads skips missing glyphs", "[canvas][sdf][layout]") {
     REQUIRE(quads.size() == 2);  // X is skipped.
 }
 
+TEST_CASE("build_text_quads handles empty text and zero render size",
+          "[canvas][sdf][layout][coverage][issue-650]") {
+    FakeAtlas atlas;
+    REQUIRE(build_text_quads(atlas, std::u32string(), 10.0f, 20.0f, 12.0f).empty());
+
+    auto zero = build_text_quads(atlas, std::u32string(U"A"),
+                                 10.0f, 20.0f, 0.0f);
+    REQUIRE(zero.size() == 1);
+    REQUIRE(zero[0].dst_x == 10.0f);
+    REQUIRE(zero[0].dst_y == 20.0f);
+    REQUIRE(zero[0].dst_w == 0.0f);
+    REQUIRE(zero[0].dst_h == 0.0f);
+}
+
 TEST_CASE("build_text_quads returns empty when atlas base size is invalid",
           "[canvas][sdf][layout][issue-641]") {
     FakeAtlas atlas;
@@ -139,6 +163,27 @@ TEST_CASE("named SDF text wrappers forward to shared quad builder",
     REQUIRE(sdf[0].codepoint == U'A');
     REQUIRE(msdf[0].codepoint == U'A');
     REQUIRE(psdf[0].codepoint == U'A');
+}
+
+TEST_CASE("named SDF text wrappers forward options consistently",
+          "[canvas][sdf][layout][coverage][issue-650]") {
+    FakeAtlas atlas;
+    SdfTextOptions opts;
+    opts.snap = SdfPenSnap::Nearest;
+
+    const auto sdf = fill_text_sdf(atlas, std::u32string(U"A"),
+                                   1.6f, 2.4f, 10.0f, opts);
+    const auto msdf = fill_text_msdf(atlas, std::u32string(U"A"),
+                                     1.6f, 2.4f, 10.0f, opts);
+    const auto psdf = fill_text_psdf(atlas, std::u32string(U"A"),
+                                     1.6f, 2.4f, 10.0f, opts);
+
+    REQUIRE(sdf.size() == 1);
+    REQUIRE(msdf.size() == 1);
+    REQUIRE(psdf.size() == 1);
+    REQUIRE(sdf[0].dst_x == msdf[0].dst_x);
+    REQUIRE(msdf[0].dst_x == psdf[0].dst_x);
+    REQUIRE(sdf[0].dst_y == psdf[0].dst_y);
 }
 
 TEST_CASE("build_text_quads works against MsdfAtlas (shared surface)",

--- a/test/test_signal.cpp
+++ b/test/test_signal.cpp
@@ -342,6 +342,39 @@ TEST_CASE("ADSR release to zero", "[signal][adsr]") {
     REQUIRE_THAT(env.next(), WithinAbs(0.0, 0.001));
 }
 
+TEST_CASE("ADSR handles immediate stages, idle note_off, and reset",
+          "[signal][adsr][issue-645]") {
+    Adsr env;
+    env.set_sample_rate(1000.0f);
+    env.set_params({0.0f, -0.01f, 0.25f, 0.0f});
+
+    env.note_off();
+    REQUIRE_FALSE(env.is_active());
+    REQUIRE(env.stage() == Adsr::Stage::idle);
+    REQUIRE_THAT(env.next(), WithinAbs(0.0f, 1e-6f));
+
+    env.note_on();
+    REQUIRE(env.stage() == Adsr::Stage::attack);
+    REQUIRE_THAT(env.next(), WithinAbs(1.0f, 1e-6f));
+    REQUIRE(env.stage() == Adsr::Stage::decay);
+    REQUIRE_THAT(env.next(), WithinAbs(0.25f, 1e-6f));
+    REQUIRE(env.stage() == Adsr::Stage::sustain);
+    REQUIRE_THAT(env.next(), WithinAbs(0.25f, 1e-6f));
+
+    env.note_off();
+    REQUIRE(env.stage() == Adsr::Stage::release);
+    REQUIRE_THAT(env.next(), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_FALSE(env.is_active());
+    REQUIRE(env.stage() == Adsr::Stage::idle);
+
+    env.note_on();
+    REQUIRE_THAT(env.next(), WithinAbs(1.0f, 1e-6f));
+    env.reset();
+    REQUIRE_FALSE(env.is_active());
+    REQUIRE(env.stage() == Adsr::Stage::idle);
+    REQUIRE_THAT(env.next(), WithinAbs(0.0f, 1e-6f));
+}
+
 // ── Biquad ───────────────────────────────────────────────────────────────────
 
 TEST_CASE("Biquad lowpass attenuates high frequencies", "[signal][biquad]") {
@@ -558,6 +591,53 @@ TEST_CASE("Oscillator triangle output", "[signal][osc]") {
     REQUIRE(rms > 0.2f); // Triangle RMS ≈ 1/sqrt(3) ≈ 0.577
 }
 
+TEST_CASE("Oscillator reset, phase wrap, and PolyBLEP edges are deterministic",
+          "[signal][osc][issue-645]") {
+    Oscillator sine;
+    sine.set_sample_rate(8.0f);
+    sine.set_frequency(2.0f);
+    sine.set_waveform(Oscillator::Waveform::sine);
+
+    REQUIRE_THAT(sine.frequency(), WithinAbs(2.0f, 1e-6f));
+    REQUIRE_THAT(sine.phase(), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(sine.next(), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(sine.phase(), WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(sine.next(), WithinAbs(1.0f, 1e-6f));
+    sine.reset();
+    REQUIRE_THAT(sine.phase(), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(sine.next(), WithinAbs(0.0f, 1e-6f));
+
+    Oscillator saw;
+    saw.set_sample_rate(10.0f);
+    saw.set_frequency(3.0f);
+    saw.set_waveform(Oscillator::Waveform::saw);
+
+    for (int i = 0; i < 4; ++i) {
+        REQUIRE(std::isfinite(saw.next()));
+    }
+    REQUIRE_THAT(saw.phase(), WithinAbs(0.2f, 1e-6f));
+
+    Oscillator square;
+    square.set_sample_rate(10.0f);
+    square.set_frequency(3.0f);
+    square.set_waveform(Oscillator::Waveform::square);
+
+    for (int i = 0; i < 4; ++i) {
+        REQUIRE(std::isfinite(square.next()));
+    }
+    REQUIRE_THAT(square.phase(), WithinAbs(0.2f, 1e-6f));
+
+    Oscillator triangle;
+    triangle.set_sample_rate(10.0f);
+    triangle.set_frequency(3.0f);
+    triangle.set_waveform(Oscillator::Waveform::triangle);
+
+    for (int i = 0; i < 4; ++i) {
+        REQUIRE(std::isfinite(triangle.next()));
+    }
+    REQUIRE_THAT(triangle.phase(), WithinAbs(0.2f, 1e-6f));
+}
+
 // ── SVF ──────────────────────────────────────────────────────────────────────
 
 TEST_CASE("SVF lowpass attenuates high frequencies", "[signal][svf]") {
@@ -678,6 +758,35 @@ TEST_CASE("NoiseGate passes loud signals", "[signal][gate]") {
     REQUIRE_THAT(out, WithinAbs(loud, 0.01));
 }
 
+TEST_CASE("NoiseGate clamps range, instant timing, reset, and buffers",
+          "[signal][gate][issue-645]") {
+    NoiseGate instant;
+    instant.set_sample_rate(1000.0f);
+    instant.set_params({-20.0f, 20.0f, 0.0f, 0.0f, -12.0f});
+
+    REQUIRE(instant.process(0.0f) == 0.0f);
+
+    const float quiet = 0.001f;
+    const float expected_range_gain = std::pow(10.0f, -12.0f / 20.0f);
+    REQUIRE_THAT(instant.process(quiet),
+                 WithinAbs(quiet * expected_range_gain, 1e-7f));
+    REQUIRE_THAT(instant.process(1.0f), WithinAbs(1.0f, 1e-6f));
+
+    float buffer[] = {quiet, 1.0f, -quiet};
+    instant.process(buffer, 3);
+    REQUIRE_THAT(buffer[0], WithinAbs(quiet * expected_range_gain, 1e-7f));
+    REQUIRE_THAT(buffer[1], WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(buffer[2], WithinAbs(-quiet * expected_range_gain, 1e-7f));
+
+    NoiseGate held;
+    held.set_sample_rate(1000.0f);
+    held.set_params({-20.0f, 20.0f, 0.0f, 1000.0f, -12.0f});
+    REQUIRE(std::abs(held.process(quiet)) < quiet);
+    REQUIRE(held.process(1.0f) < 1.0f);
+    held.reset();
+    REQUIRE_THAT(held.process(1.0f), WithinAbs(1.0f, 1e-6f));
+}
+
 // ── Panner ───────────────────────────────────────────────────────────────────
 
 TEST_CASE("Panner center", "[signal][panner]") {
@@ -746,6 +855,46 @@ TEST_CASE("Chorus produces stereo output", "[signal][chorus]") {
     REQUIRE(sum_r > 0);
     // Left and right should differ (stereo widening)
     REQUIRE(std::abs(sum_l - sum_r) > 0.01f);
+}
+
+TEST_CASE("Chorus dry mix, phase wrap, and reset are deterministic",
+          "[signal][chorus][issue-645]") {
+    Chorus dry;
+    dry.prepare(32.0f);
+    dry.set_rate(32.0f);
+    dry.set_depth(1.0f);
+    dry.set_delay_ms(20.0f);
+    dry.set_mix(0.0f);
+
+    for (float input : {1.0f, -0.5f, 0.25f}) {
+        auto out = dry.process(input);
+        REQUIRE_THAT(out.left, WithinAbs(input, 1e-6f));
+        REQUIRE_THAT(out.right, WithinAbs(input, 1e-6f));
+    }
+
+    Chorus chorus;
+    chorus.prepare(1000.0f);
+    chorus.set_rate(1000.0f);
+    chorus.set_depth(1.0f);
+    chorus.set_delay_ms(1.0f);
+    chorus.set_mix(1.0f);
+
+    const std::array<float, 6> input{{1.0f, 0.5f, -0.25f, 0.0f, 0.125f, 0.0f}};
+    std::array<Chorus::StereoSample, input.size()> first{};
+    std::array<Chorus::StereoSample, input.size()> second{};
+
+    for (size_t i = 0; i < input.size(); ++i) {
+        first[i] = chorus.process(input[i]);
+        REQUIRE(std::isfinite(first[i].left));
+        REQUIRE(std::isfinite(first[i].right));
+    }
+
+    chorus.reset();
+    for (size_t i = 0; i < input.size(); ++i) {
+        second[i] = chorus.process(input[i]);
+        REQUIRE_THAT(second[i].left, WithinAbs(first[i].left, 1e-6f));
+        REQUIRE_THAT(second[i].right, WithinAbs(first[i].right, 1e-6f));
+    }
 }
 
 // ── Phaser ───────────────────────────────────────────────────────────────────
@@ -819,6 +968,55 @@ TEST_CASE("Reverb produces decay tail", "[signal][reverb]") {
     REQUIRE(energy > 0.001f); // Should have reverb tail
 }
 
+TEST_CASE("Reverb handles zero decay, damping clamp, dry mix, and reset",
+          "[signal][reverb][issue-645]") {
+    Reverb reverb;
+    reverb.prepare(441.0f);
+    reverb.set_decay(0.0f);
+    reverb.set_damping(-1.0f);
+    reverb.set_mix(1.0f);
+
+    (void)reverb.process(1.0f);
+
+    float early_energy = 0.0f;
+    float late_energy = 0.0f;
+    for (int i = 0; i < 40; ++i) {
+        auto out = reverb.process(0.0f);
+        REQUIRE(std::isfinite(out.left));
+        REQUIRE(std::isfinite(out.right));
+        float energy = out.left * out.left + out.right * out.right;
+        if (i < 20) {
+            early_energy += energy;
+        } else {
+            late_energy += energy;
+        }
+    }
+
+    REQUIRE(early_energy > 0.0f);
+    REQUIRE_THAT(late_energy, WithinAbs(0.0f, 1e-6f));
+
+    reverb.set_decay(0.5f);
+    reverb.set_damping(4.0f);
+    (void)reverb.process(1.0f);
+    reverb.reset();
+
+    for (int i = 0; i < 24; ++i) {
+        auto out = reverb.process(0.0f);
+        REQUIRE_THAT(out.left, WithinAbs(0.0f, 1e-6f));
+        REQUIRE_THAT(out.right, WithinAbs(0.0f, 1e-6f));
+    }
+
+    Reverb dry;
+    dry.prepare(441.0f);
+    dry.set_decay(2.0f);
+    dry.set_damping(2.0f);
+    dry.set_mix(0.0f);
+
+    auto out = dry.process(0.25f);
+    REQUIRE_THAT(out.left, WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(out.right, WithinAbs(0.25f, 1e-6f));
+}
+
 // ── LadderFilter ─────────────────────────────────────────────────────────────
 
 TEST_CASE("LadderFilter lowpass behavior", "[signal][ladder]") {
@@ -836,6 +1034,35 @@ TEST_CASE("LadderFilter lowpass behavior", "[signal][ladder]") {
     }
     float rms = std::sqrt(sum_sq / 4210.0f);
     REQUIRE(rms < 0.05f); // 24dB/oct should heavily attenuate
+}
+
+TEST_CASE("LadderFilter resets buffer state and clamps resonance inputs",
+          "[signal][ladder][issue-645]") {
+    LadderFilter ladder;
+    ladder.set_sample_rate(48000.0f);
+    ladder.set_frequency(1200.0f);
+    ladder.set_resonance(-2.0f);
+
+    float impulse[] = {1.0f, 0.0f, 0.0f, 0.0f};
+    ladder.process(impulse, 4);
+    for (float sample : impulse) {
+        REQUIRE(std::isfinite(sample));
+    }
+
+    ladder.reset();
+    REQUIRE_THAT(ladder.process(0.0f), WithinAbs(0.0f, 1e-6f));
+
+    ladder.set_resonance(3.0f);
+    ladder.set_frequency(8000.0f);
+    for (int i = 0; i < 32; ++i) {
+        const float sample = (i == 0) ? 0.75f : 0.0f;
+        REQUIRE(std::isfinite(ladder.process(sample)));
+    }
+
+    float unchanged[] = {0.25f, -0.25f};
+    ladder.process(unchanged, 0);
+    REQUIRE_THAT(unchanged[0], WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(unchanged[1], WithinAbs(-0.25f, 1e-6f));
 }
 
 // ── LinkwitzRiley ────────────────────────────────────────────────────────────
@@ -868,6 +1095,55 @@ TEST_CASE("LinkwitzRiley splits into low and high bands", "[signal][lr]") {
         }
     }
     REQUIRE(high_energy > low_energy * 10.0f); // High band should dominate
+}
+
+TEST_CASE("LinkwitzRiley reset clears history while preserving coefficients",
+          "[signal][lr][issue-645]") {
+    auto impulse_response = [](LinkwitzRiley& lr) {
+        std::vector<LinkwitzRiley::BandSplit> response;
+        response.reserve(24);
+        for (int i = 0; i < 24; ++i) {
+            response.push_back(lr.process(i == 0 ? 1.0f : 0.0f));
+        }
+        return response;
+    };
+
+    LinkwitzRiley fresh;
+    fresh.set_frequency(1200.0f, 48000.0f);
+    auto expected = impulse_response(fresh);
+
+    LinkwitzRiley reused;
+    reused.set_frequency(1200.0f, 48000.0f);
+    for (int i = 0; i < 128; ++i) {
+        auto split = reused.process((i % 3 == 0) ? 0.75f : -0.25f);
+        REQUIRE(std::isfinite(split.low));
+        REQUIRE(std::isfinite(split.high));
+    }
+
+    reused.reset();
+    auto actual = impulse_response(reused);
+
+    REQUIRE(actual.size() == expected.size());
+    for (std::size_t i = 0; i < actual.size(); ++i) {
+        REQUIRE_THAT(actual[i].low, WithinAbs(expected[i].low, 1e-6f));
+        REQUIRE_THAT(actual[i].high, WithinAbs(expected[i].high, 1e-6f));
+    }
+}
+
+TEST_CASE("LinkwitzRiley cutoff boundary processing stays finite",
+          "[signal][lr][issue-645]") {
+    for (float cutoff : {0.0f, 20.0f, 20000.0f, 24000.0f}) {
+        LinkwitzRiley lr;
+        lr.set_frequency(cutoff, 48000.0f);
+
+        for (int i = 0; i < 64; ++i) {
+            float input = (i == 0) ? 1.0f : ((i % 2 == 0) ? 0.125f : -0.125f);
+            auto split = lr.process(input);
+            INFO("cutoff=" << cutoff << " sample=" << i);
+            REQUIRE(std::isfinite(split.low));
+            REQUIRE(std::isfinite(split.high));
+        }
+    }
 }
 
 // ── WindowFunction ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Consolidated codecov coverage batch to reduce GitHub macOS CI fan-out.

Supersedes small PRs: #2012, #2014, #2019, #2028, #2034, #2041.

Local macOS validation:
- CMake configure with `PULP_ENABLE_GPU=OFF`, examples off
- Built affected audio/MIDI/signal/canvas/OSC/SDF targets
- Ran affected C++ test binaries directly; all passed