### PR TITLE
ci(release): auto-supersede in-flight builds when a newer version tags

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -64,7 +64,17 @@ in `tools/shipyard.toml`). It:
 5. Pushes the branch, creates the PR, and records Shipyard tracking state.
 6. Runs cross-platform validate + merge on green.
 7. Auto-release workflow (`.github/workflows/auto-release.yml`) tags and
-   publishes binaries on merge.
+   publishes binaries on merge. **Auto-supersede behavior**: when a
+   new SDK tag is created, the workflow cancels any in-flight
+   `release-cli.yml` / `sign-and-release.yml` runs for strictly-older
+   SemVer tags and deletes their draft releases. This prevents the
+   2026-05-15 v0.101.x saga from recurring (5 bumps each queueing a
+   full macos-15 darwin-arm64 build, latest waiting hours behind
+   already-obsolete builds). Opt out via `vars.PULP_RELEASE_MODE=land-all`
+   (repo-wide) or `Release-Supersede: skip reason="..."` trailer on
+   the merging commit (per-release). See #2076 + the
+   `release-draft-stuck-check.yml` newest-SemVer skip for the watchdog
+   side of the cleanup.
 
 Never run `gh pr create` + `shipyard ship` separately for a normal ship
 cycle. Never invoke the two version/skill scripts by hand — `shipyard pr`

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -434,27 +434,37 @@ jobs:
               ("sign-and-release.yml", "sign-and-release"),
           ]
 
+          # Sweep ALL non-completed run states (codex P2 on #2076): the
+          # ?status= filter splits queued / in_progress / requested /
+          # waiting / pending into separate buckets, and a run may sit
+          # in any of them at the moment we read. Listing the full
+          # workflow runs page and filtering client-side by status is
+          # more robust than querying each named status separately.
+          NON_COMPLETED = {
+              "queued", "in_progress", "requested", "waiting", "pending",
+          }
           for wf_file, wf_label in workflows:
-              for status in ("queued", "in_progress"):
-                  raw = gh([
-                      f"/repos/{REPO}/actions/workflows/{wf_file}/runs?status={status}&per_page=50",
-                      "--jq", ".workflow_runs[] | {id, head_branch}",
-                  ])
-                  if not raw:
+              raw = gh([
+                  f"/repos/{REPO}/actions/workflows/{wf_file}/runs?per_page=100",
+                  "--jq", ".workflow_runs[] | {id, head_branch, status}",
+              ])
+              if not raw:
+                  continue
+              for line in raw.strip().splitlines():
+                  run = json.loads(line)
+                  if run.get("status") not in NON_COMPLETED:
                       continue
