### PR TITLE
test: consolidate tools host format codecov queue

### DIFF
--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -109,6 +109,9 @@ public:
     NodeId add_input_node(int channels, const std::string& name = "Input");
     NodeId add_output_node(int channels, const std::string& name = "Output");
     NodeId add_plugin_node(const PluginInfo& info);
+    NodeId add_unresolved_plugin_node(const PluginInfo& info,
+                                      int num_inputs, int num_outputs,
+                                      const std::string& name);
 
     // Add a plugin node wrapping a caller-provided slot. Useful for tests
     // (mock latency, mock processing) and for hosts that build their own

--- a/core/host/src/graph_serializer.cpp
+++ b/core/host/src/graph_serializer.cpp
@@ -253,7 +253,7 @@ GraphSerializer::LoadResult GraphSerializer::from_json(SignalGraph& graph, const
                             std::string(format_str(info.format)) + ":" + info.unique_id);
                         // Still create a placeholder Plugin node with no slot so
                         // connection IDs remain stable.
-                        new_id = graph.add_plugin_node(info);
+                        new_id = graph.add_unresolved_plugin_node(info, in_ch, out_ch, name);
                     } else {
                         if (pv.hasObjectMember("state_b64")) {
                             auto blob = b64_decode(pv["state_b64"].getString());

--- a/core/host/src/graph_serializer.cpp
+++ b/core/host/src/graph_serializer.cpp
@@ -253,7 +253,7 @@ GraphSerializer::LoadResult GraphSerializer::from_json(SignalGraph& graph, const
                             std::string(format_str(info.format)) + ":" + info.unique_id);
                         // Still create a placeholder Plugin node with no slot so
                         // connection IDs remain stable.
-                        new_id = graph.add_plugin_node(std::unique_ptr<PluginSlot>{}, in_ch, out_ch, name);
+                        new_id = graph.add_plugin_node(info);
                     } else {
                         if (pv.hasObjectMember("state_b64")) {
                             auto blob = b64_decode(pv["state_b64"].getString());

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -53,6 +53,24 @@ NodeId SignalGraph::add_plugin_node(const PluginInfo& info) {
     return nodes_.back().id;
 }
 
+NodeId SignalGraph::add_unresolved_plugin_node(const PluginInfo& info,
+                                               int num_inputs,
+                                               int num_outputs,
+                                               const std::string& name) {
+    GraphNode node;
+    node.id = next_id_++;
+    node.type = NodeType::Plugin;
+    node.name = name;
+    node.num_input_ports = num_inputs;
+    node.num_output_ports = num_outputs;
+    node.plugin_info = info;
+    node.plugin_info.num_inputs = num_inputs;
+    node.plugin_info.num_outputs = num_outputs;
+    nodes_.push_back(std::move(node));
+    invalidate_live_();
+    return nodes_.back().id;
+}
+
 NodeId SignalGraph::add_plugin_node(std::unique_ptr<PluginSlot> slot,
                                     int num_inputs, int num_outputs,
                                     const std::string& name) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1567,6 +1567,23 @@ catch_discover_tests(pulp-test-render-loop
     PROPERTIES
         LABELS coverage)
 
+add_executable(pulp-test-sdl3-surface
+    test_sdl3_surface.cpp
+    ${CMAKE_SOURCE_DIR}/core/render/src/sdl3_surface.cpp)
+target_include_directories(pulp-test-sdl3-surface PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/render/include)
+target_link_libraries(pulp-test-sdl3-surface PRIVATE
+    pulp::runtime
+    Catch2::Catch2WithMain)
+if(PULP_HAS_SDL3)
+    target_link_libraries(pulp-test-sdl3-surface PRIVATE
+        $<BUILD_INTERFACE:SDL3::SDL3-static>)
+    target_compile_definitions(pulp-test-sdl3-surface PRIVATE PULP_HAS_SDL3=1)
+endif()
+catch_discover_tests(pulp-test-sdl3-surface
+    PROPERTIES
+        LABELS coverage)
+
 # GPU-stack tests — pulp::render only exists when PULP_ENABLE_GPU=ON.
 # The sanitizer matrix builds with GPU off; without the guard configure
 # fails with "Target ... links to: pulp::render but the target was not

--- a/test/test_aax_model.cpp
+++ b/test/test_aax_model.cpp
@@ -392,10 +392,16 @@ TEST_CASE("AAX model validates fourcc and native plugin id derivation helpers", 
     REQUIRE(pulp::format::aax::fourcc("abc") == 0);
     REQUIRE(pulp::format::aax::fourcc("abcde") == 0);
     REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::fourcc("Pulp")) == "Pulp");
+    REQUIRE(pulp::format::aax::parameter_id_string(0) == "p00000000");
+    REQUIRE(pulp::format::aax::parameter_id_string(42) == "p0000002A");
+    REQUIRE(pulp::format::aax::parameter_id_string(0xffffffffu) == "pFFFFFFFF");
 
     const auto base = pulp::format::aax::fourcc("ABCD");
     REQUIRE(pulp::format::aax::derive_native_plugin_id(base, 0) == base);
     REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::derive_native_plugin_id(base, 1)) == "ABC1");
+    REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::derive_native_plugin_id(base, 10)) == "ABCA");
+    REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::derive_native_plugin_id(base, 35)) == "ABCZ");
+    REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::derive_native_plugin_id(base, 36)) == "ABCa");
     REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::derive_native_plugin_id(base, 61)) == "ABCz");
 
     const auto hashed = pulp::format::aax::derive_native_plugin_id(base, 62);
@@ -415,9 +421,67 @@ TEST_CASE("AAX model exposes stem mapping helpers for supported and unknown layo
     REQUIRE(pulp::format::aax::stem_kind_for_channels(9) == pulp::format::aax::StemKind::none);
 
     REQUIRE(pulp::format::aax::stem_channel_count(pulp::format::aax::StemKind::stereo) == 2);
+    REQUIRE(pulp::format::aax::stem_channel_count(pulp::format::aax::StemKind::surround_7_1) == 8);
     REQUIRE(std::string(pulp::format::aax::stem_signature(pulp::format::aax::StemKind::surround_5_1)) == "5.1");
+    REQUIRE(std::string(pulp::format::aax::stem_signature(pulp::format::aax::StemKind::surround_7_1)) == "7.1");
     REQUIRE(pulp::format::aax::stem_channel_count(pulp::format::aax::StemKind::lcrs) == 0);
     REQUIRE(std::string(pulp::format::aax::stem_signature(pulp::format::aax::StemKind::lcrs)) == "unknown");
+    REQUIRE(pulp::format::aax::stem_channel_count(pulp::format::aax::StemKind::surround_6_0) == 0);
+    REQUIRE(std::string(pulp::format::aax::stem_signature(pulp::format::aax::StemKind::surround_6_0)) == "unknown");
+}
+
+TEST_CASE("AAX model carries descriptor and parameter metadata into definitions", "[aax][model][coverage][issue-648]") {
+    auto codes = valid_codes();
+    auto descriptor = descriptor_with_buses(
+        {{"Main In", 2, false}},
+        {{"Main Out", 2, false}},
+        pulp::format::PluginCategory::Effect,
+        true,
+        true);
+    descriptor.name = "MetadataEffect";
+
+    ConfigurableProcessor::configure(
+        std::move(descriptor),
+        {
+            {
+                .id = 7,
+                .name = "Blend",
+                .unit = "%",
+                .range = {0.0f, 100.0f, 25.0f, 0.0f},
+                .to_string = [](float value) { return std::to_string(static_cast<int>(value)) + "%"; },
+                .from_string = [](const std::string& text) { return std::stof(text); },
+            },
+            {
+                .id = 8,
+                .name = "Shape",
+                .unit = "",
+                .range = {0.0f, 1.0f, 0.0f, 0.25f},
+            },
+        },
+        128);
+
+    auto result = pulp::format::aax::build_plugin_definition(make_configured_processor, codes);
+    REQUIRE(result.ok);
+    REQUIRE(result.definition.codes.manufacturer_id == codes.manufacturer_id);
+    REQUIRE(result.definition.supports_midi_input);
+    REQUIRE(result.definition.supports_midi_output);
+    REQUIRE(result.definition.uses_transport);
+    REQUIRE(result.definition.latency_samples == 128);
+    REQUIRE(result.definition.packet_float_count == 3);
+    REQUIRE(result.definition.parameters.size() == 2);
+    REQUIRE(result.definition.parameters[0].id == 7);
+    REQUIRE(result.definition.parameters[0].aax_id == "p00000007");
+    REQUIRE(result.definition.parameters[0].name == "Blend");
+    REQUIRE(result.definition.parameters[0].unit == "%");
+    REQUIRE(result.definition.parameters[0].range.default_value == 25.0f);
+    REQUIRE(result.definition.parameters[0].to_string(42.0f) == "42%");
+    REQUIRE(result.definition.parameters[0].from_string("64") == 64.0f);
+    REQUIRE_FALSE(result.definition.parameters[0].discrete);
+    REQUIRE(result.definition.parameters[1].discrete);
+    REQUIRE(result.definition.parameters[1].step_count == 5);
+    REQUIRE(result.definition.components.size() == 1);
+    REQUIRE(result.definition.components[0].native_plugin_id == codes.native_id_base);
+    REQUIRE(result.definition.components[0].description == "MetadataEffect stereo -> stereo");
 }
 
 TEST_CASE("AAX model truncates long labels and falls back for empty parameter names", "[aax][model]") {

--- a/test/test_ara.cpp
+++ b/test/test_ara.cpp
@@ -38,6 +38,29 @@ TEST_CASE("AraDocumentController subclass overrides work", "[ara]") {
     REQUIRE((c.supported_roles() & static_cast<int>(AraRole::EditorView)) != 0);
 }
 
+TEST_CASE("AraDocumentController defaults are inert and non-ARA", "[ara][coverage][issue-648]") {
+    AraDocumentController controller;
+    controller.begin_editing();
+    controller.notify_audio_source_content_changed(123);
+    controller.end_editing();
+    REQUIRE(controller.supported_roles() == static_cast<int>(AraRole::None));
+    REQUIRE(controller.is_ara_supported() == false);
+    REQUIRE(controller.ara_factory_name().empty());
+}
+
+TEST_CASE("AraRole bit values remain stable for adapter metadata", "[ara][coverage][issue-648]") {
+    REQUIRE(static_cast<int>(AraRole::None) == 0);
+    REQUIRE(static_cast<int>(AraRole::PlaybackRenderer) == 1);
+    REQUIRE(static_cast<int>(AraRole::EditorRenderer) == 2);
+    REQUIRE(static_cast<int>(AraRole::EditorView) == 4);
+
+    const auto render_and_view =
+        static_cast<int>(AraRole::PlaybackRenderer)
+        | static_cast<int>(AraRole::EditorRenderer)
+        | static_cast<int>(AraRole::EditorView);
+    REQUIRE(render_and_view == 7);
+}
+
 TEST_CASE("ara_sdk_generation reflects SDK headers", "[ara]") {
 #ifdef PULP_HAS_ARA
     // Compiled with the Celemony SDK — generation constant is at least

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/tools/audio/excerpt_service.hpp>
+#include <pulp/tools/audio/model_registry.hpp>
 #include <pulp/tools/audio/model_store.hpp>
 #include <pulp/tools/audio/service.hpp>
 
@@ -10,6 +11,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <string>
 #include <string_view>
 
 #ifdef _WIN32
@@ -79,7 +81,115 @@ uint64_t stable_hash64(std::string_view text) {
     return hash;
 }
 
+void write_installed_model_metadata(const fs::path& pulp_home,
+                                    const fs::path& checkpoint,
+                                    std::string_view checkpoint_key = "resolved_checkpoint_path") {
+    write_text(pulp_home / "audio" / "models" / "clap_music_audioset_v1.json", R"JSON({
+  "model_id": "clap_music_audioset_v1",
+  "backend": "clap",
+  "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
+  ")JSON" + std::string(checkpoint_key) + R"JSON(": ")JSON" + checkpoint.generic_string() + R"JSON("
+}
+)JSON");
+}
+
 } // namespace
