### PR TITLE
chore: bump versions to v0.101.2 (retry SDK build with #2018 fontconfig fix)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.101.1
+    VERSION 0.101.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
## Summary

- Bumps Pulp SDK 0.101.1 → 0.101.2.
- Retries the v0.101.x release-cli build now that #2018 has landed on main with the fontconfig link-order fix.

## Why

v0.101.0 and v0.101.1 were tagged before #2018 merged. Their `Release CLI / CLI linux-x64` jobs failed identically with undefined references to `Fc*` symbols when linking `pulp-import-design` against `libskia.a`. As a result, neither release published the 11 SDK assets — they sit as drafts with only `appcast.xml`.

#2018 (commit `7b4e9d6e8`) extracts the proven fontconfig-after-skia link helper to `tools/cmake/PulpLinkFontconfig.cmake` and applies it to `pulp-import-design`, mirroring the existing `pulp-cli` fix from #1986. Its own `Release-path build (linux-x64)` PR check went green — that's the exact target that was failing on the release tags.

## Test plan

- [ ] CI green on this bump PR
- [ ] Auto-release.yml fires on merge, tags v0.101.2
- [ ] release-cli.yml builds all 5 platforms (linux-x64, linux-arm64, darwin-arm64, windows-x64, windows-arm64) — **especially `CLI linux-x64`**
- [ ] sign-and-release.yml publishes 11 assets (10 platform tarballs + appcast.xml) instead of just appcast.xml
- [ ] Verify the draft v0.101.2 release flips to published with full asset set

This is the follow-up release that finally unblocks the SDK publishing pipeline that's been stuck since v0.95.0.