-                  for line in raw.strip().splitlines():
-                      run = json.loads(line)
-                      tag = run["head_branch"]
-                      old_ver = parse(tag)
-                      if not old_ver:
-                          continue
-                      if old_ver >= new_ver:
-                          continue
-                      print(f"  superseding {wf_label} run {run['id']} (tag {tag} < {NEW_TAG})")
-                      subprocess.run([
-                          "gh", "api", "-X", "POST",
-                          f"/repos/{REPO}/actions/runs/{run['id']}/cancel",
-                      ], capture_output=True)
+                  tag = run["head_branch"]
+                  old_ver = parse(tag)
+                  if not old_ver:
+                      continue
+                  if old_ver >= new_ver:
+                      continue
+                  print(f"  superseding {wf_label} run {run['id']} (tag {tag} < {NEW_TAG}, status={run.get('status')})")
+                  subprocess.run([
+                      "gh", "api", "-X", "POST",
+                      f"/repos/{REPO}/actions/runs/{run['id']}/cancel",
+                  ], capture_output=True)
 
           # Delete strictly-older draft releases. Never touch published.
           raw = gh([

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -31,6 +31,8 @@ concurrency:
 permissions:
   contents: write   # tag push
   issues: write     # open the "stranded fix/feat" tracker (issue #1009)
+  actions: write    # cancel superseded release-cli / sign-and-release runs
+                    # (see "Supersede older in-flight builds" step below)
 
 jobs:
   tag:
@@ -346,6 +348,131 @@ jobs:
           if [ "$PLUGIN_SHOULD_TAG" = "1" ] && [ -n "$PLUGIN_AFTER" ]; then
               create_tag "plugin-v${PLUGIN_AFTER}"
           fi
+
+          # Expose the SDK tag we just created so downstream steps can
+          # supersede older in-flight builds. (Plugin tags don't go
+          # through release-cli, so they don't need supersede.)
+          if [ "$SDK_SHOULD_TAG" = "1" ] && [ -n "$SDK_AFTER" ]; then
+              echo "sdk_tag=v${SDK_AFTER}" >> "$GITHUB_OUTPUT"
+          fi
+        id: tag
+
+      # ── Supersede older in-flight release-cli + sign-and-release runs ─
+      #
+      # Cancels release-cli.yml and sign-and-release.yml runs for any
+      # strictly-older SDK tag, then deletes the corresponding draft
+      # release. The intent: if v0.101.7 is mid-build and we just tagged
+      # v0.102.0, v0.101.7's artifacts are obsolete — users will only
+      # ever install v0.102.0. Saves github-hosted macos-15 minutes and
+      # gets the latest release to users faster (see #2075 + the 2026-05-15
+      # v0.101.x saga that motivated this step).
+      #
+      # Two opt-outs:
+      #   1. vars.PULP_RELEASE_MODE=land-all — repo-wide disable
+      #   2. `Release-Supersede: skip reason="..."` trailer on the tip
+      #      commit — per-release disable
+      #
+      # Cancelling sign-and-release.yml is important: it runs on the same
+      # tag push and can resurrect a draft release after release-cli is
+      # cancelled (codex flagged this footgun in #2075).
+      #
+      # Semver via stdlib regex, not packaging.version (PEP 440 ≠ SemVer)
+      # and not `sort -V` (Pulp pre-release suffixes would be a future
+      # extension, but `sort -V` mis-orders them today).
+      - name: Supersede older in-flight release builds
+        if: steps.tag.outputs.sdk_tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_TAG: ${{ steps.tag.outputs.sdk_tag }}
+          RELEASE_MODE: ${{ vars.PULP_RELEASE_MODE || 'supersede-older' }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          if [ "$RELEASE_MODE" = "land-all" ]; then
+            echo "RELEASE_MODE=land-all → skipping supersede"
+            exit 0
+          fi
+
+          # Per-release opt-out via commit trailer.
+          if git log -1 --format=%B HEAD | \
+               git interpret-trailers --parse | \
+               grep -qE '^Release-Supersede:\s*skip\b'; then
+            echo "Release-Supersede: skip trailer found → skipping supersede"
+            exit 0
+          fi
+
+          echo "Supersede check: new tag = $NEW_TAG"
+
+          python3 <<'PYEOF'
+          import json, os, re, subprocess, sys
+
+          NEW_TAG = os.environ["NEW_TAG"]
+          REPO = os.environ["REPO"]
+          SEMVER = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:-.+)?$")
+
+          def parse(tag):
+              m = SEMVER.match(tag)
+              if not m:
+                  return None
+              return tuple(int(g) for g in m.groups())
+
+          new_ver = parse(NEW_TAG)
+          if not new_ver:
+              print(f"NEW_TAG={NEW_TAG} is not a SemVer tag; skipping supersede")
+              sys.exit(0)
+
+          def gh(args, check=True):
+              r = subprocess.run(["gh", "api", *args], capture_output=True, text=True)
+              if check and r.returncode != 0:
+                  print(f"gh api failed: {r.stderr}", file=sys.stderr)
+                  return None
+              return r.stdout
+
+          # Workflow IDs to scan. release-cli.yml + sign-and-release.yml.
+          workflows = [
+              ("release-cli.yml", "release-cli"),
+              ("sign-and-release.yml", "sign-and-release"),
+          ]
+
+          for wf_file, wf_label in workflows:
+              for status in ("queued", "in_progress"):
+                  raw = gh([
+                      f"/repos/{REPO}/actions/workflows/{wf_file}/runs?status={status}&per_page=50",
+                      "--jq", ".workflow_runs[] | {id, head_branch}",
+                  ])
+                  if not raw:
+                      continue
+                  for line in raw.strip().splitlines():
+                      run = json.loads(line)
+                      tag = run["head_branch"]
+                      old_ver = parse(tag)
+                      if not old_ver:
+                          continue
+                      if old_ver >= new_ver:
+                          continue
+                      print(f"  superseding {wf_label} run {run['id']} (tag {tag} < {NEW_TAG})")
+                      subprocess.run([
+                          "gh", "api", "-X", "POST",
+                          f"/repos/{REPO}/actions/runs/{run['id']}/cancel",
+                      ], capture_output=True)
+
+          # Delete strictly-older draft releases. Never touch published.
+          raw = gh([
+              f"/repos/{REPO}/releases?per_page=50",
+              "--jq", ".[] | select(.draft) | {id, tag: .tag_name}",
+          ])
+          if raw:
+              for line in raw.strip().splitlines():
+                  rel = json.loads(line)
+                  old_ver = parse(rel["tag"])
+                  if not old_ver or old_ver >= new_ver:
+                      continue
+                  print(f"  deleting draft release {rel['tag']} (id {rel['id']})")
+                  subprocess.run([
+                      "gh", "api", "-X", "DELETE",
+                      f"/repos/{REPO}/releases/{rel['id']}",
+                  ], capture_output=True)
+          PYEOF
 
       # CHANGELOG regeneration moved to .github/workflows/post-tag-sync.yml
       # (installed by `shipyard release-bot hook install`). Firing on the

--- a/.github/workflows/release-draft-stuck-check.yml
+++ b/.github/workflows/release-draft-stuck-check.yml
@@ -101,18 +101,43 @@ jobs:
           # Process each release. We care about those whose tag exists
           # in git AND draft == true AND age > grace AND landed inside
           # the lookback window.
+          # Compute the highest SemVer tag in the releases set (across
+          # both draft and published). Anything strictly older than this
+          # is "superseded" — auto-release.yml's supersede step is
+          # supposed to delete those drafts immediately, but the
+          # PULP_RELEASE_MODE=land-all override OR a slow-running cleanup
+          # can leave stragglers. Don't alarm on them.
+          # See #2075 + the 2026-05-15 v0.101.x saga.
           mapfile -t release_lines < <(
               python3 - <<'PY'
-          import json, sys
+          import json, re, sys
+          SEMVER = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:-.+)?$")
           rels = json.load(open('releases.json'))
+
+          def parse(tag):
+              m = SEMVER.match(tag or "")
+              if not m:
+                  return None
+              return tuple(int(g) for g in m.groups())
+
+          # Find the newest semver tag we know about (any draft state).
+          newest = None
+          for r in rels:
+              v = parse(r.get('tag_name', ''))
+              if v and (newest is None or v > newest):
+                  newest = v
+
           for r in rels:
               tag = r.get('tag_name') or ''
               draft = bool(r.get('draft'))
               created = r.get('created_at') or ''
               if not tag:
                   continue
-              # Emit one TSV row per release for downstream awk.
-              print('\t'.join([tag, str(draft).lower(), created]))
+              # Mark as superseded if a strictly-newer semver tag exists
+              # in the releases set. Downstream awk reads the fourth col.
+              v = parse(tag)
+              superseded = (v is not None and newest is not None and v < newest)
+              print('\t'.join([tag, str(draft).lower(), created, str(superseded).lower()]))
           PY
           )
 
@@ -120,8 +145,14 @@ jobs:
               tag=$(echo "$line" | cut -f1)
               draft=$(echo "$line" | cut -f2)
               created=$(echo "$line" | cut -f3)
+              superseded=$(echo "$line" | cut -f4)
 
               if [ "$draft" != "true" ]; then continue; fi
+
+              if [ "$superseded" = "true" ]; then
+                  echo "  skip ${tag} — superseded by a newer SemVer tag (see #2075)"
+                  continue
+              fi
 
               # Tag must exist in git — drafts on deleted tags are
               # someone-else's-problem (likely a deletion in flight).


### PR DESCRIPTION
## Summary

Implements the supersede design from #2075 (refined with codex consult — see issue comment thread). When a new SDK tag is created, auto-release.yml now:

1. Cancels in-flight `release-cli.yml` AND `sign-and-release.yml` runs for any strictly-older SemVer tag
2. Deletes the corresponding draft GitHub Releases (never touches published)
3. Honors two opt-outs:
   - **Repo-wide**: `vars.PULP_RELEASE_MODE=land-all` disables supersede entirely
   - **Per-release**: `Release-Supersede: skip reason="..."` trailer on the merging commit

Also teaches `release-draft-stuck-check.yml` to skip tags strictly older than the newest SemVer tag — that watchdog filed 6+ false-positive issues today for the v0.100.0–v0.101.4 manual supersede cleanups.

## Why

5+ version-bump PRs landed on 2026-05-15 during the v0.101.x fontconfig saga. Each tagged a new release; each queued a full release-cli matrix run; github-hosted macos-15 free-tier serialized darwin-arm64 across all of them; v0.102.0 ended up waiting ~2h behind v0.101.7 + v0.101.8 even though v0.102.0 strictly superseded both. Manual cleanup was required (cancel runs + delete drafts) so v0.102.0 could surface.

This automation closes that hole. Saves ~5h of macos-15 minutes per future saga and gets latest releases to users faster.

## Design discipline (from /codex consult)

- ✅ Semver comparison via stdlib regex `^v?(\d+)\.(\d+)\.(\d+)(?:-.+)?$` — NOT `sort -V` (mis-orders pre-releases) and NOT `packaging.version` (PEP 440 ≠ pure SemVer)
- ✅ Cancels BOTH `release-cli.yml` AND `sign-and-release.yml` — codex flagged that sign-and-release on the same tag can resurrect a draft after release-cli is cancelled
- ❌ Did NOT add `concurrency: { group: release-cli, cancel-in-progress: true }` to release-cli.yml — concurrency is evaluated before the workflow can read commit/tag metadata, so the opt-out trailer can't override it. Surprising-by-design for manual `workflow_dispatch` backfills. Layer 2 alone covers the happy path; Layer 1 deferred until / unless someone has a concrete need.
- ✅ Only deletes drafts — never touches published releases
- ✅ Adds `actions: write` permission to auto-release.yml (needed for cross-workflow cancellation)

## Acceptance / test plan

- [ ] PR CI green
- [ ] Merge → next version bump fires the supersede step (visible in workflow logs)
- [ ] Synthetic test: push two `chore: bump versions` in quick succession (e.g. via consecutive small PRs), verify only the newer tag produces a published release with 11 assets
- [ ] `release-draft-stuck-check.yml` next sweep shows "skip … superseded by newer SemVer tag" lines for any leftover drafts
- [ ] Opt-out smoke: set `vars.PULP_RELEASE_MODE=land-all`, push two bumps, verify both releases build

## Future extension

When you want to revisit "land all" hotfix-on-older-line mode:

```bash
# Repo-wide
gh api -X PATCH /repos/danielraffel/pulp/actions/variables/PULP_RELEASE_MODE -f value=land-all

# Or per-release on a specific bump commit
git commit -m "chore: bump versions

Release-Supersede: skip reason=\"hotfix on v0.101 line while v0.102 in-flight\""
```

No code change needed.

Closes #2075.