+
+TEST_CASE("audio model registry resolves known models and checkpoint URLs",
+          "[audio][tools][issue-643]") {
+    const auto& models = registered_models();
+    REQUIRE_FALSE(models.empty());
+
+    auto* model = find_registered_model("clap_music_audioset_v1");
+    REQUIRE(model != nullptr);
+    REQUIRE(model->backend == "clap");
+    REQUIRE(model->auto_downloadable);
+    REQUIRE(find_registered_model("not_a_model") == nullptr);
+
+    REQUIRE(resolve_checkpoint_url("hf://user/repo/path/to/model.pt")
+            == "https://huggingface.co/user/repo/resolve/main/path/to/model.pt");
+    REQUIRE(resolve_checkpoint_url("https://example.test/model.bin")
+            == "https://example.test/model.bin");
+    REQUIRE(resolve_checkpoint_url("http://example.test/model.bin")
+            == "http://example.test/model.bin");
+    REQUIRE(resolve_checkpoint_url("hf://user-only").empty());
+    REQUIRE(resolve_checkpoint_url("hf://user/repo").empty());
+    REQUIRE(resolve_checkpoint_url("file:///tmp/model.pt").empty());
+}
+
+TEST_CASE("audio model store reads legacy metadata and malformed records fail closed",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    auto checkpoint = temp.path / "models" / "clap.pt";
+    write_text(checkpoint, "stub");
+    write_installed_model_metadata(temp.path, checkpoint, "checkpoint_path");
+
+    auto record = read_installed_model("clap_music_audioset_v1", temp.path);
+    REQUIRE(record.metadata_found);
+    REQUIRE(record.model_id == "clap_music_audioset_v1");
+    REQUIRE(record.backend == "clap");
+    REQUIRE(record.checkpoint_ref == "hf://lukewys/laion_clap/music.pt");
+    REQUIRE(record.resolved_checkpoint_path == checkpoint);
+    REQUIRE(record.checkpoint_exists);
+    REQUIRE(record.loadable());
+
+    write_text(temp.path / "audio" / "models" / "bad_model.json", "{");
+    auto bad = read_installed_model("bad_model", temp.path);
+    REQUIRE(bad.metadata_found);
+    REQUIRE(bad.model_id == "bad_model");
+    REQUIRE(bad.backend.empty());
+    REQUIRE_FALSE(bad.checkpoint_exists);
+    REQUIRE_FALSE(bad.loadable());
+}
+
+TEST_CASE("audio model list and activation JSON report inactive and error states",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+
+    auto list = list_models(temp.path);
+    REQUIRE(list.error.empty());
+    REQUIRE(list.active_model_id.empty());
+    REQUIRE(list.models.size() == 1);
+    REQUIRE(list.models[0].status == "not_installed");
+    REQUIRE_FALSE(list.models[0].active);
+
+    auto list_json = to_json(list);
+    REQUIRE(list_json.find("\"status\": \"not_installed\"") != std::string::npos);
+    REQUIRE(list_json.find("\"active\": false") != std::string::npos);
+
+    auto activation = activate_model("not_a_model", temp.path);
+    REQUIRE_FALSE(activation.ok);
+    auto activation_json = to_json(activation);
+    REQUIRE(activation_json.find("\"ok\": false") != std::string::npos);
+    REQUIRE(activation_json.find("unknown model_id: not_a_model") != std::string::npos);
+}
+
+TEST_CASE("audio model status falls back to legacy model.json and installed metadata",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    auto checkpoint = temp.path / "models" / "clap.pt";
+    write_text(checkpoint, "stub");
+    write_installed_model_metadata(temp.path, checkpoint, "checkpoint_path");
+    write_text(temp.path / "audio" / "model.json", R"JSON({
+  "model_id": "clap_music_audioset_v1"
+}
+)JSON");
+
+    auto status = query_model_status(temp.path);
+
+    REQUIRE(status.state_file_found);
+    REQUIRE(status.state_path.filename() == "model.json");
+    REQUIRE(status.configured_model_id == "clap_music_audioset_v1");
+    REQUIRE(status.backend == "clap");
+    REQUIRE(status.checkpoint_ref == "hf://lukewys/laion_clap/music.pt");
+    REQUIRE(status.resolved_checkpoint_path == checkpoint);
+    REQUIRE(status.checkpoint_exists);
+    REQUIRE(status.loadable());
+
+    auto json = to_json(status);
+    REQUIRE(json.find("\"loadable\": true") != std::string::npos);
+    REQUIRE(json.find("\"message\": \"configured model is loadable\"") != std::string::npos);
+}
 
 TEST_CASE("audio model list reports registry and install state", "[audio][tools]") {
     TempDir temp;
@@ -270,6 +380,76 @@ TEST_CASE("excerpt bundle reader fails clearly without manifest", "[audio][tools
     REQUIRE(result.error.find("bundle path does not exist") != std::string::npos);
 }
 
+TEST_CASE("excerpt bundle reader fills defaults from model and ranked result files",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    auto bundle = temp.path / "bundle";
+    fs::create_directories(bundle);
+
+    write_text(bundle / "manifest.json", R"JSON({
+  "tool": "pulp audio excerpt-find",
+  "bundle_version": 1
+}
+)JSON");
+
+    write_text(bundle / "model.json", R"JSON({
+  "model_id": "clap_music_audioset_v1",
+  "backend": "clap"
+}
+)JSON");
+
+    write_text(bundle / "ranked_results.json", R"JSON({
+  "results": [
+    {
+      "score": 0.25,
+      "source_path": "/tmp/source.wav",
+      "end_ms": 100
+    },
+    42,
+    {
+      "rank": 5,
+      "source_file": "/tmp/other.wav"
+    }
+  ]
+}
+)JSON");
+
+    auto result = read_excerpt_bundle(bundle);
+
+    REQUIRE(result.ok);
+    REQUIRE(result.requested_model_id == "clap_music_audioset_v1");
+    REQUIRE(result.loaded_model_id == "clap_music_audioset_v1");
+    REQUIRE(result.backend == "clap");
+    REQUIRE(result.result_count == 2);
+    REQUIRE(result.results.size() == 2);
+    REQUIRE(result.results[0].rank == 1);
+    REQUIRE(result.results[0].score == Catch::Approx(0.25));
+    REQUIRE(result.results[0].source_file == "/tmp/source.wav");
+    REQUIRE(result.results[1].rank == 5);
+
+    auto json = to_json(result);
+    REQUIRE(json.find("\"result_count\": 2") != std::string::npos);
+    REQUIRE(json.find("\"source_file\": \"/tmp/source.wav\"") != std::string::npos);
+}
+
+TEST_CASE("excerpt bundle reader rejects missing ranked result file",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    auto bundle = temp.path / "bundle";
+    fs::create_directories(bundle);
+
+    write_text(bundle / "manifest.json", R"JSON({
+  "tool": "pulp audio excerpt-find",
+  "bundle_version": 1
+}
+)JSON");
+
+    auto result = read_excerpt_bundle(bundle);
+
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.error.find("missing ranked results file") != std::string::npos);
+}
+
 TEST_CASE("excerpt find writes a deterministic WAV-first bundle", "[audio][tools]") {
     TempDir temp;
     auto checkpoint = temp.path / "models" / "clap.pt";
@@ -356,6 +536,93 @@ TEST_CASE("excerpt find deterministic scores use a stable hash", "[audio][tools]
     const auto key = request.text + "|" + input.string() + "|0|48000";
     const auto expected = static_cast<double>(stable_hash64(key) % 1000000ULL) / 1000000.0;
     REQUIRE(result.results.front().score == Catch::Approx(expected));
+}
+
+TEST_CASE("excerpt find validates request guard fields before model resolution",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    ExcerptFindRequest request;
+    request.input_path = temp.path;
+    request.top_k = 1;
+    request.max_candidates_per_file = 1;
+    request.window_ms = 1000;
+    request.hop_ms = 1000;
+
+    auto empty_text = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(empty_text.ok);
+    REQUIRE(empty_text.error == "text query is required");
+
+    request.text = "query";
+    request.input_path = fs::path{};
+    auto empty_input = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(empty_input.ok);
+    REQUIRE(empty_input.error == "input path is required");
+
+    request.input_path = temp.path / "missing.wav";
+    auto missing_input = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(missing_input.ok);
+    REQUIRE(missing_input.error.find("input path does not exist") != std::string::npos);
+
+    request.input_path = temp.path;
+    request.top_k = 0;
+    auto zero_top = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(zero_top.ok);
+    REQUIRE(zero_top.error == "top and max_candidates_per_file must be >= 1");
+
+    request.top_k = 1;
+    request.max_candidates_per_file = 0;
+    auto zero_candidates = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(zero_candidates.ok);
+    REQUIRE(zero_candidates.error == "top and max_candidates_per_file must be >= 1");
+
+    request.max_candidates_per_file = 1;
+    request.window_ms = 0;
+    auto zero_window = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(zero_window.ok);
+    REQUIRE(zero_window.error == "window_ms and hop_ms must be >= 1");
+
+    request.window_ms = 1000;
+    request.hop_ms = 0;
+    auto zero_hop = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(zero_hop.ok);
+    REQUIRE(zero_hop.error == "window_ms and hop_ms must be >= 1");
+}
+
+TEST_CASE("excerpt find reports unsupported inputs after model resolution",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    auto checkpoint = temp.path / "models" / "clap.pt";
+    write_text(checkpoint, "stub");
+    write_installed_model_metadata(temp.path, checkpoint);
+    write_text(temp.path / "audio" / "model-state.json", R"JSON({
+  "active_model_id": "clap_music_audioset_v1"
+}
+)JSON");
+
+    auto unsupported = temp.path / "notes.txt";
+    write_text(unsupported, "not audio");
+
+    ExcerptFindRequest request;
+    request.text = "query";
+    request.input_path = unsupported;
+    request.top_k = 1;
+    request.max_candidates_per_file = 1;
+    request.window_ms = 1000;
+    request.hop_ms = 1000;
+    request.dry_run = true;
+
+    auto result = run_excerpt_find(request, temp.path);
+
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.requested_model_id == "clap_music_audioset_v1");
+    REQUIRE(result.error == "no supported WAV inputs found");
+    REQUIRE(result.scanned_file_count == 0);
+    REQUIRE(result.skipped_files.size() == 1);
+    REQUIRE(result.skipped_files[0].find("unsupported; WAV only") != std::string::npos);
+
+    auto json = to_json(result);
+    REQUIRE(json.find("\"ok\": false") != std::string::npos);
+    REQUIRE(json.find("unsupported; WAV only") != std::string::npos);
 }
 
 #if !defined(_WIN32)

--- a/test/test_binding.cpp
+++ b/test/test_binding.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/state/binding.hpp>
+#include <vector>
 
 using namespace pulp::state;
 using Catch::Matchers::WithinAbs;
@@ -61,6 +62,41 @@ TEST_CASE("Binding normalized", "[binding]") {
     REQUIRE_THAT(b.get(), WithinAbs(24.0, 0.1));
 }
 
