### PR TITLE
fix(cmake): apply fontconfig link-order helper to all Standalone targets (#2018 follow-up)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.101.2
+    VERSION 0.101.3
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/tools/cmake/PulpUtils.cmake
+++ b/tools/cmake/PulpUtils.cmake
@@ -989,6 +989,13 @@ function(_pulp_add_standalone target name bundle_id version)
     if(COMMAND target_copy_webgpu_binaries)
         target_copy_webgpu_binaries(${target}_Standalone)
     endif()
+    # Linux+GNU-ld link-order fix: libskia.a → fontconfig. Same helper
+    # used for pulp-cli (#1986) and pulp-import-design (#2018). Standalone
+    # transitively pulls in pulp::view → pulp::canvas → libskia.a, which
+    # references Fc* symbols. Re-mention fontconfig AFTER the archive so
+    # the linker resolves them. No-op on macOS/Windows/Android.
+    include(${CMAKE_SOURCE_DIR}/tools/cmake/PulpLinkFontconfig.cmake)
+    pulp_link_fontconfig_after_skia(${target}_Standalone)
 endfunction()
 
 # ── pulp_add_app ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Extends the proven fontconfig link-order helper (`tools/cmake/PulpLinkFontconfig.cmake`, originally inlined in #1986 / extracted in #2018) to all `Standalone` targets created by `pulp_add_plugin(...)`.

Also bumps SDK 0.101.2 → 0.101.3 to retry release-cli.

## Why

v0.101.2 release-cli `CLI linux-x64` still failed — but on a *different* target this time. The previously-failing `pulp-import-design` was fixed by #2018 (release-path build linux-x64 verified GREEN on the PR). The new failing target is `examples/pulp-gain/PulpGain` (the Standalone executable), with the same undefined references to `Fc*` symbols from `libskia.a(SkFontMgr_fontconfig.o)`.

Standalone targets created via `pulp_add_plugin(... FORMATS ... Standalone ...)` link to `Pulp::standalone`, which transitively pulls in `pulp::view → pulp::canvas → skia::skia → libskia.a`. Same Linux+GNU-ld single-pass static-archive issue.

The fix is centralized in `_pulp_add_standalone` in `tools/cmake/PulpUtils.cmake`, so every plugin built with Standalone format gets the link helper automatically — no per-plugin CMakeLists changes needed.

## Test plan

- [ ] CI green on this PR (especially `Release-path build (linux-x64)` — the canary for this whole class of bug)
- [ ] Merge → auto-release.yml tags v0.101.3
- [ ] release-cli.yml builds all 5 platforms, **CLI linux-x64 PASSES**
- [ ] sign-and-release.yml publishes 11 assets (not just appcast.xml)
- [ ] v0.101.3 release flips draft → published with full asset set
- [ ] This is the deliverable: first successful SDK build since v0.94.0
