### PR TITLE
fix(canvas): force -lfontconfig at end of every downstream link line (structural fix for v0.101.x release-cli)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.101.3
+    VERSION 0.101.4
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/CMakeLists.txt
+++ b/core/canvas/CMakeLists.txt
@@ -114,6 +114,28 @@ if(PULP_HAS_SKIA)
             pkg_check_modules(FONTCONFIG IMPORTED_TARGET fontconfig)
             if(FONTCONFIG_FOUND)
                 target_link_libraries(pulp-canvas PUBLIC PkgConfig::FONTCONFIG)
+                # Force `-lfontconfig` to appear at the END of every
+                # downstream binary's link line, regardless of where
+                # CMake places the transitive PkgConfig::FONTCONFIG dep.
+                # GNU ld processes static archives left-to-right and
+                # won't re-scan to resolve `libskia.a(SkFontMgr_fontconfig.o)`'s
+                # `Fc*` references once it moves past them. The PUBLIC
+                # link above gives consumers fontconfig in the right
+                # position when only pulp::canvas is linked directly,
+                # but breaks down for transitive consumers (e.g. an
+                # executable linking only pulp::view → pulp::canvas) —
+                # those see libskia.a get pulled in before -lfontconfig
+                # appears on the line. Re-mentioning fontconfig as an
+                # INTERFACE_LINK_OPTIONS entry guarantees it tails every
+                # consumer's link, fixing the entire class of:
+                #
+                #   undefined reference to `FcGetVersion`, `FcPatternGetMatrix`,
+                #   `FcConfigSubstitute`, `FcCharSetHasChar`, etc.
+                #
+                # This obsoletes the per-target `pulp_link_fontconfig_after_skia`
+                # calls in pulp-cli / pulp-import-design / _pulp_add_standalone
+                # for new code; existing calls remain harmless redundancy.
+                target_link_options(pulp-canvas INTERFACE "-lfontconfig")
             endif()
         endif()
     # Android: Skia bundles FreeType + HarfBuzz, no system fontconfig needed


### PR DESCRIPTION
## Summary

Adds `target_link_options(pulp-canvas INTERFACE "-lfontconfig")` so `-lfontconfig` appears at the END of every consumer's link line, regardless of how CMake places the transitive `PkgConfig::FONTCONFIG` dep.

Also bumps SDK 0.101.3 → 0.101.4 to retry the release-cli build.

## Why — the same bug bit us four times in a row

Linux+GNU-ld processes static archives left-to-right and won't re-scan. `libskia.a(SkFontMgr_fontconfig.o)` references `FcGetVersion`, `FcPatternGetMatrix`, `FcFontSetMatch`, etc. — if `-lfontconfig` doesn't appear AFTER `libskia.a` in the final ld line, those symbols stay undefined.

The fix has been applied incrementally, target-by-target:

| Release | Failing target | Fix |
|---------|---------------|-----|
| v0.95–v0.97 | `pulp-cli` | #1986 (inlined helper) |
| v0.98–v0.101.1 | `pulp-import-design` | #2018 (extracted `PulpLinkFontconfig.cmake`) |
| v0.101.2 | `examples/pulp-gain/PulpGain` (Standalone) | #2056 (applied to `_pulp_add_standalone`) |
| v0.101.3 | `examples/view-bridge-demo/pulp-view-bridge-demo` | (this PR) |

Each iteration cost ~30 min of release-cycle time to discover the next failing target. Whack-a-mole.

## Root cause

`PkgConfig::FONTCONFIG` is already linked PUBLIC on `pulp-canvas` (#1962 follow-up), so direct consumers get it. But for transitive consumers — executables that only see `libskia.a` brought in by pulp::view → pulp::canvas — CMake places the transitive `-lfontconfig` somewhere in the link line, not guaranteed AFTER `libskia.a`.

`target_link_options(... INTERFACE "-lfontconfig")` is propagated through `INTERFACE_LINK_OPTIONS`, which CMake puts at the END of every consumer's link line. That's exactly where we need it. The existing per-target `pulp_link_fontconfig_after_skia` helper calls (pulp-cli, pulp-import-design, `_pulp_add_standalone`) become harmless redundancy — they continue to work, but new code no longer needs them.

## Test plan

- [ ] CI green on this PR — `Release-path build (linux-x64)` is the canary
- [ ] Merge → auto-release.yml tags v0.101.4
- [ ] release-cli.yml builds all 5 platforms, **`CLI linux-x64` PASSES**
- [ ] sign-and-release.yml publishes 11 assets (10 platform tarballs + appcast.xml)
- [ ] v0.101.4 release flips draft → published with full asset set
- [ ] **First successful SDK build since v0.94.0**