+TEST_CASE("Binding unknown parameter operations stay inert",
+          "[binding][coverage][issue-646]") {
+    auto store = make_store();
+    Binding b(*store,999);
+    int call_count = 0;
+    b.on_change([&](float) { ++call_count; });
+
+    REQUIRE(b.is_bound());
+    REQUIRE(b.id() == 999);
+    REQUIRE(b.info() == nullptr);
+    REQUIRE_THAT(b.get(), WithinAbs(0.0, 0.01));
+    REQUIRE_THAT(b.get_normalized(), WithinAbs(0.0, 0.01));
+
+    b.set(12.0f);
+    b.set_normalized(0.75f);
+    REQUIRE_FALSE(b.poll());
+    REQUIRE(call_count == 0);
+}
+
+TEST_CASE("Binding set_normalized clamps and quantizes through store",
+          "[binding][coverage][issue-646]") {
+    auto store = make_store();
+    Binding b(*store,1); // range -60..24, step 0.1
+
+    b.set_normalized(-0.25f);
+    REQUIRE_THAT(b.get(), WithinAbs(-60.0, 0.01));
+
+    b.set_normalized(1.25f);
+    REQUIRE_THAT(b.get(), WithinAbs(24.0, 0.01));
+
+    b.set_normalized(0.1234f);
+    REQUIRE_THAT(b.get(), WithinAbs(-49.6, 0.01));
+    REQUIRE_THAT(b.get_normalized(), WithinAbs(0.1238, 0.001));
+}
+
 TEST_CASE("Binding set_normalized only notifies when value changes", "[binding]") {
     auto store = make_store();
     Binding b(*store,2); // range 0..100, default 50
@@ -85,6 +121,29 @@ TEST_CASE("Binding on_change fires", "[binding]") {
 
     b.set(6.0f);
     REQUIRE_THAT(received, WithinAbs(6.0, 0.01));
+}
+
+TEST_CASE("Binding on_change callbacks fire in registration order",
+          "[binding][coverage][issue-646]") {
+    auto store = make_store();
+    Binding b(*store,1);
+    std::vector<int> calls;
+    std::vector<float> values;
+
+    b.on_change([&](float v) {
+        calls.push_back(1);
+        values.push_back(v);
+    });
+    b.on_change([&](float v) {
+        calls.push_back(2);
+        values.push_back(v);
+    });
+
+    b.set(3.5f);
+    REQUIRE(calls == std::vector<int>{1, 2});
+    REQUIRE(values.size() == 2);
+    REQUIRE_THAT(values[0], WithinAbs(3.5, 0.01));
+    REQUIRE_THAT(values[1], WithinAbs(3.5, 0.01));
 }
 
 TEST_CASE("Binding on_change does not fire for same value", "[binding]") {

--- a/test/test_child_process.cpp
+++ b/test/test_child_process.cpp
@@ -161,6 +161,35 @@ TEST_CASE("wait and read before start return default results",
     REQUIRE_FALSE(r.was_cancelled);
 }
 
+TEST_CASE("read_available_output drains stdout while process is running",
+          "[child_process][edge][issue-640]") {
+    ChildProcess cp;
+
+#ifdef _WIN32
+    REQUIRE(cp.start("cmd",
+                     {"/c", "<nul set /p dummy=available& ping -n 3 127.0.0.1 >nul"}));
+#else
+    REQUIRE(cp.start("/bin/sh", {"-c", "printf available; sleep 1"}));
+#endif
+
+    std::string observed;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (observed.find("available") == std::string::npos
+           && std::chrono::steady_clock::now() < deadline) {
+        observed += cp.read_available_output();
+        if (observed.find("available") == std::string::npos) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+
+    REQUIRE(observed.find("available") != std::string::npos);
+
+    auto r = cp.wait();
+    REQUIRE(r.exit_code == 0);
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE_FALSE(r.was_cancelled);
+}
+
 TEST_CASE("run honors working directory",
           "[child_process][edge][issue-640]") {
     auto dir = std::filesystem::temp_directory_path()

--- a/test/test_cli_fetchcontent_cache.cpp
+++ b/test/test_cli_fetchcontent_cache.cpp
@@ -88,6 +88,14 @@ std::string json_field_fragment(const std::string& key,
 
 }  // namespace
 
+TEST_CASE("status and fix labels fall back to unknown",
+          "[fetchcontent_cache][issue-643]") {
+    CHECK(std::string(fcc::status_label(fcc::CacheStatus::Healthy)) == "healthy");
+    CHECK(std::string(fcc::fix_outcome_label(fcc::FixOutcome::Removed)) == "removed");
+    CHECK(std::string(fcc::status_label(static_cast<fcc::CacheStatus>(99))) == "unknown");
+    CHECK(std::string(fcc::fix_outcome_label(static_cast<fcc::FixOutcome>(99))) == "unknown");
+}
+
 // ── Acceptance scenario 1: healthy ──────────────────────────────────────────
 
 TEST_CASE("discover: healthy entries report Healthy and exit 0",
@@ -268,6 +276,75 @@ TEST_CASE("discover: missing cache root returns empty and renders OK",
     CHECK(out.str().find("no entries") != std::string::npos);
 }
 
+TEST_CASE("discover: undeclared entries use fallback splitting and stable order",
+          "[fetchcontent_cache][issue-643]") {
+    fs::path root = "/fake/cache";
+    fs::path plain = root / "zlib";
+    fs::path split = root / "foo-bar-baz";
+    fs::path alpha = root / "alpha-v1";
+    MockState state;
+    state.children = {plain, split, alpha};
+
+    fcc::StatInfo info;
+    info.exists = true;
+    info.is_symlink = false;
+    info.is_directory = true;
+    info.is_user_writable = true;
+    state.lstat_results[plain] = info;
+    state.lstat_results[split] = info;
+    state.lstat_results[alpha] = info;
+
+    auto env = make_mock_env(root, {}, state);
+    auto entries = fcc::discover_fetchcontent_cache(env);
+
+    REQUIRE(entries.size() == 3);
+    CHECK(entries[0].name == "alpha-v1");
+    CHECK(entries[0].dep_name == "alpha");
+    CHECK(entries[0].cached_ref == "v1");
+    CHECK(entries[1].name == "foo-bar-baz");
+    CHECK(entries[1].dep_name == "foo-bar");
+    CHECK(entries[1].cached_ref == "baz");
+    CHECK(entries[2].name == "zlib");
+    CHECK(entries[2].dep_name == "zlib");
+    CHECK(entries[2].cached_ref.empty());
+    for (const auto& entry : entries) {
+        CHECK(entry.status == fcc::CacheStatus::Healthy);
+    }
+}
+
+TEST_CASE("discover: live symlink follows target and stays healthy",
+          "[fetchcontent_cache][issue-643]") {
+    fs::path root = "/fake/cache";
+    fs::path entry = root / "threejs-077dd13c0e869d9f3dbe55875686f920367de457";
+    MockState state;
+    state.children = {entry};
+
+    fcc::StatInfo link_info;
+    link_info.exists = true;
+    link_info.is_symlink = true;
+    link_info.symlink_target = "/Users/me/Code/three.js";
+    link_info.is_user_writable = true;
+    state.lstat_results[entry] = link_info;
+
+    fcc::StatInfo target_info;
+    target_info.exists = true;
+    target_info.is_directory = true;
+    target_info.is_user_writable = true;
+    state.stat_follow_results[entry] = target_info;
+
+    fcc::DeclaredRefs refs{
+        {"threejs", "077dd13c0e869d9f3dbe55875686f920367de457"}};
+    auto env = make_mock_env(root, refs, state);
+
+    auto entries = fcc::discover_fetchcontent_cache(env);
+    REQUIRE(entries.size() == 1);
+    CHECK(entries[0].status == fcc::CacheStatus::Healthy);
+    CHECK(entries[0].is_symlink);
+    CHECK(entries[0].resolved_target == fs::path("/Users/me/Code/three.js"));
+    CHECK_FALSE(fcc::any_unhealthy(entries));
+    CHECK_FALSE(fcc::blocks_preflight(entries));
+}
+
 TEST_CASE("discover: lstat miss reports Unknown and blocks preflight",
           "[fetchcontent_cache][issue-643]") {
     fs::path root = "/fake/cache";
@@ -348,6 +425,39 @@ TEST_CASE("apply_fixes: removes a real fixable entry from a tempdir",
     fs::remove_all(tmp, ec);
 }
 
+TEST_CASE("apply_fixes: removes symlinks without deleting their targets",
+          "[fetchcontent_cache][issue-643]") {
+#ifdef _WIN32
+    SKIP("symlink creation requires privileges on Windows");
+#else
+    auto tmp = fs::temp_directory_path() / "pulp-fcc-symlink-test-643";
+    std::error_code ec;
+    fs::remove_all(tmp, ec);
+    fs::create_directories(tmp / "target");
+    auto link = tmp / "stale-link";
+    fs::create_directory_symlink(tmp / "target", link, ec);
+    if (ec) {
+        fs::remove_all(tmp, ec);
+        SKIP("symlink creation unavailable in this filesystem");
+    }
+    REQUIRE(fs::is_symlink(fs::symlink_status(link)));
+    REQUIRE(fs::exists(tmp / "target"));
+
+    fcc::CacheEntry e;
+    e.name = "stale-link";
+    e.path = link;
+    e.status = fcc::CacheStatus::Dangling;
+    e.fixable = true;
+
+    auto results = fcc::apply_fixes({e}, /*dry_run=*/false);
+    REQUIRE(results.size() == 1);
+    CHECK(results[0].outcome == fcc::FixOutcome::Removed);
+    CHECK_FALSE(fs::exists(fs::symlink_status(link)));
+    CHECK(fs::exists(tmp / "target"));
+    fs::remove_all(tmp, ec);
+#endif
+}
+
 // ── parse_declared_refs_from_text: handles the real CMakeLists shape ───────
 
 TEST_CASE("parse_declared_refs_from_text: extracts name → REF map",
@@ -371,6 +481,27 @@ TEST_CASE("parse_declared_refs_from_text: extracts name → REF map",
     // is what protects stale-commit detection from false positives on
     // example/documentation snippets in CMakeLists.
     CHECK(refs.count("commented") == 0);
+}
+
+TEST_CASE("parse_declared_refs_from_file reads files and ignores missing paths",
+          "[fetchcontent_cache][issue-643]") {
+    auto tmp = fs::temp_directory_path() / "pulp-fcc-parse-file-643";
+    std::error_code ec;
+    fs::remove_all(tmp, ec);
+    fs::create_directories(tmp);
+    auto cmake = tmp / "CMakeLists.txt";
+    {
+        std::ofstream out(cmake);
+        out << "pulp_register_fetchcontent_source(Yoga REF release/3.2.12)\n";
+        out << "pulp_register_fetchcontent_source(no_ref URL https://example.invalid)\n";
+    }
+
+    auto refs = fcc::parse_declared_refs_from_file(cmake);
+    REQUIRE(refs.size() == 1);
+    CHECK(refs.at("yoga") == "release/3.2.12");
+    CHECK(refs.count("no_ref") == 0);
+    CHECK(fcc::parse_declared_refs_from_file(tmp / "missing.txt").empty());
+    fs::remove_all(tmp, ec);
 }
 
 // ── Multi-hyphen dep names split correctly ─────────────────────────────────

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -593,6 +593,90 @@ TEST_CASE("pulp status reports shipyard version and pin health",
 }
 #endif
 
+TEST_CASE("pulp config set/get/list round-trips isolated update settings",
+          "[cli][shellout][config][issue-643]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto home = unique_temp_dir("pulp-config-roundtrip");
+    fs::remove_all(home);
+    fs::create_directories(home);
+    write_text(home / "update-snooze", "dismissed\n");
+
+    ScopedEnvVar pulp_home("PULP_HOME");
+    pulp_home.set(home.string());
+    ScopedEnvVar update_disabled("PULP_UPDATE_CHECK_DISABLED");
+    update_disabled.set("1");
+
+    auto set_mode = run_pulp({"config", "set", "update.mode", "manual"}, 10000);
+    REQUIRE_FALSE(set_mode.timed_out);
+    REQUIRE(set_mode.exit_code == 0);
+    REQUIRE(set_mode.stdout_output.find("Set update.mode = manual") != std::string::npos);
+    REQUIRE_FALSE(fs::exists(home / "update-snooze"));
+
+    auto get_mode = run_pulp({"config", "get", "update.mode"}, 10000);
+    REQUIRE_FALSE(get_mode.timed_out);
+    REQUIRE(get_mode.exit_code == 0);
+    REQUIRE(get_mode.stdout_output == "manual\n");
+
+    auto set_channel = run_pulp({"config", "set", "update.channel", "beta"}, 10000);
+    REQUIRE_FALSE(set_channel.timed_out);
+    REQUIRE(set_channel.exit_code == 0);
+    REQUIRE(set_channel.stdout_output.find("Set update.channel = beta") != std::string::npos);
+
+    auto list = run_pulp({"config", "list"}, 10000);
+    const auto config_body = read_file(home / "config.toml");
+    fs::remove_all(home);
+
+    REQUIRE_FALSE(list.timed_out);
+    REQUIRE(list.exit_code == 0);
+    REQUIRE(list.stdout_output.find("update.mode = manual") != std::string::npos);
+    REQUIRE(list.stdout_output.find("update.check_interval_hours = 24") != std::string::npos);
+    REQUIRE(list.stdout_output.find("update.channel = beta") != std::string::npos);
+    REQUIRE(list.stdout_output.find("update.bump_projects = prompt") != std::string::npos);
+    REQUIRE(config_body.find("[update]") != std::string::npos);
+    REQUIRE(config_body.find("mode = \"manual\"") != std::string::npos);
+    REQUIRE(config_body.find("channel = \"beta\"") != std::string::npos);
+}
+
+TEST_CASE("pulp config rejects malformed and invalid update keys",
+          "[cli][shellout][config][issue-643]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto home = unique_temp_dir("pulp-config-invalid");
+    fs::remove_all(home);
+    fs::create_directories(home);
+
+    ScopedEnvVar pulp_home("PULP_HOME");
+    pulp_home.set(home.string());
+    ScopedEnvVar update_disabled("PULP_UPDATE_CHECK_DISABLED");
+    update_disabled.set("1");
+
+    auto malformed_get = run_pulp({"config", "get", "update"}, 10000);
+    REQUIRE_FALSE(malformed_get.timed_out);
+    REQUIRE(malformed_get.exit_code != 0);
+    REQUIRE(malformed_get.stderr_output.find("key must be dotted") != std::string::npos);
+
+    auto unknown_key = run_pulp({"config", "set", "update.not_a_key", "value"}, 10000);
+    REQUIRE_FALSE(unknown_key.timed_out);
+    REQUIRE(unknown_key.exit_code != 0);
+    REQUIRE(unknown_key.stderr_output.find("unknown config key") != std::string::npos);
+
+    auto bad_mode = run_pulp({"config", "set", "update.mode", "weekly"}, 10000);
+    REQUIRE_FALSE(bad_mode.timed_out);
+    REQUIRE(bad_mode.exit_code != 0);
+    REQUIRE(bad_mode.stderr_output.find("update.mode must be one of") != std::string::npos);
+
+    auto bad_interval =
+        run_pulp({"config", "set", "update.check_interval_hours", "-1"}, 10000);
+    const bool config_written = fs::exists(home / "config.toml");
+    fs::remove_all(home);
+
+    REQUIRE_FALSE(bad_interval.timed_out);
+    REQUIRE(bad_interval.exit_code != 0);
+    REQUIRE(bad_interval.stderr_output.find("non-negative integer") != std::string::npos);
+    REQUIRE_FALSE(config_written);
+}
+
 TEST_CASE("pulp version subcommand runs and mentions the SDK",
           "[cli][shellout][version]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }

--- a/test/test_descriptor_validation.cpp
+++ b/test/test_descriptor_validation.cpp
@@ -35,6 +35,16 @@ bool has_warning_on(const std::vector<DescriptorIssue>& issues,
     return false;
 }
 
+std::size_t warning_count_on(const std::vector<DescriptorIssue>& issues,
+                             const std::string& field) {
+    std::size_t count = 0;
+    for (const auto& i : issues) {
+        if (i.severity == DescriptorIssueSeverity::Warning && i.field == field)
+            ++count;
+    }
+    return count;
+}
+
 } // namespace
 
 TEST_CASE("DescriptorValidation: well-formed effect passes with no issues",
@@ -221,6 +231,19 @@ TEST_CASE("DescriptorValidation: supports_ump follows the accepts_midi sidecar w
         REQUIRE_FALSE(has_warning_on(issues, "accepts_midi"));
         REQUIRE(descriptor_is_valid(issues));
     }
+}
+
+TEST_CASE("DescriptorValidation: MIDI capability warnings accumulate without invalidating descriptor",
+          "[format][descriptor-validation][coverage][issue-646]") {
+    auto d = well_formed_effect();
+    d.category = PluginCategory::MidiEffect;
+    d.accepts_midi = false;
+    d.supports_mpe = true;
+    d.supports_ump = true;
+
+    auto issues = validate_descriptor(d);
+    REQUIRE(warning_count_on(issues, "accepts_midi") == 2);
+    REQUIRE(descriptor_is_valid(issues));
 }
 
 TEST_CASE("DescriptorValidation: MidiEffect without audio output is valid",

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -191,6 +191,22 @@ TEST_CASE("Environment: token move assignment replaces prior subscription",
     REQUIRE(second_calls == 1);
 }
 
+TEST_CASE("Environment: token self move assignment preserves subscription",
+          "[environment][issue-640]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+    REQUIRE(token.valid());
+
+    Environment::Token& alias = token;
+    token = std::move(alias);
+    REQUIRE(token.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(calls == 1);
+}
+
 TEST_CASE("Environment: keyboard inset change propagates separately",
           "[environment]") {
     Environment::reset_for_test();
@@ -438,6 +454,63 @@ TEST_CASE("Environment: listener unsubscribed mid-dispatch is not invoked "
     Environment::inject_for_test(make_state(ColorScheme::light));
     REQUIRE(a_calls == 2);
     REQUIRE(b_calls == 1);
+}
+
+TEST_CASE("Environment: listener removed before its dispatch turn is skipped",
+          "[environment][issue-640]") {
+    Environment::reset_for_test();
+
+    int victim_calls = 0;
+    int survivor_calls = 0;
+    Environment::Token victim;
+
+    auto killer = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { victim.reset(); });
+    victim = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++victim_calls; });
+    auto survivor = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++survivor_calls; });
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+
+    REQUIRE(killer.valid());
+    REQUIRE_FALSE(victim.valid());
+    REQUIRE(survivor.valid());
+    REQUIRE(victim_calls == 0);
+    REQUIRE(survivor_calls == 1);
+}
+
+TEST_CASE("Environment: reset during dispatch clears later callbacks",
+          "[environment][issue-640]") {
+    Environment::reset_for_test();
+
+    int resetter_calls = 0;
+    int later_calls = 0;
+    auto resetter = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) {
+            ++resetter_calls;
+            Environment::reset_for_test();
+        });
+    auto later = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++later_calls; });
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+
+    REQUIRE(resetter_calls == 1);
+    REQUIRE(later_calls == 0);
+    REQUIRE(resetter.valid());
+    REQUIRE(later.valid());
+    REQUIRE(Environment::instance().snapshot().color_scheme
+            == ColorScheme::unknown);
+
+    resetter.reset();
+    later.reset();
+    REQUIRE_FALSE(resetter.valid());
+    REQUIRE_FALSE(later.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(resetter_calls == 1);
+    REQUIRE(later_calls == 0);
 }
 
 TEST_CASE("Environment: snapshot is consistent with last publish",

--- a/test/test_graph_serializer.cpp
+++ b/test/test_graph_serializer.cpp
@@ -474,6 +474,52 @@ TEST_CASE("GraphSerializer preserves unresolved plugin identity when reserializi
     REQUIRE(second_json.find("\"state_b64\"") == std::string::npos);
 }
 
+TEST_CASE("GraphSerializer preserves unresolved plugin display name",
+          "[host][serializer][issue-493]") {
+    const auto json = R"({
+      "format_version": 1,
+      "nodes": [
+        {
+          "id": 7,
+          "type": "plugin",
+          "name": "User Label",
+          "num_input_ports": 1,
+          "num_output_ports": 1,
+          "plugin": {
+            "format": "clap",
+            "unique_id": "pulp.test.renamed.missing",
+            "name": "Plugin Metadata Name",
+            "manufacturer": "PulpTest",
+            "version": "1.0.0",
+            "last_path": "/nonexistent/Plugin Metadata Name.clap"
+          }
+        }
+      ],
+      "connections": []
+    })";
+
+    SignalGraph dst;
+    auto result = GraphSerializer::from_json(dst, json);
+    REQUIRE(result.ok);
+    REQUIRE(missing_plugins_contain(result, "clap:pulp.test.renamed.missing"));
+    REQUIRE(dst.nodes().size() == 1);
+
+    const auto& node = dst.nodes().front();
+    REQUIRE(node.type == NodeType::Plugin);
+    REQUIRE(node.plugin == nullptr);
+    REQUIRE(node.name == "User Label");
+    REQUIRE(node.plugin_info.name == "Plugin Metadata Name");
+    REQUIRE(node.plugin_info.unique_id == "pulp.test.renamed.missing");
+
+    const auto second_json = GraphSerializer::to_json(dst);
+    REQUIRE(second_json.find("\"name\": \"User Label\"") != std::string::npos);
+    REQUIRE(second_json.find("\"name\": \"Plugin Metadata Name\"") !=
+            std::string::npos);
+    REQUIRE(second_json.find("\"unique_id\": \"pulp.test.renamed.missing\"") !=
+            std::string::npos);
+    REQUIRE(second_json.find("\"state_b64\"") == std::string::npos);
+}
+
 TEST_CASE("GraphSerializer clears partially loaded graphs after plugin field errors",
           "[host][serializer][issue-493]") {
     SignalGraph dst;

--- a/test/test_graph_serializer.cpp
+++ b/test/test_graph_serializer.cpp
@@ -445,6 +445,75 @@ TEST_CASE("GraphSerializer serializes plugin formats and state blobs",
     }
 }
 
+TEST_CASE("GraphSerializer preserves unresolved plugin identity when reserializing",
+          "[host][serializer][issue-493]") {
+    SignalGraph src;
+    auto info = make_fake_plugin_info("MissingEcho", "pulp.test.missing.echo",
+                                      PluginFormat::CLAP, 2, 2);
+    src.add_plugin_node(info);
+
+    const auto first_json = GraphSerializer::to_json(src);
+    REQUIRE(first_json.find("\"unique_id\": \"pulp.test.missing.echo\"") !=
+            std::string::npos);
+    REQUIRE(first_json.find("\"state_b64\"") == std::string::npos);
+
+    SignalGraph dst;
+    auto result = GraphSerializer::from_json(dst, first_json);
+    REQUIRE(result.ok);
+    REQUIRE(missing_plugins_contain(result, "clap:pulp.test.missing.echo"));
+    REQUIRE(dst.nodes().size() == 1);
+    REQUIRE(dst.nodes().front().type == NodeType::Plugin);
+    REQUIRE(dst.nodes().front().plugin == nullptr);
+
+    const auto second_json = GraphSerializer::to_json(dst);
+    REQUIRE(second_json.find("\"format\": \"clap\"") != std::string::npos);
+    REQUIRE(second_json.find("\"unique_id\": \"pulp.test.missing.echo\"") !=
+            std::string::npos);
+    REQUIRE(second_json.find("\"last_path\": \"/nonexistent/MissingEcho.clap\"") !=
+            std::string::npos);
+    REQUIRE(second_json.find("\"state_b64\"") == std::string::npos);
+}
+
+TEST_CASE("GraphSerializer clears partially loaded graphs after plugin field errors",
+          "[host][serializer][issue-493]") {
+    SignalGraph dst;
+    auto result = GraphSerializer::from_json(dst, R"({
+  "format_version": 1,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "audio_in",
+      "name": "Input",
+      "num_input_ports": 0,
+      "num_output_ports": 1,
+      "gain": 1
+    },
+    {
+      "id": 2,
+      "type": "plugin",
+      "name": "Broken plugin",
+      "num_input_ports": 1,
+      "num_output_ports": 1,
+      "gain": 1,
+      "plugin": {
+        "format": "clap",
+        "unique_id": 123,
+        "name": "Broken plugin",
+        "manufacturer": "PulpTest",
+        "version": "1.0.0",
+        "last_path": "/missing/broken.clap"
+      }
+    }
+  ],
+  "connections": []
+})");
+
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.error.find("field deserialization failed") != std::string::npos);
+    REQUIRE(dst.nodes().empty());
+    REQUIRE(dst.connections().empty());
+}
+
 TEST_CASE("GraphSerializer round-trips MIDI routing", "[host][serializer]") {
     SignalGraph src;
     auto midi_in = src.add_midi_input_node();

--- a/test/test_headless.cpp
+++ b/test/test_headless.cpp
@@ -34,15 +34,27 @@ public:
         });
     }
 
