### PR TITLE
fix(cmake): ship PulpLinkFontconfig.cmake in SDK + use stable include path (closes #2089)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -922,6 +922,7 @@ install(FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpGenerateWindowsIcon.ps1"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpUtils.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpPlugin.cmake"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpLinkFontconfig.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/FindSkia.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpInfoPlist.aax.in"
     "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpInfoPlist.au.in"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -121,6 +121,24 @@ if(UNIX)
         LABELS "parser-import")
 endif()
 
+# Install-consumer cmake smoke test (pulp #2089). Pins three invariants
+# that together prevent the "in-tree works, install breaks" regression
+# class:
+#   1. install(FILES …) for lib/cmake/Pulp ships PulpLinkFontconfig.cmake
+#   2. PulpUtils.cmake does NOT include via ${CMAKE_SOURCE_DIR}/...
+#      (which resolves to downstream consumer's tree, not Pulp's)
+#   3. PulpUtils.cmake uses the file-scope _pulp_utils_cmake_dir
+#      pattern that survives both in-tree and downstream contexts
+#
+# Cheap static checks — runs in <1s without a real install.
+if(UNIX)
+    add_test(NAME install-consumer-cmake
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_install_consumer_cmake.sh)
+    set_tests_properties(install-consumer-cmake
+        PROPERTIES TIMEOUT 30
+        LABELS "tooling")
+endif()
+
 # Debug-SDK perf-killer guard smoke (pulp-internal task #35).
 # Hermetic — runs the guard against a tempdir-fabricated SDK install,
 # exercises the three branches (Debug-no-override → FATAL_ERROR,

