### PR TITLE
feat(tooling): refuse to run validation harness on stale checkout (#2087)

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -235,6 +235,32 @@ itself lives inside a Pulp build tree. In generic PATH-installed or split repo/S
 
 ## Automated Validation Loop
 
+### Freshness check (MUST run first)
+
+Before running any roundtrip harness against the framework, **verify your checkout is current with `origin/main`**. Lesson from pulp #2087: a roundtrip ran from a 175-commit-behind feature branch and produced "wrong UI variant" diff scores that reflected stale framework code, not main. We spent 15+ minutes drawing parser conclusions before noticing.
+
+The `tools/import-validation/*-roundtrip.sh` scripts now refuse to run on a stale checkout. Bypass only when you specifically want to validate a feature branch:
+
+```bash
+# Default: refuse to run if HEAD is behind origin/main
+tools/import-validation/spectr-roundtrip.sh
+
+# Explicitly allow staleness (e.g., validating a feature branch's code)
+PULP_FRESHNESS_BYPASS=1 tools/import-validation/spectr-roundtrip.sh
+
+# Or accept up to N commits behind
+tools/scripts/check_workspace_freshness.sh --max-behind 10 && tools/import-validation/spectr-roundtrip.sh
+```
+
+Also verify the **installed SDK** matches your expectations:
+```bash
+pulp sdk status              # what's installed
+pulp doctor --versions       # CLI vs project vs installed
+```
+If you ran `pulp upgrade` recently, the CLI bumped but the SDK might not have. Use `pulp sdk install` to pull the latest SDK matching the CLI.
+
+### Diff loop
+
 After generating Pulp code, ALWAYS validate by comparing with the source design:
 
 1. **Screenshot the source design** via MCP:

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.38.0"
+  "version": "0.39.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v01020"></a>
+## [0.39.0]
+
 ## [0.102.0] - 2026-05-15
 
 - feat(mcp): ship pulp-mcp in tarball + per-tool feature detection (#2067, #2070) ([#2068](https://github.com/danielraffel/pulp/pull/2068))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -121,6 +121,18 @@ if(UNIX)
         LABELS "parser-import")
 endif()
 
+# Workspace freshness guard (pulp #2087 lesson) — refuse to run
+# validation harnesses on a checkout behind origin/main. Test
+# exercises 7 scenarios across enforce/warn/max-behind/bypass/json
+# modes against synthetic git repos.
+if(UNIX)
+    add_test(NAME workspace-freshness
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_workspace_freshness.sh)
+    set_tests_properties(workspace-freshness
+        PROPERTIES TIMEOUT 30
+        LABELS "tooling")
+endif()
+
 # Debug-SDK perf-killer guard smoke (pulp-internal task #35).
 # Hermetic — runs the guard against a tempdir-fabricated SDK install,
 # exercises the three branches (Debug-no-override → FATAL_ERROR,

--- a/test/test_workspace_freshness.sh
+++ b/test/test_workspace_freshness.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# test_workspace_freshness.sh — exercise tools/scripts/check_workspace_freshness.sh
+# against synthetic git repo states (fresh, behind, ahead, dirty, bypassed).
+#
+# Why this test exists
+# --------------------
+# pulp #2087 lesson — a roundtrip ran from a 175-commits-behind branch and
+# we drew wrong parser conclusions before noticing. The freshness check is
+# the guard. This test pins its behavior so the guard can't silently regress.
+#
+# Pattern: each scenario sets up a temp git repo with a controlled
+# ahead/behind relationship, runs the script, asserts exit code + key
+# output substring.
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/tools/scripts/check_workspace_freshness.sh"
+[[ -x "$SCRIPT" ]] || { echo "FAIL: $SCRIPT missing or not executable"; exit 1; }
+
+PASS=0
+FAIL=0
+
+mk_repo() {
+  local dir="$1"
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  git -C "$dir" init -q -b main
+  git -C "$dir" config user.email t@t
+  git -C "$dir" config user.name t
+  echo a > "$dir/a"
+  git -C "$dir" add a
+  git -C "$dir" commit -q -m initial
+  # Synthesize an "origin" by cloning to a parallel bare path
+  git clone -q --bare "$dir" "${dir}-origin.git"
+  git -C "$dir" remote add origin "${dir}-origin.git"
+  git -C "$dir" fetch -q origin main
+  git -C "$dir" branch --set-upstream-to=origin/main main 2>/dev/null || true
+}
+
+advance_origin() {
+  local dir="$1" n="${2:-1}"
+  local tmp=$(mktemp -d)
+  git clone -q "${dir}-origin.git" "$tmp"
+  cd "$tmp"
+  git config user.email t@t; git config user.name t
+  for i in $(seq 1 "$n"); do
+    echo "$i" > "f${i}"
+    git add "f${i}"
+    git commit -q -m "advance ${i}"
+  done
+  git push -q origin main
+  cd - >/dev/null
+  rm -rf "$tmp"
+  git -C "$dir" fetch -q origin main
+}
+
+assert() {
+  local label="$1" expected_rc="$2" actual_rc="$3"
+  if [[ "$expected_rc" == "$actual_rc" ]]; then
+    echo "  PASS — $label (rc=$actual_rc)"
+    PASS=$((PASS+1))
+  else
+    echo "  FAIL — $label (expected rc=$expected_rc, got rc=$actual_rc)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# ── Scenario 1: fresh checkout (HEAD == origin/main) → exit 0
+TEST_DIR=$(mktemp -d)/freshness-1
+mk_repo "$TEST_DIR"
+( cd "$TEST_DIR" && "$SCRIPT" >/dev/null 2>&1; ) && actual=$? || actual=$?
+assert "scenario 1: fresh checkout" 0 "$actual"
+
+# ── Scenario 2: 5 commits behind → exit 1
+TEST_DIR=$(mktemp -d)/freshness-2
+mk_repo "$TEST_DIR"
+advance_origin "$TEST_DIR" 5
+( cd "$TEST_DIR" && "$SCRIPT" >/dev/null 2>&1; ) && actual=$? || actual=$?
+assert "scenario 2: 5 commits behind, enforce" 1 "$actual"
+
+# ── Scenario 3: 5 behind with --warn → exit 0
+( cd "$TEST_DIR" && "$SCRIPT" --warn >/dev/null 2>&1; ) && actual=$? || actual=$?
+assert "scenario 3: 5 behind --warn" 0 "$actual"
+
+# ── Scenario 4: 5 behind with --max-behind 10 → exit 0
+( cd "$TEST_DIR" && "$SCRIPT" --max-behind 10 >/dev/null 2>&1; ) && actual=$? || actual=$?
+assert "scenario 4: 5 behind --max-behind 10" 0 "$actual"
+
+# ── Scenario 5: 5 behind with --max-behind 3 → exit 1
+( cd "$TEST_DIR" && "$SCRIPT" --max-behind 3 >/dev/null 2>&1; ) && actual=$? || actual=$?
+assert "scenario 5: 5 behind --max-behind 3" 1 "$actual"
+
+# ── Scenario 6: PULP_FRESHNESS_BYPASS=1 → exit 0
+( cd "$TEST_DIR" && PULP_FRESHNESS_BYPASS=1 "$SCRIPT" >/dev/null 2>&1; ) && actual=$? || actual=$?
+assert "scenario 6: bypass env var" 0 "$actual"
+
+# ── Scenario 7: --json mode emits parseable JSON
+TEST_DIR=$(mktemp -d)/freshness-7
+mk_repo "$TEST_DIR"
+out=$( cd "$TEST_DIR" && "$SCRIPT" --json 2>/dev/null )
+if echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['behind']==0; assert d['mode']=='enforce'"; then
+  echo "  PASS — scenario 7: --json output parseable + correct"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL — scenario 7: --json output garbled or wrong"
+  FAIL=$((FAIL+1))
+fi
+
+echo ""
+echo "Result: $PASS pass, $FAIL fail"
+[[ "$FAIL" == "0" ]]

--- a/tools/import-validation/designmd-roundtrip.sh
+++ b/tools/import-validation/designmd-roundtrip.sh
@@ -9,6 +9,14 @@
 set -euo pipefail
 
 PULP_DIR="${PULP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# pulp #2087 lesson — refuse to run on a stale checkout. Bypass with
+# PULP_FRESHNESS_BYPASS=1 to validate a feature branch's code instead.
+if ! ( cd "$PULP_DIR" && "$PULP_DIR/tools/scripts/check_workspace_freshness.sh" ); then
+  echo "ERROR: refusing to run validation against stale checkout" >&2
+  exit 2
+fi
+
 BUILD_DIR="${PULP_BUILD_DIR:-$PULP_DIR/build-designmd-import}"
 BUILD_TYPE="${PULP_BUILD_TYPE:-Debug}"
 BUILD_JOBS="${PULP_BUILD_JOBS:-1}"

--- a/tools/import-validation/figma-roundtrip.sh
+++ b/tools/import-validation/figma-roundtrip.sh
@@ -8,6 +8,14 @@
 set -euo pipefail
 
 PULP_DIR="${PULP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# pulp #2087 lesson — refuse to run on a stale checkout. Bypass with
+# PULP_FRESHNESS_BYPASS=1 to validate a feature branch's code instead.
+if ! ( cd "$PULP_DIR" && "$PULP_DIR/tools/scripts/check_workspace_freshness.sh" ); then
+  echo "ERROR: refusing to run validation against stale checkout" >&2
+  exit 2
+fi
+
 DEFAULT_PLANNING_FIXTURE="$PULP_DIR/planning/fixtures/figma/level-meter-panel.tsx"
 DEFAULT_TEST_FIXTURE="$PULP_DIR/test/fixtures/figma/level-meter-panel.tsx"
 if [[ -n "${PULP_FIGMA_FIXTURE:-}" ]]; then

--- a/tools/import-validation/pencil-roundtrip.sh
+++ b/tools/import-validation/pencil-roundtrip.sh
@@ -8,6 +8,14 @@
 set -euo pipefail
 
 PULP_DIR="${PULP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# pulp #2087 lesson — refuse to run on a stale checkout. Bypass with
+# PULP_FRESHNESS_BYPASS=1 to validate a feature branch's code instead.
+if ! ( cd "$PULP_DIR" && "$PULP_DIR/tools/scripts/check_workspace_freshness.sh" ); then
+  echo "ERROR: refusing to run validation against stale checkout" >&2
+  exit 2
+fi
+
 DEFAULT_PLANNING_FIXTURE="$PULP_DIR/planning/fixtures/pencil/gain-stage-card.tsx"
 DEFAULT_TEST_FIXTURE="$PULP_DIR/test/fixtures/pencil/gain-stage-card.tsx"
 if [[ -n "${PULP_PENCIL_FIXTURE:-}" ]]; then

--- a/tools/import-validation/rn-roundtrip.sh
+++ b/tools/import-validation/rn-roundtrip.sh
@@ -8,6 +8,14 @@
 set -euo pipefail
 
 PULP_DIR="${PULP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# pulp #2087 lesson — refuse to run on a stale checkout. Bypass with
+# PULP_FRESHNESS_BYPASS=1 to validate a feature branch's code instead.
+if ! ( cd "$PULP_DIR" && "$PULP_DIR/tools/scripts/check_workspace_freshness.sh" ); then
+  echo "ERROR: refusing to run validation against stale checkout" >&2
+  exit 2
+fi
+
 DEFAULT_PLANNING_FIXTURE="$PULP_DIR/planning/fixtures/rn/gain-stage.tsx"
 DEFAULT_TEST_FIXTURE="$PULP_DIR/test/fixtures/rn/gain-stage.tsx"
 if [[ -n "${PULP_RN_FIXTURE:-}" ]]; then

--- a/tools/import-validation/spectr-roundtrip.sh
+++ b/tools/import-validation/spectr-roundtrip.sh
@@ -52,6 +52,16 @@ yel()   { printf '\033[33m%s\033[0m\n' "$*"; }
 which pulp >/dev/null || { red "ERROR: pulp CLI not in PATH"; exit 2; }
 which python3 >/dev/null || { red "ERROR: python3 required for diff"; exit 2; }
 
+# Freshness — refuse to validate from a checkout behind origin/main.
+# Lesson from 2026-05-15: a roundtrip ran from a feature branch 175 commits
+# behind. The diff score reflected stale framework code, not main. Bypass
+# with PULP_FRESHNESS_BYPASS=1 if you specifically want to validate a feature
+# branch's code.
+( cd "$PULP" && "$PULP/tools/scripts/check_workspace_freshness.sh" ) || {
+  red "ERROR: refusing to run roundtrip against stale checkout (see freshness output above)"
+  exit 2
+}
+
 mkdir -p "$OUT_DIR"
 
 # ── [1/5] Re-import via pulp ───────────────────────────────────────────────

--- a/tools/import-validation/stitch-roundtrip.sh
+++ b/tools/import-validation/stitch-roundtrip.sh
@@ -8,6 +8,14 @@
 set -euo pipefail
 
 PULP_DIR="${PULP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# pulp #2087 lesson — refuse to run on a stale checkout. Bypass with
+# PULP_FRESHNESS_BYPASS=1 to validate a feature branch's code instead.
+if ! ( cd "$PULP_DIR" && "$PULP_DIR/tools/scripts/check_workspace_freshness.sh" ); then
+  echo "ERROR: refusing to run validation against stale checkout" >&2
+  exit 2
+fi
+
 DEFAULT_PLANNING_FIXTURE="$PULP_DIR/planning/fixtures/stitch/transport-bar.tsx"
 DEFAULT_TEST_FIXTURE="$PULP_DIR/test/fixtures/stitch/transport-bar.tsx"
 if [[ -n "${PULP_STITCH_FIXTURE:-}" ]]; then

--- a/tools/import-validation/v0-roundtrip.sh
+++ b/tools/import-validation/v0-roundtrip.sh
@@ -8,6 +8,14 @@
 set -euo pipefail
 
 PULP_DIR="${PULP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# pulp #2087 lesson — refuse to run on a stale checkout. Bypass with
+# PULP_FRESHNESS_BYPASS=1 to validate a feature branch's code instead.
+if ! ( cd "$PULP_DIR" && "$PULP_DIR/tools/scripts/check_workspace_freshness.sh" ); then
+  echo "ERROR: refusing to run validation against stale checkout" >&2
+  exit 2
+fi
+
 DEFAULT_PLANNING_FIXTURE="$PULP_DIR/planning/fixtures/v0-dev/audio-control-panel.tsx"
 DEFAULT_TEST_FIXTURE="$PULP_DIR/test/fixtures/v0-dev/audio-control-panel.tsx"
 if [[ -n "${PULP_V0_FIXTURE:-}" ]]; then

--- a/tools/scripts/check_workspace_freshness.sh
+++ b/tools/scripts/check_workspace_freshness.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# check_workspace_freshness.sh — guard against running validation on a
+# stale checkout / SDK install.
+#
+# Why this exists
+# ---------------
+# Real session 2026-05-15: a Spectr roundtrip was run from a feature branch
+# 175 commits behind origin/main. The score (0.5408) reflected the stale
+# branch's framework code, not current main. We spent 15 minutes drawing
+# parser conclusions before noticing the checkout was old.
+#
+# This script is the preflight that would have caught it. Source it from
+# any validation harness that's supposed to reflect "what's on main."
+#
+# Usage
+# -----
+#   tools/scripts/check_workspace_freshness.sh                # exits non-zero if stale
+#   tools/scripts/check_workspace_freshness.sh --warn         # warn-only
+#   tools/scripts/check_workspace_freshness.sh --max-behind N # tolerate up to N commits behind
+#   tools/scripts/check_workspace_freshness.sh --json         # machine-readable status
+#   PULP_FRESHNESS_BYPASS=1 tools/scripts/check_workspace_freshness.sh   # bypass entirely
+#
+# Exit codes
+#   0 — fresh enough (or bypassed / warn-only)
+#   1 — stale (in enforcing mode)
+#   2 — invocation / git error
+
+set -euo pipefail
+
+MODE="enforce"
+MAX_BEHIND=0
+JSON=0
+REMOTE="origin"
+BRANCH="main"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --warn) MODE="warn"; shift ;;
+    --max-behind) MAX_BEHIND="${2:-0}"; shift 2 ;;
+    --json) JSON=1; shift ;;
+    --remote) REMOTE="${2:-origin}"; shift 2 ;;
+    --branch) BRANCH="${2:-main}"; shift 2 ;;
+    -h|--help)
+      sed -n '2,/^set -e/p' "$0" | head -30
+      exit 0
+      ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ "${PULP_FRESHNESS_BYPASS:-0}" == "1" ]]; then
+  if [[ "$JSON" == "1" ]]; then
+    printf '{"bypassed": true, "behind": 0, "ahead": 0}\n'
+  else
+    echo "[freshness] PULP_FRESHNESS_BYPASS=1 set; skipping check"
+  fi
+  exit 0
+fi
+
+# Must be in a git repo
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "[freshness] error: not in a git repository" >&2
+  exit 2
+fi
+
+# Fetch latest origin/main (best-effort; fall back to existing ref if offline)
+git fetch --quiet "$REMOTE" "$BRANCH" 2>/dev/null || true
+
+if ! git rev-parse --verify --quiet "$REMOTE/$BRANCH" >/dev/null; then
+  echo "[freshness] error: $REMOTE/$BRANCH not found (fetch failed?)" >&2
+  exit 2
+fi
+
+# Calculate ahead/behind from the merge base
+HEAD_SHA=$(git rev-parse HEAD)
+REMOTE_SHA=$(git rev-parse "$REMOTE/$BRANCH")
+read -r AHEAD BEHIND < <(git rev-list --left-right --count "HEAD...$REMOTE/$BRANCH" 2>/dev/null || echo "0 0")
+
+# Detect dirty working tree
+DIRTY=0
+if ! git diff --quiet 2>/dev/null || ! git diff --quiet --cached 2>/dev/null; then
+  DIRTY=1
+fi
+
+if [[ "$JSON" == "1" ]]; then
+  printf '{"head": "%s", "remote": "%s", "ahead": %d, "behind": %d, "dirty": %d, "max_behind": %d, "mode": "%s"}\n' \
+    "$HEAD_SHA" "$REMOTE_SHA" "$AHEAD" "$BEHIND" "$DIRTY" "$MAX_BEHIND" "$MODE"
+fi
+
+# Decide
+STALE=0
+if (( BEHIND > MAX_BEHIND )); then
+  STALE=1
+fi
+
+if (( STALE == 0 )); then
+  if [[ "$JSON" != "1" ]]; then
+    printf '[freshness] OK — HEAD %s is %d ahead, %d behind %s/%s (max_behind=%d)\n' \
+      "${HEAD_SHA:0:9}" "$AHEAD" "$BEHIND" "$REMOTE" "$BRANCH" "$MAX_BEHIND"
+  fi
+  exit 0
+fi
+
+# Stale — emit a clear human-readable message
+if [[ "$JSON" != "1" ]]; then
+  cat >&2 <<MSG
+[freshness] WARNING — checkout is $BEHIND commits behind $REMOTE/$BRANCH
+
+  HEAD:    ${HEAD_SHA:0:9}
+  remote:  ${REMOTE_SHA:0:9}  ($REMOTE/$BRANCH)
+  delta:   $AHEAD ahead, $BEHIND behind
+  dirty:   $([[ $DIRTY == 1 ]] && echo yes || echo no)
+
+Validation results from this checkout will reflect old framework code, not
+current $REMOTE/$BRANCH. To reset:
+
+  # Option A — fast-forward this branch (loses uncommitted changes if dirty)
+  git fetch $REMOTE && git reset --hard $REMOTE/$BRANCH
+
+  # Option B — work in a fresh worktree off $REMOTE/$BRANCH
+  git worktree add /tmp/pulp-fresh $REMOTE/$BRANCH
+  cd /tmp/pulp-fresh
+  # … run validation here
+
+  # Option C — explicitly accept the staleness for this run
+  PULP_FRESHNESS_BYPASS=1 <command>
+  # or use --warn / --max-behind N when invoking the harness
+MSG
+fi
+
+if [[ "$MODE" == "warn" ]]; then
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
Adds tools/scripts/check_workspace_freshness.sh — a freshness guard the
*-roundtrip.sh scripts now call before doing any work. Refuses (rc=1)
if HEAD is behind origin/main, with a clear message + bypass options.

