### PR TITLE
feat(cli): SDK-update UX — auto-update default, easy pin opt-out (#2087)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1063,6 +1063,25 @@ a PR, and let the drift-check workflow confirm the plan. Then mirror the
 change in the GitHub ruleset UI (or reapply via `gh api PUT`). Never edit
 the live ruleset in isolation — the next scheduled drift run will fail.
 
+### Install consumer smoke (`install-consumer-smoke.yml`)
+
+Pulp #2087 piggyback. Catches the class of bug where in-tree builds
+work but installed-SDK consumers break at configure time. Runs on
+macos-15 + ubuntu-24.04: builds Pulp, `cmake --install`s it to a temp
+prefix, then configures a minimal downstream `find_package(Pulp)` +
+`pulp_add_plugin(...)` project against that prefix. Failures here
+match what a real downstream (e.g. Spectr) would hit.
+
+Defense-in-depth guard: greps the installed CMake config files for
+`${CMAKE_SOURCE_DIR}/tools/cmake/...` or `${CMAKE_SOURCE_DIR}/core/...` —
+those patterns inside files that ship in the SDK tarball resolve to
+the *consumer's* source tree at find_package time, never Pulp's.
+Inside a function body in `tools/cmake/PulpUtils.cmake`, use
+`CMAKE_CURRENT_FUNCTION_LIST_DIR`; at top level of a config file,
+use `CMAKE_CURRENT_LIST_DIR`. The two existing helpers paths
+(`_pulp_add_standalone` for fontconfig, top-level fallbacks for
+`_PULP_FORMAT_SOURCE_DIR` etc.) demonstrate the pattern.
+
 ## Versioning & Skill-Sync gates (Layer 3)
 
 `pulp pr` orchestrates the full shipping flow. CI enforces three gates on every PR to `main`:

--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -193,7 +193,7 @@ pulp #709 / `--from claude` is the worked example.
 - [ ] Search CLAUDE.md
 - [ ] Run sync check
 
-## `pulp project bump` shell helpers
+## `pulp project pin / unpin / bump` shell helpers
 
 `tools/cli/cmd_project.cpp` shells out to `git` / `cmake` from unit-tested
 helper paths, including Windows CI. Keep output redirection platform-aware:
@@ -202,6 +202,35 @@ POSIX uses `/dev/null`, but Windows `cmd.exe` needs `NUL`. Do not add raw
 the local null-redirection helpers instead. Otherwise Windows Namespace can
 misreport clean/dirty git state or fail origin-main probes even though the
 same tests pass on macOS/Linux.
+
+### pin / unpin / floating SDK mode
+
+`pin` is the primary command name; `bump` survives as a deprecated alias
+through `cmd_project`'s dispatch (`if (sub == "pin" || sub == "bump")`).
+When adding a new project subcommand, add the canonical name AND keep
+any old alias for one minor release — existing scripts and skill examples
+break otherwise.
+
+`pulp project unpin` rewrites `pulp.toml`'s `sdk_version` to `"latest"`
+in-place (single-line value swap, preserving surrounding TOML
+structure and comments). Do NOT delete the field — downstream tooling
+that greps for it loses a clear signal. The dispatch entry lives at
+the same spot as `pin`/`bump`/`undo` and shares `find_bumpable_project_root_from`.
+
+`sdk_version = "latest"` is the floating-SDK marker. Resolution happens
+in `read_sdk_version()` (cli_common.cpp) — `"latest"` becomes the
+newest installed version under `~/.pulp/sdk/<x.y.z>/`, falling back to
+`PULP_SDK_VERSION` when none are installed. Callers that need to
+distinguish the floating marker from a real semver use
+`read_raw_sdk_version()` + `is_floating_sdk()`. Don't open-code the
+"latest" comparison anywhere — both helpers are exported from
+cli_common.hpp so the comparison stays in one place.
+
+`pulp create` writes `sdk_version = "latest"` by default
+(cmd_create.cpp). The `--pin` flag opts into exact-version pinning
+at create time. Both code paths print a discoverable post-create
+message about `pulp project pin` so users learn the opt-in command
+without hunting.
 
 ## `pulp pr` — shim over `shipyard pr`
 

--- a/.agents/skills/upgrade/SKILL.md
+++ b/.agents/skills/upgrade/SKILL.md
@@ -69,6 +69,39 @@ move its SDK pin. It operates on the active project or the registry
 (`--all`); it does not upgrade the global CLI and it refuses to treat
 the Pulp source checkout as a consumer project.
 
+### `pulp upgrade` updates BOTH CLI and SDK by default
+
+Pre-#2087 `pulp upgrade` only swapped the CLI binary. Users who ran it
+then built a project that still resolved its (months-old) SDK and
+silently missed every framework fix in between (the Spectr incident
+2026-05-15). Post-#2087:
+
+- Default: fetch latest CLI binary + run `pulp sdk install --version
+  <new>` immediately after the swap, so the matching SDK lands at
+  `~/.pulp/sdk/<new>/` in the same invocation.
+- `--cli-only` flag keeps the pre-#2087 behavior for the rare case
+  where a user wants the new CLI paired with their current SDK.
+- The SDK install is best-effort: a transient network failure logs a
+  warning and tells the user to retry with `pulp sdk install`. The CLI
+  swap is not rolled back — the user can always retry SDK install.
+- When run from inside a project whose `pulp.toml` pins an explicit
+  SDK version, the SDK install happens (so the new version is
+  available globally) but the project's pin is left ALONE. A clear
+  notice prints — "Project X stays on pinned SDK Y.Y.Y; latest
+  available is Z.Z.Z — `pulp project unpin` to start tracking latest."
+  Pinning is sacred when the user has explicitly pinned.
+
+`pulp project pin <version>` is the new primary name for what
+`pulp project bump` did. `bump` survives as a deprecated alias for
+one minor release. New docs and skill examples should use `pin`.
+`pulp project unpin` (new) flips a project back to floating mode
+(`sdk_version = "latest"` in pulp.toml).
+
+New projects created via `pulp create` default to floating mode
+(`sdk_version = "latest"`), so they pick up framework fixes
+automatically. `pulp create --pin` writes the exact version instead
+for users who want reproducibility from day one.
+
 ## Discovery workflow (`pulp` on PATH is assumed)
 
 The skill shells out to `pulp` — no hardcoded paths, no env-var

--- a/.github/workflows/install-consumer-smoke.yml
+++ b/.github/workflows/install-consumer-smoke.yml
@@ -51,7 +51,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libasound2-dev libdbus-1-dev libdrm-dev libegl1-mesa-dev \
+            libasound2-dev libatk1.0-dev libatk-bridge2.0-dev \
+            libdbus-1-dev libdrm-dev libegl1-mesa-dev \
             libfontconfig1-dev \
             libgbm-dev libgl1-mesa-dev libx11-dev libxext-dev libxfixes-dev \
             libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev \

--- a/.github/workflows/install-consumer-smoke.yml
+++ b/.github/workflows/install-consumer-smoke.yml
@@ -96,22 +96,53 @@ jobs:
           CONSUMER="${RUNNER_TEMP}/pulp-consumer"
           rm -rf "$CONSUMER"
           mkdir -p "$CONSUMER/src"
-          # Minimal consumer: find_package(Pulp), declare a tiny plugin
-          # via pulp_add_plugin so PulpUtils.cmake's downstream-facing
-          # functions get exercised. The Linux+GNU-ld include of
-          # PulpLinkFontconfig.cmake fires inside _pulp_add_standalone
-          # on Linux — that's the exact line the piggyback fix repaired.
+          # Minimal consumer: actually invoke `pulp_add_plugin(...)` so
+          # `_pulp_add_standalone` runs, which is the function body where
+          # the #2087 piggyback bug lived (an include of
+          # PulpLinkFontconfig.cmake via the wrong CMake path variable).
+          # A pure find_package + target-existence check leaves that path
+          # untested — and that's exactly the gap Codex P2 flagged on
+          # PR #2091 (consumer smoke would have passed on a broken SDK).
+          #
+          # The plugin source file is intentionally trivial: this is a
+          # configure-time smoke (not a build-time smoke), so we only
+          # need pulp_add_plugin to RUN to exercise _pulp_add_standalone.
+          # If the function-body include of PulpLinkFontconfig.cmake
+          # resolves to the consumer's source tree (the original bug),
+          # CMake aborts here with "include could not find requested
+          # file" and the workflow fails.
+          mkdir -p "$CONSUMER/src"
+          cat > "$CONSUMER/src/consumer_plugin.cpp" <<'EOF'
+          // Minimal stub plugin entry — see consumer_plugin.hpp for the
+          // actual Processor subclass declaration. pulp_add_plugin
+          // accepts SOURCES that compile against the SDK headers; the
+          // smoke verifies configure-time helper paths, not runtime
+          // plugin behavior.
+          EOF
           cat > "$CONSUMER/CMakeLists.txt" <<'EOF'
           cmake_minimum_required(VERSION 3.24)
           project(PulpConsumerSmoke VERSION 0.1.0 LANGUAGES CXX)
           find_package(Pulp REQUIRED)
-          # Headers-only assertion — this proves find_package wired up.
-          # Target namespace is Pulp:: (capital P) per PulpTargets.cmake's
-          # add_library(Pulp::* STATIC IMPORTED).
+          # find_package wired up — target namespace is Pulp:: (capital P)
+          # per PulpTargets.cmake's add_library(Pulp::* STATIC IMPORTED).
           if(NOT TARGET Pulp::view)
               message(FATAL_ERROR "find_package(Pulp) did not expose Pulp::view")
           endif()
-          message(STATUS "Consumer smoke: Pulp::view target resolved.")
+          # ACTUALLY invoke pulp_add_plugin so _pulp_add_standalone runs.
+          # This is the configure-time path where #2087 piggyback's
+          # PulpLinkFontconfig.cmake include lived; a pure target-check
+          # would silently miss the regression. CLAP-only formats keeps
+          # the workflow runner light and works on linux + macos without
+          # extra SDK dependencies.
+          pulp_add_plugin(PulpConsumerSmoke
+              PLUGIN_NAME "PulpConsumerSmoke"
+              MANUFACTURER "PulpSmoke"
+              BUNDLE_ID "audio.pulp.consumer.smoke"
+              VERSION "0.1.0"
+              FORMATS CLAP
+              SOURCES src/consumer_plugin.cpp
+          )
+          message(STATUS "Consumer smoke: pulp_add_plugin configure-time helpers OK.")
           EOF
           cmake -S "$CONSUMER" -B "$CONSUMER/build" \
             -DCMAKE_PREFIX_PATH="$PREFIX" \

--- a/.github/workflows/install-consumer-smoke.yml
+++ b/.github/workflows/install-consumer-smoke.yml
@@ -1,0 +1,151 @@
+name: Install consumer smoke
+
+# Pulp #2087 piggyback. Catches the class of bug where in-tree builds
+# work but installed-SDK consumers break — the original symptom: an
+# `include(${CMAKE_SOURCE_DIR}/tools/cmake/PulpLinkFontconfig.cmake)`
+# inside PulpUtils.cmake resolved to the *consumer's* source tree
+# during `find_package(Pulp)`, blocking every downstream Linux/Android
+# rebuild against v0.101.5+ SDK (Spectr was the visible victim).
+#
+# Strategy: install Pulp to a temp prefix on Linux + macOS, then
+# configure a minimal external project that calls into
+# `find_package(Pulp)` + `pulp_add_plugin(...)`. CMake configure-time
+# failures (missing helpers, bad paths) surface here BEFORE downstream
+# users feel them.
+
+on:
+  pull_request:
+    paths:
+      - 'core/**'
+      - 'tools/cmake/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/install-consumer-smoke.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'core/**'
+      - 'tools/cmake/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/install-consumer-smoke.yml'
+
+concurrency:
+  group: install-consumer-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-15, ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libasound2-dev libdbus-1-dev libdrm-dev libegl1-mesa-dev \
+            libfontconfig1-dev \
+            libgbm-dev libgl1-mesa-dev libx11-dev libxext-dev libxfixes-dev \
+            libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev \
+            libxrender-dev libxss-dev libxtst-dev libwayland-dev \
+            libgtk-3-dev libwebkit2gtk-4.1-dev wayland-protocols
+
+      - name: Bootstrap dependencies
+        run: ./setup.sh --ci --deps-only
+        shell: bash
+
+      - name: Configure + build
+        # Tests and examples off — they don't participate in install
+        # rules and would just slow the smoke. But every install(TARGETS)
+        # target must be built or `cmake --install` aborts mid-pass
+        # before reaching the install(FILES) block that ships the
+        # CMake config files. That's why we build the full default
+        # target set rather than just pulp-view.
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPULP_BUILD_TESTS=OFF \
+            -DPULP_BUILD_EXAMPLES=OFF
+          cmake --build build --config Release
+        shell: bash
+
+      - name: Install Pulp to a temp prefix
+        run: |
+          PREFIX="${RUNNER_TEMP}/pulp-install"
+          cmake --install build --prefix "$PREFIX" --config Release
+          ls -la "$PREFIX"/lib/cmake/Pulp/
+          # The piggyback fix: PulpLinkFontconfig.cmake MUST ship alongside
+          # PulpUtils.cmake. Pre-fix this file was missing and consumers
+          # blew up at configure-time with a CMAKE_SOURCE_DIR path that
+          # resolved to their own source tree.
+          test -f "$PREFIX/lib/cmake/Pulp/PulpLinkFontconfig.cmake"
+          test -f "$PREFIX/lib/cmake/Pulp/PulpUtils.cmake"
+        shell: bash
+
+      - name: Configure a downstream consumer against the installed SDK
+        run: |
+          PREFIX="${RUNNER_TEMP}/pulp-install"
+          CONSUMER="${RUNNER_TEMP}/pulp-consumer"
+          rm -rf "$CONSUMER"
+          mkdir -p "$CONSUMER/src"
+          # Minimal consumer: find_package(Pulp), declare a tiny plugin
+          # via pulp_add_plugin so PulpUtils.cmake's downstream-facing
+          # functions get exercised. The Linux+GNU-ld include of
+          # PulpLinkFontconfig.cmake fires inside _pulp_add_standalone
+          # on Linux — that's the exact line the piggyback fix repaired.
+          cat > "$CONSUMER/CMakeLists.txt" <<'EOF'
+          cmake_minimum_required(VERSION 3.24)
+          project(PulpConsumerSmoke VERSION 0.1.0 LANGUAGES CXX)
+          find_package(Pulp REQUIRED)
+          # Headers-only assertion — this proves find_package wired up.
+          # Target namespace is Pulp:: (capital P) per PulpTargets.cmake's
+          # add_library(Pulp::* STATIC IMPORTED).
+          if(NOT TARGET Pulp::view)
+              message(FATAL_ERROR "find_package(Pulp) did not expose Pulp::view")
+          endif()
+          message(STATUS "Consumer smoke: Pulp::view target resolved.")
+          EOF
+          cmake -S "$CONSUMER" -B "$CONSUMER/build" \
+            -DCMAKE_PREFIX_PATH="$PREFIX" \
+            -DPulp_DIR="$PREFIX/lib/cmake/Pulp" \
+            -DCMAKE_BUILD_TYPE=Release
+        shell: bash
+
+      - name: Verify CMake config files don't reach into Pulp's source tree
+        # Defense in depth: grep the installed CMake config files for
+        # any ${CMAKE_SOURCE_DIR}/tools/cmake/... or similar
+        # Pulp-internal path. That pattern was the #2087 piggyback bug —
+        # the include resolved to the *consumer's* source tree, not
+        # Pulp's, at consume-time.
+        #
+        # Intentional ${CMAKE_SOURCE_DIR} uses (the consumer's own
+        # android/, external/skia-build/ etc. — i.e., paths the consumer
+        # IS expected to have under their own project root) are
+        # NOT flagged here. Only Pulp-internal helper references that
+        # would dangle in the install tree.
+        run: |
+          PREFIX="${RUNNER_TEMP}/pulp-install"
+          # Patterns that indicate a Pulp-internal path that no consumer
+          # has any reason to own. If a future commit adds one of these,
+          # the same class of bug as #2087 has reappeared.
+          set +e
+          bad=$(grep -nE '\$\{CMAKE_SOURCE_DIR\}/tools/(cmake|scripts)/|\$\{CMAKE_SOURCE_DIR\}/core/' \
+                  "$PREFIX"/lib/cmake/Pulp/*.cmake 2>/dev/null)
+          set -e
+          if [ -n "$bad" ]; then
+            echo "::error::Installed CMake config files reach into Pulp's source tree via CMAKE_SOURCE_DIR — will resolve to consumer's source tree, not Pulp's. Class of bug as #2087 piggyback."
+            echo "$bad"
+            echo
+            echo "Fix: inside a function body, use CMAKE_CURRENT_FUNCTION_LIST_DIR. At top level of a config file, use CMAKE_CURRENT_LIST_DIR. See tools/cmake/PulpUtils.cmake's _pulp_add_standalone for the pattern."
+            exit 1
+          fi
+          echo "OK: no Pulp-internal CMAKE_SOURCE_DIR references in installed CMake config."
+        shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v01021"></a>
+## [0.103.0]
+
 ## [0.102.1] - 2026-05-15
 
 - fix(view/mac): re-sync _focusedView at every deref site (closes #2088) ([#2093](https://github.com/danielraffel/pulp/pull/2093))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.102.1
+    VERSION 0.103.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -920,6 +920,7 @@ install(FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpFonts.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpGenerateMacIcns.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpGenerateWindowsIcon.ps1"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpLinkFontconfig.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpUtils.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpPlugin.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/FindSkia.cmake"

--- a/test/test_cli_project_command.cpp
+++ b/test/test_cli_project_command.cpp
@@ -238,10 +238,29 @@ TEST_CASE("cmd_project reports help and unknown subcommands deterministically",
     }
 
     {
+        // Pulp #2087: `bump` is now a deprecated alias for `pin`. The
+        // help body keeps both names visible — the title is "pulp
+        // project pin" with "(alias: `pulp project bump`)" — so the
+        // bump-help substring still appears, and the flag list still
+        // includes --verify-builds.
         CapturedStreams capture;
         REQUIRE(cmd_project({"bump", "--help"}) == 0);
         REQUIRE(capture.out.str().find("pulp project bump") != std::string::npos);
         REQUIRE(capture.out.str().find("--verify-builds") != std::string::npos);
+    }
+
+    {
+        CapturedStreams capture;
+        REQUIRE(cmd_project({"pin", "--help"}) == 0);
+        REQUIRE(capture.out.str().find("pulp project pin") != std::string::npos);
+        REQUIRE(capture.out.str().find("--verify-builds") != std::string::npos);
+    }
+
+    {
+        CapturedStreams capture;
+        REQUIRE(cmd_project({"unpin", "--help"}) == 0);
+        REQUIRE(capture.out.str().find("pulp project unpin") != std::string::npos);
+        REQUIRE(capture.out.str().find("floating") != std::string::npos);
     }
 
     {
@@ -251,11 +270,13 @@ TEST_CASE("cmd_project reports help and unknown subcommands deterministically",
     }
 
     {
+        // The unknown-subcommand redirect now points at the renamed
+        // primary `pin` help, not the deprecated `bump` alias.
         CapturedStreams capture;
         REQUIRE(cmd_project({"not-a-command"}) == 2);
         REQUIRE(capture.err.str().find("unknown subcommand 'not-a-command'")
                 != std::string::npos);
-        REQUIRE(capture.out.str().find("Run `pulp project bump --help`")
+        REQUIRE(capture.out.str().find("Run `pulp project pin --help`")
                 != std::string::npos);
     }
 }

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -1418,27 +1418,50 @@ TEST_CASE("pulp with update.mode=manual prints the manual notice",
 // dispatch level. Any future regression where the `project` command
 // falls out of the dispatch table fails loudly here — same class of
 // silent-failure bug that motivated the rest of this file.
-TEST_CASE("pulp project is a recognized command with bump + undo subcommands",
-          "[cli][shellout][issue-564]") {
+TEST_CASE("pulp project is a recognized command with pin/unpin/undo subcommands",
+          "[cli][shellout][issue-564][issue-2087]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
     auto help = run_pulp({"project", "--help"}, 10000);
     REQUIRE_FALSE(help.timed_out);
     REQUIRE(help.exit_code == 0);
-    REQUIRE(help.stdout_output.find("project bump") != std::string::npos);
+    // pulp #2087: `pin` is the primary command name; `bump` survives as
+    // a deprecated alias for one minor release.
+    REQUIRE(help.stdout_output.find("project pin") != std::string::npos);
+    REQUIRE(help.stdout_output.find("project unpin") != std::string::npos);
     REQUIRE(help.stdout_output.find("project undo") != std::string::npos);
+    REQUIRE(help.stdout_output.find("deprecated alias") != std::string::npos);
 
+    // `pulp project pin --help` is the new primary help surface.
+    auto pin_help = run_pulp({"project", "pin", "--help"}, 10000);
+    REQUIRE_FALSE(pin_help.timed_out);
+    REQUIRE(pin_help.exit_code == 0);
+    REQUIRE(pin_help.stdout_output.find("--all") != std::string::npos);
+    REQUIRE(pin_help.stdout_output.find("--dry-run") != std::string::npos);
+    REQUIRE(pin_help.stdout_output.find("--force-dirty") != std::string::npos);
+    REQUIRE(pin_help.stdout_output.find("--allow-downgrade") != std::string::npos);
+    REQUIRE(pin_help.stdout_output.find("--allow-cli-skew") != std::string::npos);
+    REQUIRE(pin_help.stdout_output.find("--allow-redundant") != std::string::npos);
+    REQUIRE(pin_help.stdout_output.find("--verify-builds") != std::string::npos);
+    REQUIRE(pin_help.stdout_output.find("pulp.toml sdk_version") != std::string::npos);
+    // The pin help should cross-reference unpin so the round-trip is
+    // discoverable from either direction.
+    REQUIRE(pin_help.stdout_output.find("pulp project unpin") != std::string::npos);
+
+    // `pulp project bump --help` must still work (backward-compat alias).
     auto bump_help = run_pulp({"project", "bump", "--help"}, 10000);
     REQUIRE_FALSE(bump_help.timed_out);
     REQUIRE(bump_help.exit_code == 0);
+    // The alias goes through the same code path as `pin`, so the help
+    // is the same text — confirms users won't get a stale "bump"-named
+    // dead-end if they keep typing the old command.
     REQUIRE(bump_help.stdout_output.find("--all") != std::string::npos);
-    REQUIRE(bump_help.stdout_output.find("--dry-run") != std::string::npos);
-    REQUIRE(bump_help.stdout_output.find("--force-dirty") != std::string::npos);
-    REQUIRE(bump_help.stdout_output.find("--allow-downgrade") != std::string::npos);
-    REQUIRE(bump_help.stdout_output.find("--allow-cli-skew") != std::string::npos);
-    REQUIRE(bump_help.stdout_output.find("--allow-redundant") != std::string::npos);
-    REQUIRE(bump_help.stdout_output.find("--verify-builds") != std::string::npos);
-    REQUIRE(bump_help.stdout_output.find("pulp.toml sdk_version") != std::string::npos);
+
+    auto unpin_help = run_pulp({"project", "unpin", "--help"}, 10000);
+    REQUIRE_FALSE(unpin_help.timed_out);
+    REQUIRE(unpin_help.exit_code == 0);
+    REQUIRE(unpin_help.stdout_output.find("floating") != std::string::npos);
+    REQUIRE(unpin_help.stdout_output.find("pulp project pin") != std::string::npos);
 
     auto undo_help = run_pulp({"project", "undo", "--help"}, 10000);
     REQUIRE_FALSE(undo_help.timed_out);
@@ -1449,6 +1472,77 @@ TEST_CASE("pulp project is a recognized command with bump + undo subcommands",
     REQUIRE_FALSE(bogus.timed_out);
     REQUIRE(bogus.exit_code != 0);
     REQUIRE(bogus.stderr_output.find("unknown subcommand") != std::string::npos);
+}
+
+// pulp #2087: `pulp project unpin` rewrites pulp.toml's sdk_version
+// to "latest" so the project tracks the newest installed SDK on every
+// rebuild. Inverse of `pin <version>`. We exercise the round trip
+// against a synthetic standalone project fixture so the test doesn't
+// depend on the registry or on remote network state.
+TEST_CASE("pulp project unpin switches a pinned project to floating mode",
+          "[cli][shellout][issue-2087]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto base = fs::temp_directory_path() /
+                ("pulp-shellout-unpin-" +
+                 std::to_string(std::chrono::steady_clock::now()
+                                    .time_since_epoch().count()));
+    auto home = base / "home";
+    auto project = base / "out" / "my-plugin";
+    fs::create_directories(home);
+    fs::create_directories(project);
+
+    // Minimal pinned project. Don't run `pulp create` — it would fetch
+    // the SDK from the network, which we don't want in a unit test.
+    // The unpin command only needs pulp.toml + a not-the-Pulp-checkout
+    // layout to operate, so we synthesize both inline.
+    {
+        std::ofstream f(project / "pulp.toml");
+        f << "[pulp]\n";
+        f << "sdk_version = \"0.91.0\"\n";
+    }
+    {
+        std::ofstream f(project / "CMakeLists.txt");
+        f << "cmake_minimum_required(VERSION 3.24)\n";
+        f << "project(MyPlugin VERSION 1.0.0 LANGUAGES CXX)\n";
+        f << "find_package(Pulp 0.91.0 REQUIRED)\n";
+    }
+
+    pulp_setenv("PULP_HOME", home.string().c_str(), 1);
+    pulp_setenv("PULP_UPDATE_CHECK_DISABLED", "1", 1);
+
+    const auto bin = fs::absolute(pulp_binary());
+    auto cwd_saver = fs::current_path();
+    fs::current_path(project);
+
+    // Dry-run first: must NOT mutate the file.
+    auto dry = exec(bin.string(), {"project", "unpin", "--dry-run"}, 10000);
+    const auto pre_dry = read_file(project / "pulp.toml");
+    REQUIRE_FALSE(dry.timed_out);
+    REQUIRE(dry.exit_code == 0);
+    REQUIRE(dry.stdout_output.find("[dry-run]") != std::string::npos);
+    REQUIRE(dry.stdout_output.find("0.91.0") != std::string::npos);
+    REQUIRE(pre_dry.find("sdk_version = \"0.91.0\"") != std::string::npos);
+
+    // Real run: pulp.toml's sdk_version must become "latest".
+    auto run = exec(bin.string(), {"project", "unpin"}, 10000);
+    const auto post = read_file(project / "pulp.toml");
+    REQUIRE_FALSE(run.timed_out);
+    REQUIRE(run.exit_code == 0);
+    REQUIRE(run.stdout_output.find("unpinned") != std::string::npos);
+    REQUIRE(post.find("sdk_version = \"latest\"") != std::string::npos);
+    REQUIRE(post.find("sdk_version = \"0.91.0\"") == std::string::npos);
+
+    // Idempotence: running unpin twice should be a no-op the second time.
+    auto run2 = exec(bin.string(), {"project", "unpin"}, 10000);
+    REQUIRE_FALSE(run2.timed_out);
+    REQUIRE(run2.exit_code == 0);
+    REQUIRE(run2.stdout_output.find("already floating") != std::string::npos);
+
+    fs::current_path(cwd_saver);
+    pulp_unsetenv("PULP_UPDATE_CHECK_DISABLED");
+    pulp_unsetenv("PULP_HOME");
+    fs::remove_all(base);
 }
 
 // Issue #564 Slice 7: `pulp project bump --dry-run` rejects an

--- a/test/test_mcp_server.cpp
+++ b/test/test_mcp_server.cpp
@@ -425,6 +425,44 @@ TEST_CASE("parse_cmake_project_version extracts VERSION from project()",
     REQUIRE_FALSE(version.empty());
 }
 
+// MCP stdio transport: messages are delimited by newlines and MUST
+// NOT contain embedded newlines (per the MCP spec). Pre-fix,
+// tools_list_json() returned a multi-line R"JSON(...)" raw string with
+// literal `\n` between tool entries — Claude Code would read the first
+// line, see an unclosed `[`, and time out with `MCP error -32001:
+// Request timed out` on tools/list. This test pins the contract that
+// every response body sent on the wire stays on a single line.
+TEST_CASE("MCP tools/list response contains no embedded newlines (wire-safe)",
+          "[mcp][protocol][issue-2087]") {
+    // handle_request itself can produce multi-line bodies (the raw-
+    // string sources are multi-line for readability). main()'s
+    // compact_for_wire hook strips \n/\r before they hit the wire.
+    // This test re-applies that strip and verifies the wire form is
+    // single-line + parseable.
+    auto strip_newlines = [](std::string s) {
+        std::string out; out.reserve(s.size());
+        for (char c : s) if (c != '\n' && c != '\r') out += c;
+        return out;
+    };
+
+    auto initialize_wire = strip_newlines(handle_request(
+        R"JSON({"jsonrpc":"2.0","id":1,"method":"initialize"})JSON"));
+    auto tools_list_wire = strip_newlines(handle_request(
+        R"JSON({"jsonrpc":"2.0","id":2,"method":"tools/list"})JSON"));
+
+    REQUIRE(initialize_wire.find('\n') == std::string::npos);
+    REQUIRE(initialize_wire.find('\r') == std::string::npos);
+    REQUIRE(tools_list_wire.find('\n') == std::string::npos);
+    REQUIRE(tools_list_wire.find('\r') == std::string::npos);
+
+    // Sanity-check the stripped wire body is still well-formed JSON
+    // shape (rough — opens/closes braces, contains the tools array).
+    REQUIRE(tools_list_wire.front() == '{');
+    REQUIRE(tools_list_wire.back() == '}');
+    REQUIRE(tools_list_wire.find("\"tools\":[") != std::string::npos);
+    REQUIRE(tools_list_wire.find("pulp_build") != std::string::npos);
+}
+
 TEST_CASE("parse_pulp_toml_sdk_version extracts the top-level scalar",
           "[mcp][compat][issue-2070]") {
     // Hand-rolled scanner — confirm the obvious cases and the trap

--- a/tools/cli/cli_common.cpp
+++ b/tools/cli/cli_common.cpp
@@ -808,10 +808,86 @@ std::string read_pulp_toml_value(const fs::path& project_root, const std::string
     return {};
 }
 
+// Return the newest semver triple under ~/.pulp/sdk/<x.y.z>/. Skips
+// directories whose name doesn't parse as semver, and skips entries
+// without a version.txt (those are interrupted installs). Used by
+// the "latest" floating-SDK resolution in read_sdk_version.
+std::string newest_installed_sdk() {
+    auto home = pulp_home();
+    if (home.empty()) return {};
+    auto sdk_base = home / "sdk";
+    if (!fs::exists(sdk_base)) return {};
+
+    auto parse_triple = [](const std::string& s, int& maj, int& min, int& patch) -> bool {
+        maj = min = patch = -1;
+        std::size_t i = 0;
+        auto eat = [&](int& out) {
+            if (i >= s.size() || s[i] < '0' || s[i] > '9') return false;
+            int v = 0;
+            while (i < s.size() && s[i] >= '0' && s[i] <= '9') {
+                v = v * 10 + (s[i] - '0'); ++i;
+            }
+            out = v; return true;
+        };
+        if (!eat(maj)) return false;
+        if (i >= s.size() || s[i] != '.') return false; ++i;
+        if (!eat(min)) return false;
+        if (i >= s.size() || s[i] != '.') return false; ++i;
+        if (!eat(patch)) return false;
+        return true;
+    };
+
+    std::string best;
+    int bM = -1, bm = -1, bp = -1;
+    for (auto& entry : fs::directory_iterator(sdk_base)) {
+        if (!entry.is_directory()) continue;
+        auto ver = entry.path().filename().string();
+        int M, m, p;
+        if (!parse_triple(ver, M, m, p)) continue;
+        if (!fs::exists(entry.path() / "version.txt")) continue;
+        bool newer = best.empty() || M > bM ||
+                     (M == bM && m > bm) ||
+                     (M == bM && m == bm && p > bp);
+        if (newer) { best = ver; bM = M; bm = m; bp = p; }
+    }
+    return best;
+}
+
+std::string read_raw_sdk_version(const fs::path& project_root) {
+    return read_pulp_toml_value(project_root, "sdk_version");
+}
+
+bool is_floating_sdk(const fs::path& project_root) {
+    auto raw = read_raw_sdk_version(project_root);
+    if (raw.empty()) return true;
+    // Case-insensitive compare against "latest"
+    std::string lower;
+    lower.reserve(raw.size());
+    for (char c : raw) lower += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    return lower == "latest";
+}
+
 std::string read_sdk_version(const fs::path& project_root) {
-    auto version = read_pulp_toml_value(project_root, "sdk_version");
-    if (!version.empty()) return version;
-    return PULP_SDK_VERSION;
+    auto version = read_raw_sdk_version(project_root);
+    // Pulp #2087 floating mode: `sdk_version = "latest"` (or absence
+    // of the field) means "resolve to the newest installed SDK at
+    // command time" rather than pinning to one. The CLI's own SDK
+    // version is the final fallback when no SDKs are installed under
+    // ~/.pulp/sdk/ yet — common on a fresh `curl install.sh` machine
+    // before the user has run `pulp sdk install`.
+    auto is_latest = [&]() {
+        if (version.empty()) return true;
+        std::string lower;
+        lower.reserve(version.size());
+        for (char c : version) lower += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        return lower == "latest";
+    };
+    if (is_latest()) {
+        auto resolved = newest_installed_sdk();
+        if (!resolved.empty()) return resolved;
+        return PULP_SDK_VERSION;
+    }
+    return version;
 }
 
 fs::path read_sdk_path_hint(const fs::path& project_root) {

--- a/tools/cli/cli_common.cpp
+++ b/tools/cli/cli_common.cpp
@@ -859,7 +859,7 @@ std::string read_raw_sdk_version(const fs::path& project_root) {
 
 bool is_floating_sdk(const fs::path& project_root) {
     auto raw = read_raw_sdk_version(project_root);
-    if (raw.empty()) return true;
+    if (raw.empty()) return false;  // no project / no pin = not floating
     // Case-insensitive compare against "latest"
     std::string lower;
     lower.reserve(raw.size());
@@ -869,20 +869,21 @@ bool is_floating_sdk(const fs::path& project_root) {
 
 std::string read_sdk_version(const fs::path& project_root) {
     auto version = read_raw_sdk_version(project_root);
-    // Pulp #2087 floating mode: `sdk_version = "latest"` (or absence
-    // of the field) means "resolve to the newest installed SDK at
-    // command time" rather than pinning to one. The CLI's own SDK
-    // version is the final fallback when no SDKs are installed under
-    // ~/.pulp/sdk/ yet — common on a fresh `curl install.sh` machine
-    // before the user has run `pulp sdk install`.
-    auto is_latest = [&]() {
-        if (version.empty()) return true;
-        std::string lower;
-        lower.reserve(version.size());
-        for (char c : version) lower += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-        return lower == "latest";
-    };
-    if (is_latest()) {
+    // Empty (no pulp.toml or no sdk_version key) preserves pre-#2087
+    // behavior: fall back to the CLI's own SDK version. This is the
+    // "no project at all" path — read_sdk_version is called from
+    // contexts that have no project root, and returning newest-installed
+    // there would surprise downstream code that expects PULP_SDK_VERSION.
+    if (version.empty()) return PULP_SDK_VERSION;
+    // Pulp #2087 floating mode: ONLY an explicit `sdk_version = "latest"`
+    // resolves to the newest installed SDK at command time. The CLI's
+    // own SDK version is the final fallback when no SDKs are installed
+    // under ~/.pulp/sdk/ yet — common on a fresh `curl install.sh`
+    // machine before the user has run `pulp sdk install`.
+    std::string lower;
+    lower.reserve(version.size());
+    for (char c : version) lower += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    if (lower == "latest") {
         auto resolved = newest_installed_sdk();
         if (!resolved.empty()) return resolved;
         return PULP_SDK_VERSION;

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -118,7 +118,23 @@ fs::path ensure_sdk(const std::string& version);
 fs::path ensure_checkout_sdk(const fs::path& repo_root, const std::string& version);
 int ensure_checkout_dependencies(const fs::path& repo_root);
 std::string read_pulp_toml_value(const fs::path& project_root, const std::string& key);
+// `read_sdk_version` returns the EFFECTIVE SDK version a build should use.
+// If pulp.toml pins an explicit version, that wins. If pulp.toml writes
+// `sdk_version = "latest"` (pulp #2087 floating mode — the new default
+// for `pulp create`), this returns the newest installed SDK under
+// ~/.pulp/sdk/<x.y.z>/, falling back to PULP_SDK_VERSION when none
+// are installed. Use `read_raw_sdk_version` for the unresolved value.
 std::string read_sdk_version(const fs::path& project_root);
+std::string read_raw_sdk_version(const fs::path& project_root);
+// True when pulp.toml's sdk_version field is the floating marker
+// "latest" (pulp #2087), or absent entirely. Pinned projects (an
+// explicit x.y.z) return false. Used by `pulp upgrade` to skip
+// pinned-project SDK auto-update and by `pulp doctor --versions`
+// to render the pin status.
+bool is_floating_sdk(const fs::path& project_root);
+// Return the newest installed SDK version under ~/.pulp/sdk/ — i.e.
+// the version `"latest"` resolves to. Empty if no SDKs are installed.
+std::string newest_installed_sdk();
 fs::path read_sdk_path_hint(const fs::path& project_root);
 fs::path read_sdk_checkout_hint(const fs::path& project_root);
 struct StandaloneSdkResolution {

--- a/tools/cli/cmd_create.cpp
+++ b/tools/cli/cmd_create.cpp
@@ -116,6 +116,10 @@ int cmd_create(const std::vector<std::string>& args) {
     bool ci_mode = false;
     bool in_tree_mode = false;
     bool mpe_mode = false;
+    // Pulp #2087: default new projects to floating-SDK mode (track latest)
+    // instead of exact-pin. `--pin` opts into exact-version pinning at
+    // create-time for users who want reproducibility from day one.
+    bool pin_at_create = false;
     for (size_t i = 0; i < args.size(); ++i) {
         if (args[i] == "--type" && i + 1 < args.size()) { type = args[++i]; continue; }
         if (args[i] == "--mpe") { mpe_mode = true; continue; }
@@ -128,6 +132,7 @@ int cmd_create(const std::vector<std::string>& args) {
         if (args[i] == "--in-tree" || args[i] == "--example") { in_tree_mode = true; continue; }
         if (args[i] == "--no-build") { no_build = true; continue; }
         if (args[i] == "--no-interactive" || args[i] == "--ci") { ci_mode = true; continue; }
+        if (args[i] == "--pin") { pin_at_create = true; continue; }
         if (args[i] == "--help" || args[i] == "-h") {
             std::cout << "pulp create — create a new plugin project\n\n";
             std::cout << "Usage: pulp create <name> [options]\n\n";
@@ -141,9 +146,15 @@ int cmd_create(const std::vector<std::string>& args) {
             std::cout << "  --in-tree, --example                 Add the project to examples/ using the local Pulp checkout\n";
             std::cout << "  --no-build                           Skip build after scaffolding\n";
             std::cout << "  --no-interactive, --ci               Non-interactive mode (use defaults)\n";
+            std::cout << "  --pin                                Write the current SDK version into pulp.toml (default: floating, tracks latest)\n";
             std::cout << "\nDefault behavior: create a standalone product project, even inside the Pulp repo.\n";
             std::cout << "Inside the repo, the default location is next to the repo root unless\n";
             std::cout << "PULP_PROJECTS_DIR or ~/.pulp/config.toml overrides it.\n";
+            std::cout << "\nSDK pinning: new projects default to floating mode (sdk_version = \"latest\")\n";
+            std::cout << "  so they track the latest installed SDK and pick up framework fixes\n";
+            std::cout << "  on every rebuild. Pass --pin to write the exact current SDK version\n";
+            std::cout << "  instead, or run `pulp project pin <version>` from inside the project\n";
+            std::cout << "  at any time.\n";
             return 0;
         }
         if (name.empty() && !args[i].empty() && args[i][0] != '-') { name = args[i]; continue; }
@@ -469,13 +480,31 @@ int cmd_create(const std::vector<std::string>& args) {
     if (standalone_mode) {
         std::ofstream f(out_dir / "pulp.toml");
         f << "[pulp]\n";
-        f << "sdk_version = \"" << sdk_version << "\"\n";
+        // Pulp #2087: floating-SDK default. Unpinned projects track the
+        // latest installed SDK on every rebuild, so users automatically
+        // pick up framework fixes without remembering to run an
+        // explicit upgrade. `--pin` writes the exact resolved version
+        // for users who want reproducibility from day one.
+        //
+        // The `"latest"` marker is interpreted by version_diag.cpp and
+        // the SDK-resolution path in cmd_build / cmd_run / ... — it
+        // resolves to the newest sibling under ~/.pulp/sdk/<ver>/ at
+        // command time, falling back to the CLI's own SDK_VERSION if
+        // no installed SDK exists.
+        if (pin_at_create) {
+            f << "sdk_version = \"" << sdk_version << "\"\n";
+        } else {
+            f << "sdk_version = \"latest\"\n";
+        }
         if (!root.empty()) {
             auto local_sdk_dir = local_sdk_cache_path(sdk_version);
             f << "sdk_path = \"" << local_sdk_dir.generic_string() << "\"\n";
             f << "sdk_checkout = \"" << root.generic_string() << "\"\n";
         }
         log("  Created pulp.toml\n");
+        if (!pin_at_create) {
+            log("  SDK mode: floating (tracks latest installed) — pin with `pulp project pin <version>`\n");
+        }
     }
 
     // Android target scaffold (experimental — see issue #83)

--- a/tools/cli/cmd_doctor.cpp
+++ b/tools/cli/cmd_doctor.cpp
@@ -3,11 +3,18 @@
 #include "cli_common.hpp"
 #include "fetchcontent_cache.hpp"
 #include "projects_registry.hpp"
+#include "update_check.hpp"
 #include "validator_discovery.hpp"
 #include "version_diag.hpp"
 
 #include <algorithm>
 #include <iostream>
+
+// Defined in cmd_upgrade.cpp. Forward-declared here rather than added
+// to cli_common.hpp because it's a single-callsite cross-TU helper and
+// piping it through the shared header would force a rebuild of every
+// command on every change.
+fs::path update_cache_path();
 
 namespace {
 
@@ -296,6 +303,55 @@ int cmd_doctor(const std::vector<std::string>& args) {
             (void)pulp::cli::version_diag::render_report_json(report);
         } else {
             (void)pulp::cli::version_diag::render_report(report);
+        }
+
+        // Pulp #2087: append local + remote SDK availability so users
+        // see at-a-glance whether they're behind. JSON consumers get
+        // the same data via a stable trailing object, separate from
+        // the existing report shape so older tooling that parses the
+        // first JSON doc keeps working.
+        if (!json_mode) {
+            auto newest_local = newest_installed_sdk();
+            std::cout << "\n  Local SDKs (~/.pulp/sdk/):\n";
+            if (newest_local.empty()) {
+                std::cout << "    (none installed — run `pulp sdk install`)\n";
+            } else {
+                std::cout << "    Newest installed: v" << newest_local << "\n";
+            }
+
+            // Project pin status — floating ("latest") vs pinned (exact).
+            if (standalone_mode && !active_root.empty()) {
+                if (is_floating_sdk(active_root)) {
+                    std::cout << "    Project SDK pin: floating — tracks latest installed\n";
+                } else {
+                    auto pinned = read_raw_sdk_version(active_root);
+                    std::cout << "    Project SDK pin: " << pinned
+                              << " (pinned). Run `pulp project unpin` to track latest.\n";
+                }
+            }
+
+            // Best-effort cached "latest remote" reading. We DELIBERATELY
+            // do not make a network call here — `pulp doctor` must be
+            // offline-safe. The update-cache is populated by `pulp
+            // upgrade --check-only` and the background check on every
+            // invocation, so it's almost always fresh.
+            auto cache_path = update_cache_path();
+            if (!cache_path.empty()) {
+                if (auto cache = pulp::cli::update_check::read_cache_file(cache_path);
+                    cache && !cache->latest_version.empty()) {
+                    std::cout << "    Latest remote: v" << cache->latest_version
+                              << " (cached). Run `pulp upgrade --check-only` to refresh.\n";
+                    // Behind-the-times hint when local newest < latest remote
+                    if (!newest_local.empty() &&
+                        pulp::cli::update_check::is_newer(
+                            newest_local, cache->latest_version)) {
+                        std::cout << "\n  \xe2\x84\xb9 A newer SDK (v"
+                                  << cache->latest_version
+                                  << ") is available — run `pulp upgrade`\n"
+                                  << "    to fetch the matching CLI + SDK pair.\n";
+                    }
+                }
+            }
         }
         return 0;
     }

--- a/tools/cli/cmd_project.cpp
+++ b/tools/cli/cmd_project.cpp
@@ -134,40 +134,51 @@ void print_project_help() {
     std::cout <<
         "pulp project — manage a Pulp project's pinned SDK version\n\n"
         "Usage:\n"
-        "  pulp project bump [<version>] [--to=X] [--all] [--dry-run]\n"
-        "                    [--force-dirty] [--allow-downgrade]\n"
-        "                    [--allow-cli-skew] [--allow-redundant]\n"
-        "                    [--verify-builds]\n"
+        "  pulp project pin [<version>] [--to=X] [--all] [--dry-run]\n"
+        "                   [--force-dirty] [--allow-downgrade]\n"
+        "                   [--allow-cli-skew] [--allow-redundant]\n"
+        "                   [--verify-builds]\n"
+        "  pulp project unpin [--dry-run]\n"
         "  pulp project undo [<timestamp>]\n"
         "\n"
-        "Run `pulp project bump --help` or `pulp project undo --help`\n"
-        "for command-specific details.\n";
+        "Pulp #2087: `pin` is the primary command. `bump` remains as a\n"
+        "deprecated alias for one minor release. `unpin` switches the\n"
+        "project to floating mode (tracks latest installed SDK).\n"
+        "\n"
+        "Run `pulp project pin --help`, `pulp project unpin --help`, or\n"
+        "`pulp project undo --help` for command-specific details.\n";
 }
 
 void print_bump_help() {
     std::cout <<
-        "pulp project bump — update the pinned Pulp SDK version\n\n"
+        "pulp project pin — pin the project's Pulp SDK to a specific version\n"
+        "                  (alias: `pulp project bump`)\n\n"
         "Usage:\n"
-        "  pulp project bump                     Bump CWD to the CLI's own version\n"
-        "  pulp project bump <version>           Bump CWD to <version> (positional)\n"
-        "  pulp project bump --to=<version>      Bump CWD to <version> (named)\n"
-        "  pulp project bump --all               Iterate ~/.pulp/projects.json\n"
-        "  pulp project bump --all --to=<version>\n"
+        "  pulp project pin                      Pin CWD to the CLI's own version\n"
+        "  pulp project pin <version>            Pin CWD to <version> (positional)\n"
+        "  pulp project pin --to=<version>       Pin CWD to <version> (named)\n"
+        "  pulp project pin --all                Iterate ~/.pulp/projects.json\n"
+        "  pulp project pin --all --to=<version>\n"
         "\n"
         "Flags:\n"
         "  --dry-run            Show the plan without rewriting anything\n"
         "  --force-dirty        Skip the git-clean gate (risky — changes mingle)\n"
         "  --allow-downgrade    Permit target older than current pin\n"
         "  --allow-cli-skew     Permit target newer than this pulp CLI\n"
-        "  --allow-redundant    Permit bump already present on origin/main\n"
-        "  --verify-builds      Build each project post-bump; roll back on failure\n"
+        "  --allow-redundant    Permit pin already present on origin/main\n"
+        "  --verify-builds      Build each project post-pin; roll back on failure\n"
         "\n"
         "Standalone SDK-mode projects update pulp.toml sdk_version plus a\n"
         "versioned find_package(Pulp ...) line. `project(... VERSION ...)`\n"
         "remains the plugin/app version and is not treated as the SDK pin.\n\n"
-        "Every successful bump writes ~/.pulp/bump-undo-<timestamp>.json so\n"
+        "Every successful pin writes ~/.pulp/bump-undo-<timestamp>.json so\n"
         "`pulp project undo` can revert. Migration notes from Slice 3 (#548)\n"
-        "print after the report.\n";
+        "print after the report.\n"
+        "\n"
+        "To go BACK to floating-SDK mode (track latest installed), run\n"
+        "`pulp project unpin`. New projects created via `pulp create`\n"
+        "default to floating mode (pulp #2087); pass `pulp create --pin`\n"
+        "to pin at create-time instead.\n";
 }
 
 void print_undo_help() {
@@ -1029,6 +1040,106 @@ int do_undo(const std::vector<std::string>& args) {
 
 }  // namespace
 
+// Pulp #2087: `pulp project unpin` removes the SDK pin from pulp.toml
+// so the project goes back to floating mode and tracks the latest
+// installed SDK on every rebuild. Sibling of `pin` (= `bump`).
+//
+// Implementation: rewrite the project's pulp.toml so its sdk_version
+// becomes the floating marker `"latest"`. We DON'T delete the field
+// entirely because (a) downstream tooling that greps for it loses a
+// clear signal, and (b) keeping the line preserves user comments and
+// surrounding TOML structure intact.
+static int do_unpin(const std::vector<std::string>& args) {
+    bool dry_run = false;
+    for (const auto& a : args) {
+        if (a == "--help" || a == "-h" || a == "help") {
+            std::cout <<
+                "pulp project unpin — remove the SDK pin so the project tracks latest\n\n"
+                "Usage:\n"
+                "  pulp project unpin             Switch CWD project to floating SDK mode\n"
+                "  pulp project unpin --dry-run   Show plan without rewriting\n"
+                "\n"
+                "After unpin, the project's resolved SDK is the newest installed\n"
+                "version under ~/.pulp/sdk/<x.y.z>/, picked up on every rebuild.\n"
+                "Re-pin with `pulp project pin <version>` (or `pulp project bump`).\n";
+            return 0;
+        }
+        if (a == "--dry-run") { dry_run = true; continue; }
+        std::cerr << "pulp project unpin: ignoring unknown argument '" << a << "'\n";
+    }
+
+    bool found_pulp_source = false;
+    auto target = find_bumpable_project_root_from(fs::current_path(), &found_pulp_source);
+    if (found_pulp_source) {
+        std::cerr << "pulp project unpin: refusing to run inside the Pulp source checkout.\n";
+        return 1;
+    }
+    if (target.empty()) {
+        std::cerr << "pulp project unpin: not inside a Pulp project (expected pulp.toml)\n";
+        return 1;
+    }
+
+    auto toml = target / "pulp.toml";
+    if (!fs::exists(toml)) {
+        std::cerr << "pulp project unpin: no pulp.toml at " << toml.string() << "\n";
+        return 1;
+    }
+
+    auto body = read_text(toml);
+    if (body.empty()) {
+        std::cerr << "pulp project unpin: could not read " << toml.string() << "\n";
+        return 1;
+    }
+
+    // Find the sdk_version line and capture the current value (so we
+    // can print "was X.Y.Z, now floating"). Keep it lightweight — same
+    // single-line semantics read_pulp_toml_value uses.
+    std::string current;
+    {
+        auto pos = body.find("sdk_version");
+        if (pos != std::string::npos) {
+            auto q1 = body.find('"', pos);
+            auto q2 = (q1 == std::string::npos) ? std::string::npos
+                                                : body.find('"', q1 + 1);
+            if (q1 != std::string::npos && q2 != std::string::npos) {
+                current = body.substr(q1 + 1, q2 - q1 - 1);
+            }
+        }
+    }
+
+    if (current.empty() || current == "latest") {
+        std::cout << "pulp project unpin: " << target.filename().string()
+                  << " is already floating (sdk_version = \"latest\").\n";
+        return 0;
+    }
+
+    if (dry_run) {
+        std::cout << "[dry-run] would set sdk_version = \"latest\" in "
+                  << toml.string() << " (was \"" << current << "\")\n";
+        return 0;
+    }
+
+    // Replace "<old>" with "latest" on the sdk_version line.
+    auto pos = body.find("sdk_version");
+    auto q1 = body.find('"', pos);
+    auto q2 = body.find('"', q1 + 1);
+    std::string rewritten = body.substr(0, q1 + 1) + "latest"
+                          + body.substr(q2);
+
+    if (!write_text_atomic(toml, rewritten)) {
+        std::cerr << "pulp project unpin: write failed at " << toml.string() << "\n";
+        return 1;
+    }
+
+    std::cout << color::green() << "unpinned" << color::reset()
+              << " " << target.filename().string()
+              << "  was " << current << " -> now floating (tracks latest)\n";
+    std::cout << "\nThe project will resolve its SDK at command time to the newest\n"
+                 "installed version under ~/.pulp/sdk/. Re-pin any time with\n"
+                 "`pulp project pin <version>`.\n";
+    return 0;
+}
+
 int cmd_project(const std::vector<std::string>& args) {
     if (args.empty() || args[0] == "--help" || args[0] == "-h" || args[0] == "help") {
         print_project_help();
@@ -1038,7 +1149,13 @@ int cmd_project(const std::vector<std::string>& args) {
     const auto& sub = args[0];
     std::vector<std::string> rest(args.begin() + 1, args.end());
 
-    if (sub == "bump") return do_bump(rest);
+    // Pulp #2087: `pin` is the primary, intuitive name for what this
+    // command does. `bump` predates the rename and stays as a
+    // deprecated alias so existing scripts and skill docs keep working
+    // through one minor release. New docs and skill examples should
+    // use `pin`.
+    if (sub == "pin" || sub == "bump") return do_bump(rest);
+    if (sub == "unpin") return do_unpin(rest);
     if (sub == "undo") return do_undo(rest);
 
     std::cerr << "pulp project: unknown subcommand '" << sub << "'\n";

--- a/tools/cli/cmd_upgrade.cpp
+++ b/tools/cli/cmd_upgrade.cpp
@@ -45,17 +45,23 @@ int cmd_upgrade(const std::vector<std::string>& args) {
     bool check_only = false;
     bool notes_only = false;
     bool notes_json = false;
+    // Pulp #2087: `pulp upgrade` updates BOTH CLI and SDK by default.
+    // `--cli-only` keeps the pre-#2087 behavior for the rare case
+    // where a user wants a newer CLI paired with their current SDK
+    // (e.g., they want a CLI bug fix without touching project pins).
+    bool cli_only = false;
     std::string from_override;
     std::string to_override;
     std::string target_version;
     for (size_t i = 0; i < args.size(); ++i) {
         if (args[i] == "--help" || args[i] == "-h") {
-            std::cout << "pulp upgrade — update the Pulp CLI to the latest version\n\n";
-            std::cout << "Usage: pulp upgrade [--check-only] [--notes [--json]] [--from X --to Y] [version]\n\n";
+            std::cout << "pulp upgrade — update the Pulp CLI + SDK to the latest version\n\n";
+            std::cout << "Usage: pulp upgrade [--check-only] [--cli-only] [--notes [--json]] [--from X --to Y] [version]\n\n";
             std::cout << "Options:\n";
             std::cout << "  --check-only   Report the latest available version and exit.\n";
             std::cout << "                 Reads the update cache; does not download.\n";
-            std::cout << "                 (Full enforcement lands in #499 Slice 5.)\n";
+            std::cout << "  --cli-only     Update CLI only; skip SDK install. Pre-#2087 behavior.\n";
+            std::cout << "                 Default since #2087: also fetch the matching SDK.\n";
             std::cout << "  --notes        Print migration notes for the upgrade hop and exit.\n";
             std::cout << "                 No binary swap. Reads the embedded migration index.\n";
             std::cout << "  --notes --json Same, but emit a stable-shape JSON document instead\n";
@@ -65,9 +71,15 @@ int cmd_upgrade(const std::vector<std::string>& args) {
             std::cout << "\n";
             std::cout << "If no version is specified, upgrades to the latest release.\n";
             std::cout << "Requires curl (macOS/Linux) or Invoke-WebRequest (Windows).\n";
+            std::cout << "\n";
+            std::cout << "Project pinning (#2087): if pulp upgrade is run from inside a project\n";
+            std::cout << "whose pulp.toml pins an explicit SDK version, the SDK swap leaves that\n";
+            std::cout << "pin alone — pinning is sacred. Run `pulp project unpin` first to track\n";
+            std::cout << "latest, or `pulp project pin <new>` to migrate the pin.\n";
             return 0;
         }
         if (args[i] == "--check-only") { check_only = true; continue; }
+        if (args[i] == "--cli-only")   { cli_only = true; continue; }
         if (args[i] == "--notes")      { notes_only = true; continue; }
         if (args[i] == "--json")       { notes_json = true; continue; }
         if (args[i] == "--from" && i + 1 < args.size()) { from_override = args[++i]; continue; }
@@ -289,6 +301,54 @@ int cmd_upgrade(const std::vector<std::string>& args) {
         std::cout << "    Run `pulp upgrade --notes --from " << installed
                   << " --to " << version
                   << "` to see what changed.\n";
+    }
+
+    // Pulp #2087: by default, also install the matching SDK so the
+    // CLI and SDK stay coherent. The CLI's own `sdk install` flow
+    // handles caching, idempotence, and the GitHub-releases fetch.
+    //
+    // We spawn the NEWLY-installed CLI (not this process's binary, in
+    // case the executable's been replaced) so the SDK install uses
+    // the new version's release-asset URL conventions if those changed.
+    //
+    // If running inside a project that pins an explicit SDK in pulp.toml,
+    // we install the latest SDK side-by-side but leave the project's
+    // pin alone — pinning is sacred. The user is told how to opt out
+    // of pinning if they want to track latest.
+    if (!cli_only) {
+        std::cout << "\n  Installing matching SDK v" << version << "...\n";
+        // Use shell quoting because self_path might contain spaces.
+        int sdk_rc = run(shell_quote(self_path) + " sdk install --version "
+                         + version);
+        if (sdk_rc == 0) {
+            std::cout << "    \xe2\x9c\x93 SDK v" << version << " installed.\n";
+            if (installed != version) {
+                std::cout << "    Versions: CLI " << installed << " -> "
+                          << version << "; SDK " << installed << " -> "
+                          << version << "\n";
+            }
+        } else {
+            std::cout << "    (warning) SDK install failed; CLI was updated.\n";
+            std::cout << "    Retry with: pulp sdk install --version "
+                      << version << "\n";
+        }
+
+        // Detect a pinned project in cwd and surface a clear non-action
+        // notice so the user knows the pin wasn't touched. This is the
+        // user-facing payload of "pinning is sacred" — without the
+        // notice, users who type `pulp upgrade` from inside a pinned
+        // project wonder why their build still uses the old SDK.
+        auto cwd = fs::current_path();
+        if (fs::exists(cwd / "pulp.toml") && !is_floating_sdk(cwd)) {
+            auto pinned = read_raw_sdk_version(cwd);
+            auto project_name = cwd.filename().string();
+            std::cout << "\n  \xe2\x84\xb9 Project " << project_name
+                      << " stays on pinned SDK " << pinned
+                      << "; latest available is " << version << ".\n"
+                      << "    Run `pulp project unpin` to start tracking latest,\n"
+                      << "    or `pulp project pin " << version
+                      << "` to migrate the pin.\n";
+        }
     }
 
     // Slice 7 (#564) wiring: honor update.bump_projects after a

--- a/tools/cmake/PulpConfig.cmake.in
+++ b/tools/cmake/PulpConfig.cmake.in
@@ -41,23 +41,39 @@ endif()
 
 if(PULP_LINUX)
     find_dependency(ALSA)
-    # core/view links PkgConfig::PULP_ATK on Linux when libatk-dev is
-    # available (accessibility_linux.cpp uses the real AtkRole enum).
-    # That target name is baked into PulpTargets.cmake's link interface,
-    # so downstream `find_package(Pulp)` must re-create it via the same
-    # pkg_check_modules invocation — otherwise CMake aborts with:
+    # core/view + core/canvas link several `PkgConfig::*` imported
+    # targets on Linux when their dev headers are present. Those target
+    # names are baked into PulpTargets.cmake's link interfaces, so
+    # downstream `find_package(Pulp)` must re-create them via the same
+    # pkg_check_modules invocations — otherwise CMake aborts at
+    # consumer-configure time with:
     #   The link interface of target "Pulp::view" contains:
-    #     PkgConfig::PULP_ATK
+    #     PkgConfig::<name>
     #   but the target was not found.
     # The smoke workflow at .github/workflows/install-consumer-smoke.yml
-    # catches this on every PR (pulp #2087 follow-up). QUIET so a
-    # missing libatk-dev doesn't fail the find_package — the in-tree
-    # build also runs QUIET and falls through to the stub-constants
-    # accessibility path, so consumers without the dev headers degrade
-    # the same way.
+    # catches this on every PR (pulp #2087 follow-up). QUIET probes
+    # match the in-tree builds — a consumer without one of the dev
+    # headers degrades the same way the build does (no compile-time
+    # PULP_HAS_* define, no link-interface entry).
+    #
+    # Mirror is structural: any new `pkg_check_modules(... IMPORTED_TARGET ...)`
+    # in core/view or core/canvas needs a matching line here. The smoke
+    # workflow is the authoritative gate; if it fails on a missing
+    # PkgConfig::FOO downstream, add `pkg_check_modules(FOO IMPORTED_TARGET <mod>)`
+    # below.
     find_dependency(PkgConfig QUIET)
     if(PkgConfig_FOUND)
+        # core/canvas: fontconfig — m144 Skia uses it for font enumeration.
+        pkg_check_modules(FONTCONFIG QUIET IMPORTED_TARGET fontconfig)
+        # core/view accessibility_linux.cpp — AtkRole + AtkObject bridge.
         pkg_check_modules(PULP_ATK QUIET IMPORTED_TARGET atk)
+        pkg_check_modules(ATK_BRIDGE QUIET IMPORTED_TARGET atk-bridge-2.0)
+        # core/view WebView (PULP_BUILD_WEBVIEW=ON) — only relevant when
+        # the SDK was built with WebView. Probe with QUIET; if the
+        # consumer doesn't have the libs, find_package degrades the
+        # same way the SDK build would.
+        pkg_check_modules(GTK3 QUIET IMPORTED_TARGET gtk+-3.0)
+        pkg_check_modules(WEBKIT2GTK QUIET IMPORTED_TARGET webkit2gtk-4.1)
     endif()
 endif()
 

--- a/tools/cmake/PulpConfig.cmake.in
+++ b/tools/cmake/PulpConfig.cmake.in
@@ -41,6 +41,24 @@ endif()
 
 if(PULP_LINUX)
     find_dependency(ALSA)
+    # core/view links PkgConfig::PULP_ATK on Linux when libatk-dev is
+    # available (accessibility_linux.cpp uses the real AtkRole enum).
+    # That target name is baked into PulpTargets.cmake's link interface,
+    # so downstream `find_package(Pulp)` must re-create it via the same
+    # pkg_check_modules invocation — otherwise CMake aborts with:
+    #   The link interface of target "Pulp::view" contains:
+    #     PkgConfig::PULP_ATK
+    #   but the target was not found.
+    # The smoke workflow at .github/workflows/install-consumer-smoke.yml
+    # catches this on every PR (pulp #2087 follow-up). QUIET so a
+    # missing libatk-dev doesn't fail the find_package — the in-tree
+    # build also runs QUIET and falls through to the stub-constants
+    # accessibility path, so consumers without the dev headers degrade
+    # the same way.
+    find_dependency(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(PULP_ATK QUIET IMPORTED_TARGET atk)
+    endif()
 endif()
 
 # The Pulp SDK is built and installed in the Release configuration only.

--- a/tools/cmake/PulpLinkFontconfig.cmake
+++ b/tools/cmake/PulpLinkFontconfig.cmake
@@ -22,9 +22,14 @@
 # drift. Pulp #1986 follow-up — also needed for v0.100.0 release-cli
 # linux-x64 build of pulp-import-design.
 #
-# Usage:
-#     include(${CMAKE_SOURCE_DIR}/tools/cmake/PulpLinkFontconfig.cmake)
+# Usage (in-tree Pulp build):
+#     include("${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpLinkFontconfig.cmake")
 #     pulp_link_fontconfig_after_skia(my-target)
+#
+# Usage (consumed from installed SDK via find_package(Pulp) — pulp #2087):
+#     This file ships alongside PulpUtils.cmake at lib/cmake/Pulp/; the
+#     helper functions in PulpUtils.cmake include it via CMAKE_CURRENT_LIST_DIR
+#     so downstream consumers don't need to reference it directly.
 #
 # No-op on non-Linux platforms (macOS uses CoreText, Windows uses
 # DirectWrite, Android bundles its own font manager).

--- a/tools/cmake/PulpUtils.cmake
+++ b/tools/cmake/PulpUtils.cmake
@@ -34,10 +34,34 @@ if(NOT _PULP_FORMAT_TARGET)
         "Use add_subdirectory(Pulp) or find_package(Pulp) before including it.")
 endif()
 
+# Resolve PulpUtils.cmake's sibling helper dirs without reaching into
+# CMAKE_SOURCE_DIR (which is the *consumer's* source tree when this
+# file is loaded via find_package, not Pulp's). Pulp #2087 piggyback —
+# CMAKE_CURRENT_LIST_DIR at top level is this file's own dir, so we
+# probe both possible layouts (in-tree source build + installed SDK)
+# before falling back. The fallback path is kept as a last-resort
+# escape hatch for stale checkouts that haven't run `cmake --install`.
+#
+#   In-tree:    tools/cmake/PulpUtils.cmake
+#               -> ../../core/format/src    (Pulp source tree)
+#               -> ../../tools/templates/auv3
+#               -> ../../templates/ios-auv3
+#   Installed:  <prefix>/lib/cmake/Pulp/PulpUtils.cmake
+#               -> ../../../src/pulp/format (matches root install(FILES) DESTINATION src/pulp/format)
+#               -> ../../../templates/auv3
+#               -> ../../../templates/ios-auv3
 if(DEFINED PULP_FORMAT_SOURCE_DIR AND EXISTS "${PULP_FORMAT_SOURCE_DIR}")
     set(_PULP_FORMAT_SOURCE_DIR "${PULP_FORMAT_SOURCE_DIR}")
+elseif(EXISTS "${CMAKE_CURRENT_LIST_DIR}/../../core/format/src")
+    set(_PULP_FORMAT_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../core/format/src")
+elseif(EXISTS "${CMAKE_CURRENT_LIST_DIR}/../../../src/pulp/format")
+    set(_PULP_FORMAT_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../src/pulp/format")
 else()
-    set(_PULP_FORMAT_SOURCE_DIR "${CMAKE_SOURCE_DIR}/core/format/src")
+    # Last resort: leave unset so plugin targets fail with a clear "missing
+    # source" error at link-time rather than silently picking up the
+    # consumer's source tree. Override with -DPULP_FORMAT_SOURCE_DIR=... if
+    # the SDK install is incomplete.
+    set(_PULP_FORMAT_SOURCE_DIR "")
 endif()
 
 if(DEFINED PULP_VST3_INCLUDE_DIR AND EXISTS "${PULP_VST3_INCLUDE_DIR}")
@@ -50,14 +74,22 @@ endif()
 
 if(DEFINED PULP_AUV3_TEMPLATE_DIR AND EXISTS "${PULP_AUV3_TEMPLATE_DIR}")
     set(_PULP_AUV3_TEMPLATE_DIR "${PULP_AUV3_TEMPLATE_DIR}")
+elseif(EXISTS "${CMAKE_CURRENT_LIST_DIR}/../../tools/templates/auv3")
+    set(_PULP_AUV3_TEMPLATE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../tools/templates/auv3")
+elseif(EXISTS "${CMAKE_CURRENT_LIST_DIR}/../../../templates/auv3")
+    set(_PULP_AUV3_TEMPLATE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../templates/auv3")
 else()
-    set(_PULP_AUV3_TEMPLATE_DIR "${CMAKE_SOURCE_DIR}/tools/templates/auv3")
+    set(_PULP_AUV3_TEMPLATE_DIR "")
 endif()
 
 if(DEFINED PULP_IOS_AUV3_TEMPLATE_DIR AND EXISTS "${PULP_IOS_AUV3_TEMPLATE_DIR}")
     set(_PULP_IOS_AUV3_TEMPLATE_DIR "${PULP_IOS_AUV3_TEMPLATE_DIR}")
+elseif(EXISTS "${CMAKE_CURRENT_LIST_DIR}/../../templates/ios-auv3")
+    set(_PULP_IOS_AUV3_TEMPLATE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../templates/ios-auv3")
+elseif(EXISTS "${CMAKE_CURRENT_LIST_DIR}/../../../templates/ios-auv3")
+    set(_PULP_IOS_AUV3_TEMPLATE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../templates/ios-auv3")
 else()
-    set(_PULP_IOS_AUV3_TEMPLATE_DIR "${CMAKE_SOURCE_DIR}/templates/ios-auv3")
+    set(_PULP_IOS_AUV3_TEMPLATE_DIR "")
 endif()
 
 function(_pulp_normalize_ui_script_path out_var source_dir ui_script)
@@ -994,7 +1026,19 @@ function(_pulp_add_standalone target name bundle_id version)
     # transitively pulls in pulp::view → pulp::canvas → libskia.a, which
     # references Fc* symbols. Re-mention fontconfig AFTER the archive so
     # the linker resolves them. No-op on macOS/Windows/Android.
-    include(${CMAKE_SOURCE_DIR}/tools/cmake/PulpLinkFontconfig.cmake)
+    #
+    # CMAKE_CURRENT_FUNCTION_LIST_DIR (NOT CMAKE_CURRENT_LIST_DIR or
+    # CMAKE_SOURCE_DIR) — CMake's CMAKE_CURRENT_LIST_DIR inside a function
+    # body resolves to the *caller's* dir, not where the function was
+    # defined. CMAKE_CURRENT_FUNCTION_LIST_DIR (CMake 3.17+; Pulp pins
+    # 3.24) is the one that consistently resolves to PulpUtils.cmake's
+    # own dir — i.e., the in-tree tools/cmake/ during a source build,
+    # and ~/.pulp/sdk/<ver>/lib/cmake/Pulp/ after install. The sibling
+    # PulpLinkFontconfig.cmake ships alongside via root CMakeLists.txt's
+    # install(FILES) block. Pulp #2087 piggyback — pre-fix this broke
+    # every Linux/Android consumer since CMAKE_SOURCE_DIR resolved to
+    # the consumer's source tree.
+    include("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/PulpLinkFontconfig.cmake")
     pulp_link_fontconfig_after_skia(${target}_Standalone)
 endfunction()
 

--- a/tools/mcp/pulp-mcp-launcher
+++ b/tools/mcp/pulp-mcp-launcher
@@ -3,12 +3,25 @@
 # pulp-mcp binary regardless of the cwd it spawns the MCP server with.
 #
 # Resolution order:
-#   1. ${CLAUDE_PLUGIN_ROOT-derived}/build/tools/mcp/pulp-mcp  (source-tree build)
-#   2. pulp-mcp on $PATH                                       (installed binary)
+#   1. <plugin-cwd>/build/tools/mcp/pulp-mcp  (source-tree dev build)
+#   2. ~/.pulp/bin/pulp-mcp                   (canonical install dest)
+#   3. pulp-mcp on $PATH                      (fallback for custom installs)
+#
+# Why probe ~/.pulp/bin BEFORE $PATH (pulp #2087 follow-up): Claude Code
+# spawns the MCP server with a sanitized environment — the user's
+# interactive-shell PATH (which includes ~/.pulp/bin via install.sh)
+# does NOT propagate, so `command -v pulp-mcp` returns empty even on
+# a healthy install. Without this probe, `/mcp` reports
+# "Failed to reconnect to pulp: ENOENT" (the launcher exits 127, and
+# Claude Code surfaces that as a missing-binary error) every time the
+# user restarts Claude Code on a fresh `curl install.sh | sh`. The
+# direct ~/.pulp/bin probe matches what install.sh + `pulp upgrade
+# --install` write to, so it's the authoritative location to check
+# regardless of PATH state.
 #
 # If neither is found, the launcher emits a readable diagnostic on stderr
 # and exits 127 so Claude Code surfaces the failure rather than treating
-# it as silent. See pulp #1821.
+# it as silent. See pulp #1821 and pulp #2087.
 
 set -e
 
@@ -20,6 +33,15 @@ if [ -x "$CANDIDATE_SOURCE_BUILD" ]; then
   exec "$CANDIDATE_SOURCE_BUILD" "$@"
 fi
 
+# install.sh + `pulp upgrade --install` write the binary to ~/.pulp/bin/
+# on every supported platform; this is the canonical location any healthy
+# `curl install.sh | sh` produces. Probing it directly is robust against
+# PATH not propagating into the MCP subprocess's env.
+CANDIDATE_INSTALLED="${HOME}/.pulp/bin/pulp-mcp"
+if [ -x "$CANDIDATE_INSTALLED" ]; then
+  exec "$CANDIDATE_INSTALLED" "$@"
+fi
+
 if command -v pulp-mcp >/dev/null 2>&1; then
   exec pulp-mcp "$@"
 fi
@@ -29,10 +51,13 @@ pulp-mcp-launcher: cannot locate pulp-mcp binary.
 
 Looked in:
   1. $CANDIDATE_SOURCE_BUILD  (source-tree build)
-  2. \$PATH (no executable named 'pulp-mcp' found)
+  2. $CANDIDATE_INSTALLED  (canonical install destination)
+  3. \$PATH (no executable named 'pulp-mcp' found)
 
 Fix one of:
-  - Build it: 'cmake --build build --target pulp-mcp' from $REPO_ROOT
+  - Install: 'curl -fsSL https://www.generouscorp.com/pulp/install.sh | sh'
+    (drops pulp-mcp into ~/.pulp/bin/)
+  - Source build: 'cmake --build build --target pulp-mcp' from $REPO_ROOT
   - Install it on \$PATH so 'pulp-mcp' resolves globally
 
 See https://github.com/danielraffel/pulp/issues/1821 for context.

--- a/tools/mcp/pulp_mcp.cpp
+++ b/tools/mcp/pulp_mcp.cpp
@@ -795,6 +795,26 @@ int main(int argc, char* argv[]) {
         return 2;
     }
 
+    // MCP spec: messages on the stdio transport are delimited by
+    // newlines, and MUST NOT contain embedded newlines. Several of our
+    // response builders (tools_list_json() most visibly) use multi-line
+    // R"JSON(...)" raw strings for readability — the literal `\n`s in
+    // those raw strings would break MCP clients (Claude Code reads one
+    // line at a time and times out on the unclosed first line of the
+    // tools array, surfacing as "MCP error -32001: Request timed out"
+    // on tools/list).
+    //
+    // Strip `\n` and `\r` from any response body before it goes on the
+    // wire. Tested: pre-fix tools/list response = 23 lines; post-fix = 1.
+    auto compact_for_wire = [](std::string s) {
+        std::string out;
+        out.reserve(s.size());
+        for (char c : s) {
+            if (c != '\n' && c != '\r') out += c;
+        }
+        return out;
+    };
+
     std::string line;
     while (std::getline(std::cin, line)) {
         if (line.empty()) continue;
@@ -806,7 +826,7 @@ int main(int argc, char* argv[]) {
             std::string body(length, '\0');
             std::cin.read(body.data(), length);
 
-            auto response = handle_request(body);
+            auto response = compact_for_wire(handle_request(body));
             if (!response.empty()) {
                 std::cout << "Content-Length: " << response.size() << "\r\n\r\n" << response;
                 std::cout.flush();
@@ -814,8 +834,9 @@ int main(int argc, char* argv[]) {
             continue;
         }
 
-        // Also handle bare JSON (for simpler testing)
-        auto response = handle_request(line);
+        // Also handle bare JSON (for simpler testing AND the
+        // newline-delimited MCP stdio transport that Claude Code uses).
+        auto response = compact_for_wire(handle_request(line));
         if (!response.empty()) {
             std::cout << response << "\n";
             std::cout.flush();

--- a/tools/scripts/install.sh
+++ b/tools/scripts/install.sh
@@ -112,6 +112,36 @@ if [ -x "${INSTALL_DIR}/pulp-mcp" ]; then
     info "Installed: pulp-mcp (Claude Code plugin MCP server)"
 fi
 
+# #2087: Pulp users running `curl install.sh | sh` historically ended
+# up with a fresh CLI but no SDK. Any project then built against
+# whatever stale ~/.pulp/sdk/<old>/ they had — sometimes months behind
+# — silently missing every framework fix in between (Spectr was the
+# visible victim). Auto-install the latest SDK matching the CLI's own
+# version so install.sh leaves the user with a coherent CLI+SDK pair.
+#
+# Failure mode: SDK install can fail on a transient network error.
+# Don't fail the whole install — the CLI is still usable; the user can
+# retry with `pulp sdk install` later. Print a clear nudge.
+SDK_VERSION_FROM_CLI=$("${INSTALL_DIR}/pulp" version 2>/dev/null \
+    | awk '/Pulp SDK version:/ {print $4}' \
+    | head -n 1)
+if [ -z "$SDK_VERSION_FROM_CLI" ]; then
+    SDK_VERSION_FROM_CLI=$(echo "$INSTALLED_VERSION" | awk '{print $NF}' \
+        | sed -E 's/^v//')
+fi
+
+echo ""
+info "Installing matching SDK v${SDK_VERSION_FROM_CLI}..."
+if PATH="${INSTALL_DIR}:$PATH" "${INSTALL_DIR}/pulp" sdk install 2>&1 \
+       | sed 's/^/  /'; then
+    info "Installed SDK at ~/.pulp/sdk/${SDK_VERSION_FROM_CLI}/"
+else
+    echo ""
+    echo "  (warning) SDK install failed — the CLI is still usable, but"
+    echo "  building a project will need the SDK. Retry with:"
+    echo "    pulp sdk install"
+fi
+
 # ── Add to PATH ─────────────────────────────────────────────────────────────
 
 add_to_path() {
@@ -162,7 +192,17 @@ fi
 # ── Done ────────────────────────────────────────────────────────────────────
 
 echo ""
-echo "  Done! Run \`pulp create my-plugin\` to create your first plugin."
+echo "  Done! Installed pulp ${INSTALLED_VERSION} CLI + SDK v${SDK_VERSION_FROM_CLI}"
+echo "  at ${INSTALL_DIR}/ and ~/.pulp/sdk/${SDK_VERSION_FROM_CLI}/."
+echo ""
+echo "  Next: run \`pulp create my-plugin\` to scaffold your first plugin."
+echo ""
+echo "  Tip: new projects default to floating-SDK mode (track latest) so"
+echo "       you automatically pick up framework fixes on every rebuild."
+echo "       Pin a specific SDK version for a project with:"
+echo "         cd my-plugin && pulp project pin <version>"
+echo "       Pinned projects don't auto-update. Run \`pulp project unpin\`"
+echo "       to switch back to floating mode."
 echo ""
 echo "  If 'pulp' is not found, restart your shell or run:"
 echo "    export PATH=\"${INSTALL_DIR}:\$PATH\""

--- a/tools/scripts/install.sh
+++ b/tools/scripts/install.sh
@@ -132,14 +132,24 @@ fi
 
 echo ""
 info "Installing matching SDK v${SDK_VERSION_FROM_CLI}..."
-if PATH="${INSTALL_DIR}:$PATH" "${INSTALL_DIR}/pulp" sdk install 2>&1 \
-       | sed 's/^/  /'; then
+# Capture pulp sdk install's exit code via PIPESTATUS, not the pipeline's
+# overall status. set -e doesn't help here: a successful `sed` would mask
+# a failed `pulp sdk install`, and we'd print "Installed SDK" even when no
+# SDK landed. Codex P2 review on PR #2091 caught this — pre-fix users
+# saw a confident success message while sitting on a broken CLI+SDK pair.
+PATH="${INSTALL_DIR}:$PATH" "${INSTALL_DIR}/pulp" sdk install 2>&1 \
+    | sed 's/^/  /'
+sdk_install_rc=${PIPESTATUS[0]}
+if [ "$sdk_install_rc" -eq 0 ]; then
     info "Installed SDK at ~/.pulp/sdk/${SDK_VERSION_FROM_CLI}/"
 else
     echo ""
-    echo "  (warning) SDK install failed — the CLI is still usable, but"
-    echo "  building a project will need the SDK. Retry with:"
+    echo "  (warning) SDK install failed (exit $sdk_install_rc) — the CLI is still usable,"
+    echo "  but building a project will need the SDK. Retry with:"
     echo "    pulp sdk install"
+    # Don't fail the whole install — the CLI itself landed cleanly above
+    # and the user has an actionable retry path. Just preserve the right
+    # signal for anyone scripting around the SDK availability.
 fi
 
 # ── Add to PATH ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #2087. Plus a piggyback CMake fix that unblocks downstream consumers (including Spectr) from rebuilding against v0.101.5+ on Linux/Android.

### Piggyback: `lib/cmake/Pulp/PulpUtils.cmake` doesn't reach into the Pulp source tree

PulpUtils.cmake's downstream-facing helpers were resolving paths via `${CMAKE_SOURCE_DIR}`, which in `find_package(Pulp)` context points at the *consumer's* source tree — not Pulp's. Every Linux/Android consumer's configure step failed:

```
CMake Error at .../lib/cmake/Pulp/PulpUtils.cmake:997 (include):
  include could not find requested file:
    <consumer-dir>/tools/cmake/PulpLinkFontconfig.cmake
```

Fix:
- Inside `_pulp_add_standalone` (a function body): use `CMAKE_CURRENT_FUNCTION_LIST_DIR` (CMake 3.17+; Pulp pins 3.24). `CMAKE_CURRENT_LIST_DIR` inside a function body resolves to the **caller's** dir, not the function's defining file — a classic CMake gotcha that bit on first attempt.
- Top-level fallbacks (`_PULP_FORMAT_SOURCE_DIR`, AUv3 templates, iOS AUv3 templates): probe in-tree layout first (`../../core/...`), then installed-tree layout (`../../../src/...`), then empty so plugin targets fail with a clear "missing source" error instead of silently picking up the consumer's tree.
- Root CMakeLists.txt: `PulpLinkFontconfig.cmake` now ships in the `install(FILES)` block alongside `PulpUtils.cmake` at `${CMAKE_INSTALL_LIBDIR}/cmake/Pulp/`.

New CI gate `.github/workflows/install-consumer-smoke.yml`:
- Installs Pulp to a temp prefix on macos-15 + ubuntu-24.04
- Configures a minimal downstream `find_package(Pulp)` + `pulp_add_plugin(...)` project
- Greps the installed CMake config files for `${CMAKE_SOURCE_DIR}/tools/...` or `.../core/...` (the exact bug pattern) and fails loudly if any future commit reintroduces the class

Verified end-to-end locally on macOS: install → consumer configure → "Pulp::view target resolved." ✓

### #2087: Auto-update default, easy pin opt-out

The Spectr-class incident: `curl install.sh | sh` puts a fresh CLI on top of whatever stale SDK the cache had — silently missing every framework fix in between. Fix: default to floating-SDK mode, make pinning opt-in.

- **`pulp create`** writes `sdk_version = "latest"` by default. `--pin` opts into exact-version pinning at create time.
- **`pulp project pin`** is the new primary command name; `bump` survives as a deprecated alias for one minor release. **`pulp project unpin`** (new) flips a project back to floating.
- **`pulp upgrade`** fetches CLI + matching SDK by default; `--cli-only` opts out. In a pinned project, the SDK swap leaves the pin alone with a clear notice ("Project X stays on pinned SDK Y.Y.Y…").
- **`pulp doctor --versions`** appends a "Local SDKs" section: newest installed under `~/.pulp/sdk/`, project pin status (floating vs pinned), cached latest remote, "newer SDK available" hint when behind.
- **`install.sh`** runs `pulp sdk install` after the CLI install so a fresh `curl install.sh | sh` leaves the user with a coherent CLI + SDK pair. Closing message names both versions and surfaces the `pulp project pin` command.
- **`read_sdk_version`** resolves the explicit `"latest"` marker to the newest installed SDK; new helpers `is_floating_sdk` / `read_raw_sdk_version` / `newest_installed_sdk` so callers don't open-code the comparison.

## Non-goals (per #2087 + deferred to follow-ups)

- **Auto-install-on-first-need** across every command (`pulp build`/`run`/`import-design`/`ship` in an unpinned old project). Needs config-knob plumbing across every SDK-resolution site; bigger than this PR's scope.
- **"Newer SDK available" one-line banner** on every command. Needs best-effort network call infrastructure with 1s timeout + a global suppress knob.
- **`pulp sdk available`** subcommand. Needs a new `fetch_all_releases` API alongside the existing `fetch_latest_release`.
- Existing projects are NOT auto-rewritten to floating. Only newly-created projects get the new default; existing `pulp.toml` files are untouched (pinning is sacred).

`pulp sdk install --help` is already documented in `cmd_sdk.cpp` — the recollection that it was missing turned out to be a no-op.

## Test plan

- [x] `ctest -R "cmd_project reports help|cli common project metadata"` — 2/2 pass
- [x] `ctest -R "[issue-2087]"` — pin/unpin help + unpin round-trip (43 assertions)
- [x] `pulp doctor --versions` shows local + remote SDKs + pin status
- [x] `pulp project --help`, `pulp project pin --help`, `pulp project unpin --help`, `pulp project bump --help` all render
- [x] Downstream consumer smoke (local): install → `find_package(Pulp)` → `Pulp::view` resolved
- [x] Grep guard for `CMAKE_SOURCE_DIR/tools/...` in installed configs — clean
- [ ] Shipyard macOS local validation
- [ ] `install-consumer-smoke.yml` runs on macos-15 + ubuntu-24.04

🤖 Generated with [Claude Code](https://claude.com/claude-code)