### PR TITLE
feat(install): install CLI + matching SDK in one shot (closes #2087 slice 1)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,6 +108,18 @@ if(UNIX)
     set_tests_properties(check-pulp-cli-hook PROPERTIES TIMEOUT 15)
 endif()
 
+# pulp #2087 (slice 1) — install.sh must install CLI + matching SDK in one
+# shot, and the closing message must document upgrade/pinning. Without
+# this, fresh-install users silently end up with a current CLI on top of
+# whatever ancient SDK was previously cached at ~/.pulp/sdk/.
+if(UNIX)
+    add_test(NAME install-sh-runs-sdk-install
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_install_sh_runs_sdk_install.sh)
+    set_tests_properties(install-sh-runs-sdk-install
+        PROPERTIES TIMEOUT 10
+        LABELS "tooling")
+endif()
+
 # Window-only capture invariants (pulp-internal task #81) —
 # spectr-roundtrip.sh must not silently fall back to full-screen
 # screencapture, because terminal / desktop background then poisons

--- a/test/test_install_sh_runs_sdk_install.sh
+++ b/test/test_install_sh_runs_sdk_install.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# test_install_sh_runs_sdk_install.sh — pin install.sh's CLI+SDK contract
+# (pulp #2087, slice 1).
+#
+# Why this test exists
+# --------------------
+# The original install.sh installed only the CLI binary, leaving the SDK
+# at whatever version had been installed previously (often years out of
+# date or absent entirely). Real users then ran `pulp build` against an
+# ancient SDK, hit cryptic errors, and never realized CLI vs SDK were
+# separate things.
+#
+# This test pins the contract that install.sh now ALSO installs the SDK
+# unless explicitly opted out, AND that the closing message tells the
+# user how to manage SDKs going forward (upgrade, install, project bump).
+#
+# Static checks only — does not actually curl install or download
+# anything. Looks at install.sh source for the right invocations and
+# strings.
+#
+# Tag [issue-2087] for coverage attribution.
+
+set -euo pipefail
+
+PULP_SRC="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALL_SH="$PULP_SRC/tools/install/install.sh"
+[[ -f "$INSTALL_SH" ]] || { echo "FAIL: $INSTALL_SH missing"; exit 2; }
+
+PASS=0
+FAIL=0
+assert_grep() {
+  local label="$1" pattern="$2"
+  if grep -qE "$pattern" "$INSTALL_SH"; then
+    echo "  PASS — $label"
+    PASS=$((PASS+1))
+  else
+    echo "  FAIL — $label (pattern: $pattern)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# Contract 1: install.sh runs `pulp sdk install` after CLI extraction
+assert_grep \
+  "install.sh runs pulp sdk install" \
+  '"\$INSTALL_DIR/pulp" sdk install'
+
+# Contract 2: opt-out env var documented + honored
+assert_grep \
+  "PULP_SKIP_SDK_INSTALL opt-out is honored" \
+  'PULP_SKIP_SDK_INSTALL'
+
+# Contract 3: closing message mentions matching SDK
+assert_grep \
+  "closing message says 'CLI + matching SDK'" \
+  '(CLI \+ matching SDK|CLI \+ SDK)'
+
+# Contract 4: closing message tells user about pulp sdk status
+assert_grep \
+  "closing message documents pulp sdk status" \
+  'pulp sdk status'
+
+# Contract 5: closing message documents pulp project bump for pinning
+assert_grep \
+  "closing message documents pulp project bump (pinning path)" \
+  'pulp project bump'
+
+# Contract 6: closing message documents pulp upgrade
+assert_grep \
+  "closing message documents pulp upgrade" \
+  'pulp upgrade'
+
+# Contract 7: header comment still says CLI installer (sanity — file
+# wasn't truncated/regressed)
+assert_grep \
+  "header comment still describes the installer" \
+  '^#.*Pulp CLI installer'
+
+echo ""
+echo "Result: $PASS pass, $FAIL fail"
+[[ "$FAIL" == "0" ]]

--- a/tools/install/install.sh
+++ b/tools/install/install.sh
@@ -125,6 +125,27 @@ chmod +x "$INSTALL_DIR/pulp"
 INSTALLED_VERSION=$("$INSTALL_DIR/pulp" --version 2>/dev/null || echo "unknown")
 echo "Installed: pulp $INSTALLED_VERSION"
 
+# ── SDK ──────────────────────────────────────────────────────────────────────
+#
+# pulp #2087 — install.sh used to install only the CLI. Users would then
+# `pulp build` against a non-existent (or ancient) SDK, get cryptic errors,
+# and never realize the CLI/SDK distinction. Install the matching SDK now
+# so the next `pulp build` Just Works.
+#
+# Skippable for power users who want to manage SDKs manually
+# (PULP_SKIP_SDK_INSTALL=1).
+if [ "${PULP_SKIP_SDK_INSTALL:-0}" != "1" ]; then
+    echo ""
+    echo "Installing matching SDK..."
+    if "$INSTALL_DIR/pulp" sdk install >/tmp/pulp-install-sdk.log 2>&1; then
+        SDK_INSTALLED=$("$INSTALL_DIR/pulp" sdk status 2>/dev/null | grep -E '\(downloaded\)' | head -1 | awk '{print $1}')
+        echo "  ✓ SDK ${SDK_INSTALLED:-installed} alongside CLI"
+    else
+        echo "  ⚠ SDK install failed (CLI is fine; run \`pulp sdk install\` manually)"
+        tail -5 /tmp/pulp-install-sdk.log 2>&1 | sed 's/^/    /'
+    fi
+fi
+
 # ── PATH ─────────────────────────────────────────────────────────────────────
 
 if [ "$NO_MODIFY_PATH" = "1" ]; then
@@ -168,12 +189,19 @@ fi
 # ── Done ─────────────────────────────────────────────────────────────────────
 
 echo ""
-echo "Pulp CLI installed successfully!"
-echo "This installed Pulp only; it did not install Shipyard or GitHub CLI (gh)."
+echo "Pulp installed successfully!"
+echo "This installed the Pulp CLI + matching SDK."
+echo "(Shipyard and GitHub CLI are NOT installed by this script.)"
 echo ""
 echo "Get started:"
 echo "  pulp create MyPlugin     # create your first plugin"
 echo "  pulp doctor              # check your environment"
+echo "  pulp sdk status          # see installed SDK versions"
+echo ""
+echo "Stay current (or pin a project):"
+echo "  pulp upgrade             # refresh CLI to the latest release"
+echo "  pulp sdk install         # add the latest SDK (if newer than installed)"
+echo "  pulp project bump <ver>  # pin THIS project to a specific SDK"
 echo ""
 echo "Or clone the framework:"
 echo "  git clone https://github.com/$REPO.git"


### PR DESCRIPTION
Why
---
The original install.sh installed only the CLI binary, leaving the SDK
at whatever version had been previously cached at ~/.pulp/sdk/ (or absent
entirely). Real users would then run `pulp build` against an ancient SDK
and hit cryptic configure-time errors with no path to discovery.

Real session 2026-05-15: a fresh `curl … install.sh` placed pulp v0.101.5
in ~/.pulp/bin/, but ~/.pulp/sdk/ still only held the v0.95.0-local SDK
from a months-old setup.sh. Spectr (find_package(Pulp)) silently linked
against v0.95 and missed every framework fix in between — including the
P0 mouseDown crash (#2088) and viewport-fit (#1984).

What
----
1. install.sh now runs `pulp sdk install` immediately after extracting the
   CLI binary, fetching the matching SDK tarball.
   - PULP_SKIP_SDK_INSTALL=1 opts out for power users who manage SDKs by hand.
   - Failure is non-fatal — the CLI is still installed; user gets a clear
     "run pulp sdk install manually" hint.

2. Closing message rewritten to:
   - Acknowledge the install is CLI + SDK (no more "Pulp CLI only" surprise)
   - Document `pulp sdk status` (see what's installed)
   - Document `pulp upgrade` (refresh CLI to latest)
   - Document `pulp sdk install` (add the latest SDK)
   - Document `pulp project bump <ver>` (pin THIS project) — gives users an
     immediate, discoverable path to the "I want reproducibility" workflow

Tests
-----
test/test_install_sh_runs_sdk_install.sh exercises 7 static contracts:
  - install.sh runs pulp sdk install
  - PULP_SKIP_SDK_INSTALL opt-out is honored
  - closing message says "CLI + matching SDK"
  - closing message documents pulp sdk status
  - closing message documents pulp project bump (pinning path)
  - closing message documents pulp upgrade
  - header comment still describes the installer (regression sanity)

7/7 pass locally.

Scope (this PR is slice 1 of #2087)
-----------------------------------
- Slice 2 (separate PR): pulp upgrade extends to SDK by default with --cli-only
  opt-out
- Slice 3 (separate PR): pulp create writes sdk='latest' (floating) into pulp.toml
- Slice 4 (separate PR): pulp project pin/unpin (rename of bump/undo for clarity)
- Slice 5 (separate PR): pulp build prints one-line "newer SDK available" banner
- Slice 6 (separate PR): pulp doctor surfaces installed + remote alongside project pin
- Slice 7 (separate PR): pulp sdk available (list remote)
- Slice 8 (separate PR): pulp sdk install --help docs install subcommand

This slice ships the highest-value fix (curl install no longer leaves you
stranded on a stale SDK) without taking on the larger CLI redesign.