Why
---
Real session 2026-05-15: a Spectr roundtrip ran from a feature branch
175 commits behind origin/main. The diff score (0.5408, "wrong-variant")
reflected stale framework code, not main. We spent 15+ min interpreting
those numbers and drawing wrong parser conclusions before noticing the
checkout was old.

Behavior
--------
- Default: refuse to run, point at fixes (fast-forward / fresh worktree
  / explicit bypass)
- --warn: print but don't fail (advisory)
- --max-behind N: tolerate up to N commits behind
- --json: machine-readable output for CI / agent consumption
- PULP_FRESHNESS_BYPASS=1: env-var bypass (legitimate when validating a
  feature branch's framework code is the actual intent)

Wired into all 7 import-validation roundtrip scripts:
  spectr-, figma-, pencil-, rn-, stitch-, v0-, designmd-roundtrip.sh

Test
----
test/test_workspace_freshness.sh exercises 7 scenarios across
fresh/behind/--warn/--max-behind/--bypass/--json modes against
synthetic git repos. Registered as `workspace-freshness` ctest.

7/7 scenarios pass locally.

Skill
-----
.agents/skills/import-design/SKILL.md gets a new "Freshness check
(MUST run first)" section + a note about CLI vs SDK skew (the same
session also surfaced #2087 — install.sh installs CLI but not SDK,
so the CLI version can be far ahead of what plugins actually link
against).

Cross-refs
----------
- #2087 — SDK-update UX (the broader pattern this guard codifies one
  piece of)
- #2088 — P0 Spectr mouseDown crash (uncovered by today's validation)
- #2089 — SDK install missing PulpLinkFontconfig.cmake (same path)