-    void prepare(const pulp::format::PrepareContext&) override {}
+    void prepare(const pulp::format::PrepareContext& context) override {
+        ++prepare_calls;
+        last_prepare_context = context;
+    }
+
+    void release() override { ++release_calls; }
 
     void process(
         pulp::audio::BufferView<float>& output,
         const pulp::audio::BufferView<const float>& input,
-        pulp::midi::MidiBuffer&, pulp::midi::MidiBuffer&,
+        pulp::midi::MidiBuffer& midi_in, pulp::midi::MidiBuffer&,
         const pulp::format::ProcessContext& context) override
     {
         last_context = context;
+        ++process_calls;
+        midi_in_events = 0;
+        for (const auto& event : midi_in) {
+            if (event.is_note_on()) ++midi_note_ons;
+            ++midi_in_events;
+        }
+
         float db = state().get_value(1);
         float gain = std::pow(10.0f, db / 20.0f);
         for (std::size_t ch = 0; ch < output.num_channels() && ch < input.num_channels(); ++ch) {
@@ -63,6 +75,12 @@ public:
     }
 
     std::string plugin_state;
+    pulp::format::PrepareContext last_prepare_context{};
+    int prepare_calls = 0;
+    int release_calls = 0;
+    int process_calls = 0;
+    int midi_in_events = 0;
+    int midi_note_ons = 0;
 };
 
 std::unique_ptr<pulp::format::Processor> create_test_gain() {
@@ -100,6 +118,41 @@ TEST_CASE("HeadlessHost processes audio at unity gain", "[headless]") {
 
     // 0 dB = unity gain
     REQUIRE_THAT(out.channel(0)[0], WithinAbs(0.5, 0.001));
+}
+
+TEST_CASE("HeadlessHost forwards prepare context and release",
+          "[headless][coverage][issue-647]") {
+    pulp::format::HeadlessHost host(create_test_gain);
+    REQUIRE(last_processor != nullptr);
+    auto* processor = last_processor;
+
+    host.prepare(96000.0, 1024, 1, 4);
+    REQUIRE(processor->prepare_calls == 1);
+    REQUIRE_THAT(processor->last_prepare_context.sample_rate,
+                 WithinAbs(96000.0, 0.001));
+    REQUIRE(processor->last_prepare_context.max_buffer_size == 1024);
+    REQUIRE(processor->last_prepare_context.input_channels == 1);
+    REQUIRE(processor->last_prepare_context.output_channels == 4);
+
+    host.release();
+    REQUIRE(processor->release_calls == 1);
+}
+
+TEST_CASE("HeadlessHost fills default process context",
+          "[headless][coverage][issue-647]") {
+    pulp::format::HeadlessHost host(create_test_gain);
+    host.prepare(44100.0, 512);
+
+    pulp::audio::Buffer<float> in(2, 32), out(2, 32);
+    const float* in_ptrs[2] = {in.channel(0).data(), in.channel(1).data()};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 2, 32);
+    auto out_view = out.view();
+
+    last_context = {};
+    host.process(out_view, in_view);
+
+    REQUIRE_THAT(last_context.sample_rate, WithinAbs(44100.0, 0.001));
+    REQUIRE(last_context.num_samples == 32);
 }
 
 TEST_CASE("HeadlessHost applies parameter changes", "[headless]") {
@@ -152,6 +205,47 @@ TEST_CASE("HeadlessHost accepts explicit transport context for offline stepping"
     REQUIRE(last_context.position_samples == 2048);
     REQUIRE(last_context.time_sig_numerator == 7);
     REQUIRE(last_context.time_sig_denominator == 8);
+}
+
+TEST_CASE("HeadlessHost forwards explicit MIDI buffers",
+          "[headless][coverage][issue-647]") {
+    pulp::format::HeadlessHost host(create_test_gain);
+    host.prepare(48000.0, 256);
+    REQUIRE(last_processor != nullptr);
+    auto* processor = last_processor;
+
+    pulp::audio::Buffer<float> in(2, 16), out(2, 16);
+    const float* in_ptrs[2] = {in.channel(0).data(), in.channel(1).data()};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 2, 16);
+    auto out_view = out.view();
+    pulp::midi::MidiBuffer midi_in;
+    pulp::midi::MidiBuffer midi_out;
+    midi_in.add(pulp::midi::MidiEvent::note_on(0, 64, 100));
+
+    host.process(out_view, in_view, midi_in, midi_out);
+
+    REQUIRE(processor->process_calls == 1);
+    REQUIRE(processor->midi_in_events == 1);
+    REQUIRE(processor->midi_note_ons == 1);
+}
+
+TEST_CASE("HeadlessHost null processor process and release are no-ops",
+          "[headless][coverage][issue-647]") {
+    pulp::format::HeadlessHost host(create_null_processor);
+    host.prepare(48000.0, 64);
+
+    pulp::audio::Buffer<float> in(1, 4), out(1, 4);
+    for (std::size_t i = 0; i < 4; ++i) out.channel(0)[i] = 7.0f;
+    const float* in_ptrs[1] = {in.channel(0).data()};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 1, 4);
+    auto out_view = out.view();
+
+    host.process(out_view, in_view);
+    host.release();
+
+    for (std::size_t i = 0; i < 4; ++i) {
+        REQUIRE_THAT(out.channel(0)[i], WithinAbs(7.0, 0.001));
+    }
 }
 
 TEST_CASE("HeadlessHost state round-trip", "[headless]") {

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -481,6 +481,35 @@ TEST_CASE("SignalGraph connections", "[host][graph]") {
     REQUIRE(graph.connections().size() == 1);
 }
 
+TEST_CASE("SignalGraph rejects missing-node and duplicate edge variants",
+          "[host][graph][issue-493]") {
+    SignalGraph graph;
+    auto input = graph.add_input_node(2);
+    auto gain = graph.add_gain_node("Gain");
+    auto output = graph.add_output_node(2);
+    auto midi_in = graph.add_midi_input_node("MIDI In");
+    auto midi_out = graph.add_midi_output_node("MIDI Out");
+
+    REQUIRE_FALSE(graph.connect(999, 0, gain, 0));
+    REQUIRE_FALSE(graph.connect(input, 0, 999, 0));
+    REQUIRE_FALSE(graph.disconnect(input, 0, gain, 0));
+
+    REQUIRE(graph.connect(input, 0, gain, 0));
+    REQUIRE_FALSE(graph.connect(input, 0, gain, 0));
+    REQUIRE(graph.disconnect(input, 0, gain, 0));
+    REQUIRE_FALSE(graph.disconnect(input, 0, gain, 0));
+
+    REQUIRE_FALSE(graph.connect_feedback(999, 0, output, 0));
+    REQUIRE_FALSE(graph.connect_feedback(gain, 0, 999, 0));
+    REQUIRE(graph.connect_feedback(gain, 0, output, 0));
+    REQUIRE_FALSE(graph.connect_feedback(gain, 0, output, 0));
+
+    REQUIRE_FALSE(graph.connect_midi(999, midi_out));
+    REQUIRE_FALSE(graph.connect_midi(midi_in, 999));
+    REQUIRE(graph.connect_midi(midi_in, midi_out));
+    REQUIRE_FALSE(graph.connect_midi(midi_in, midi_out));
+}
+
 TEST_CASE("SignalGraph cycle detection", "[host][graph]") {
     SignalGraph graph;
     auto a = graph.add_input_node(2);
@@ -567,6 +596,71 @@ TEST_CASE("SignalGraph routes input -> gain -> output", "[host][graph][routing]"
         REQUIRE(std::abs(out_r[i] - 0.2f) < 1e-6f);
     }
     graph.release();
+}
+
+TEST_CASE("SignalGraph live gain updates and release silence output",
+          "[host][graph][routing][issue-493]") {
+    SignalGraph graph;
+    auto in  = graph.add_input_node(1, "in");
+    auto gain = graph.add_gain_node("gain");
+    auto out = graph.add_output_node(1, "out");
+
+    REQUIRE(graph.connect(in, 0, gain, 0));
+    REQUIRE(graph.connect(gain, 0, out, 0));
+    REQUIRE(graph.prepare(48000.0, 16));
+
+    std::vector<float> input(16, 0.8f);
+    std::vector<float> output(16, -1.0f);
+    const float* in_ptrs[1] = {input.data()};
+    float* out_ptrs[1] = {output.data()};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 1, 16);
+    pulp::audio::BufferView<float> out_view(out_ptrs, 1, 16);
+
+    graph.process(out_view, in_view, 16);
+    for (float sample : output) REQUIRE_THAT(sample, WithinAbs(0.8f, 1e-6f));
+
+    REQUIRE(graph.set_node_gain(gain, 0.25f));
+    REQUIRE(graph.node_gain(gain) == 0.25f);
+    std::fill(output.begin(), output.end(), -1.0f);
+    graph.process(out_view, in_view, 16);
+    for (float sample : output) REQUIRE_THAT(sample, WithinAbs(0.2f, 1e-6f));
+
+    graph.release();
+    std::fill(output.begin(), output.end(), -1.0f);
+    graph.process(out_view, in_view, 16);
+    for (float sample : output) REQUIRE(sample == 0.0f);
+    REQUIRE(graph.latency_samples() == 0);
+    REQUIRE(graph.node_latency_samples(gain) == 0);
+}
+
+TEST_CASE("SignalGraph query helpers handle non-plugin and cleared nodes",
+          "[host][graph][issue-493]") {
+    SignalGraph graph;
+    auto input = graph.add_input_node(2);
+    auto gain = graph.add_gain_node("Gain");
+    auto output = graph.add_output_node(2);
+
+    REQUIRE_FALSE(graph.prepare(48000.0, 0));
+    REQUIRE_FALSE(graph.prepare(48000.0, -16));
+    REQUIRE_FALSE(graph.set_node_gain(999, 0.5f));
+    REQUIRE(graph.node_gain(999) == 1.0f);
+    REQUIRE_FALSE(graph.set_node_parameter(gain, 7, 0.25f));
+    REQUIRE(graph.get_node_parameter(gain, 7) == 0.0f);
+    REQUIRE_FALSE(graph.set_node_parameter(999, 7, 0.25f));
+    REQUIRE(graph.get_node_parameter(999, 7) == 0.0f);
+    REQUIRE(graph.node_latency_samples(999) == 0);
+
+    REQUIRE(graph.connect(input, 0, gain, 0));
+    REQUIRE(graph.connect(gain, 0, output, 0));
+    REQUIRE(graph.prepare(48000.0, 16));
+    REQUIRE(graph.node_latency_samples(gain) == 0);
+
+    graph.clear();
+    REQUIRE(graph.nodes().empty());
+    REQUIRE(graph.connections().empty());
+    REQUIRE(graph.latency_samples() == 0);
+    REQUIRE(graph.node_latency_samples(gain) == 0);
+    REQUIRE(graph.node_gain(gain) == 1.0f);
 }
 
 TEST_CASE("SignalGraph disconnected output stays silent", "[host][graph][routing]") {

--- a/test/test_ios_audio_session.cpp
+++ b/test/test_ios_audio_session.cpp
@@ -88,6 +88,54 @@ TEST_CASE("C ABI entry routes to the C++ listener",
     pulp_ios_audio_session_set_callback(nullptr, nullptr);
 }
 
+TEST_CASE("C ABI ignores null events and prefers C++ listeners over raw callbacks",
+          "[ios][audio-session][c-abi][coverage][issue-648]") {
+    int c_calls = 0;
+    pulp_ios_audio_session_set_callback(
+        [](const PulpIosAudioSessionEvent*, void* ud) {
+            ++(*static_cast<int*>(ud));
+        },
+        &c_calls);
+    pulp_ios_audio_session_emit(nullptr);
+    REQUIRE(c_calls == 0);
+
+    int cpp_calls = 0;
+    set_ios_audio_session_listener(
+        [&](const PulpIosAudioSessionEvent&) { ++cpp_calls; });
+
+    PulpIosAudioSessionEvent e{};
+    e.event = PULP_IOS_AUDIO_EVENT_ROUTE_CHANGED;
+    e.reason = PULP_IOS_ROUTE_CHANGE_CATEGORY_CHANGE;
+    pulp_ios_audio_session_emit(&e);
+    REQUIRE(cpp_calls == 1);
+    REQUIRE(c_calls == 0);
+
+    set_ios_audio_session_listener({});
+    pulp_ios_audio_session_emit(&e);
+    REQUIRE(c_calls == 1);
+
+    pulp_ios_audio_session_set_callback(nullptr, nullptr);
+}
+
+TEST_CASE("audio session listener replacement detaches the previous sink",
+          "[ios][audio-session][coverage][issue-648]") {
+    int first_calls = 0;
+    int second_calls = 0;
+    set_ios_audio_session_listener(
+        [&](const PulpIosAudioSessionEvent&) { ++first_calls; });
+    set_ios_audio_session_listener(
+        [&](const PulpIosAudioSessionEvent&) { ++second_calls; });
+
+    PulpIosAudioSessionEvent e{};
+    e.event = PULP_IOS_AUDIO_EVENT_INTERRUPTION_ENDED;
+    REQUIRE(emit_ios_audio_session_event(e));
+    REQUIRE(first_calls == 0);
+    REQUIRE(second_calls == 1);
+
+    set_ios_audio_session_listener({});
+    REQUIRE_FALSE(emit_ios_audio_session_event(e));
+}
+
 TEST_CASE("to_string covers every event code",
           "[ios][audio-session]") {
     REQUIRE(to_string(PULP_IOS_AUDIO_EVENT_NONE) == "none");

--- a/test/test_plugin_state_io.cpp
+++ b/test/test_plugin_state_io.cpp
@@ -213,6 +213,26 @@ TEST_CASE("plugin_state_io preserves legacy raw StateStore blobs and resets plug
     REQUIRE(restored.processor.last_payload.empty());
 }
 
+TEST_CASE("plugin_state_io envelope with empty plugin payload resets plugin state",
+          "[format][plugin-state][coverage][issue-647]") {
+    TestRig source;
+    source.store.set_value(1, -15.0f);
+    auto store_blob = source.store.serialize();
+    auto envelope = make_envelope(store_blob, {});
+
+    TestRig restored;
+    restored.store.set_value(1, 6.0f);
+    restored.processor.plugin_state = "stale";
+
+    REQUIRE(pulp::format::plugin_state_io::deserialize(envelope,
+                                                       restored.store,
+                                                       restored.processor));
+    REQUIRE_THAT(restored.store.get_value(1), WithinAbs(-15.0, 0.01));
+    REQUIRE(restored.processor.plugin_state.empty());
+    REQUIRE(restored.processor.deserialize_calls == 1);
+    REQUIRE(restored.processor.last_payload.empty());
+}
+
 TEST_CASE("plugin_state_io serialize falls back to raw StateStore blobs when plugin payload is empty",
           "[format][plugin-state]") {
     TestRig source;
@@ -345,6 +365,44 @@ TEST_CASE("plugin_state_io rejects malformed blobs without touching live state",
         REQUIRE(restored.processor.plugin_state == "keep");
         REQUIRE(restored.processor.deserialize_calls == 0);
     }
+
+    SECTION("empty inner StateStore payload") {
+        const std::array<uint8_t, 4> plugin_blob = {'K', 'E', 'E', 'P'};
+        auto blob = make_envelope({}, plugin_blob);
+
+        TestRig restored;
+        restored.store.set_value(1, 3.0f);
+        restored.processor.plugin_state = "keep";
+
+        REQUIRE_FALSE(pulp::format::plugin_state_io::deserialize(blob,
+                                                                 restored.store,
+                                                                 restored.processor));
+        REQUIRE_THAT(restored.store.get_value(1), WithinAbs(3.0, 0.01));
+        REQUIRE(restored.processor.plugin_state == "keep");
+        REQUIRE(restored.processor.deserialize_calls == 0);
+    }
+}
+
+TEST_CASE("plugin_state_io rejects envelope CRC mismatch without plugin callback",
+          "[format][plugin-state][coverage][issue-647]") {
+    TestRig source;
+    source.store.set_value(1, -21.0f);
+    source.processor.plugin_state = "snapshot-c";
+    auto store_blob = source.store.serialize();
+    auto plugin_blob = source.processor.serialize_plugin_state();
+    auto blob = make_envelope(store_blob, plugin_blob);
+    blob[8] ^= 0x01; // mutate store size after CRC calculation
+
+    TestRig restored;
+    restored.store.set_value(1, 2.0f);
+    restored.processor.plugin_state = "keep";
+
+    REQUIRE_FALSE(pulp::format::plugin_state_io::deserialize(blob,
+                                                             restored.store,
+                                                             restored.processor));
+    REQUIRE_THAT(restored.store.get_value(1), WithinAbs(2.0, 0.01));
+    REQUIRE(restored.processor.plugin_state == "keep");
+    REQUIRE(restored.processor.deserialize_calls == 0);
 }
 
 TEST_CASE("plugin_state_io rolls back StateStore when plugin payload restore fails",

--- a/test/test_preset_manager.cpp
+++ b/test/test_preset_manager.cpp
@@ -223,6 +223,23 @@ TEST_CASE("PresetManager load skips malformed parameter values", "[state][preset
     REQUIRE(load_callbacks == 1);
 }
 
+TEST_CASE("PresetManager load clamps out-of-range parameter values",
+          "[state][preset][coverage][issue-647]") {
+    pulp::test::PresetTestSandbox sandbox("pulp-preset-load-clamp");
+    StateStore store;
+    setup_test_store(store);
+    PresetManager pm(store, "TestCo", "TestPlugin");
+
+    const auto preset_path = sandbox.root / "Clamped.json";
+    write_text_file(preset_path,
+                    R"json({"parameters":{"Gain":999,"Mix":-50}})json");
+
+    REQUIRE(pm.load(preset_path));
+    REQUIRE(store.get_value(1) == Catch::Approx(12.0f));
+    REQUIRE(store.get_value(2) == Catch::Approx(0.0f));
+    REQUIRE(pm.current_preset_name() == "Clamped");
+}
+
 TEST_CASE("PresetManager save scans subfolders and reports list changes", "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-save-subfolder");
     StateStore store;
@@ -247,6 +264,29 @@ TEST_CASE("PresetManager save scans subfolders and reports list changes", "[stat
     REQUIRE(presets.size() == 2);
     REQUIRE(presets[0].name == "Alpha");
     REQUIRE(presets[1].name == "Beta");
+}
+
+TEST_CASE("PresetManager user preset scan ignores non-json files and records nested folders",
+          "[state][preset][coverage][issue-647]") {
+    pulp::test::PresetTestSandbox sandbox("pulp-preset-scan-filter");
+    StateStore store;
+    setup_test_store(store);
+    PresetManager pm(store, "TestCo", "TestPlugin");
+
+    REQUIRE(pm.save("Root"));
+    write_text_file(pm.user_presets_dir() / "Bank" / "Lead.json",
+                    R"json({"parameters":{"Gain":-6}})json");
+    write_text_file(pm.user_presets_dir() / "Bank" / "Ignore.txt", "not a preset");
+    std::error_code ec;
+    fs::create_directories(pm.user_presets_dir() / "EmptyDir", ec);
+    REQUIRE_FALSE(ec);
+
+    auto presets = pm.user_presets();
+    REQUIRE(presets.size() == 2);
+    REQUIRE(presets[0].name == "Lead");
+    REQUIRE(presets[0].folder == "Bank");
+    REQUIRE(presets[1].name == "Root");
+    REQUIRE(presets[1].folder.empty());
 }
 
 TEST_CASE("PresetManager rename and delete update current preset and callbacks", "[state][preset]") {
@@ -277,6 +317,25 @@ TEST_CASE("PresetManager rename and delete update current preset and callbacks",
     REQUIRE_FALSE(pm.rename(new_preset, "Again"));
     REQUIRE_FALSE(pm.delete_preset(new_preset));
     REQUIRE(list_changes == 2);
+}
+
+TEST_CASE("PresetManager delete missing user preset is inert",
+          "[state][preset][coverage][issue-647]") {
+    pulp::test::PresetTestSandbox sandbox("pulp-preset-delete-missing");
+    StateStore store;
+    setup_test_store(store);
+    PresetManager pm(store, "TestCo", "TestPlugin");
+
+    int list_changes = 0;
+    pm.on_list_changed = [&] { ++list_changes; };
+
+    PresetInfo missing;
+    missing.name = "Missing";
+    missing.path = sandbox.root / "missing.json";
+    missing.is_factory = false;
+
+    REQUIRE_FALSE(pm.delete_preset(missing));
+    REQUIRE(list_changes == 0);
 }
 
 TEST_CASE("PresetManager import copies external presets into the user directory", "[state][preset]") {
@@ -327,4 +386,16 @@ TEST_CASE("PresetManager navigation wraps sorted presets and handles missing cur
 
     REQUIRE(pm.load_next());
     REQUIRE(pm.current_preset_name() == "Alpha");
+}
+
+TEST_CASE("PresetManager navigation on empty preset list returns false",
+          "[state][preset][coverage][issue-647]") {
+    pulp::test::PresetTestSandbox sandbox("pulp-preset-navigation-empty");
+    StateStore store;
+    setup_test_store(store);
+    PresetManager pm(store, "TestCo", "TestPlugin");
+
+    REQUIRE_FALSE(pm.load_next());
+    REQUIRE_FALSE(pm.load_previous());
+    REQUIRE(pm.current_preset_name().empty());
 }

--- a/test/test_sdl3_surface.cpp
+++ b/test/test_sdl3_surface.cpp
@@ -1,0 +1,37 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/render/sdl3_surface.hpp>
+
+using namespace pulp;
+
+TEST_CASE("SDL3 surface info validity follows backend state - issue-646",
+          "[render][sdl3][issue-646]") {
+    render::Sdl3SurfaceInfo info;
+    REQUIRE_FALSE(info.is_valid());
+
+    info.x11_display = reinterpret_cast<void*>(0x1);
+    info.x11_window = 42;
+    REQUIRE_FALSE(info.is_valid());
+
+    info.backend = render::Sdl3SurfaceInfo::Backend::vulkan_x11;
+    REQUIRE(info.is_valid());
+
+    info = {};
+    info.hwnd = reinterpret_cast<void*>(0x2);
+    info.hinstance = reinterpret_cast<void*>(0x3);
+    info.backend = render::Sdl3SurfaceInfo::Backend::d3d12;
+    REQUIRE(info.is_valid());
+}
+
+TEST_CASE("SDL3 surface extraction rejects null windows - issue-646",
+          "[render][sdl3][issue-646]") {
+    auto info = render::extract_sdl3_surface(nullptr);
+    REQUIRE_FALSE(info.is_valid());
+    REQUIRE(info.backend == render::Sdl3SurfaceInfo::Backend::none);
+    REQUIRE(info.metal_layer == nullptr);
+    REQUIRE(info.hwnd == nullptr);
+    REQUIRE(info.hinstance == nullptr);
+    REQUIRE(info.x11_display == nullptr);
+    REQUIRE(info.x11_window == 0);
+    REQUIRE(info.wayland_display == nullptr);
+    REQUIRE(info.wayland_surface == nullptr);
+}

--- a/test/test_standalone_editor_chrome.cpp
+++ b/test/test_standalone_editor_chrome.cpp
@@ -40,6 +40,7 @@ public:
     void hide() override {}
     bool is_visible() const override { return false; }
     void repaint() override {}
+    std::vector<uint8_t> capture_png() override { return {0x89, 'P', 'N', 'G'}; }
     void set_close_callback(std::function<void()>) override {}
     void run_event_loop() override {}
 };
@@ -487,6 +488,8 @@ TEST_CASE("WindowHost default content-size and resize callback are no-ops",
         resize_fired = true;
     });
     REQUIRE_FALSE(resize_fired);
+
+    REQUIRE(window.capture_back_buffer_png() == std::vector<uint8_t>{0x89, 'P', 'N', 'G'});
 }
 
 TEST_CASE("Standalone host sync installs a resize callback and applies initial size",

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/state/state.hpp>
+#include <cstring>
 #include <vector>
 
 using namespace pulp::state;
@@ -13,6 +14,33 @@ static ParamInfo make_param_info(ParamID id, const char* name, const char* unit,
     info.unit = unit;
     info.range = range;
     return info;
+}
+
+static uint32_t read_u32_le(const std::vector<uint8_t>& data, std::size_t offset) {
+    return static_cast<uint32_t>(data[offset])
+        | (static_cast<uint32_t>(data[offset + 1]) << 8)
+        | (static_cast<uint32_t>(data[offset + 2]) << 16)
+        | (static_cast<uint32_t>(data[offset + 3]) << 24);
+}
+
+static void write_u32_le(std::vector<uint8_t>& data, std::size_t offset, uint32_t value) {
+    data[offset] = static_cast<uint8_t>(value & 0xffu);
+    data[offset + 1] = static_cast<uint8_t>((value >> 8) & 0xffu);
+    data[offset + 2] = static_cast<uint8_t>((value >> 16) & 0xffu);
+    data[offset + 3] = static_cast<uint8_t>((value >> 24) & 0xffu);
+}
+
+static uint32_t crc32_simple_for_test(const std::vector<uint8_t>& data,
+                                      std::size_t len) {
+    uint32_t crc = 0xFFFFFFFFu;
+    for (std::size_t i = 0; i < len; ++i) {
+        crc ^= data[i];
+        for (int j = 0; j < 8; ++j) {
+            const uint32_t mask = (crc & 1u) ? 0xFFFFFFFFu : 0u;
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+    return ~crc;
 }
 
 TEST_CASE("ParamRange normalization", "[state][range]") {
@@ -32,6 +60,26 @@ TEST_CASE("ParamRange with step", "[state][range]") {
 
     REQUIRE_THAT(range.denormalize(0.33f), WithinAbs(3.0, 0.5));
     REQUIRE_THAT(range.denormalize(0.77f), WithinAbs(8.0, 0.5));
+}
+
+TEST_CASE("ParamRange clamps normalized conversions at range boundaries",
+          "[state][range][coverage][issue-646]") {
+    ParamRange range{-10.0f, 30.0f, 5.0f, 0.0f};
+
+    REQUIRE_THAT(range.normalize(-100.0f), WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(range.normalize(100.0f), WithinAbs(1.0, 0.001));
+    REQUIRE_THAT(range.denormalize(-0.5f), WithinAbs(-10.0, 0.001));
+    REQUIRE_THAT(range.denormalize(1.5f), WithinAbs(30.0, 0.001));
+}
+
+TEST_CASE("ParamRange zero-width ranges normalize safely",
+          "[state][range][coverage][issue-646]") {
+    ParamRange range{7.0f, 7.0f, 7.0f, 0.0f};
+
+    REQUIRE_THAT(range.normalize(7.0f), WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(range.normalize(100.0f), WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(range.denormalize(0.25f), WithinAbs(7.0, 0.001));
+    REQUIRE_THAT(range.denormalize(2.0f), WithinAbs(7.0, 0.001));
 }
 
 TEST_CASE("StateStore basic operations", "[state][store]") {
@@ -158,6 +206,53 @@ TEST_CASE("StateStore serialization", "[state][serialize]") {
     SECTION("Too-short data rejected") {
         REQUIRE_FALSE(store.deserialize(std::span<const uint8_t>{}));
     }
+}
+
+TEST_CASE("StateStore serialization records header fields and rejects future versions",
+          "[state][serialize][coverage][issue-646]") {
+    StateStore store;
+    auto p1 = make_param_info(10, "Drive", "", {0.0f, 1.0f, 0.25f});
+    auto p2 = make_param_info(20, "Tone", "", {-1.0f, 1.0f, 0.0f});
+    store.add_parameter(p1);
+    store.add_parameter(p2);
+    store.set_value(10, 0.75f);
+
+    auto data = store.serialize();
+    REQUIRE(data.size() == 32);
+    REQUIRE(std::memcmp(data.data(), "PULP", 4) == 0);
+    REQUIRE(read_u32_le(data, 4) == 1);
+    REQUIRE(read_u32_le(data, 8) == 2);
+    REQUIRE(read_u32_le(data, 12) == 10);
+    REQUIRE(read_u32_le(data, 20) == 20);
+
+    auto future = data;
+    write_u32_le(future, 4, 999u);
+    const auto payload_size = future.size() - 4;
+    write_u32_le(future, payload_size, crc32_simple_for_test(future, payload_size));
+
+    StateStore target;
+    target.add_parameter(p1);
+    target.set_value(10, 0.1f);
+    REQUIRE_FALSE(target.deserialize(future));
+    REQUIRE_THAT(target.get_value(10), WithinAbs(0.1, 0.001));
+}
+
+TEST_CASE("StateStore set_normalized clamps and quantizes via ParamRange",
+          "[state][store][coverage][issue-646]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "Steps", "", {0.0f, 10.0f, 5.0f, 2.0f}));
+
+    store.set_normalized(1, -1.0f);
+    REQUIRE_THAT(store.get_value(1), WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(store.get_normalized(1), WithinAbs(0.0, 0.001));
+
+    store.set_normalized(1, 0.34f);
+    REQUIRE_THAT(store.get_value(1), WithinAbs(4.0, 0.001));
+    REQUIRE_THAT(store.get_normalized(1), WithinAbs(0.4, 0.001));
+
+    store.set_normalized(1, 4.0f);
+    REQUIRE_THAT(store.get_value(1), WithinAbs(10.0, 0.001));
+    REQUIRE_THAT(store.get_normalized(1), WithinAbs(1.0, 0.001));
 }
 
 TEST_CASE("StateStore change listener", "[state][listener]") {

--- a/test/test_validation_harness.cpp
+++ b/test/test_validation_harness.cpp
@@ -99,6 +99,12 @@ std::filesystem::path make_temp_path(const char* stem) {
     return std::filesystem::temp_directory_path() / (std::string(stem) + "-" + unique + ".json");
 }
 
+std::filesystem::path make_temp_dir(const char* stem) {
+    auto unique = std::to_string(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+    return std::filesystem::temp_directory_path() / (std::string(stem) + "-" + unique);
+}
+
 } // anonymous namespace
 
 using Catch::Matchers::WithinAbs;
@@ -122,6 +128,20 @@ TEST_CASE("ValidationHarness set/get param", "[harness][phase2]") {
     REQUIRE_THAT(harness.get_param(2), WithinAbs(0.5, 0.01));
 }
 
+TEST_CASE("ValidationHarness configure creates artifact directory",
+          "[harness][phase2][coverage][issue-646]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    auto out_dir = make_temp_dir("pulp-harness-output-dir");
+    REQUIRE_FALSE(std::filesystem::exists(out_dir));
+
+    harness.configure({.output_dir = out_dir});
+
+    REQUIRE(std::filesystem::is_directory(out_dir));
+    std::error_code ec;
+    std::filesystem::remove_all(out_dir, ec);
+    REQUIRE_FALSE(ec);
+}
+
 TEST_CASE("ValidationHarness processes silence blocks", "[harness][phase2]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({.buffer_size = 64});
@@ -132,6 +152,18 @@ TEST_CASE("ValidationHarness processes silence blocks", "[harness][phase2]") {
     REQUIRE(output.size() == 128);
 
     // All zeros (silence in, unity gain)
+    for (float s : output) {
+        REQUIRE_THAT(static_cast<double>(s), WithinAbs(0.0, 0.0001));
+    }
+}
+
+TEST_CASE("ValidationHarness process_blocks zero blocks returns one silent buffer",
+          "[harness][phase2][coverage][issue-646]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    harness.configure({.buffer_size = 8, .output_channels = 2});
+
+    auto output = harness.process_blocks(0);
+    REQUIRE(output.size() == 16);
     for (float s : output) {
         REQUIRE_THAT(static_cast<double>(s), WithinAbs(0.0, 0.0001));
     }
@@ -253,6 +285,29 @@ TEST_CASE("ValidationHarness generates valid report JSON", "[harness][phase2]") 
     REQUIRE_THAT(report, ContainsSubstring("\"total\": 50"));
 }
 
+TEST_CASE("ValidationHarness report escapes JSON metadata and entry strings",
+          "[harness][phase2][coverage][issue-646]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    harness.configure({
+        .git_ref = "branch/quote\"slash\\",
+        .run_id = "run\nwith\ttabs",
+    });
+
+    pulp::format::ReportEntry entry;
+    entry.type = "validator";
+    entry.status = pulp::format::ValidationStatus::error;
+    entry.target = "Plugin \"A\"";
+    entry.error_message = "line1\nline2\\done";
+    entry.payload_json = "{\"tool\":\"fake\"}";
+    harness.add_entry(entry);
+
+    auto report = harness.generate_report();
+    REQUIRE_THAT(report, ContainsSubstring("branch/quote\\\"slash\\\\"));
+    REQUIRE_THAT(report, ContainsSubstring("run\\nwith\\ttabs"));
+    REQUIRE_THAT(report, ContainsSubstring("Plugin \\\"A\\\""));
+    REQUIRE_THAT(report, ContainsSubstring("line1\\nline2\\\\done"));
+}
+
 TEST_CASE("ValidationHarness empty report is valid", "[harness][phase2]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
@@ -291,6 +346,21 @@ TEST_CASE("ValidationHarness write_report creates file", "[harness][phase2]") {
     REQUIRE_FALSE(ec);
 }
 
+TEST_CASE("ValidationHarness write_report creates nested directories",
+          "[harness][phase2][coverage][issue-646]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    harness.configure({});
+
+    auto dir = make_temp_dir("pulp-harness-nested-report");
+    auto report_path = dir / "a" / "b" / "report.json";
+    REQUIRE(harness.write_report(report_path));
+    REQUIRE(std::filesystem::is_regular_file(report_path));
+
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+    REQUIRE_FALSE(ec);
+}
+
 // ── Validator graceful degradation ──────────────────────────────────────────
 
 TEST_CASE("ValidationHarness run_validator skips missing tool", "[harness][phase2]") {
@@ -319,6 +389,23 @@ TEST_CASE("ValidationHarness run_validator errors on missing plugin", "[harness]
 
     REQUIRE(entry.status == pulp::format::ValidationStatus::error);
     REQUIRE_THAT(entry.error_message, ContainsSubstring("not found"));
+}
+
+TEST_CASE("ValidationHarness run_validator errors on unknown installed tool",
+          "[harness][phase2][coverage][issue-646]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    harness.configure({});
+
+    auto tmp_plugin = make_temp_path("fake-plugin-for-unknown-validator");
+    { std::ofstream f(tmp_plugin); f << "dummy"; }
+
+    auto entry = harness.run_validator("sh", tmp_plugin);
+    REQUIRE(entry.status == pulp::format::ValidationStatus::error);
+    REQUIRE_THAT(entry.error_message, ContainsSubstring("Unknown validator tool: sh"));
+
+    std::error_code ec;
+    std::filesystem::remove(tmp_plugin, ec);
+    REQUIRE_FALSE(ec);
 }
 
 // ── Screenshot / inspector providers (#298) ─────────────────────────────────

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -2011,6 +2011,28 @@ TEST_CASE("Widget setters skip repaint when value is unchanged [issue-73]",
         knob.set_label("Cutoff");
         REQUIRE(host.repaint_count == after);
     }
+
+    SECTION("Fader::set_label idempotent") {
+        Fader fader;
+        CountingHost host;
+        fader.set_window_host(&host);
+        fader.set_label("Volume");
+        int after = host.repaint_count;
+
+        fader.set_label("Volume");
+        REQUIRE(host.repaint_count == after);
+    }
+
+    SECTION("ToggleButton::set_label idempotent") {
+        ToggleButton tb;
+        CountingHost host;
+        tb.set_window_host(&host);
+        tb.set_label("Bypass");
+        int after = host.repaint_count;
+
+        tb.set_label("Bypass");
+        REQUIRE(host.repaint_count == after);
+    }
 }
 
 TEST_CASE("Widget set_label programmatic mutation requests repaint [issue-73]",
@@ -2044,4 +2066,20 @@ TEST_CASE("Widget set_label programmatic mutation requests repaint [issue-73]",
         tb.set_label("Mute");
         REQUIRE(host.repaint_count > before);
     }
+}
+
+TEST_CASE("Knob format setter requests repaint without changing value [issue-73]",
+          "[view][widget][issue-73]") {
+    Knob knob;
+    knob.set_value(0.25f);
+    CountingHost host;
+    knob.set_window_host(&host);
+    int before = host.repaint_count;
+
+    knob.set_format([](float value) {
+        return std::to_string(static_cast<int>(value * 100.0f)) + "%";
+    });
+
+    REQUIRE(knob.value() == 0.25f);
+    REQUIRE(host.repaint_count > before);
 }

--- a/tools/packages/test_freshness_check_extra.py
+++ b/tools/packages/test_freshness_check_extra.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Additional unit tests for package freshness checking edge paths.
+
+Run:
+    python3 tools/packages/test_freshness_check_extra.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).parent
+
+
+def load_module(name: str, path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+fc = load_module("freshness_check_extra_target", ROOT / "freshness_check.py")
+
+
+@contextlib.contextmanager
+def argv(args: list[str]):
+    old = sys.argv[:]
+    sys.argv = args[:]
+    try:
+        yield
+    finally:
+        sys.argv = old
+
+
+@contextlib.contextmanager
+def module_attr(module, name: str, value):
+    old = getattr(module, name)
+    setattr(module, name, value)
+    try:
+        yield
+    finally:
+        setattr(module, name, old)
+
+
+class FreshnessCheckExtraTests(unittest.TestCase):
+    def test_result_preserves_explicit_issue_list(self) -> None:
+        issues = ["already known"]
+
+        result = fc.CheckResult(
+            package="audio-lib",
+            pinned_version="1.0.0",
+            issues=issues,
+        )
+
+        self.assertIs(result.issues, issues)
+
+    def test_extract_owner_repo_rejects_incomplete_github_url(self) -> None:
+        self.assertIsNone(fc.extract_owner_repo("https://github.com/acme"))
+
+    def test_check_package_falls_back_to_tags_without_release(self) -> None:
+        responses = {
+            "repos/acme/audio-lib": {"archived": False, "pushed_at": ""},
+            "repos/acme/audio-lib/releases?per_page=1": [],
+            "repos/acme/audio-lib/tags?per_page=1": [{"name": "v1.2.3"}],
+            "repos/acme/audio-lib/license": {"license": {"spdx_id": "NOASSERTION"}},
+        }
+
+        with mock.patch.object(fc, "run_gh", side_effect=lambda args: responses[args[0]]):
+            result = fc.check_package(
+                "audio-lib",
+                {
+                    "version": "v1.2.3",
+                    "license": "MIT",
+                    "fetch": {"git_repository": "https://github.com/acme/audio-lib"},
+                },
+            )
+
+        self.assertEqual(result.latest_version, "v1.2.3")
+        self.assertIsNone(result.last_commit_date)
+        self.assertFalse(result.archived)
+        self.assertFalse(result.license_changed)
+        self.assertEqual(result.issues, [])
+
+    def test_check_package_tolerates_missing_tags_and_license(self) -> None:
+        responses = {
+            "repos/acme/audio-lib": {"archived": False},
+            "repos/acme/audio-lib/releases?per_page=1": None,
+            "repos/acme/audio-lib/tags?per_page=1": [],
+            "repos/acme/audio-lib/license": None,
+        }
+
+        with mock.patch.object(fc, "run_gh", side_effect=lambda args: responses[args[0]]):
+            result = fc.check_package(
+                "audio-lib",
+                {
+                    "version": "v1.2.3",
+                    "license": "MIT",
+                    "fetch": {"git_repository": "https://github.com/acme/audio-lib"},
+                },
+            )
+
+        self.assertIsNone(result.latest_version)
+        self.assertIsNone(result.last_commit_date)
+        self.assertEqual(result.issues, [])
+
+    def test_main_emits_markdown_for_all_packages(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            registry_path = pathlib.Path(td) / "registry.json"
+            registry_path.write_text(
+                json.dumps(
+                    {
+                        "packages": {
+                            "ok": {"version": "1.0.0"},
+                            "stale": {"version": "1.0.0"},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            def fake_check(slug: str, pkg: dict):
+                if slug == "stale":
+                    return fc.CheckResult(
+                        package=slug,
+                        pinned_version=pkg["version"],
+                        latest_version="2.0.0",
+                        issues=["Newer version available"],
+                    )
+                return fc.CheckResult(
+                    package=slug,
+                    pinned_version=pkg["version"],
+                    latest_version=pkg["version"],
+                    last_commit_date="2026-04-01",
+                )
+
+            out = io.StringIO()
+            err = io.StringIO()
+            with module_attr(fc, "REGISTRY", registry_path), mock.patch.object(fc, "check_package", fake_check):
+                with argv(["freshness_check.py", "--format", "markdown"]):
+                    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                        rc = fc.main()
+
+        self.assertEqual(rc, 1)
+        text = out.getvalue()
+        self.assertIn("| Package | Pinned | Latest | Last Commit | Issues |", text)
+        self.assertIn("| ok | 1.0.0 | 1.0.0 | 2026-04-01 | OK |", text)
+        self.assertIn("| stale | 1.0.0 | 2.0.0 | ? | Newer version available |", text)
+        self.assertIn("2 packages checked, 1 issues", err.getvalue())
+
+    def test_main_emits_text_for_ok_and_issue_results(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            registry_path = pathlib.Path(td) / "registry.json"
+            registry_path.write_text(
+                json.dumps(
+                    {
+                        "packages": {
+                            "ok": {"version": "1.0.0"},
+                            "stale": {"version": "1.0.0"},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            def fake_check(slug: str, pkg: dict):
+                if slug == "stale":
+                    return fc.CheckResult(
+                        package=slug,
+                        pinned_version=pkg["version"],
+                        issues=["Cannot reach GitHub API"],
+                    )
+                return fc.CheckResult(package=slug, pinned_version=pkg["version"])
+
+            out = io.StringIO()
+            err = io.StringIO()
+            with module_attr(fc, "REGISTRY", registry_path), mock.patch.object(fc, "check_package", fake_check):
+                with argv(["freshness_check.py"]):
+                    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                        rc = fc.main()
+
+        self.assertEqual(rc, 1)
+        text = out.getvalue()
+        self.assertRegex(text, r"ok\s+\.+\s+OK")
+        self.assertRegex(text, r"stale\s+\.+\s+ISSUES")
+        self.assertIn("    - Cannot reach GitHub API", text)
+        self.assertIn("2 packages checked, 1 issues", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/scripts/test_auto_release_decision_extra.py
+++ b/tools/scripts/test_auto_release_decision_extra.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Additional edge coverage for auto_release_decision.py."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import pathlib
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+
+HERE = pathlib.Path(__file__).resolve().parent
+SCRIPT = HERE / "auto_release_decision.py"
+
+spec = importlib.util.spec_from_file_location("auto_release_decision", SCRIPT)
+ard = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(ard)
+
+
+class ParseVersionEdgeTests(unittest.TestCase):
+    def test_parse_version_returns_tuple_for_exact_semver(self) -> None:
+        self.assertEqual(ard.parse_version("10.2.300"), (10, 2, 300))
+
+    def test_parse_version_rejects_wrong_part_counts(self) -> None:
+        self.assertIsNone(ard.parse_version("1.2"))
+        self.assertIsNone(ard.parse_version("1.2.3.4"))
+
+    def test_parse_version_rejects_non_numeric_parts(self) -> None:
+        self.assertIsNone(ard.parse_version("1.two.3"))
+
+
+class MainCliEdgeTests(unittest.TestCase):
+    def test_main_prints_json_decision_for_plugin_surface(self) -> None:
+        argv = [
+            str(SCRIPT),
+            "--head-version",
+            "2.0.0",
+            "--tag-version",
+            "1.9.9",
+            "--bump-commit-has-skip",
+            "0",
+            "--surface",
+            "plugin",
+        ]
+        output = io.StringIO()
+        with mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(output):
+            self.assertEqual(ard.main(), 0)
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(payload["should_tag"], 1)
+        self.assertEqual(payload["surface"], "plugin")
+        self.assertIn("tagging", payload["reason"])
+
+    def test_script_entrypoint_handles_empty_head_version(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT), "--surface", "sdk"],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["should_tag"], 0)
+        self.assertIn("no sdk version", payload["reason"])
+
+    def test_script_entrypoint_rejects_invalid_skip_flag(self) -> None:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--head-version",
+                "1.0.0",
+                "--bump-commit-has-skip",
+                "2",
+            ],
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("invalid choice", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/scripts/test_check_format_validation.py
+++ b/tools/scripts/test_check_format_validation.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/check_format_validation.py."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "tools" / "check_format_validation.py"
+
+spec = importlib.util.spec_from_file_location("check_format_validation", SCRIPT)
+assert spec and spec.loader
+cfv = importlib.util.module_from_spec(spec)
+sys.modules["check_format_validation"] = cfv
+spec.loader.exec_module(cfv)
+
+
+class ExtractFormatsTests(unittest.TestCase):
+    def test_extract_formats_reads_nested_platform_statuses(self) -> None:
+        text = """\
+formats:
+  vst3:
+    macos: stable
+    windows: usable
+  clap:
+    linux: experimental
+production_validated:
+  vst3:
+    macos: [Reaper]
+"""
+
+        self.assertEqual(
+            cfv.extract_formats(text),
+            {
+                "vst3": {"macos": "stable", "windows": "usable"},
+                "clap": {"linux": "experimental"},
+            },
+        )
+
+    def test_extract_formats_returns_empty_when_block_absent(self) -> None:
+        self.assertEqual(cfv.extract_formats("production_validated:\n"), {})
+
+
+class ExtractProductionTests(unittest.TestCase):
+    def test_extract_production_reads_empty_and_populated_inline_lists(self) -> None:
+        text = """\
+production_validated:
+  vst3:
+    macos: [Reaper, "Logic Pro", 'Cubase']
+    windows: []
+  clap:
+    linux: [Bitwig]
+formats:
+  vst3:
+    macos: stable
+"""
+
+        self.assertEqual(
+            cfv.extract_production(text),
+            {
+                "vst3": {
+                    "macos": ["Reaper", "Logic Pro", "Cubase"],
+                    "windows": [],
+                },
+                "clap": {"linux": ["Bitwig"]},
+            },
+        )
+
+    def test_extract_production_ignores_comments_and_blank_lines(self) -> None:
+        text = """\
+production_validated:
+  # Populated during host smoke validation.
+
+  auv2:
+    macos: []
+"""
+
+        self.assertEqual(cfv.extract_production(text), {"auv2": {"macos": []}})
+
+    def test_extract_production_returns_empty_when_block_absent(self) -> None:
+        self.assertEqual(cfv.extract_production("formats:\n"), {})
+
+
+class MainTests(unittest.TestCase):
+    def _run_main(self, matrix_text: str, *args: str) -> tuple[int, str, str]:
+        with tempfile.TemporaryDirectory() as td:
+            matrix = pathlib.Path(td) / "support-matrix.yaml"
+            matrix.write_text(matrix_text, encoding="utf-8")
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with mock.patch.object(cfv, "MATRIX_PATH", matrix), \
+                 mock.patch.object(sys, "argv", ["check_format_validation.py", *args]), \
+                 contextlib.redirect_stdout(stdout), \
+                 contextlib.redirect_stderr(stderr):
+                rc = cfv.main()
+            return rc, stdout.getvalue(), stderr.getvalue()
+
+    def test_warn_mode_reports_gaps_but_exits_zero(self) -> None:
+        rc, out, err = self._run_main(
+            """\
+formats:
+  vst3:
+    macos: stable
+    windows: usable
+    linux: experimental
+  clap:
+    linux: stable
+production_validated:
+  vst3:
+    macos: [Reaper]
+    windows: []
+""",
+        )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(err, "")
+        self.assertIn("1 format/platform pairs host-validated", out)
+        self.assertIn("1 acknowledged but empty", out)
+        self.assertIn("1 missing from production_validated", out)
+        self.assertIn("EMPTY:   vst3.windows is 'usable'", out)
+        self.assertIn("MISSING: production_validated.clap.linux absent", out)
+        self.assertNotIn("vst3.linux", out)
+
+    def test_report_mode_returns_one_when_required_validation_is_missing(self) -> None:
+        rc, out, _ = self._run_main(
+            """\
+formats:
+  vst3:
+    macos: stable
+production_validated:
+  vst3:
+    macos: []
+""",
+            "--mode=report",
+        )
+
+        self.assertEqual(rc, 1)
+        self.assertIn("mode=report", out)
+        self.assertIn("EMPTY:   vst3.macos is 'stable'", out)
+
+    def test_report_mode_returns_zero_when_all_required_pairs_have_hosts(self) -> None:
+        rc, out, err = self._run_main(
+            """\
+formats:
+  vst3:
+    macos: stable
+  clap:
+    linux: usable
+production_validated:
+  vst3:
+    macos: [Reaper]
+  clap:
+    linux: [Bitwig]
+""",
+            "--mode=report",
+        )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(err, "")
+        self.assertIn("2 format/platform pairs host-validated", out)
+        self.assertIn("0 acknowledged but empty", out)
+        self.assertIn("0 missing from production_validated", out)
+
+    def test_read_error_returns_two_and_writes_stderr(self) -> None:
+        missing = pathlib.Path(tempfile.gettempdir()) / "pulp-missing-support-matrix.yaml"
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with mock.patch.object(cfv, "MATRIX_PATH", missing), \
+             mock.patch.object(sys, "argv", ["check_format_validation.py"]), \
+             contextlib.redirect_stdout(stdout), \
+             contextlib.redirect_stderr(stderr):
+            rc = cfv.main()
+
+        self.assertEqual(rc, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("Failed to read", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/test_fetch_skia_for_release_extra.py
+++ b/tools/scripts/test_fetch_skia_for_release_extra.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Additional unit tests for tools/scripts/fetch_skia_for_release.py."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import importlib.util
+import io
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+import zipfile
+from unittest import mock
+
+
+SCRIPT = pathlib.Path(__file__).parent / "fetch_skia_for_release.py"
+
+spec = importlib.util.spec_from_file_location("fetch_skia_for_release_extra_target", SCRIPT)
+assert spec and spec.loader
+skia = importlib.util.module_from_spec(spec)
+sys.modules["fetch_skia_for_release_extra_target"] = skia
+spec.loader.exec_module(skia)
+
+
+class _FakeResponse:
+    def __init__(self, data: bytes):
+        self._data = data
+        self._offset = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self, size: int = -1) -> bytes:
+        if self._offset >= len(self._data):
+            return b""
+        if size < 0:
+            size = len(self._data) - self._offset
+        chunk = self._data[self._offset:self._offset + size]
+        self._offset += len(chunk)
+        return chunk
+
+
+def make_zip_bytes(rel_path: pathlib.Path, payload: bytes = b"skia") -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(rel_path.as_posix(), payload)
+    return buf.getvalue()
+
+
+@contextlib.contextmanager
+def cwd(path: pathlib.Path):
+    old = pathlib.Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old)
+
+
+class FetchSkiaForReleaseExtraTests(unittest.TestCase):
+    def test_main_usage_unknown_platform_and_missing_manifest_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(skia.main(["fetch"]), 2)
+            self.assertIn("usage:", err.getvalue())
+
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(skia.main(["fetch", "weird-platform"]), 0)
+            self.assertIn("unknown matrix platform", err.getvalue())
+
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 1)
+            self.assertIn("manifest.json not found", err.getvalue())
+
+    def test_main_skips_platform_without_release_asset(self) -> None:
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            manifest = pathlib.Path("tools/deps/manifest.json")
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(
+                json.dumps({"dependencies": [{"name": "Skia", "determinism": {"release_assets": {}}}]}),
+                encoding="utf-8",
+            )
+
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                self.assertEqual(skia.main(["fetch", "linux-arm64"]), 0)
+            self.assertIn("no Skia release asset", out.getvalue())
+
+    def test_main_reports_missing_skia_entry_and_checksum_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            manifest = pathlib.Path("tools/deps/manifest.json")
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(json.dumps({"dependencies": []}), encoding="utf-8")
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 1)
+            self.assertIn("no 'Skia' dependency", err.getvalue())
+
+            manifest.write_text(
+                json.dumps({
+                    "dependencies": [{
+                        "name": "Skia",
+                        "determinism": {
+                            "release_assets": {
+                                "mac-arm64": {"url": "https://example.invalid/skia.zip", "sha256": "0" * 64}
+                            }
+                        },
+                    }]
+                }),
+                encoding="utf-8",
+            )
+            with mock.patch.object(skia.urllib.request, "urlopen", return_value=_FakeResponse(b"not a zip")), \
+                 contextlib.redirect_stderr(err := io.StringIO()), \
+                 contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 1)
+            self.assertIn("sha256 mismatch", err.getvalue())
+
+    def test_main_unpacks_valid_asset_and_reports_zip_layout_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            data = make_zip_bytes(pathlib.Path("build/mac-gpu/lib/Release/libskia.a"), b"abc")
+            digest = hashlib.sha256(data).hexdigest()
+            manifest = pathlib.Path("tools/deps/manifest.json")
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(
+                json.dumps({
+                    "dependencies": [{
+                        "name": "skia",
+                        "determinism": {
+                            "release_assets": {
+                                "mac-arm64": {"url": "https://example.invalid/skia.zip", "sha256": digest}
+                            }
+                        },
+                    }]
+                }),
+                encoding="utf-8",
+            )
+
+            out = io.StringIO()
+            with mock.patch.object(skia.urllib.request, "urlopen", return_value=_FakeResponse(data)), \
+                 contextlib.redirect_stdout(out):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 0)
+
+            self.assertTrue(skia.expected_library_path("darwin-arm64").is_file())
+            self.assertFalse(pathlib.Path("skia-release-asset.zip").exists())
+            self.assertIn("OK:", out.getvalue())
+
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            data = make_zip_bytes(pathlib.Path("wrong/place/libskia.a"), b"abc")
+            digest = hashlib.sha256(data).hexdigest()
+            manifest = pathlib.Path("tools/deps/manifest.json")
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(
+                json.dumps({
+                    "dependencies": [{
+                        "name": "Skia",
+                        "determinism": {
+                            "release_assets": {
+                                "mac-arm64": {"url": "https://example.invalid/skia.zip", "sha256": digest}
+                            }
+                        },
+                    }]
+                }),
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(skia.urllib.request, "urlopen", return_value=_FakeResponse(data)), \
+                 contextlib.redirect_stdout(io.StringIO()), \
+                 contextlib.redirect_stderr(err := io.StringIO()):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 1)
+            self.assertIn("expected library not found", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/test_host_pump_lint.py
+++ b/tools/scripts/test_host_pump_lint.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/scripts/host_pump_lint.py."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPT = pathlib.Path(__file__).parent / "host_pump_lint.py"
+
+spec = importlib.util.spec_from_file_location("host_pump_lint", SCRIPT)
+assert spec and spec.loader
+hpl = importlib.util.module_from_spec(spec)
+sys.modules["host_pump_lint"] = hpl
+spec.loader.exec_module(hpl)
+
+
+class HostPumpLintTests(unittest.TestCase):
+    def test_scan_file_ignores_missing_files(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            missing = pathlib.Path(td) / "missing.cpp"
+            self.assertEqual(hpl.scan_file(missing), [])
+
+    def test_scan_file_accepts_paired_calls_in_same_block(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            source = pathlib.Path(td) / "main.cpp"
+            source.write_text(
+                """
+void tick() {
+    bridge->poll_async_results();
+    bridge->service_frame_callbacks();
+}
+""",
+                encoding="utf-8",
+            )
+            self.assertEqual(hpl.scan_file(source), [])
+
+    def test_scan_file_flags_unpaired_poll_before_block_close(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            source = root / "examples" / "design-tool" / "main.cpp"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                """
+void tick() {
+    bridge->poll_async_results();
+}
+void later() {
+    bridge->service_frame_callbacks();
+}
+""",
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(hpl, "REPO_ROOT", root):
+                violations = hpl.scan_file(source)
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("examples/design-tool/main.cpp:3", violations[0])
+            self.assertIn("not paired", violations[0])
+
+    def test_scan_file_accepts_inline_skip_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            source = pathlib.Path(td) / "main.cpp"
+            source.write_text(
+                f"bridge->poll_async_results(); // {hpl.SKIP_MARKER} - one-shot\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(hpl.scan_file(source), [])
+
+    def test_scan_file_respects_window_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            source = pathlib.Path(td) / "main.cpp"
+            gap = "\n".join("    do_work();" for _ in range(hpl.WINDOW_LINES + 1))
+            source.write_text(
+                f"""
+void tick() {{
+    bridge->poll_async_results();
+{gap}
+    bridge->service_frame_callbacks();
+}}
+""",
+                encoding="utf-8",
+            )
+            self.assertEqual(len(hpl.scan_file(source)), 1)
+
+    def test_main_reports_violations_and_read_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            host = root / "host.cpp"
+            host.write_text("bridge->poll_async_results();\n", encoding="utf-8")
+
+            err = io.StringIO()
+            with mock.patch.object(hpl, "REPO_ROOT", root), \
+                 mock.patch.object(hpl, "HOST_FILES", ["host.cpp"]), \
+                 contextlib.redirect_stderr(err):
+                self.assertEqual(hpl.main(), 1)
+            self.assertIn("idle-pump pairing violations", err.getvalue())
+
+            with mock.patch.object(hpl, "HOST_FILES", ["host.cpp"]), \
+                 mock.patch.object(hpl, "scan_file", side_effect=OSError("denied")), \
+                 contextlib.redirect_stderr(err := io.StringIO()):
+                self.assertEqual(hpl.main(), 2)
+            self.assertIn("failed to read", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/test_macos_reroute_watcher.py
+++ b/tools/scripts/test_macos_reroute_watcher.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/scripts/macos_reroute_watcher.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+
+SCRIPT = pathlib.Path(__file__).parent / "macos_reroute_watcher.py"
+
+spec = importlib.util.spec_from_file_location("macos_reroute_watcher", SCRIPT)
+assert spec and spec.loader
+watcher = importlib.util.module_from_spec(spec)
+sys.modules["macos_reroute_watcher"] = watcher
+spec.loader.exec_module(watcher)
+
+
+class MacosRerouteWatcherTests(unittest.TestCase):
+    def test_gh_returns_stripped_stdout(self) -> None:
+        completed = subprocess.CompletedProcess(["gh"], 0, stdout="  ok\n")
+        with mock.patch.object(watcher.subprocess, "run", return_value=completed) as run:
+            self.assertEqual(watcher._gh(["repos/acme/project"]), "ok")
+        run.assert_called_once()
+        self.assertEqual(run.call_args.args[0], ["gh", "api", "repos/acme/project"])
+        self.assertEqual(run.call_args.kwargs["timeout"], 20)
+
+    def test_local_is_busy_detects_runner_processes_and_failures(self) -> None:
+        busy_output = (
+            "/Users/runner/actions-runner/_work/pulp/pulp/_temp cmake --build build\n"
+            "/usr/bin/other\n"
+        )
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["ps"], 0, stdout=busy_output),
+        ):
+            self.assertTrue(watcher.local_is_busy())
+
+        worker_output = "/Users/runner/actions-runner/_work/pulp/pulp Runner.Worker spawnclient\n"
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["ps"], 0, stdout=worker_output),
+        ):
+            self.assertTrue(watcher.local_is_busy())
+
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["ps"], 0, stdout="/usr/bin/idle\n"),
+        ):
+            self.assertFalse(watcher.local_is_busy())
+
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["ps"], timeout=10),
+        ):
+            self.assertIsNone(watcher.local_is_busy())
+
+    def test_macos_job_target_detection(self) -> None:
+        with mock.patch.object(watcher, "_gh", return_value="self-hosted,macOS"):
+            self.assertFalse(watcher._macos_job_targets_cloud(10))
+
+        for labels in ("macos-15,ARM64", "nscloud-macos,macOS", "namespace-profile-macos"):
+            with self.subTest(labels=labels), mock.patch.object(watcher, "_gh", return_value=labels):
+                self.assertTrue(watcher._macos_job_targets_cloud(10))
+
+        with mock.patch.object(watcher, "_gh", return_value=""):
+            self.assertFalse(watcher._macos_job_targets_cloud(10))
+
+        with mock.patch.object(watcher, "_gh", side_effect=subprocess.CalledProcessError(1, ["gh"])):
+            self.assertFalse(watcher._macos_job_targets_cloud(10))
+
+    def test_list_queued_cloud_bat_runs_filters_invalid_and_local_rows(self) -> None:
+        raw = "\n".join([
+            json.dumps({"id": 101, "pr": 11}),
+            "{not json",
+            json.dumps({"id": None, "pr": 12}),
+            json.dumps({"id": 102, "pr": None}),
+            json.dumps({"id": 103, "pr": 13}),
+        ])
+
+        def fake_cloud(run_id: int) -> bool:
+            return run_id == 101
+
+        with mock.patch.object(watcher, "_gh", return_value=raw), \
+             mock.patch.object(watcher, "_macos_job_targets_cloud", side_effect=fake_cloud):
+            self.assertEqual(watcher.list_queued_cloud_bat_runs(), [(11, 101)])
+
+        with mock.patch.object(watcher, "_gh", side_effect=subprocess.CalledProcessError(1, ["gh"])):
+            self.assertEqual(watcher.list_queued_cloud_bat_runs(), [])
+
+    def test_reroute_to_local_reports_success_and_failure(self) -> None:
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["pulp"], 0, stdout="done\n", stderr=""),
+        ) as run:
+            self.assertTrue(watcher.reroute_to_local(42))
+        self.assertEqual(
+            run.call_args.args[0],
+            ["pulp", "macos", "retarget", "--pr", "42", "--to", "local"],
+        )
+
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["pulp"], 2, stdout="", stderr="nope"),
+        ):
+            self.assertFalse(watcher.reroute_to_local(42))
+
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["pulp"], timeout=60),
+        ):
+            self.assertFalse(watcher.reroute_to_local(42))
+
+    def test_flap_guard_window_and_trim(self) -> None:
+        guard = watcher.FlapGuard(window_seconds=10)
+        with mock.patch.object(watcher.time, "time", return_value=100.0):
+            self.assertTrue(guard.can_reroute(1))
+            guard.record(1)
+            self.assertFalse(guard.can_reroute(1))
+        with mock.patch.object(watcher.time, "time", return_value=111.0):
+            self.assertTrue(guard.can_reroute(1))
+
+        guard = watcher.FlapGuard(window_seconds=10)
+        guard._last[2] = 80.0
+        guard._last[3] = 95.0
+        with mock.patch.object(watcher.time, "time", return_value=111.0):
+            guard.record(4)
+        self.assertNotIn(2, guard._last)
+        self.assertIn(3, guard._last)
+        self.assertIn(4, guard._last)
+
+    def test_tick_respects_busy_probe_candidates_flap_guard_and_one_reroute(self) -> None:
+        guard = watcher.FlapGuard(window_seconds=300)
+
+        with mock.patch.object(watcher, "local_is_busy", return_value=None), \
+             mock.patch.object(watcher, "list_queued_cloud_bat_runs") as queued:
+            watcher.tick(guard)
+            queued.assert_not_called()
+
+        with mock.patch.object(watcher, "local_is_busy", return_value=True), \
+             mock.patch.object(watcher, "list_queued_cloud_bat_runs") as queued:
+            watcher.tick(guard)
+            queued.assert_not_called()
+
+        with mock.patch.object(watcher, "local_is_busy", return_value=False), \
+             mock.patch.object(watcher, "list_queued_cloud_bat_runs", return_value=[]), \
+             mock.patch.object(watcher, "reroute_to_local") as reroute:
+            watcher.tick(guard)
+            reroute.assert_not_called()
+
+        with mock.patch.object(watcher, "local_is_busy", return_value=False), \
+             mock.patch.object(watcher, "list_queued_cloud_bat_runs", return_value=[(10, 100), (11, 101)]), \
+             mock.patch.object(watcher, "reroute_to_local", return_value=True) as reroute, \
+             mock.patch.object(watcher.time, "time", return_value=1000.0):
+            watcher.tick(guard)
+            reroute.assert_called_once_with(10)
+
+        with mock.patch.object(watcher, "local_is_busy", return_value=False), \
+             mock.patch.object(watcher, "list_queued_cloud_bat_runs", return_value=[(10, 102), (11, 103)]), \
+             mock.patch.object(watcher, "reroute_to_local", return_value=True) as reroute, \
+             mock.patch.object(watcher.time, "time", return_value=1001.0):
+            watcher.tick(guard)
+            reroute.assert_called_once_with(11)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/test_ruleset_drift_config.py
+++ b/tools/scripts/test_ruleset_drift_config.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Structural tests for the ruleset drift workflow.
+
+These tests keep the checked-in branch protection intent aligned with the
+workflow that compares it to GitHub's live ruleset. They are intentionally
+offline: no GitHub API calls, no workflow dispatch, and no runner access.
+
+Run:
+    python3 tools/scripts/test_ruleset_drift_config.py
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import unittest
+
+import yaml
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ruleset-drift-check.yml"
+RULESET = REPO_ROOT / ".github" / "rulesets" / "main-protection.json"
+
+EXPECTED_REQUIRED_CONTEXTS = {
+    "macos",
+    "linux",
+    "windows",
+    "Enforce version & skill sync",
+}
+
+EXPECTED_ADVISORY_CONTEXTS = {
+    "AddressSanitizer (macOS ARM64)",
+    "ThreadSanitizer (macOS ARM64)",
+    "UndefinedBehaviorSanitizer (macOS ARM64)",
+    "RealtimeSanitizer (Linux x86_64, Clang 18)",
+}
+
+
+def workflow_on(doc: dict) -> dict:
+    """Return the GitHub Actions `on:` block from a PyYAML-loaded document."""
+    # PyYAML's YAML 1.1 resolver treats the bare word "on" as boolean True.
+    # GitHub Actions treats it as a literal key.
+    return doc.get("on") or doc.get(True) or {}
+
+
+def required_contexts(ruleset: dict) -> set[str]:
+    contexts: set[str] = set()
+    for rule in ruleset.get("rules", []):
+        if rule.get("type") != "required_status_checks":
+            continue
+        params = rule.get("parameters", {})
+        for check in params.get("required_status_checks", []):
+            context = check.get("context")
+            if context:
+                contexts.add(context)
+    return contexts
+
+
+def advisory_contexts(ruleset: dict) -> set[str]:
+    advisory = ruleset.get("advisory_status_checks", {})
+    return {
+        check["context"]
+        for check in advisory.get("checks", [])
+        if check.get("context")
+    }
+
+
+class RulesetDriftConfig(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow_text = WORKFLOW.read_text(encoding="utf-8")
+        cls.workflow = yaml.safe_load(cls.workflow_text)
+        cls.ruleset = json.loads(RULESET.read_text(encoding="utf-8"))
+
+    def test_pull_request_trigger_is_scoped_to_ruleset_files(self) -> None:
+        trigger = workflow_on(self.workflow)
+        pull_request = trigger.get("pull_request", {})
+
+        self.assertEqual(pull_request.get("branches"), ["main"])
+        self.assertEqual(
+            set(pull_request.get("paths", [])),
+            {
+                ".github/rulesets/**",
+                ".github/workflows/ruleset-drift-check.yml",
+            },
+        )
+
+    def test_manual_trigger_can_override_drift_failure(self) -> None:
+        trigger = workflow_on(self.workflow)
+        dispatch = trigger.get("workflow_dispatch", {})
+        fail_on_drift = dispatch.get("inputs", {}).get("fail_on_drift", {})
+
+        self.assertEqual(
+            fail_on_drift.get("default"),
+            "",
+            "manual runs should default to the workflow's event-sensitive "
+            "failure policy instead of forcing failures on every dispatch",
+        )
+        self.assertFalse(fail_on_drift.get("required", True))
+
+    def test_workflow_points_at_checked_in_ruleset_name(self) -> None:
+        diff_job = self.workflow["jobs"]["diff"]
+        env = diff_job["env"]
+
+        self.assertEqual(
+            env["CHECKED_IN_PATH"],
+            ".github/rulesets/main-protection.json",
+        )
+        self.assertEqual(env["RULESET_NAME"], self.ruleset["name"])
+        self.assertEqual(self.ruleset["target"], "branch")
+        self.assertEqual(self.ruleset["source_type"], "Repository")
+        self.assertEqual(self.ruleset["enforcement"], "active")
+
+    def test_required_and_advisory_contexts_stay_separate(self) -> None:
+        required = required_contexts(self.ruleset)
+        advisory = advisory_contexts(self.ruleset)
+
+        self.assertEqual(required, EXPECTED_REQUIRED_CONTEXTS)
+        self.assertEqual(advisory, EXPECTED_ADVISORY_CONTEXTS)
+        self.assertTrue(
+            required.isdisjoint(advisory),
+            "slow sanitizer contexts must remain advisory-only unless branch "
+            "protection policy changes explicitly",
+        )
+
+    def test_fetch_filters_out_inherited_org_rulesets(self) -> None:
+        self.assertIn(
+            "includes_parents=false",
+            self.workflow_text,
+            "ruleset drift fetch must ignore inherited org rulesets so a "
+            "same-named org ruleset cannot mask repo-local drift",
+        )
+        self.assertIn(
+            "source_type')=='Repository'",
+            self.workflow_text,
+            "ruleset id selection must require Repository source_type",
+        )
+
+    def test_pr_comment_is_fork_safe_and_scheduled_drift_fails(self) -> None:
+        self.assertIn(
+            "github.event.pull_request.head.repo.full_name == github.repository",
+            self.workflow_text,
+            "PR drift comments must be skipped for fork heads because their "
+            "GITHUB_TOKEN cannot write issue comments",
+        )
+        self.assertIn(
+            "steps.diff.outputs.drift == 'true' && github.event_name != 'pull_request'",
+            self.workflow_text,
+            "scheduled/manual drift must surface as a failing check while PR "
+            "drift remains advisory",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Consolidated codecov coverage batch to reduce GitHub macOS CI fan-out.

Supersedes small PRs: #2016, #2022, #2024, #2035, #2037, #2038.

Local macOS validation:
- CMake configure with `PULP_ENABLE_GPU=OFF`, examples off
- Built affected tools/host/format/state targets
- Ran affected C++ test binaries directly; all passed
- Ran Python unittest entrypoints for added tools tests; all passed

Note: pre-push diff-cover attempted its own coverage configure and hit a transient Highway FetchContent checkout failure, then demoted under `PULP_DISABLE_PREPUSH_DIFF_COVER=1`; focused local validation above is green.