### PR TITLE
fix(view/mac): re-sync _focusedView at every deref site (closes #2088)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.102.0
+    VERSION 0.102.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -237,9 +237,25 @@ static std::vector<uint8_t> capture_window_screencapture_png(NSWindow* window) {
 - (BOOL)acceptsFirstResponder { return YES; }
 - (BOOL)acceptsFirstMouse:(NSEvent*)e { (void)e; return YES; }
 
+// pulp #2088 — the Obj-C `_focusedView` ivar is a parallel pointer to
+// `pulp::view::View::focused_input_`. The static is auto-cleared by ~View()
+// (pulp #1708) when the focused widget is destroyed (e.g. React unmount
+// of a clicked widget); the ivar is not. The #1818 fix re-syncs at the
+// TOP of mouseDown — but mouseDown's own work (overlay dispatch, ComboBox
+// routing, on_mouse_event → React unmount) can destroy the focused view
+// MID-FUNCTION, after which subsequent _focusedView derefs PAC-fault on
+// the vtable load. Read the live pointer through this accessor everywhere
+// _focusedView could be reached after a callback that might destroy a view.
+- (pulp::view::View*)liveFocusedView {
+    if (_focusedView != pulp::view::View::focused_input_) {
+        _focusedView = pulp::view::View::focused_input_;
+    }
+    return _focusedView;
+}
+
 - (void)clearInteractionState {
     _dragTarget = nullptr;
-    if (_focusedView) _focusedView->release_input_focus();
+    if (auto* fv = [self liveFocusedView]) fv->release_input_focus();
     _focusedView = nullptr;
 }
 
@@ -401,17 +417,19 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             }
             auto pt = [self localPoint:event];
 
-            // pulp #1818 — the Obj-C `_focusedView` ivar is a parallel
+            // pulp #1818 / #2088 — the Obj-C `_focusedView` ivar is a parallel
             // pointer to `pulp::view::View::focused_input_`. The static is
             // auto-cleared by ~View() (pulp #1708) when the focused widget
-            // is destroyed (e.g., a React unmount of a clicked widget),
-            // but nothing clears the ivar. The next mouseDown then
-            // dereferences `_focusedView->on_focus_changed(false)` on
-            // freed memory and PAC-faults on the vtable load — this is
-            // the exact crash in pulp #1818 ("-[PulpView mouseDown:] + 664",
-            // KERN_INVALID_ADDRESS, x9 = corrupt high bits). Re-sync from
-            // the auto-clearing static at the top of every mouseDown so
-            // the ivar can never be dangling for any deref below.
+            // is destroyed (e.g., a React unmount of a clicked widget); the
+            // ivar is not. The original #1818 fix re-synced ONLY at this top
+            // of mouseDown — but mouseDown's own work (overlay dispatch, ComboBox
+            // routing, on_mouse_event → React unmount) can destroy the focused
+            // view MID-FUNCTION, so subsequent _focusedView derefs PAC-faulted
+            // (#2088: "-[PulpView mouseDown:] + 1172"). The complete fix routes
+            // every deref below through -[liveFocusedView], which performs the
+            // re-sync at each access site. This top-level re-sync is now
+            // redundant with the per-call accessor, but kept as defense-in-depth
+            // for any future deref that forgets to use the accessor.
             if (_focusedView && _focusedView != pulp::view::View::focused_input_) {
                 _focusedView = pulp::view::View::focused_input_;
             }
@@ -495,14 +513,14 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                     auto local = toLocal(pt, _dragTarget, self.rootView);
 
                     if (_dragTarget->focusable()) {
-                        if (_focusedView && _focusedView != _dragTarget)
-                            _focusedView->on_focus_changed(false);
+                        if (auto* fv = [self liveFocusedView]; fv && fv != _dragTarget)
+                            fv->on_focus_changed(false);
                         _focusedView = _dragTarget;
                         _focusedView->on_focus_changed(true);
                         _focusedView->claim_input_focus();
-                    } else if (_focusedView) {
-                        _focusedView->on_focus_changed(false);
-                        _focusedView->release_input_focus();
+                    } else if (auto* fv = [self liveFocusedView]) {
+                        fv->on_focus_changed(false);
+                        fv->release_input_focus();
                         _focusedView = nullptr;
                     }
 
@@ -546,14 +564,14 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             auto local = toLocal(pt, _dragTarget, self.rootView);
 
             if (_dragTarget->focusable()) {
-                if (_focusedView && _focusedView != _dragTarget)
-                    _focusedView->on_focus_changed(false);
+                if (auto* fv = [self liveFocusedView]; fv && fv != _dragTarget)
+                    fv->on_focus_changed(false);
                 _focusedView = _dragTarget;
                 _focusedView->on_focus_changed(true);
                 _focusedView->claim_input_focus();
-            } else if (_focusedView) {
-                _focusedView->on_focus_changed(false);
-                _focusedView->release_input_focus();
+            } else if (auto* fv = [self liveFocusedView]) {
+                fv->on_focus_changed(false);
+                fv->release_input_focus();
                 _focusedView = nullptr;
             }
 
@@ -781,12 +799,15 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
         }
 
         if (key == pulp::view::KeyCode::tab && self.rootView) {
-            auto* old = _focusedView;
+            // pulp #2088 — re-sync via liveFocusedView so a destroyed prior
+            // focused view doesn't leak a dangling ivar into focus_next/prev
+            // and the on_focus_changed/release_input_focus calls below.
+            auto* old = [self liveFocusedView];
             pulp::view::View* next = nullptr;
             if (mods & pulp::view::kModShift)
-                next = pulp::view::View::focus_prev(*self.rootView, _focusedView);
+                next = pulp::view::View::focus_prev(*self.rootView, old);
             else
-                next = pulp::view::View::focus_next(*self.rootView, _focusedView);
+                next = pulp::view::View::focus_next(*self.rootView, old);
             if (next && next != old) {
                 if (old) {
                     old->on_focus_changed(false);
@@ -858,13 +879,17 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
 
         [self interpretKeyEvents:@[event]];
 
-            if (_focusedView) {
+            // pulp #2088 — interpretKeyEvents above can dispatch IME / app
+            // commands that ultimately destroy the focused widget (e.g.,
+            // a JS key handler triggers a React unmount). Re-sync via
+            // liveFocusedView so we don't deref a freed view here.
+            if (auto* fv = [self liveFocusedView]) {
                 pulp::view::KeyEvent ke;
                 ke.key = key;
                 ke.modifiers = mods;
                 ke.is_down = true;
                 ke.is_repeat = event.isARepeat;
-                _focusedView->on_key_event(ke);
+                fv->on_key_event(ke);
                 [self startAnimationTimerIfNeeded];
                 [self setNeedsDisplay:YES];
             }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2349,4 +2349,16 @@ if(APPLE AND NOT PULP_IOS AND PULP_HAS_SKIA)
         "-framework QuartzCore"
     )
     catch_discover_tests(pulp-test-mac-platform-harness)
+
+    # pulp #2088 — pin the invariant -[PulpView liveFocusedView] depends on:
+    # ~View() must auto-clear focused_input_ (#1708 contract) so the
+    # accessor can safely re-sync the ivar to nullptr before any deref.
+    add_executable(pulp-test-mac-mousedown-stale-focus
+        test_mac_mousedown_stale_focus.mm
+    )
+    target_link_libraries(pulp-test-mac-mousedown-stale-focus PRIVATE
+        pulp::view
+        Catch2::Catch2WithMain
+    )
+    catch_discover_tests(pulp-test-mac-mousedown-stale-focus)
 endif()

--- a/test/test_mac_mousedown_stale_focus.mm
+++ b/test/test_mac_mousedown_stale_focus.mm
@@ -1,0 +1,113 @@
+// pulp #2088 — pin the underlying invariant the mid-mouseDown stale-pointer
+// fix in -[PulpView liveFocusedView] relies on.
+//
+// Background
+// ----------
+// `-[PulpView mouseDown:]` keeps an Obj-C ivar `_focusedView` that mirrors
+// `pulp::view::View::focused_input_`. The static is auto-cleared by ~View()
+// (#1708); the ivar is not. PR #1819 ("fix #1818") re-synced ONLY at the top
+// of mouseDown — but mouseDown's own work (overlay dispatch, ComboBox
+// routing, on_mouse_event → React unmount) can destroy the focused view
+// MID-FUNCTION. Subsequent `_focusedView->...` derefs PAC-faulted (#2088).
+//
+// The complete fix routes every `_focusedView` deref through
+// `-[liveFocusedView]`, which re-syncs from the static at each access site.
+//
+// What this test pins
+// -------------------
+// The accessor's correctness depends on ONE invariant: when a focused view
+// is destroyed, `pulp::view::View::focused_input_` becomes nullptr. If that
+// ever regresses, every PulpView callsite that reads through the accessor
+// gets a stale pointer and PAC-faults the way #1818/#2088 did.
+//
+// This test:
+//   1. Claim focus on view A → focused_input_ = A.
+//   2. Cache the pointer (simulates PulpView's `_focusedView` ivar).
+//   3. Destroy A. focused_input_ MUST become nullptr (#1708 contract).
+//   4. Cache is now dangling; assert the live static differs — this is
+//      exactly the condition `-[liveFocusedView]` checks before re-syncing.
+//
+// A full mouseDown integration test (click A → destroy A → click B → assert
+// no crash) is harder to construct in the existing #2001 harness because
+// `simulate_mouse` runs Yoga on the test root and the test view bounds
+// don't survive layout in a way that makes hit_test deterministic. Filed as
+// a follow-up gap in the harness; manually verified by rebuilding Spectr
+// against this fix and confirming first-click no longer crashes.
+//
+// Tag [issue-2088] for coverage attribution.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/view/view.hpp>
+
+using pulp::view::View;
+
+namespace {
+
+class TestView : public View {
+public:
+    void paint(pulp::canvas::Canvas&) override {}
+};
+
+struct FocusGuard {
+    FocusGuard() { View::focused_input_ = nullptr; }
+    ~FocusGuard() { View::focused_input_ = nullptr; }
+};
+
+}  // namespace
+
+TEST_CASE("destroyed focused view must auto-clear focused_input_ "
+          "(invariant -[PulpView liveFocusedView] depends on) [issue-2088]",
+          "[view][focus][mac]") {
+    FocusGuard guard;
+
+    // Step 1: focus A through the public API.
+    auto a = std::make_unique<TestView>();
+    a->claim_input_focus();
+    REQUIRE(View::focused_input_ == a.get());
+
+    // Step 2: cache the pointer — simulates the way -[PulpView mouseDown:]
+    // stores a parallel `_focusedView` ivar before dispatching nested work.
+    auto* cached = View::focused_input_;
+    REQUIRE(cached == a.get());
+
+    // Step 3: destroy A. ~View must null `focused_input_` (#1708 contract).
+    // If this regresses, every PulpView callsite that re-syncs from the
+    // static will keep its stale ivar and crash on the next deref.
+    a.reset();
+    REQUIRE(View::focused_input_ == nullptr);
+
+    // Step 4: the cached pointer is now dangling. -[PulpView liveFocusedView]
+    // detects this exact condition by comparing the ivar to the live static
+    // and resetting the ivar to nullptr before any deref. Pin the comparison
+    // here so the contract that supports the fix can't silently change.
+    REQUIRE(cached != View::focused_input_);
+}
+
+TEST_CASE("focus transfer between views keeps focused_input_ in sync "
+          "[issue-2088]",
+          "[view][focus][mac]") {
+    FocusGuard guard;
+
+    auto a = std::make_unique<TestView>();
+    auto b = std::make_unique<TestView>();
+
+    a->claim_input_focus();
+    REQUIRE(View::focused_input_ == a.get());
+
+    // Transfer focus to B. A's release_input_focus() should also clear the
+    // static if A still owns it.
+    a->release_input_focus();
+    REQUIRE(View::focused_input_ == nullptr);
+
+    b->claim_input_focus();
+    REQUIRE(View::focused_input_ == b.get());
+
+    // ~View on either view must clear if the destructed view holds focus.
+    b.reset();
+    REQUIRE(View::focused_input_ == nullptr);
+
+    // A is still alive but doesn't hold focus — its destruction shouldn't
+    // affect a stale slot.
+    a.reset();
+    REQUIRE(View::focused_input_ == nullptr);
+}


### PR DESCRIPTION
PulpView's `_focusedView` ivar mirrors `pulp::view::View::focused_input_`.
The static is auto-cleared by ~View() (#1708); the ivar is not. PR #1819
fixed the equivalent crash at the TOP of mouseDown — but mouseDown's own
work (overlay dispatch, ComboBox routing, on_mouse_event → React unmount)
can destroy the focused view MID-FUNCTION. Subsequent `_focusedView`
derefs PAC-faulted ("-[PulpView mouseDown:] + 1172", #2088).

Spectr crashed on the first user click against v0.101.5 SDK with this
exact signature.

The complete fix
----------------
Add `-[PulpView liveFocusedView]` accessor that re-syncs from the static
on every call, and route every `_focusedView->X` deref through it:

- clearInteractionState (line 242)
- mouseDown overlay-dispatch path (lines 499/504-505)
- mouseDown standard hit_test path (lines 550/555-556)
- keyDown Tab focus walker (lines 784-787)
- keyDown text-input dispatch (line 867)

Writes (`_focusedView = next/_dragTarget;`) stay simple because the very
next `claim_input_focus()` resyncs the static back to match.

The top-of-mouseDown re-sync from #1819 stays as defense-in-depth in
case a future deref forgets to use the accessor.

Test
----
test_mac_mousedown_stale_focus.mm pins the underlying #1708 invariant the
accessor depends on: when a focused View is destroyed, focused_input_
auto-nulls, so the cached ivar is detectably stale (the accessor's check).

A full mouseDown integration test (click A → destroy A → click B → assert
no PAC fault) is harder in the existing #2001 mac harness because Yoga
recomputes view bounds on the test root and the test view never gets the
hit area I asked for. Filed as a harness gap; manually verified the fix
by rebuilding Spectr against this branch and confirming first-click no
longer crashes.

Cross-refs
----------
- #1708 — auto-clear focused_input_ on ~View
- #1818 — original crash report
- #1819 — partial fix (top-of-mouseDown only)
- #2088 — this issue, full fix at all deref sites