--- a/test/test_install_consumer_cmake.sh
+++ b/test/test_install_consumer_cmake.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# test_install_consumer_cmake.sh — pin the SDK install layout invariants.
+#
+# Why this test exists
+# --------------------
+# pulp #2089: `lib/cmake/Pulp/PulpUtils.cmake` did
+#   include(${CMAKE_SOURCE_DIR}/tools/cmake/PulpLinkFontconfig.cmake)
+# which resolves to the DOWNSTREAM project's source tree, not Pulp's.
+# Spectr (and any consumer of `find_package(Pulp REQUIRED)` that calls
+# pulp_add_plugin(... STANDALONE ...)) hit a configure-time error:
+#   include could not find requested file:
+#     /Users/.../spectr/tools/cmake/PulpLinkFontconfig.cmake
+#
+# The bug only surfaces when Pulp is consumed via an installed SDK —
+# in-tree builds of Pulp itself never hit it because CMAKE_SOURCE_DIR
+# IS Pulp's source there.
+#
+# What this test pins (cheap static checks, no real install needed)
+# ----------------------------------------------------------------
+# 1. Root CMakeLists.txt's `install(FILES … DESTINATION lib/cmake/Pulp)`
+#    rule includes `tools/cmake/PulpLinkFontconfig.cmake` so the helper
+#    actually lands in the SDK tarball.
+# 2. PulpUtils.cmake's include of PulpLinkFontconfig.cmake uses
+#    a path that resolves both in-tree AND inside an installed SDK.
+#    Specifically: NOT `${CMAKE_SOURCE_DIR}/tools/cmake/...` (the bug),
+#    NOT bare `${CMAKE_CURRENT_LIST_DIR}/...` inside a function (resolves
+#    to caller's file at function-call time, also broken downstream).
+#
+# Why static checks instead of a real install + consumer build
+# ------------------------------------------------------------
+# A real install requires building all SDK targets (pulp-cpp, libwgpu,
+# etc.) which is multi-minute. The SHAPE of the bug is purely about
+# cmake-script paths that are decidable from source. Release CI does the
+# end-to-end install consumer test; this test catches the regression at
+# pre-merge time without a heavy build.
+#
+# Tag [issue-2089] for coverage attribution.
+
+set -euo pipefail
+
+PULP_SRC="$(cd "$(dirname "$0")/.." && pwd)"
+
+PASS=0
+FAIL=0
+assert() {
+  local label="$1" cond="$2"
+  if eval "$cond"; then
+    echo "  PASS — $label"
+    PASS=$((PASS+1))
+  else
+    echo "  FAIL — $label"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# ── Check 1: install(FILES …) rule includes PulpLinkFontconfig.cmake ──
+ROOT_CMAKE="$PULP_SRC/CMakeLists.txt"
+[[ -f "$ROOT_CMAKE" ]] || { echo "FAIL: missing $ROOT_CMAKE"; exit 2; }
+
+# Find the install(FILES … DESTINATION lib/cmake/Pulp) block and confirm
+# PulpLinkFontconfig.cmake is in it. Use python for multi-line block parse.
+python3 - "$ROOT_CMAKE" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+# Find any install(FILES …) block whose body mentions DESTINATION
+# lib/cmake/Pulp. Tolerant of formatting (whitespace, line wraps).
+blocks = re.findall(r'install\s*\(\s*FILES(.*?)\)', src, re.DOTALL)
+matching = [b for b in blocks if 'lib/cmake/Pulp' in b or 'cmake/Pulp' in b]
+if not matching:
+    print("  FAIL — no install(FILES …) block targets lib/cmake/Pulp/")
+    sys.exit(1)
+joined = '\n'.join(matching)
+if 'PulpLinkFontconfig.cmake' not in joined:
+    print("  FAIL — install(FILES …) block does not list PulpLinkFontconfig.cmake")
+    print("         (this is the regression that broke v0.101.5 SDK consumers)")
+    sys.exit(1)
+print("  PASS — install(FILES …) block ships PulpLinkFontconfig.cmake")
+PY
+[[ $? -eq 0 ]] && PASS=$((PASS+1)) || FAIL=$((FAIL+1))
+
+# ── Check 2: PulpUtils.cmake uses a stable, file-scope-captured include
+#           path for PulpLinkFontconfig.cmake ──────────────────────────
+UTILS="$PULP_SRC/tools/cmake/PulpUtils.cmake"
+[[ -f "$UTILS" ]] || { echo "FAIL: missing $UTILS"; exit 2; }
+
+# Reject the broken patterns explicitly. Both of these "look right" at a
+# glance but break under find_package consumers.
+if grep -nE 'include\([^)]*\$\{CMAKE_SOURCE_DIR\}.*PulpLinkFontconfig' "$UTILS" >/dev/null; then
+  echo "  FAIL — PulpUtils.cmake still uses \${CMAKE_SOURCE_DIR}/... for PulpLinkFontconfig"
+  echo "         (this points at downstream consumer's tree, not Pulp's — see #2089)"
+  FAIL=$((FAIL+1))
+else
+  echo "  PASS — PulpUtils.cmake does NOT use \${CMAKE_SOURCE_DIR}/... for PulpLinkFontconfig"
+  PASS=$((PASS+1))
+fi
+
+# Inside a function body, ${CMAKE_CURRENT_LIST_DIR} resolves to the
+# CALLER's file at execution time. So a bare ${CMAKE_CURRENT_LIST_DIR}/X
+# inside `function(_pulp_add_standalone …)` is ALSO broken downstream.
+# Detect by checking whether the include line uses our file-scope-captured
+# variable instead.
+if ! grep -nE 'include\([^)]*\$\{_pulp_utils_cmake_dir\}.*PulpLinkFontconfig' "$UTILS" >/dev/null; then
+  echo "  FAIL — PulpUtils.cmake does NOT use the file-scope \${_pulp_utils_cmake_dir}/..."
+  echo "         pattern for PulpLinkFontconfig (only that pattern survives both"
+  echo "         in-tree and downstream-find_package contexts — see #2089)"
+  FAIL=$((FAIL+1))
+else
+  echo "  PASS — PulpUtils.cmake uses file-scope \${_pulp_utils_cmake_dir}/..."
+  PASS=$((PASS+1))
+fi
+
+# Check 3: the file-scope variable is actually defined.
+if ! grep -nE '^set\(_pulp_utils_cmake_dir' "$UTILS" >/dev/null; then
+  echo "  FAIL — _pulp_utils_cmake_dir is referenced but never set at file scope"
+  FAIL=$((FAIL+1))
+else
+  echo "  PASS — _pulp_utils_cmake_dir is set at file scope"
+  PASS=$((PASS+1))
+fi
+
+echo ""
+echo "Result: $PASS pass, $FAIL fail"
+[[ "$FAIL" == "0" ]]

--- a/tools/cmake/PulpUtils.cmake
+++ b/tools/cmake/PulpUtils.cmake
@@ -7,6 +7,13 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/PulpAppIcon.cmake")
 
+# pulp #2089 — capture this file's directory at parse time. Inside function
+# bodies, CMAKE_CURRENT_LIST_DIR reflects the CALLER's file (downstream
+# consumer's CMakeLists.txt), not where this .cmake file lives. Capturing
+# at file scope gives us a stable handle whether we're loaded in-tree
+# (tools/cmake/) or as part of an installed SDK (lib/cmake/Pulp/).
+set(_pulp_utils_cmake_dir "${CMAKE_CURRENT_LIST_DIR}")
+
 function(_pulp_pick_target out_var)
     foreach(_candidate IN LISTS ARGN)
         if(TARGET "${_candidate}")
@@ -994,7 +1001,13 @@ function(_pulp_add_standalone target name bundle_id version)
     # transitively pulls in pulp::view → pulp::canvas → libskia.a, which
     # references Fc* symbols. Re-mention fontconfig AFTER the archive so
     # the linker resolves them. No-op on macOS/Windows/Android.
-    include(${CMAKE_SOURCE_DIR}/tools/cmake/PulpLinkFontconfig.cmake)
+    #
+    # pulp #2089 — use the file-scope-captured directory (set above when
+    # PulpUtils.cmake is parsed) so the include resolves whether we're
+    # in-tree (tools/cmake/) or consumed downstream from an installed SDK
+    # (lib/cmake/Pulp/). The earlier ${CMAKE_SOURCE_DIR} variant pointed
+    # at the downstream project's tree (broke find_package consumers).
+    include("${_pulp_utils_cmake_dir}/PulpLinkFontconfig.cmake")
     pulp_link_fontconfig_after_skia(${target}_Standalone)
 endfunction()
 


### PR DESCRIPTION
Two-part fix for the broken downstream-find_package consumer flow:

1. Root CMakeLists.txt: add `tools/cmake/PulpLinkFontconfig.cmake` to the
   `install(FILES … DESTINATION lib/cmake/Pulp)` rule so the helper actually
   ships in the SDK tarball (it was being referenced from PulpUtils.cmake but
   never installed).

2. tools/cmake/PulpUtils.cmake: replace the broken
     include(${CMAKE_SOURCE_DIR}/tools/cmake/PulpLinkFontconfig.cmake)
   with
     include("${_pulp_utils_cmake_dir}/PulpLinkFontconfig.cmake")
   where `_pulp_utils_cmake_dir` is captured at file-parse-time (file scope,
   not function scope). The original `${CMAKE_SOURCE_DIR}` resolved to the
   downstream consumer's source tree (e.g. /Users/.../spectr/), not Pulp's,
   so any plugin doing `find_package(Pulp REQUIRED)` and calling
   `pulp_add_plugin(... STANDALONE ...)` hit a configure-time
   "include could not find requested file" error.

   A naïve fix using bare `${CMAKE_CURRENT_LIST_DIR}` inside the function
   body would ALSO break — that variable reflects the caller's current
   list file at function-call time, not where PulpUtils.cmake lives. The
   file-scope capture is the only pattern that survives both contexts.

Repro
-----
v0.101.5 SDK install (the latest published) blocked any downstream from
configuring against an installed SDK on Linux paths. Verified the fix
locally by editing ~/.pulp/sdk/0.101.5/lib/cmake/Pulp/PulpUtils.cmake to
match this PR's pattern — Spectr then configured + built cleanly.

Test
----
test/test_install_consumer_cmake.sh exercises three static invariants
that together pin both halves of the bug:

1. install(FILES …) for lib/cmake/Pulp ships PulpLinkFontconfig.cmake
2. PulpUtils.cmake doesn't include via ${CMAKE_SOURCE_DIR}/...
3. PulpUtils.cmake uses the file-scope `_pulp_utils_cmake_dir` pattern

The release pipeline can layer a heavier "real install + consumer build"
test on top; this is the cheap pre-merge guard that catches this bug
class without a multi-minute build.

4/4 assertions pass locally.

Cross-refs
----------
- #2089 — original report from Spectr-rebuild attempt 2026-05-15
- #1986 — original PulpLinkFontconfig.cmake (same fontconfig fix for pulp-cli)
- #2018 — same fix for pulp-import-design