### PR TITLE
test: batch ship package coverage helpers

### DIFF
--- a/test/test_android_package.cpp
+++ b/test/test_android_package.cpp
@@ -228,6 +228,16 @@ void write_fake_gradlew(const fs::path& project_dir, const fs::path& log_path) {
 #endif
 }
 
+void write_failing_gradlew(const fs::path& project_dir, int exit_code) {
+#ifdef _WIN32
+    write_tool(project_dir / "gradlew.bat",
+        "exit /b " + std::to_string(exit_code) + "\r\n");
+#else
+    write_tool(project_dir / "gradlew",
+        "exit " + std::to_string(exit_code) + "\n");
+#endif
+}
+
 void write_fake_bundletool(const fs::path& path, const fs::path& log_path) {
 #ifdef _WIN32
     write_tool(path,
@@ -304,6 +314,108 @@ TEST_CASE("Android SDK discovery falls back to SDK root and dedicated NDK home",
     REQUIRE(find_android_ndk() == standalone_ndk);
 }
 
+TEST_CASE("Android SDK discovery returns empty for invalid env roots",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto invalid_home = temp.path / "not-an-sdk";
+    fs::create_directories(invalid_home);
+
+    ScopedEnvVar android_home("ANDROID_HOME", invalid_home.string());
+    ScopedEnvVar android_sdk_root("ANDROID_SDK_ROOT", invalid_home.string());
+    ScopedEnvVar android_ndk_home("ANDROID_NDK_HOME", (temp.path / "not-an-ndk").string());
+    ScopedEnvVar home("HOME", (temp.path / "home").string());
+    ScopedUnsetEnvVar userprofile("USERPROFILE");
+
+    REQUIRE(detect_android_sdk().empty());
+    REQUIRE(find_android_ndk().empty());
+    REQUIRE(android_build_tools_version().empty());
+    REQUIRE(find_android_build_tool("apksigner").empty());
+}
+
+TEST_CASE("Android SDK discovery ignores empty tool directories",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto sdk = temp.path / "sdk";
+    fs::create_directories(sdk / "build-tools");
+    fs::create_directories(sdk / "ndk");
+
+    ScopedEnvVar android_home("ANDROID_HOME", sdk.string());
+    ScopedUnsetEnvVar android_sdk_root("ANDROID_SDK_ROOT");
+    ScopedUnsetEnvVar android_ndk_home("ANDROID_NDK_HOME");
+
+    REQUIRE(detect_android_sdk() == sdk);
+    REQUIRE(android_build_tools_version().empty());
+    REQUIRE(find_android_ndk().empty());
+}
+
+TEST_CASE("Android SDK discovery treats malformed revisions as zero",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto sdk = temp.path / "sdk";
+    fs::create_directories(sdk / "build-tools" / "preview");
+    fs::create_directories(sdk / "build-tools" / "1.preview");
+    fs::create_directories(sdk / "build-tools" / "1.0.1");
+    fs::create_directories(sdk / "ndk" / "beta" / "toolchains");
+    fs::create_directories(sdk / "ndk" / "1.0.1" / "toolchains");
+
+    ScopedEnvVar android_home("ANDROID_HOME", sdk.string());
+    ScopedUnsetEnvVar android_sdk_root("ANDROID_SDK_ROOT");
+    ScopedUnsetEnvVar android_ndk_home("ANDROID_NDK_HOME");
+
+    REQUIRE(android_build_tools_version() == "1.0.1");
+    REQUIRE(find_android_ndk() == sdk / "ndk" / "1.0.1");
+}
+
+TEST_CASE("Android Java version detection parses quoted java output",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto bin_dir = temp.path / "bin";
+    fs::create_directories(bin_dir);
+
+#ifdef _WIN32
+    write_tool(tool_path(bin_dir, "java"),
+        "echo openjdk version \"21.0.2\" 2026-01-16\r\n"
+        "exit /b 0\r\n");
+#else
+    write_tool(bin_dir / "java",
+        "echo 'openjdk version \"21.0.2\" 2026-01-16' >&2\n");
+#endif
+
+    auto old_path = read_env_var("PATH").value_or("");
+#ifdef _WIN32
+    ScopedEnvVar path_env("PATH", bin_dir.string() + ";" + old_path);
+#else
+    ScopedEnvVar path_env("PATH", bin_dir.string() + ":" + old_path);
+#endif
+
+    REQUIRE(detect_java_version() == "21.0.2");
+}
+
+TEST_CASE("Android Java version detection returns empty for unquoted output",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto bin_dir = temp.path / "bin";
+    fs::create_directories(bin_dir);
+
+#ifdef _WIN32
+    write_tool(tool_path(bin_dir, "java"),
+        "echo openjdk version 21.0.2\r\n"
+        "exit /b 0\r\n");
+#else
+    write_tool(bin_dir / "java",
+        "echo 'openjdk version 21.0.2' >&2\n");
+#endif
+
+    auto old_path = read_env_var("PATH").value_or("");
+#ifdef _WIN32
+    ScopedEnvVar path_env("PATH", bin_dir.string() + ";" + old_path);
+#else
+    ScopedEnvVar path_env("PATH", bin_dir.string() + ":" + old_path);
+#endif
+
+    REQUIRE(detect_java_version().empty());
+}
+
 TEST_CASE("Android signing helpers use SDK tools and parse APK verification output", "[ship][android]") {
     TempDir temp;
     auto sdk = make_fake_sdk(temp.path);
@@ -342,6 +454,30 @@ TEST_CASE("Android signing helpers use SDK tools and parse APK verification outp
     REQUIRE_THAT(log, ContainsSubstring("sign"));
     REQUIRE_THAT(log, ContainsSubstring("--ks-key-alias"));
     REQUIRE_THAT(log, ContainsSubstring("verify --print-certs --verbose"));
+}
+
+TEST_CASE("Android signing helpers fail cleanly when SDK tools are unavailable",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    ScopedEnvVar android_home("ANDROID_HOME", (temp.path / "missing-sdk").string());
+    ScopedUnsetEnvVar android_sdk_root("ANDROID_SDK_ROOT");
+    ScopedEnvVar home("HOME", (temp.path / "home").string());
+    ScopedUnsetEnvVar userprofile("USERPROFILE");
+
+    auto apk = temp.path / "app.apk";
+    std::ofstream(apk) << "apk";
+
+    AndroidKeystoreConfig keystore;
+    keystore.keystore_path = temp.path / "release.jks";
+    keystore.store_password = "store-pass";
+    keystore.key_alias = "release";
+
+    REQUIRE_FALSE(zipalign_apk(apk, temp.path / "aligned.apk"));
+    REQUIRE_FALSE(sign_apk(apk, keystore));
+
+    auto info = check_android_signing(apk);
+    REQUIRE_FALSE(info.is_signed);
+    REQUIRE_THAT(info.error, ContainsSubstring("apksigner not found"));
 }
 
 TEST_CASE("Android AAB signing and verification use jarsigner on PATH", "[ship][android]") {
@@ -413,6 +549,47 @@ TEST_CASE("Android Gradle packaging collects APK and AAB artifacts", "[ship][and
     REQUIRE_THAT(args, ContainsSubstring("-Pandroid.injected.signing.key.alias=release"));
 }
 
+TEST_CASE("Android Gradle packaging supports APK-only and AAB-only builds",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto project = temp.path / "android";
+    fs::create_directories(project);
+    auto gradle_log = temp.path / "gradle.args";
+    write_fake_gradlew(project, gradle_log);
+
+    auto apk_only = build_android_package(project, {}, nullptr, false, true);
+    INFO(apk_only.error);
+    REQUIRE(apk_only.success);
+    REQUIRE(apk_only.apk_path.filename() == "app-release.apk");
+    REQUIRE(apk_only.aab_path.empty());
+    REQUIRE_THAT(read_text(gradle_log), ContainsSubstring("assembleRelease"));
+    REQUIRE(read_text(gradle_log).find("bundleRelease") == std::string::npos);
+
+    fs::remove_all(project / "app" / "build" / "outputs");
+    auto aab_only = build_android_package(project, {}, nullptr, true, false);
+    INFO(aab_only.error);
+    REQUIRE(aab_only.success);
+    REQUIRE(aab_only.apk_path.empty());
+    REQUIRE(aab_only.aab_path.filename() == "app-release.aab");
+    REQUIRE_THAT(read_text(gradle_log), ContainsSubstring("bundleRelease"));
+    REQUIRE(read_text(gradle_log).find("assembleRelease") == std::string::npos);
+}
+
+TEST_CASE("Android Gradle packaging reports command failures",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto project = temp.path / "android";
+    fs::create_directories(project);
+    write_failing_gradlew(project, 7);
+
+    auto result = build_android_package(project, {"arm64-v8a"}, nullptr, true, true);
+
+    REQUIRE_FALSE(result.success);
+    REQUIRE(result.apk_path.empty());
+    REQUIRE(result.aab_path.empty());
+    REQUIRE_THAT(result.error, ContainsSubstring("Gradle build failed (exit code 7)"));
+}
+
 TEST_CASE("Android Gradle packaging reports missing wrapper and missing artifacts", "[ship][android]") {
     TempDir temp;
     auto missing_wrapper = build_android_package(temp.path / "missing", {}, nullptr, true, true);
@@ -461,4 +638,38 @@ TEST_CASE("Android bundletool conversion passes optional signing config", "[ship
     REQUIRE_THAT(args, ContainsSubstring("--bundle=" + aab.string()));
     REQUIRE_THAT(args, ContainsSubstring("--output=" + apks.string()));
     REQUIRE_THAT(args, ContainsSubstring("--ks-key-alias=release"));
+}
+
+TEST_CASE("Android bundletool conversion supports unsigned output",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto bundletool = tool_path(temp.path, "bundletool");
+    auto bundletool_log = temp.path / "bundletool-unsigned.args";
+    write_fake_bundletool(bundletool, bundletool_log);
+    ScopedEnvVar bundletool_env("BUNDLETOOL", bundletool.string());
+
+    auto aab = temp.path / "app-release.aab";
+    auto apks = temp.path / "app-release.apks";
+    std::ofstream(aab) << "aab";
+
+    REQUIRE(aab_to_apks(aab, apks, nullptr));
+    REQUIRE(fs::exists(apks));
+
+    auto args = read_text(bundletool_log);
+    REQUIRE_THAT(args, ContainsSubstring("build-apks"));
+    REQUIRE_THAT(args, ContainsSubstring("--overwrite"));
+    REQUIRE(args.find("--ks=") == std::string::npos);
+}
+
+TEST_CASE("Android bundletool conversion reports missing command",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    ScopedEnvVar bundletool_env("BUNDLETOOL", (temp.path / "missing-bundletool").string());
+
+    auto aab = temp.path / "app-release.aab";
+    auto apks = temp.path / "app-release.apks";
+    std::ofstream(aab) << "aab";
+
+    REQUIRE_FALSE(aab_to_apks(aab, apks, nullptr));
+    REQUIRE_FALSE(fs::exists(apks));
 }

--- a/test/test_android_package.cpp
+++ b/test/test_android_package.cpp
@@ -314,6 +314,23 @@ TEST_CASE("Android SDK discovery falls back to SDK root and dedicated NDK home",
     REQUIRE(find_android_ndk() == standalone_ndk);
 }
 
+TEST_CASE("Android SDK discovery skips invalid primary env roots",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto sdk = make_fake_sdk(temp.path);
+    auto invalid_sdk = temp.path / "invalid-sdk";
+    auto invalid_ndk = temp.path / "invalid-ndk";
+    fs::create_directories(invalid_sdk);
+    fs::create_directories(invalid_ndk);
+
+    ScopedEnvVar android_home("ANDROID_HOME", invalid_sdk.string());
+    ScopedEnvVar android_sdk_root("ANDROID_SDK_ROOT", sdk.string());
+    ScopedEnvVar android_ndk_home("ANDROID_NDK_HOME", invalid_ndk.string());
+
+    REQUIRE(detect_android_sdk() == sdk);
+    REQUIRE(find_android_ndk() == sdk / "ndk" / "27.0.12077973");
+}
+
 TEST_CASE("Android SDK discovery returns empty for invalid env roots",
           "[ship][android][coverage][issue-644]") {
     TempDir temp;
@@ -364,6 +381,24 @@ TEST_CASE("Android SDK discovery treats malformed revisions as zero",
 
     REQUIRE(android_build_tools_version() == "1.0.1");
     REQUIRE(find_android_ndk() == sdk / "ndk" / "1.0.1");
+}
+
+TEST_CASE("Android SDK discovery handles very large revision components",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto sdk = temp.path / "sdk";
+    const std::string huge = "999999999999999999999999999999";
+    fs::create_directories(sdk / "build-tools" / "100.0.0");
+    fs::create_directories(sdk / "build-tools" / huge);
+    fs::create_directories(sdk / "ndk" / "100.0.0" / "toolchains");
+    fs::create_directories(sdk / "ndk" / huge / "toolchains");
+
+    ScopedEnvVar android_home("ANDROID_HOME", sdk.string());
+    ScopedUnsetEnvVar android_sdk_root("ANDROID_SDK_ROOT");
+    ScopedUnsetEnvVar android_ndk_home("ANDROID_NDK_HOME");
+
+    REQUIRE(android_build_tools_version() == huge);
+    REQUIRE(find_android_ndk() == sdk / "ndk" / huge);
 }
 
 TEST_CASE("Android Java version detection parses quoted java output",

--- a/test/test_appcast.cpp
+++ b/test/test_appcast.cpp
@@ -236,6 +236,58 @@ TEST_CASE("Appcast from_xml ignores malformed enclosure length", "[ship][appcast
     REQUIRE(parsed->items[1].file_size == 0);
 }
 
+TEST_CASE("Appcast XML uses short version as build number when build is empty",
+          "[ship][appcast][coverage][issue-644]") {
+    Appcast feed;
+    feed.title = "Fallback Feed";
+    feed.link = "https://example.com/appcast.xml";
+    feed.description = "Fallback build number";
+
+    AppcastItem item;
+    item.version = "6.2.1";
+    item.title = "Version 6.2.1";
+    item.pub_date = "Sat, 06 Jun 2026 12:00:00 +0000";
+    item.download_url = "https://example.com/Pulp-6.2.1.pkg";
+    item.file_size = 621;
+    feed.items.push_back(item);
+
+    auto xml = feed.to_xml();
+
+    REQUIRE(xml.find("<sparkle:version>6.2.1</sparkle:version>") != std::string::npos);
+    REQUIRE(xml.find("<sparkle:shortVersionString>6.2.1</sparkle:shortVersionString>") != std::string::npos);
+}
+
+TEST_CASE("Appcast from_xml accepts rss with item-only metadata",
+          "[ship][appcast][coverage][issue-644]") {
+    auto parsed = Appcast::from_xml(R"(<rss version="2.0">
+  <channel>
+    <item>
+      <title>Nameless Release</title>
+      <sparkle:version>700</sparkle:version>
+      <sparkle:shortVersionString>7.0.0</sparkle:shortVersionString>
+      <enclosure url="https://example.com/Pulp-7.0.0.pkg" length="700" />
+    </item>
+  </channel>
+</rss>)");
+
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->title == "Nameless Release");
+    REQUIRE(parsed->link.empty());
+    REQUIRE(parsed->description.empty());
+    REQUIRE(parsed->items.size() == 1);
+    REQUIRE(parsed->items[0].title == "Nameless Release");
+    REQUIRE(parsed->items[0].build_number == "700");
+    REQUIRE(parsed->items[0].version == "7.0.0");
+}
+
+TEST_CASE("Appcast from_xml only requires rss marker",
+          "[ship][appcast][coverage][issue-644]") {
+    auto parsed = Appcast::from_xml("<rss version=\"2.0\"></rss>");
+
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->items.empty());
+}
+
 TEST_CASE("Version comparison", "[ship][version]") {
     REQUIRE(compare_versions("1.0.0", "1.0.0") == 0);
     REQUIRE(compare_versions("1.0.0", "1.0.1") == -1);
@@ -249,6 +301,15 @@ TEST_CASE("Version comparison tolerates non-numeric segments", "[ship][version]"
     REQUIRE(compare_versions("01.002.0003", "1.2.3") == 0);
     REQUIRE(compare_versions("1.beta.5", "1.0.7") == -1);
     REQUIRE(compare_versions("1..5", "1.0.4") == 1);
+}
+
+TEST_CASE("Version comparison pads and orders long mixed versions",
+          "[ship][version][coverage][issue-644]") {
+    REQUIRE(compare_versions("", "0") == 0);
+    REQUIRE(compare_versions("1.0.0", "1.0.0.0.0") == 0);
+    REQUIRE(compare_versions("1.0.0.0.1", "1.0.0.0") == 1);
+    REQUIRE(compare_versions("2.alpha.0", "2.0.1") == -1);
+    REQUIRE(compare_versions("2026.05.15", "2026.5.14") == 1);
 }
 
 // #295 P0 regression: sign_file_ed25519 MUST NOT silently return an

--- a/test/test_codesign.cpp
+++ b/test/test_codesign.cpp
@@ -33,6 +33,32 @@ TEST_CASE("check_notarization on nonexistent path is false", "[ship][codesign]")
     REQUIRE_FALSE(check_notarization("/nonexistent/binary"));
 }
 
+TEST_CASE("codesign rejects nonexistent path and identity",
+          "[ship][codesign][coverage][issue-644]") {
+    REQUIRE_FALSE(codesign("/nonexistent/binary", "Developer ID Application: Missing"));
+}
+
+TEST_CASE("codesign includes entitlements path on failure path",
+          "[ship][codesign][coverage][issue-644]") {
+    REQUIRE_FALSE(codesign("/nonexistent/binary",
+                           "Developer ID Application: Missing",
+                           "/nonexistent/entitlements.plist"));
+}
+
+TEST_CASE("notarization staple on nonexistent path is false",
+          "[ship][codesign][coverage][issue-644]") {
+    REQUIRE_FALSE(notarize_staple("/nonexistent/binary"));
+}
+
+TEST_CASE("create_pkg on nonexistent component is false",
+          "[ship][codesign][coverage][issue-644]") {
+    auto output = (fs::temp_directory_path() / "pulp-missing-component.pkg").string();
+    REQUIRE_FALSE(create_pkg("/nonexistent/component.vst3",
+                             output,
+                             "dev.pulp.missing",
+                             "1.0.0"));
+}
+
 TEST_CASE("list_signing_identities does not crash", "[ship][codesign]") {
     auto ids = list_signing_identities();
     // May be empty on CI, but should not crash

--- a/test/test_nsis_installer.cpp
+++ b/test/test_nsis_installer.cpp
@@ -193,3 +193,69 @@ TEST_CASE("NSIS script maps standalone and unknown formats to INSTDIR", "[ship][
     REQUIRE_THAT(script, ContainsSubstring("RMDir /r \"$INSTDIR\\TestPlugin.exe\""));
     REQUIRE_THAT(script, ContainsSubstring("RMDir /r \"$INSTDIR\\TestPlugin.lv2\""));
 }
+
+TEST_CASE("NSIS script handles empty plugin list with only post and uninstall sections",
+          "[ship][installer][coverage][issue-644]") {
+    auto config = make_test_config();
+    config.plugins.clear();
+    auto script = generate_nsis_script(config);
+
+    REQUIRE_THAT(script, ContainsSubstring("Name \"TestPlugin\""));
+    REQUIRE_THAT(script, ContainsSubstring("Section \"Uninstall\""));
+    REQUIRE_THAT(script, ContainsSubstring("Section \"-Post\""));
+    REQUIRE(script.find("TestPlugin (VST3)") == std::string::npos);
+    REQUIRE(script.find("TestPlugin (CLAP)") == std::string::npos);
+}
+
+TEST_CASE("NSIS script honors configured output path and install root",
+          "[ship][installer][coverage][issue-644]") {
+    auto config = make_test_config();
+    config.output_path = "dist/TestPlugin Setup.exe";
+    config.publisher = "Acme Audio";
+    auto script = generate_nsis_script(config);
+
+    REQUIRE_THAT(script, ContainsSubstring("OutFile \"dist/TestPlugin Setup.exe\""));
+    REQUIRE_THAT(script, ContainsSubstring("InstallDir \"$PROGRAMFILES\\Acme Audio\\TestPlugin\""));
+    REQUIRE_THAT(script, ContainsSubstring("InstallDirRegKey HKLM \"Software\\Acme Audio\\TestPlugin\""));
+}
+
+TEST_CASE("NSIS script installs file plugins without recursive flag",
+          "[ship][installer][coverage][issue-644]") {
+    ScopedTempDir temp;
+    auto plugin = temp.path / "TestPlugin.clap";
+    std::ofstream(plugin) << "plugin";
+
+    auto config = make_test_config();
+    config.plugins = {{plugin.string(), "", "clap"}};
+    auto script = generate_nsis_script(config);
+
+    REQUIRE_THAT(script, ContainsSubstring("File \"" + plugin.string() + "\""));
+    REQUIRE(script.find("File /r \"" + plugin.string() + "\"") == std::string::npos);
+    REQUIRE_THAT(script, ContainsSubstring("RMDir /r \"$COMMONFILES\\CLAP\\TestPlugin.clap\""));
+}
+
+TEST_CASE("NSIS script uses per-user plugin common directories",
+          "[ship][installer][coverage][issue-644]") {
+    auto config = make_test_config();
+    config.per_user_install = true;
+    auto script = generate_nsis_script(config);
+
+    REQUIRE_THAT(script, ContainsSubstring("SetOutPath \"$LOCALAPPDATA\\Programs\\Common\\VST3\""));
+    REQUIRE_THAT(script, ContainsSubstring("SetOutPath \"$LOCALAPPDATA\\Programs\\Common\\CLAP\""));
+    REQUIRE_THAT(script, ContainsSubstring("RMDir /r \"$LOCALAPPDATA\\Programs\\Common\\VST3\\TestPlugin.vst3\""));
+    REQUIRE_THAT(script, ContainsSubstring("RMDir /r \"$LOCALAPPDATA\\Programs\\Common\\CLAP\\TestPlugin.clap\""));
+}
+
+TEST_CASE("NSIS script keeps install_dir field non-authoritative for format destinations",
+          "[ship][installer][coverage][issue-644]") {
+    auto config = make_test_config();
+    config.plugins = {
+        {"/tmp/custom/TestPlugin.vst3", "C:/Ignored/VST3", "vst3"},
+        {"/tmp/custom/TestPlugin.clap", "C:/Ignored/CLAP", "clap"},
+    };
+    auto script = generate_nsis_script(config);
+
+    REQUIRE_THAT(script, ContainsSubstring("SetOutPath \"$COMMONFILES\\VST3\""));
+    REQUIRE_THAT(script, ContainsSubstring("SetOutPath \"$COMMONFILES\\CLAP\""));
+    REQUIRE(script.find("C:/Ignored") == std::string::npos);
+}

--- a/tools/local-ci/test_local_ci_extra.py
+++ b/tools/local-ci/test_local_ci_extra.py
@@ -36,6 +36,14 @@ class LocalCiPureHelperTests(unittest.TestCase):
 
     def test_state_dir_uses_xdg_and_home_fallbacks_on_non_macos(self) -> None:
         with mock.patch.object(self.mod.Path, "home", return_value=self.root / "home"):
+            with mock.patch.object(self.mod.sys, "platform", "darwin"):
+                with mock.patch.dict(os.environ, {}, clear=True):
+                    self.assertEqual(
+                        self.mod.state_dir(),
+                        self.root / "home" / "Library" / "Application Support" / "Pulp" / "local-ci",
+                    )
+
+        with mock.patch.object(self.mod.Path, "home", return_value=self.root / "home"):
             with mock.patch.object(self.mod.sys, "platform", "linux"):
                 with mock.patch.dict(os.environ, {"XDG_STATE_HOME": str(self.root / "xdg")}, clear=True):
                     self.assertEqual(
@@ -48,10 +56,35 @@ class LocalCiPureHelperTests(unittest.TestCase):
                         self.root / "home" / ".local" / "state" / "pulp" / "local-ci",
                     )
 
+    def test_state_path_helpers_create_expected_directories_and_logs(self) -> None:
+        with mock.patch.dict(os.environ, {"PULP_LOCAL_CI_HOME": str(self.root / "state")}, clear=True):
+            self.mod.ensure_state_dirs()
+            for path in (
+                self.mod.results_dir(),
+                self.mod.cloud_runs_dir(),
+                self.mod.logs_dir(),
+                self.mod.bundles_dir(),
+                self.mod.desktop_state_dir(),
+                self.mod.desktop_receipts_dir(),
+            ):
+                self.assertTrue(path.is_dir(), f"{path} should exist")
+
+            log_path = self.mod.prepare_target_log("job-1", "mac")
+            self.assertEqual(log_path, self.mod.target_log_path("job-1", "mac"))
+            self.assertTrue(log_path.is_file())
+            self.assertEqual(log_path.read_text(), "")
+
     def test_default_desktop_artifact_root_platform_branches(self) -> None:
         with mock.patch.object(self.mod.Path, "home", return_value=self.root / "home"):
             with mock.patch.dict(os.environ, {"PULP_DESKTOP_ARTIFACT_ROOT": str(self.root / "override")}, clear=True):
                 self.assertEqual(self.mod.default_desktop_artifact_root(), self.root / "override")
+
+            with mock.patch.object(self.mod.sys, "platform", "darwin"):
+                with mock.patch.dict(os.environ, {}, clear=True):
+                    self.assertEqual(
+                        self.mod.default_desktop_artifact_root(),
+                        self.root / "home" / "Library" / "Application Support" / "Pulp" / "desktop-automation" / "runs",
+                    )
 
             with mock.patch.object(self.mod.sys, "platform", "win32"):
                 with mock.patch.dict(os.environ, {"LOCALAPPDATA": str(self.root / "localapp")}, clear=True):
@@ -65,6 +98,11 @@ class LocalCiPureHelperTests(unittest.TestCase):
                     self.assertEqual(
                         self.mod.default_desktop_artifact_root(),
                         self.root / "xdg" / "pulp" / "desktop-automation" / "runs",
+                    )
+                with mock.patch.dict(os.environ, {}, clear=True):
+                    self.assertEqual(
+                        self.mod.default_desktop_artifact_root(),
+                        self.root / "home" / ".local" / "state" / "pulp" / "desktop-automation" / "runs",
                     )
 
     def test_normalizers_reject_invalid_modes_and_parse_booleans(self) -> None:

--- a/tools/scripts/test_android_target.py
+++ b/tools/scripts/test_android_target.py
@@ -56,6 +56,17 @@ class AndroidSdkDiscoveryTests(unittest.TestCase):
                  mock.patch.object(android_target.os, "getlogin", return_value="tester"):
                 self.assertEqual(android_target.find_android_sdk(), str(sdk))
 
+    def test_find_android_sdk_checks_linux_default_location(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            home = pathlib.Path(td)
+            sdk = home / "Android" / "Sdk"
+            sdk.mkdir(parents=True)
+
+            with mock.patch.dict(os.environ, {}, clear=True), \
+                 mock.patch.object(android_target.Path, "home", return_value=home), \
+                 mock.patch.object(android_target.os, "getlogin", return_value="tester"):
+                self.assertEqual(android_target.find_android_sdk(), str(sdk))
+
     def test_find_android_sdk_returns_empty_string_when_missing(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             home = pathlib.Path(td)
@@ -211,6 +222,24 @@ class BuildAndroidTests(unittest.TestCase):
         self.assertEqual(run.call_args.args[0], [str(gradlew), "assembleDebug"])
         self.assertIn("Android APK built", out.getvalue())
         self.assertIn("2.0 MB", out.getvalue())
+
+    def test_build_android_reports_success_when_expected_apk_is_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            android_dir = root / "android"
+            android_dir.mkdir()
+            gradlew = android_dir / "gradlew"
+            gradlew.write_text("#!/bin/sh\n", encoding="utf-8")
+            completed = subprocess.CompletedProcess([str(gradlew), "assembleDebug"], 0)
+
+            out = io.StringIO()
+            with mock.patch.object(android_target, "find_android_sdk", return_value="/sdk"), \
+                 mock.patch.object(android_target.subprocess, "run", return_value=completed), \
+                 contextlib.redirect_stdout(out):
+                rc = android_target.build_android(root, verbose=True)
+
+        self.assertEqual(rc, 0)
+        self.assertIn("Build succeeded but APK path not found", out.getvalue())
 
     def test_build_android_returns_gradle_failure_status(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/scripts/test_android_target.py
+++ b/tools/scripts/test_android_target.py
@@ -76,6 +76,24 @@ class AndroidSdkDiscoveryTests(unittest.TestCase):
                  mock.patch.object(android_target.os, "getlogin", return_value="tester"):
                 self.assertEqual(android_target.find_android_sdk(), "")
 
+    def test_find_android_sdk_ignores_missing_env_paths_and_falls_back(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            home = pathlib.Path(td)
+            sdk = home / "Android" / "Sdk"
+            sdk.mkdir(parents=True)
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "ANDROID_HOME": str(home / "missing-home"),
+                    "ANDROID_SDK_ROOT": str(home / "missing-root"),
+                },
+                clear=True,
+            ), \
+                 mock.patch.object(android_target.Path, "home", return_value=home), \
+                 mock.patch.object(android_target.os, "getlogin", return_value="tester"):
+                self.assertEqual(android_target.find_android_sdk(), str(sdk))
+
 
 class NdkDiscoveryTests(unittest.TestCase):
     def test_find_ndk_returns_latest_installation_with_toolchain_file(self) -> None:
@@ -152,6 +170,21 @@ class PrerequisiteTests(unittest.TestCase):
                  side_effect=FileNotFoundError,
              ):
             self.assertEqual(android_target.check_prerequisites(), ["Java not found in PATH"])
+
+    def test_check_prerequisites_reports_empty_java_version_output(self) -> None:
+        completed = subprocess.CompletedProcess(
+            ["java", "-version"],
+            0,
+            stderr="",
+        )
+
+        with mock.patch.object(android_target, "find_android_sdk", return_value="/sdk"), \
+             mock.patch.object(android_target, "find_ndk", return_value="/sdk/ndk/30"), \
+             mock.patch.object(android_target.subprocess, "run", return_value=completed):
+            self.assertEqual(
+                android_target.check_prerequisites(),
+                ["Java 17+ required. Found: "],
+            )
 
 
 class BuildAndroidTests(unittest.TestCase):

--- a/tools/scripts/test_auto_release_decision.py
+++ b/tools/scripts/test_auto_release_decision.py
@@ -36,6 +36,17 @@ spec.loader.exec_module(ard)
 
 
 class SemverCmpTests(unittest.TestCase):
+    def test_parse_version_accepts_numeric_triplets(self):
+        self.assertEqual(ard.parse_version("1.2.3"), (1, 2, 3))
+        self.assertEqual(ard.parse_version("01.002.0003"), (1, 2, 3))
+
+    def test_parse_version_rejects_missing_or_malformed_values(self):
+        self.assertIsNone(ard.parse_version(""))
+        self.assertIsNone(ard.parse_version(None))
+        self.assertIsNone(ard.parse_version("1.2"))
+        self.assertIsNone(ard.parse_version("1.2.3.4"))
+        self.assertIsNone(ard.parse_version("1.two.3"))
+
     def test_strict_greater(self):
         self.assertEqual(ard.semver_cmp("0.23.1", "0.23.0"), "gt")
         self.assertEqual(ard.semver_cmp("1.0.0", "0.99.99"), "gt")
@@ -58,6 +69,8 @@ class SemverCmpTests(unittest.TestCase):
         # Not strictly required, but document behavior
         self.assertEqual(ard.semver_cmp("not.a.version", "0.1.0"), "lt")
         self.assertEqual(ard.semver_cmp("0.1", "0.1.0"), "lt")
+        self.assertEqual(ard.semver_cmp("1.0.0", "latest"), "gt")
+        self.assertEqual(ard.semver_cmp("broken", "also-broken"), "eq")
 
 
 class DecideTests(unittest.TestCase):
@@ -282,6 +295,16 @@ class CliContractTests(unittest.TestCase):
 
         self.assertEqual(cm.exception.code, 2)
         self.assertIn("invalid choice", stderr.getvalue())
+
+    def test_cli_help_exits_zero(self):
+        stdout = io.StringIO()
+        with mock.patch.object(sys, "argv", ["auto_release_decision.py", "--help"]), \
+             contextlib.redirect_stdout(stdout):
+            with self.assertRaises(SystemExit) as cm:
+                ard.main()
+
+        self.assertEqual(cm.exception.code, 0)
+        self.assertIn("Decide whether auto-release.yml", stdout.getvalue())
 
     def test_script_entrypoint_prints_json_and_exits_zero(self):
         stdout = io.StringIO()

--- a/tools/scripts/test_build_migration_index_extra.py
+++ b/tools/scripts/test_build_migration_index_extra.py
@@ -144,6 +144,24 @@ class CodegenAndMainExtra(unittest.TestCase):
         self.assertIn("const MigrationEntry* const kMigrationIndex = nullptr;", generated)
         self.assertIn("const std::size_t kMigrationIndexSize = 0;", generated)
 
+    def test_emit_cpp_nonbreaking_default_and_source_comments(self):
+        entry = _bmi.Entry(
+            version="0.40.0",
+            breaking=False,
+            applies_if="",
+            summary="plain",
+            body="body",
+            source_path=pathlib.Path("docs/migrations/v0.40.0.md"),
+        )
+
+        generated = _bmi.emit_cpp([entry])
+
+        self.assertIn("// source: docs/migrations/v0.40.0.md", generated)
+        self.assertIn('"0.40.0"', generated)
+        self.assertIn("false", generated)
+        self.assertIn("const MigrationEntry* const kMigrationIndex = kTable;", generated)
+        self.assertIn("sizeof(kTable) / sizeof(kTable[0])", generated)
+
     def test_main_success_sorts_skips_readme_escapes_and_is_idempotent(self):
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)
@@ -200,6 +218,19 @@ class CodegenAndMainExtra(unittest.TestCase):
 
         self.assertEqual(result, 2)
         self.assertIn("docs dir not found", stderr)
+
+    def test_main_empty_docs_dir_writes_null_index(self):
+        with tempfile.TemporaryDirectory() as td:
+            docs = pathlib.Path(td) / "docs"
+            docs.mkdir()
+            out = pathlib.Path(td) / "generated" / "migration_index.cpp"
+
+            result = _bmi.main(["--docs-dir", str(docs), "--out", str(out)])
+
+            self.assertEqual(result, 0)
+            text = out.read_text(encoding="utf-8")
+            self.assertIn("No migration docs found", text)
+            self.assertIn("kMigrationIndex = nullptr", text)
 
     def test_main_duplicate_versions_fail_before_writing(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tools/scripts/test_coverage_diff_comment_extra.py
+++ b/tools/scripts/test_coverage_diff_comment_extra.py
@@ -36,11 +36,64 @@ class RenderPlainReportTests(unittest.TestCase):
         self.assertIn("core/runtime/src/base64.cpp", body)
         self.assertIn("<details>", body)
 
+    def test_top_level_heading_only_report_still_renders_details(self) -> None:
+        body = cdc.render(
+            "# Diff Coverage\n",
+            flip_date="2026-05-05",
+            threshold=80,
+        )
+
+        self.assertIn("<details>", body)
+        self.assertIn("</details>", body)
+        self.assertNotIn("# Diff Coverage", body)
+
+    def test_required_empty_report_uses_required_banner_without_details(self) -> None:
+        body = cdc.render(
+            "",
+            flip_date="2026-05-05",
+            threshold=80,
+            advisory=False,
+        )
+
+        self.assertIn("## Diff coverage (required)", body)
+        self.assertIn("Diff coverage threshold: **80%**", body)
+        self.assertIn("did not touch any instrumented source", body)
+        self.assertNotIn("informational only", body)
+        self.assertNotIn("<details>", body)
+
 
 class ReadReportEdgeTests(unittest.TestCase):
     def test_directory_report_returns_none(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             self.assertIsNone(cdc._read_report(pathlib.Path(tmpdir)))
+
+
+class MainExtraTests(unittest.TestCase):
+    def test_main_no_advisory_flag_writes_required_comment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = pathlib.Path(tmpdir)
+            report = tmp / "coverage-diff.md"
+            out = tmp / "coverage-diff-comment.md"
+            report.write_text(PLAIN_REPORT, encoding="utf-8")
+
+            rc = cdc.main(
+                [
+                    "--report",
+                    str(report),
+                    "--flip-date",
+                    "2026-05-05",
+                    "--threshold",
+                    "80",
+                    "--no-advisory",
+                    "--out",
+                    str(out),
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            body = out.read_text(encoding="utf-8")
+            self.assertIn("## Diff coverage (required)", body)
+            self.assertIn("core/runtime/src/base64.cpp", body)
 
 
 class ScriptEntrypointTests(unittest.TestCase):

--- a/tools/scripts/test_coverage_tier_check_extra.py
+++ b/tools/scripts/test_coverage_tier_check_extra.py
@@ -334,6 +334,25 @@ class RenderExtraTests(unittest.TestCase):
 
         self.assertEqual(result.percent, 100.0)
 
+    def test_render_failure_lists_only_failed_tiers(self) -> None:
+        body = ctc.render(
+            [
+                ctc.TierResult(
+                    tier=ctc.Tier("audio-critical", 80, ("core/audio/**",)),
+                    touched_lines=4,
+                    covered_lines=4,
+                ),
+                ctc.TierResult(
+                    tier=ctc.Tier("user-facing", 70, ("core/view/**",)),
+                    touched_lines=4,
+                    covered_lines=2,
+                ),
+            ]
+        )
+
+        self.assertIn("**Per-tier gate failed:** user-facing", body)
+        self.assertNotIn("audio-critical below", body)
+
 
 class AggregateExtraTests(unittest.TestCase):
 
@@ -356,11 +375,65 @@ class AggregateExtraTests(unittest.TestCase):
         self.assertEqual(results[0].touched_lines, 0)
         self.assertEqual(results[0].files, [])
 
+    def test_missing_instrumented_file_records_uncovered_diff_lines(self) -> None:
+        tier = ctc.Tier("audio-critical", 80, ("core/audio/**",))
+
+        results = ctc.aggregate(
+            [tier],
+            ["core/audio/src/new_voice.cpp"],
+            {},
+            lines_getter=lambda _p: {3, 4, 5},
+        )
+
+        self.assertEqual(results[0].touched_lines, 3)
+        self.assertEqual(results[0].covered_lines, 0)
+        self.assertEqual(results[0].files, ["core/audio/src/new_voice.cpp"])
+        self.assertFalse(results[0].passed)
+
+    def test_unclassified_instrumented_file_is_ignored_by_per_tier_gate(self) -> None:
+        tier = ctc.Tier("audio-critical", 80, ("core/audio/**",))
+        getter = mock.Mock(return_value={1, 2, 3})
+
+        results = ctc.aggregate(
+            [tier],
+            ["third_party/lib.cpp"],
+            {},
+            lines_getter=getter,
+        )
+
+        self.assertEqual(results[0].touched_lines, 0)
+        getter.assert_not_called()
+
+    def test_non_instrumented_tier_file_does_not_query_diff_lines(self) -> None:
+        tier = ctc.Tier("infra", 50, ("tools/**",))
+        getter = mock.Mock(return_value={1, 2, 3})
+
+        results = ctc.aggregate(
+            [tier],
+            ["tools/scripts/release_notes.py"],
+            {},
+            lines_getter=getter,
+        )
+
+        self.assertEqual(results[0].touched_lines, 0)
+        getter.assert_not_called()
+
 
 class InstrumentedSourceExtraTests(unittest.TestCase):
 
     def test_extensionless_path_is_not_instrumented(self) -> None:
         self.assertFalse(ctc.is_instrumented_source("tools/scripts/pulp-helper"))
+
+    def test_extension_match_is_case_insensitive(self) -> None:
+        self.assertTrue(ctc.is_instrumented_source("core/audio/src/Plugin.CPP"))
+
+    def test_react_surface_matches_only_exact_prefix(self) -> None:
+        self.assertTrue(
+            ctc.is_instrumented_source("packages/pulp-react/src/widget.tsx")
+        )
+        self.assertFalse(
+            ctc.is_instrumented_source("packages/pulp-reactive/src/widget.tsx")
+        )
 
 
 if __name__ == "__main__":

--- a/tools/scripts/test_fetch_skia_for_release.py
+++ b/tools/scripts/test_fetch_skia_for_release.py
@@ -168,6 +168,31 @@ class ManifestValidation(unittest.TestCase):
 
         self.assertEqual(rc, 0)
 
+    def test_known_platform_without_asset_reports_matrix_and_manifest_key(self):
+        with _in_tempdir() as td:
+            (td / "tools" / "deps").mkdir(parents=True)
+            manifest = {
+                "dependencies": [
+                    {
+                        "name": "Skia",
+                        "determinism": {"release_assets": {}},
+                    }
+                ]
+            }
+            (td / "tools" / "deps" / "manifest.json").write_text(
+                json.dumps(manifest), encoding="utf-8"
+            )
+
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                rc = fetch_skia.main(
+                    ["fetch_skia_for_release.py", "windows-arm64"]
+                )
+
+        self.assertEqual(rc, 0)
+        self.assertIn("matrix=windows-arm64", out.getvalue())
+        self.assertIn("manifest key 'win-arm64'", out.getvalue())
+
 
 class FlatLayoutSucceeds(unittest.TestCase):
     """Pre-m144 layout: libs flat under Release/ (no arch subdir)."""
@@ -193,6 +218,7 @@ class FlatLayoutSucceeds(unittest.TestCase):
             )
             self.assertTrue(expected.is_file())
             self.assertEqual(expected.read_bytes(), b"skia-flat")
+            self.assertFalse((td / "skia-release-asset.zip").exists())
 
 
 class ArchSubdirLayoutFlattens(unittest.TestCase):
@@ -340,6 +366,27 @@ class MissingLibFails(unittest.TestCase):
                 ["fetch_skia_for_release.py", "darwin-arm64"]
             )
             self.assertEqual(rc, 1, "missing libskia.a must exit non-zero")
+
+    def test_no_lib_prints_directory_listing(self):
+        with _in_tempdir() as td:
+            zip_path = td / "skia-empty.zip"
+            payload = {
+                "build/mac-gpu/lib/Release/README.txt": b"no libs here",
+            }
+            sha = _make_zip(zip_path, payload)
+            _write_manifest(
+                td, f"file://{zip_path.as_posix()}", sha, "mac-arm64"
+            )
+
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                rc = fetch_skia.main(
+                    ["fetch_skia_for_release.py", "darwin-arm64"]
+                )
+
+        self.assertEqual(rc, 1)
+        self.assertIn("expected library not found", err.getvalue())
+        self.assertIn("README.txt", err.getvalue())
 
 
 class Sha256MismatchFails(unittest.TestCase):

--- a/tools/scripts/test_fetch_skia_for_release.py
+++ b/tools/scripts/test_fetch_skia_for_release.py
@@ -104,12 +104,25 @@ class ExpectedLibraryPath(unittest.TestCase):
 
 
 class UnknownMatrixPlatform(unittest.TestCase):
+    def test_missing_platform_argument_returns_usage_error(self):
+        with _in_tempdir():
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                rc = fetch_skia.main(["fetch_skia_for_release.py"])
+
+        self.assertEqual(rc, 2)
+        self.assertIn("usage:", err.getvalue())
+
     def test_returns_zero_with_warning(self):
         with _in_tempdir():
-            rc = fetch_skia.main(
-                ["fetch_skia_for_release.py", "amiga-68k"]
-            )
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                rc = fetch_skia.main(
+                    ["fetch_skia_for_release.py", "amiga-68k"]
+                )
+
         self.assertEqual(rc, 0)
+        self.assertIn("unknown matrix platform", err.getvalue())
 
 
 class ManifestValidation(unittest.TestCase):
@@ -258,6 +271,56 @@ class ArchSubdirLayoutFlattens(unittest.TestCase):
             )
             self.assertTrue(expected.is_file())
             self.assertEqual(expected.read_bytes(), b"linux-skia")
+
+    def test_windows_x64_arch_subdir(self):
+        with _in_tempdir() as td:
+            zip_path = td / "skia-win.zip"
+            payload = {
+                "build/win-gpu/lib/Release/x64/skia.lib": b"windows-skia",
+                "build/win-gpu/lib/Release/x64/skparagraph.lib": b"windows-para",
+            }
+            sha = _make_zip(zip_path, payload)
+            _write_manifest(
+                td, f"file://{zip_path.as_posix()}", sha, "win-x64"
+            )
+
+            rc = fetch_skia.main(["fetch_skia_for_release.py", "windows-x64"])
+
+            self.assertEqual(rc, 0)
+            release_dir = (
+                td / "external/skia-build/build/win-gpu/lib/Release"
+            )
+            self.assertEqual((release_dir / "skia.lib").read_bytes(), b"windows-skia")
+            self.assertEqual(
+                (release_dir / "skparagraph.lib").read_bytes(), b"windows-para"
+            )
+
+    def test_arch_subdir_does_not_clobber_existing_flat_file(self):
+        with _in_tempdir() as td:
+            zip_path = td / "skia-mac.zip"
+            payload = {
+                "build/mac-gpu/lib/Release/arm64/libskia.a": b"arch-copy",
+                "build/mac-gpu/lib/Release/libdawn_combined.a": b"already-flat",
+                "build/mac-gpu/lib/Release/arm64/libdawn_combined.a": b"dawn",
+            }
+            sha = _make_zip(zip_path, payload)
+            _write_manifest(
+                td, f"file://{zip_path.as_posix()}", sha, "mac-arm64"
+            )
+
+            rc = fetch_skia.main(
+                ["fetch_skia_for_release.py", "darwin-arm64"]
+            )
+
+            self.assertEqual(rc, 0)
+            release_dir = (
+                td / "external/skia-build/build/mac-gpu/lib/Release"
+            )
+            self.assertEqual((release_dir / "libskia.a").read_bytes(), b"arch-copy")
+            self.assertEqual(
+                (release_dir / "libdawn_combined.a").read_bytes(), b"already-flat"
+            )
+            self.assertTrue((release_dir / "arm64" / "libdawn_combined.a").is_file())
 
 
 class MissingLibFails(unittest.TestCase):

--- a/tools/scripts/test_fetch_skia_for_release.py
+++ b/tools/scripts/test_fetch_skia_for_release.py
@@ -112,6 +112,50 @@ class UnknownMatrixPlatform(unittest.TestCase):
         self.assertEqual(rc, 0)
 
 
+class ManifestValidation(unittest.TestCase):
+    def test_missing_manifest_fails_for_known_platform(self):
+        with _in_tempdir():
+            rc = fetch_skia.main(
+                ["fetch_skia_for_release.py", "darwin-arm64"]
+            )
+        self.assertEqual(rc, 1)
+
+    def test_manifest_without_skia_dependency_fails(self):
+        with _in_tempdir() as td:
+            (td / "tools" / "deps").mkdir(parents=True)
+            (td / "tools" / "deps" / "manifest.json").write_text(
+                json.dumps({"dependencies": [{"name": "Other"}]}),
+                encoding="utf-8",
+            )
+
+            rc = fetch_skia.main(
+                ["fetch_skia_for_release.py", "darwin-arm64"]
+            )
+
+        self.assertEqual(rc, 1)
+
+    def test_known_platform_without_asset_skips(self):
+        with _in_tempdir() as td:
+            (td / "tools" / "deps").mkdir(parents=True)
+            manifest = {
+                "dependencies": [
+                    {
+                        "name": "Skia",
+                        "determinism": {"release_assets": {}},
+                    }
+                ]
+            }
+            (td / "tools" / "deps" / "manifest.json").write_text(
+                json.dumps(manifest), encoding="utf-8"
+            )
+
+            rc = fetch_skia.main(
+                ["fetch_skia_for_release.py", "windows-arm64"]
+            )
+
+        self.assertEqual(rc, 0)
+
+
 class FlatLayoutSucceeds(unittest.TestCase):
     """Pre-m144 layout: libs flat under Release/ (no arch subdir)."""
 
@@ -172,6 +216,28 @@ class ArchSubdirLayoutFlattens(unittest.TestCase):
                 (release_dir / "arm64").exists(),
                 "arm64/ subdir should be removed after flatten",
             )
+
+    def test_arch_subdir_with_nested_dir_keeps_nonempty_dir(self):
+        with _in_tempdir() as td:
+            zip_path = td / "skia-mac.zip"
+            payload = {
+                "build/mac-gpu/lib/Release/arm64/libskia.a": b"skia-arch",
+                "build/mac-gpu/lib/Release/arm64/obj/keep.txt": b"keep",
+            }
+            sha = _make_zip(zip_path, payload)
+            _write_manifest(
+                td, f"file://{zip_path.as_posix()}", sha, "mac-arm64"
+            )
+            rc = fetch_skia.main(
+                ["fetch_skia_for_release.py", "darwin-arm64"]
+            )
+
+            self.assertEqual(rc, 0)
+            release_dir = (
+                td / "external/skia-build/build/mac-gpu/lib/Release"
+            )
+            self.assertTrue((release_dir / "libskia.a").is_file())
+            self.assertTrue((release_dir / "arm64" / "obj" / "keep.txt").is_file())
 
     def test_linux_x64_arch_subdir(self):
         with _in_tempdir() as td:

--- a/tools/scripts/test_merge_cobertura_extra.py
+++ b/tools/scripts/test_merge_cobertura_extra.py
@@ -62,6 +62,32 @@ class ParseXmlEdgeTests(unittest.TestCase):
             },
         )
 
+    def test_parse_normalizes_windows_paths_and_filters_ignored_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            coverage = ET.Element("coverage")
+            classes = ET.SubElement(
+                ET.SubElement(ET.SubElement(coverage, "packages"), "package"),
+                "classes",
+            )
+            for filename in (
+                r"core\format\src\clap_adapter.cpp",
+                r"test\test_host.cpp",
+                r"build\generated.cpp",
+                r"external\dep.cpp",
+            ):
+                cls = ET.SubElement(
+                    classes,
+                    "class",
+                    attrib={"name": filename, "filename": filename},
+                )
+                lines = ET.SubElement(cls, "lines")
+                ET.SubElement(lines, "line", attrib={"number": "1", "hits": "1"})
+
+            parsed = mc.parse_xml(_write_tree(tmp / "windows.xml", coverage))
+
+        self.assertEqual(parsed, {"core/format/src/clap_adapter.cpp": {1: 1}})
+
 
 class RenderEdgeTests(unittest.TestCase):
     def test_render_handles_empty_totals_and_empty_file_line_sets(self) -> None:
@@ -109,6 +135,28 @@ class CliEntrypointTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertIn("merged 1 XML(s)", proc.stderr)
         self.assertEqual(reparsed, {"core/cli.cpp": {9: 2}})
+
+    def test_main_returns_distinct_code_when_all_inputs_are_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            out = tmp / "merged.xml"
+
+            rc = mc.main([str(tmp / "missing.xml"), "--out", str(out)])
+
+        self.assertEqual(rc, mc.EXIT_ALL_INPUTS_MISSING)
+        self.assertFalse(out.exists())
+
+    def test_main_rejects_corrupt_xml_without_empty_input_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            corrupt = tmp / "corrupt.xml"
+            corrupt.write_text("<coverage>", encoding="utf-8")
+            out = tmp / "merged.xml"
+
+            rc = mc.main(["--out", str(out), str(corrupt)])
+
+        self.assertEqual(rc, 1)
+        self.assertFalse(out.exists())
 
 
 if __name__ == "__main__":

--- a/tools/scripts/test_package_cli_extra.py
+++ b/tools/scripts/test_package_cli_extra.py
@@ -82,6 +82,50 @@ class FindWgpuLibExtraTests(unittest.TestCase):
 
 
 class RpathExtraTests(unittest.TestCase):
+    def test_fix_rpath_macos_deletes_multiple_absolute_rpaths(self) -> None:
+        otool_output = """
+Load command 1
+          cmd LC_RPATH
+      cmdsize 48
+         path /Users/runner/Library/Caches/Pulp/wgpu (offset 12)
+Load command 2
+          cmd LC_RPATH
+      cmdsize 48
+         path /opt/pulp/cache/wgpu (offset 12)
+Load command 3
+          cmd LC_RPATH
+      cmdsize 40
+         path @loader_path (offset 12)
+        """
+        binary = pathlib.Path("/tmp/pulp")
+
+        with mock.patch.object(pc.subprocess, "check_output", return_value=otool_output):
+            with mock.patch.object(pc.subprocess, "check_call") as check_call:
+                with mock.patch.object(pc.subprocess, "run") as run:
+                    pc.fix_rpath_macos(binary)
+
+        self.assertEqual(check_call.call_count, 2)
+        check_call.assert_any_call(
+            [
+                "install_name_tool",
+                "-delete_rpath",
+                "/Users/runner/Library/Caches/Pulp/wgpu",
+                str(binary),
+            ]
+        )
+        check_call.assert_any_call(
+            [
+                "install_name_tool",
+                "-delete_rpath",
+                "/opt/pulp/cache/wgpu",
+                str(binary),
+            ]
+        )
+        run.assert_called_once_with(
+            ["install_name_tool", "-add_rpath", "@loader_path", str(binary)],
+            check=False,
+        )
+
     def test_fix_rpath_macos_ignores_relative_rpath(self) -> None:
         otool_output = """
 Load command 1
@@ -111,6 +155,35 @@ Load command 1
 
         check_call.assert_not_called()
         run.assert_called_once()
+
+
+class StageBinaryExtraTests(unittest.TestCase):
+    def test_stage_binary_sets_unix_executable_bit(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            src = root / "built-pulp"
+            src.write_text("binary", encoding="utf-8")
+            stage = root / "stage"
+            stage.mkdir()
+
+            staged = pc.stage_binary(src, stage, "pulp", is_windows=False)
+
+            self.assertEqual(staged, stage / "pulp")
+            self.assertEqual(staged.read_text(encoding="utf-8"), "binary")
+            self.assertTrue(pc.os.access(staged, pc.os.X_OK))
+
+    def test_stage_binary_keeps_windows_copy_non_executable(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            src = root / "built-pulp.exe"
+            src.write_text("binary", encoding="utf-8")
+            stage = root / "stage"
+            stage.mkdir()
+
+            staged = pc.stage_binary(src, stage, "pulp.exe", is_windows=True)
+
+            self.assertEqual(staged, stage / "pulp.exe")
+            self.assertEqual(staged.read_text(encoding="utf-8"), "binary")
 
 
 class MainExtraTests(unittest.TestCase):
@@ -144,6 +217,39 @@ class MainExtraTests(unittest.TestCase):
             fix_rpath.assert_called_once()
             with tarfile.open(out, "r:gz") as tar:
                 self.assertEqual(sorted(tar.getnames()), ["libwgpu_native.dylib", "pulp"])
+
+    def test_main_packages_unknown_platform_as_tarball_without_rpath(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp-built"
+            binary.write_text("binary", encoding="utf-8")
+            wgpu = root / "libwgpu_native.custom"
+            wgpu.write_text("wgpu", encoding="utf-8")
+            out = root / "pulp-custom.tar.gz"
+
+            with mock.patch.object(pc, "find_wgpu_lib", return_value=wgpu):
+                with mock.patch.object(pc, "fix_rpath_macos") as mac_rpath:
+                    with mock.patch.object(pc, "fix_rpath_linux") as linux_rpath:
+                        with argv(
+                            [
+                                "package_cli.py",
+                                "--binary",
+                                str(binary),
+                                "--build-dir",
+                                str(root / "build"),
+                                "--platform",
+                                "haiku-x64",
+                                "--out",
+                                str(out),
+                            ]
+                        ):
+                            rc = pc.main()
+
+            self.assertEqual(rc, 0)
+            mac_rpath.assert_not_called()
+            linux_rpath.assert_not_called()
+            with tarfile.open(out, "r:gz") as tar:
+                self.assertEqual(sorted(tar.getnames()), ["libwgpu_native.custom", "pulp"])
 
     def test_script_entrypoint_reports_missing_binary(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/scripts/test_package_cli_extra.py
+++ b/tools/scripts/test_package_cli_extra.py
@@ -35,6 +35,20 @@ def argv(args: list[str]):
 
 
 class FindWgpuLibExtraTests(unittest.TestCase):
+    def test_find_wgpu_lib_prefers_build_dir_before_cache_roots(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_lib = root / "build" / "_deps" / "wgpu" / "libwgpu_native.so"
+            cache_lib = root / "home" / ".cache" / "pulp" / "libwgpu_native.so"
+            build_lib.parent.mkdir(parents=True)
+            cache_lib.parent.mkdir(parents=True)
+            build_lib.write_text("build", encoding="utf-8")
+            cache_lib.write_text("cache", encoding="utf-8")
+
+            with mock.patch.object(pc.Path, "home", return_value=root / "home"):
+                with mock.patch.dict(pc.os.environ, {}, clear=True):
+                    self.assertEqual(pc.find_wgpu_lib(root / "build", "linux-x64"), build_lib)
+
     def test_find_wgpu_lib_dedupes_roots_and_ignores_non_file_matches(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)
@@ -281,6 +295,48 @@ class MainExtraTests(unittest.TestCase):
                 self.assertEqual(
                     sorted(z.namelist()),
                     ["pulp-cpp.exe", "pulp.exe", "wgpu_native.dll"],
+                )
+
+    def test_main_rewrites_macos_rpath_for_primary_and_delegate(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp-built"
+            cpp_binary = root / "pulp-cpp-built"
+            wgpu = root / "libwgpu_native.dylib"
+            binary.write_text("binary", encoding="utf-8")
+            cpp_binary.write_text("cpp", encoding="utf-8")
+            wgpu.write_text("wgpu", encoding="utf-8")
+            out = root / "pulp-darwin-x64.tar.gz"
+
+            with mock.patch.object(pc, "find_wgpu_lib", return_value=wgpu):
+                with mock.patch.object(pc, "fix_rpath_macos") as fix_rpath:
+                    with argv(
+                        [
+                            "package_cli.py",
+                            "--binary",
+                            str(binary),
+                            "--cpp-binary",
+                            str(cpp_binary),
+                            "--build-dir",
+                            str(root / "build"),
+                            "--platform",
+                            "darwin-x64",
+                            "--out",
+                            str(out),
+                        ]
+                    ):
+                        rc = pc.main()
+
+            self.assertEqual(rc, 0)
+            self.assertEqual(fix_rpath.call_count, 2)
+            self.assertEqual(
+                [call.args[0].name for call in fix_rpath.call_args_list],
+                ["pulp", "pulp-cpp"],
+            )
+            with tarfile.open(out, "r:gz") as tar:
+                self.assertEqual(
+                    sorted(tar.getnames()),
+                    ["libwgpu_native.dylib", "pulp", "pulp-cpp"],
                 )
 
     def test_main_rewrites_linux_rpath_for_primary_and_delegate(self) -> None:

--- a/tools/scripts/test_package_cli_extra.py
+++ b/tools/scripts/test_package_cli_extra.py
@@ -12,6 +12,7 @@ import sys
 import tarfile
 import tempfile
 import unittest
+import zipfile
 from unittest import mock
 
 
@@ -187,6 +188,143 @@ class StageBinaryExtraTests(unittest.TestCase):
 
 
 class MainExtraTests(unittest.TestCase):
+    def test_main_rejects_missing_cpp_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp-built"
+            binary.write_text("binary", encoding="utf-8")
+
+            with argv(
+                [
+                    "package_cli.py",
+                    "--binary",
+                    str(binary),
+                    "--cpp-binary",
+                    str(root / "missing-pulp-cpp"),
+                    "--build-dir",
+                    str(root / "build"),
+                    "--platform",
+                    "linux-x64",
+                    "--out",
+                    str(root / "pulp-linux-x64.tar.gz"),
+                ]
+            ):
+                with contextlib.redirect_stderr(io.StringIO()) as stderr:
+                    rc = pc.main()
+
+            self.assertEqual(rc, 2)
+            self.assertIn("FAIL: --cpp-binary not at", stderr.getvalue())
+
+    def test_main_rejects_missing_wgpu_library(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp-built"
+            binary.write_text("binary", encoding="utf-8")
+            out = root / "pulp-linux-x64.tar.gz"
+
+            with mock.patch.object(pc, "find_wgpu_lib", return_value=None):
+                with argv(
+                    [
+                        "package_cli.py",
+                        "--binary",
+                        str(binary),
+                        "--build-dir",
+                        str(root / "build"),
+                        "--platform",
+                        "linux-x64",
+                        "--out",
+                        str(out),
+                    ]
+                ):
+                    with contextlib.redirect_stderr(io.StringIO()) as stderr:
+                        rc = pc.main()
+
+            self.assertEqual(rc, 1)
+            self.assertFalse(out.exists())
+            self.assertIn("wgpu native library not found", stderr.getvalue())
+
+    def test_main_packages_windows_zip_with_delegate_and_dll(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp-built.exe"
+            cpp_binary = root / "pulp-cpp-built.exe"
+            wgpu = root / "wgpu_native.dll"
+            binary.write_text("binary", encoding="utf-8")
+            cpp_binary.write_text("cpp", encoding="utf-8")
+            wgpu.write_text("wgpu", encoding="utf-8")
+            out = root / "pulp-windows-x64.zip"
+
+            with mock.patch.object(pc, "find_wgpu_lib", return_value=wgpu):
+                with mock.patch.object(pc, "fix_rpath_macos") as mac_rpath:
+                    with mock.patch.object(pc, "fix_rpath_linux") as linux_rpath:
+                        with argv(
+                            [
+                                "package_cli.py",
+                                "--binary",
+                                str(binary),
+                                "--cpp-binary",
+                                str(cpp_binary),
+                                "--build-dir",
+                                str(root / "build"),
+                                "--platform",
+                                "windows-x64",
+                                "--out",
+                                str(out),
+                            ]
+                        ):
+                            rc = pc.main()
+
+            self.assertEqual(rc, 0)
+            mac_rpath.assert_not_called()
+            linux_rpath.assert_not_called()
+            with zipfile.ZipFile(out) as z:
+                self.assertEqual(
+                    sorted(z.namelist()),
+                    ["pulp-cpp.exe", "pulp.exe", "wgpu_native.dll"],
+                )
+
+    def test_main_rewrites_linux_rpath_for_primary_and_delegate(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp-built"
+            cpp_binary = root / "pulp-cpp-built"
+            wgpu = root / "libwgpu_native.so"
+            binary.write_text("binary", encoding="utf-8")
+            cpp_binary.write_text("cpp", encoding="utf-8")
+            wgpu.write_text("wgpu", encoding="utf-8")
+            out = root / "pulp-linux-x64.tar.gz"
+
+            with mock.patch.object(pc, "find_wgpu_lib", return_value=wgpu):
+                with mock.patch.object(pc, "fix_rpath_linux") as fix_rpath:
+                    with argv(
+                        [
+                            "package_cli.py",
+                            "--binary",
+                            str(binary),
+                            "--cpp-binary",
+                            str(cpp_binary),
+                            "--build-dir",
+                            str(root / "build"),
+                            "--platform",
+                            "linux-x64",
+                            "--out",
+                            str(out),
+                        ]
+                    ):
+                        rc = pc.main()
+
+            self.assertEqual(rc, 0)
+            self.assertEqual(fix_rpath.call_count, 2)
+            self.assertEqual(
+                [call.args[0].name for call in fix_rpath.call_args_list],
+                ["pulp", "pulp-cpp"],
+            )
+            with tarfile.open(out, "r:gz") as tar:
+                self.assertEqual(
+                    sorted(tar.getnames()),
+                    ["libwgpu_native.so", "pulp", "pulp-cpp"],
+                )
+
     def test_main_packages_macos_tarball_and_rewrites_rpath(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)

--- a/tools/scripts/test_package_cli_extra.py
+++ b/tools/scripts/test_package_cli_extra.py
@@ -381,6 +381,52 @@ class MainExtraTests(unittest.TestCase):
                     ["libwgpu_native.so", "pulp", "pulp-cpp"],
                 )
 
+    def test_main_rewrites_linux_rpath_for_mcp_binary_too(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp-built"
+            cpp_binary = root / "pulp-cpp-built"
+            mcp_binary = root / "pulp-mcp-built"
+            wgpu = root / "libwgpu_native.so"
+            binary.write_text("binary", encoding="utf-8")
+            cpp_binary.write_text("cpp", encoding="utf-8")
+            mcp_binary.write_text("mcp", encoding="utf-8")
+            wgpu.write_text("wgpu", encoding="utf-8")
+            out = root / "pulp-linux-x64.tar.gz"
+
+            with mock.patch.object(pc, "find_wgpu_lib", return_value=wgpu):
+                with mock.patch.object(pc, "fix_rpath_linux") as fix_rpath:
+                    with argv(
+                        [
+                            "package_cli.py",
+                            "--binary",
+                            str(binary),
+                            "--cpp-binary",
+                            str(cpp_binary),
+                            "--mcp-binary",
+                            str(mcp_binary),
+                            "--build-dir",
+                            str(root / "build"),
+                            "--platform",
+                            "linux-x64",
+                            "--out",
+                            str(out),
+                        ]
+                    ):
+                        rc = pc.main()
+
+            self.assertEqual(rc, 0)
+            self.assertEqual(fix_rpath.call_count, 3)
+            self.assertEqual(
+                [call.args[0].name for call in fix_rpath.call_args_list],
+                ["pulp", "pulp-cpp", "pulp-mcp"],
+            )
+            with tarfile.open(out, "r:gz") as tar:
+                self.assertEqual(
+                    sorted(tar.getnames()),
+                    ["libwgpu_native.so", "pulp", "pulp-cpp", "pulp-mcp"],
+                )
+
     def test_main_packages_macos_tarball_and_rewrites_rpath(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)

--- a/tools/scripts/test_release_workflow_test_step.py
+++ b/tools/scripts/test_release_workflow_test_step.py
@@ -183,6 +183,58 @@ class ReleaseCliLinuxNoWebView(unittest.TestCase):
         )
 
 
+class ReleaseCliDualBinaryPackaging(unittest.TestCase):
+    """release-cli.yml must keep `pulp` and `pulp-cpp` bundled and smoked.
+
+    The Rust CLI delegates several C++-owned subcommands to `pulp-cpp`.
+    A release archive that contains only `pulp` can pass a basic CLI smoke
+    test but fail later when a user runs a delegated command.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = RELEASE_CLI.read_text(encoding="utf-8")
+
+    def _find_step_run(self, step_name: str) -> str:
+        pattern = re.compile(
+            rf"-\s*name:\s*{re.escape(step_name)}\s*\n"
+            r"(?:(?!\n\s*-\s*name:).)*?"
+            r"\s*run:\s*(.+?)(?=\n\s*-\s*name:|\Z)",
+            re.DOTALL,
+        )
+        match = pattern.search(self.text)
+        self.assertIsNotNone(match, f"could not locate `{step_name}` step")
+        return match.group(1)
+
+    def test_unix_package_step_bundles_cpp_delegate(self) -> None:
+        run_block = self._find_step_run("Package CLI (Unix)")
+        self.assertIn("tools/scripts/package_cli.py", run_block)
+        self.assertRegex(run_block, r"--binary\s+build/pulp")
+        self.assertRegex(run_block, r"--cpp-binary\s+build/tools/cli/pulp-cpp")
+        self.assertRegex(run_block, r"--out\s+pulp-\$\{\{\s*matrix\.platform\s*\}\}\.tar\.gz")
+
+    def test_windows_package_step_bundles_cpp_delegate(self) -> None:
+        run_block = self._find_step_run("Package CLI (Windows)")
+        self.assertIn("tools/scripts/package_cli.py", run_block)
+        self.assertRegex(run_block, r"--binary\s+build/pulp\.exe")
+        self.assertRegex(run_block, r"--cpp-binary\s+build/tools/cli/Release/pulp-cpp\.exe")
+        self.assertRegex(run_block, r"--out\s+pulp-\$\{\{\s*matrix\.platform\s*\}\}\.zip")
+
+    def test_unix_smoke_step_exercises_both_cli_binaries(self) -> None:
+        run_block = self._find_step_run("Smoke `pulp help` + `pulp-cpp help` (Unix)")
+        self.assertRegex(run_block, r"for\s+ART\s+in\s+pulp\s+pulp-cpp")
+        self.assertIn('"$BIN" help', run_block)
+        self.assertIn("Library not loaded", run_block)
+        self.assertIn("cannot open shared object", run_block)
+
+    def test_windows_smoke_step_exercises_both_cli_binaries(self) -> None:
+        run_block = self._find_step_run("Smoke `pulp help` + `pulp-cpp help` (Windows)")
+        self.assertIn('@("pulp.exe", "pulp-cpp.exe")', run_block)
+        self.assertIn('-ArgumentList "help"', run_block)
+        self.assertIn("DLL was not found", run_block)
+        self.assertIn("missing.*\\.dll", run_block)
+
+
 class SignAndReleaseContentsWriteTest(unittest.TestCase):
     """#724: sign-and-release.yml must declare `contents: write` on its
     macOS job so the final `Create GitHub Release` step can call the

--- a/tools/scripts/test_release_workflow_test_step.py
+++ b/tools/scripts/test_release_workflow_test_step.py
@@ -211,6 +211,7 @@ class ReleaseCliDualBinaryPackaging(unittest.TestCase):
         self.assertIn("tools/scripts/package_cli.py", run_block)
         self.assertRegex(run_block, r"--binary\s+build/pulp")
         self.assertRegex(run_block, r"--cpp-binary\s+build/tools/cli/pulp-cpp")
+        self.assertRegex(run_block, r"--mcp-binary\s+build/tools/mcp/pulp-mcp")
         self.assertRegex(run_block, r"--out\s+pulp-\$\{\{\s*matrix\.platform\s*\}\}\.tar\.gz")
 
     def test_windows_package_step_bundles_cpp_delegate(self) -> None:
@@ -218,19 +219,27 @@ class ReleaseCliDualBinaryPackaging(unittest.TestCase):
         self.assertIn("tools/scripts/package_cli.py", run_block)
         self.assertRegex(run_block, r"--binary\s+build/pulp\.exe")
         self.assertRegex(run_block, r"--cpp-binary\s+build/tools/cli/Release/pulp-cpp\.exe")
+        self.assertRegex(run_block, r"--mcp-binary\s+build/tools/mcp/Release/pulp-mcp\.exe")
         self.assertRegex(run_block, r"--out\s+pulp-\$\{\{\s*matrix\.platform\s*\}\}\.zip")
 
-    def test_unix_smoke_step_exercises_both_cli_binaries(self) -> None:
-        run_block = self._find_step_run("Smoke `pulp help` + `pulp-cpp help` (Unix)")
-        self.assertRegex(run_block, r"for\s+ART\s+in\s+pulp\s+pulp-cpp")
-        self.assertIn('"$BIN" help', run_block)
+    def test_unix_smoke_step_exercises_all_cli_binaries(self) -> None:
+        run_block = self._find_step_run(
+            "Smoke `pulp help` + `pulp-cpp help` + `pulp-mcp --version` (Unix)"
+        )
+        self.assertRegex(run_block, r"for\s+ART\s+in\s+pulp\s+pulp-cpp\s+pulp-mcp")
+        self.assertIn('pulp-mcp) echo "--version"', run_block)
+        self.assertIn('"$BIN" $CMD', run_block)
         self.assertIn("Library not loaded", run_block)
         self.assertIn("cannot open shared object", run_block)
 
-    def test_windows_smoke_step_exercises_both_cli_binaries(self) -> None:
-        run_block = self._find_step_run("Smoke `pulp help` + `pulp-cpp help` (Windows)")
-        self.assertIn('@("pulp.exe", "pulp-cpp.exe")', run_block)
-        self.assertIn('-ArgumentList "help"', run_block)
+    def test_windows_smoke_step_exercises_all_cli_binaries(self) -> None:
+        run_block = self._find_step_run(
+            "Smoke `pulp help` + `pulp-cpp help` + `pulp-mcp --version` (Windows)"
+        )
+        self.assertIn('"pulp.exe"      = "help"', run_block)
+        self.assertIn('"pulp-cpp.exe"  = "help"', run_block)
+        self.assertIn('"pulp-mcp.exe"  = "--version"', run_block)
+        self.assertIn("-ArgumentList $cmd", run_block)
         self.assertIn("DLL was not found", run_block)
         self.assertIn("missing.*\\.dll", run_block)
 

--- a/tools/scripts/test_resolve_runs_on_extra.py
+++ b/tools/scripts/test_resolve_runs_on_extra.py
@@ -23,6 +23,32 @@ spec.loader.exec_module(resolver)
 
 
 class ResolverEdgeTests(unittest.TestCase):
+    def test_load_selector_accepts_string_and_array_json(self) -> None:
+        self.assertEqual(
+            resolver._load_selector('"ubuntu-latest"', "Linux"),
+            '"ubuntu-latest"',
+        )
+        self.assertEqual(
+            resolver._load_selector('["self-hosted","macos"]', "macOS"),
+            '["self-hosted", "macos"]',
+        )
+
+    def test_load_selector_rejects_invalid_json_with_target_name(self) -> None:
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as ctx:
+                resolver._load_selector("{bad", "Windows")
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("Windows runner selector JSON is not valid", stderr.getvalue())
+
+    def test_env_nonempty_handles_missing_none_and_whitespace(self) -> None:
+        with mock.patch.dict(os.environ, {"EMPTY": "   ", "VALUE": " label "}, clear=True):
+            self.assertEqual(resolver._env_nonempty(None), "")
+            self.assertEqual(resolver._env_nonempty("MISSING"), "")
+            self.assertEqual(resolver._env_nonempty("EMPTY"), "")
+            self.assertEqual(resolver._env_nonempty("VALUE"), "label")
+
     def test_optional_namespace_returns_empty_when_namespace_has_no_selector(self) -> None:
         with mock.patch.dict(
             os.environ,
@@ -77,6 +103,55 @@ class ResolverEdgeTests(unittest.TestCase):
 
         self.assertEqual(ctx.exception.code, 1)
         self.assertIn("Unsupported runner_provider: self-hosted", stderr.getvalue())
+
+    def test_provider_mode_can_read_custom_requested_provider_env(self) -> None:
+        stdout = io.StringIO()
+        with mock.patch.dict(
+            os.environ,
+            {
+                "PULP_RUNNER_PROVIDER": "local",
+                "LOCAL_LINUX_RUNS_ON_JSON": '["self-hosted","linux"]',
+            },
+            clear=True,
+        ):
+            with contextlib.redirect_stdout(stdout):
+                rc = resolver.main(
+                    [
+                        "--target-name",
+                        "Linux (x64)",
+                        "--mode",
+                        "provider",
+                        "--requested-provider-env",
+                        "PULP_RUNNER_PROVIDER",
+                        "--github-hosted-label",
+                        "ubuntu-latest",
+                        "--local-env",
+                        "LOCAL_LINUX_RUNS_ON_JSON",
+                    ]
+                )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout.getvalue(), '["self-hosted", "linux"]')
+
+    def test_optional_namespace_main_prints_empty_for_github_hosted(self) -> None:
+        stdout = io.StringIO()
+        with mock.patch.dict(os.environ, {"REQUESTED_PROVIDER": "github-hosted"}, clear=True):
+            with contextlib.redirect_stdout(stdout):
+                rc = resolver.main(
+                    [
+                        "--target-name",
+                        "macOS (ARM64)",
+                        "--mode",
+                        "optional-namespace",
+                        "--explicit-env",
+                        "EXPLICIT_MACOS_RUNNER_SELECTOR_JSON",
+                        "--namespace-env",
+                        "NAMESPACE_MACOS_RUNS_ON_JSON",
+                    ]
+                )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout.getvalue(), "")
 
 
 if __name__ == "__main__":

--- a/tools/scripts/test_run_python_coverage_extra.py
+++ b/tools/scripts/test_run_python_coverage_extra.py
@@ -115,6 +115,60 @@ class SurfaceExtraTests(unittest.TestCase):
     def test_matches_any_glob_returns_false_for_empty_pattern_set(self) -> None:
         self.assertFalse(rpc._matches_any_glob("tools/scripts/run.py", []))
 
+    def test_selected_surfaces_appends_always_include_surface(self) -> None:
+        selected = rpc._selected_surfaces(
+            [rpc.REPO_ROOT / "tools/scripts/test_alpha.py"]
+        )
+
+        self.assertGreaterEqual(len(selected), 2)
+        self.assertEqual(selected[0].source_roots, ("tools/scripts",))
+        self.assertTrue(selected[-1].always_include)
+
+    def test_normalized_source_roots_drops_children_when_parent_selected(self) -> None:
+        surfaces = [
+            rpc.CoverageSurface(("tools",), ("tools/test_*.py",)),
+            rpc.CoverageSurface(("tools/scripts",), ("tools/scripts/test_*.py",)),
+            rpc.CoverageSurface(("core/view/js",), ("tools/test_*.py",)),
+        ]
+
+        self.assertEqual(rpc._normalized_source_roots(surfaces), ["tools", "core/view/js"])
+
+    def test_report_source_files_respects_omit_globs_and_private_modules(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            script_dir = root / "tools" / "scripts"
+            script_dir.mkdir(parents=True)
+            keep = script_dir / "run_me.py"
+            keep.write_text("print('keep')\n", encoding="utf-8")
+            (script_dir / "test_run_me.py").write_text("print('test')\n", encoding="utf-8")
+            (script_dir / "_private.py").write_text("print('private')\n", encoding="utf-8")
+
+            with mock.patch.object(rpc, "REPO_ROOT", root):
+                files = rpc._report_source_files(
+                    ["tools/scripts"],
+                    ["tools/scripts/test_*.py", "tools/scripts/_*.py"],
+                )
+
+        self.assertEqual(files, [keep])
+
+    def test_write_coveragerc_requires_selected_sources_and_writes_omit(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            out = pathlib.Path(td)
+            with mock.patch.object(rpc, "OUTPUT_DIR", out), \
+                 mock.patch.object(rpc, "HTML_DIR", out / "html"), \
+                 mock.patch.object(rpc, "XML_FILE", out / "coverage.xml"), \
+                 mock.patch.object(rpc, "RCFILE", out / ".coveragerc"):
+                with self.assertRaises(ValueError):
+                    rpc._write_coveragerc([])
+
+                rpc._write_coveragerc(
+                    [rpc.CoverageSurface(("tools/scripts",), ("tools/scripts/test_*.py",))]
+                )
+                text = (out / ".coveragerc").read_text(encoding="utf-8")
+
+        self.assertIn("source =\n    tools/scripts", text)
+        self.assertIn("omit =\n    tools/scripts/test_*.py", text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/scripts/test_validate_hosts.py
+++ b/tools/scripts/test_validate_hosts.py
@@ -118,6 +118,12 @@ class RemoteCommandTests(unittest.TestCase):
         self.assertIn("$branch='feature/one''two'", command)
         self.assertIn("-NoTests:$false", command)
 
+    def test_windows_remote_command_can_skip_tests(self) -> None:
+        command = vh.windows_remote_command("C:\\repo", "main", True)
+
+        self.assertIn("-NoTests:$true", command)
+        self.assertIn("validate-build.ps1", command)
+
 
 class MainTests(unittest.TestCase):
     def test_main_builds_local_unix_and_windows_commands_from_config(self) -> None:
@@ -200,6 +206,31 @@ class MainTests(unittest.TestCase):
                     rc = vh.main()
 
         self.assertEqual(rc, 1)
+
+    def test_main_uses_current_branch_when_branch_argument_is_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            config = pathlib.Path(td) / "missing-hosts.json"
+            observed: list[tuple[str, list[str]]] = []
+
+            def fake_run(label: str, cmd: list[str]) -> bool:
+                observed.append((label, cmd))
+                return True
+
+            with mock.patch.object(vh, "current_branch", return_value="feature/current"), \
+                 mock.patch.object(vh, "run", side_effect=fake_run):
+                with argv(["validate_hosts.py", "--config", str(config)]):
+                    rc = vh.main()
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(observed), 1)
+        self.assertEqual(observed[0][0], "local")
+        self.assertEqual(observed[0][1], [
+            "bash",
+            "./validate-build.sh",
+            "--quiet",
+            "--ref",
+            "feature/current",
+        ])
 
     def test_script_entrypoint_exits_with_main_status(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/scripts/test_validate_hosts.py
+++ b/tools/scripts/test_validate_hosts.py
@@ -60,6 +60,22 @@ class ConfigTests(unittest.TestCase):
             self.assertEqual(vh.load_config(config)["unix_targets"][0]["host"], "linux")
             self.assertEqual(vh.load_config(config)["windows_targets"][0]["host"], "win")
 
+    def test_load_config_preserves_extra_keys_for_future_callers(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            config = pathlib.Path(td) / "hosts.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "unix_targets": [],
+                        "windows_targets": [],
+                        "notes": {"owner": "release"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(vh.load_config(config)["notes"], {"owner": "release"})
+
 
 class SubprocessTests(unittest.TestCase):
     def test_current_branch_returns_stripped_git_output(self) -> None:
@@ -98,6 +114,16 @@ class SubprocessTests(unittest.TestCase):
         text = out.getvalue()
         self.assertIn("success: OK", text)
         self.assertIn("failure: FAILED (7)", text)
+
+    def test_run_uses_repo_root_for_subprocess(self) -> None:
+        with mock.patch.object(
+            vh.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["true"], 0),
+        ) as run:
+            self.assertTrue(vh.run("rooted", ["true"]))
+
+        run.assert_called_once_with(["true"], cwd=vh.ROOT)
 
 
 class RemoteCommandTests(unittest.TestCase):
@@ -206,6 +232,33 @@ class MainTests(unittest.TestCase):
                     rc = vh.main()
 
         self.assertEqual(rc, 1)
+
+    def test_main_continues_after_local_failure_to_collect_remote_results(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            config = pathlib.Path(td) / "hosts.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "unix_targets": [{"host": "linux-host", "path": "/srv/pulp"}],
+                        "windows_targets": [{"host": "win-host", "path": "C:\\pulp"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            labels: list[str] = []
+
+            def fake_run(label: str, cmd: list[str]) -> bool:
+                labels.append(label)
+                return label != "local"
+
+            with mock.patch.object(vh, "run", side_effect=fake_run):
+                with argv(
+                    ["validate_hosts.py", "--config", str(config), "--branch", "local/test"]
+                ):
+                    rc = vh.main()
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(labels, ["local", "ssh linux-host", "ssh win-host"])
 
     def test_main_uses_current_branch_when_branch_argument_is_absent(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/scripts/test_validate_registry_extra.py
+++ b/tools/scripts/test_validate_registry_extra.py
@@ -317,6 +317,84 @@ class MainTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("1 packages validated, 0 errors, 2 warnings", out.getvalue())
 
+    def test_main_non_strict_allows_warnings_and_skips_license_check(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            registry = root / "registry.json"
+            schema = root / "schema.json"
+            write_json(
+                registry,
+                {
+                    "registry_version": 2,
+                    "packages": {
+                        "desktop-only": {
+                            "version": "1.0.0",
+                            "license": "Commercial",
+                            "verification": {
+                                "verified_version": "0.9.0",
+                                "build_status": {"Linux-x64": "pass"},
+                            },
+                            "platforms": {"Linux": {}},
+                        },
+                    },
+                },
+            )
+            write_json(schema, {})
+
+            out = io.StringIO()
+            with mock.patch.object(vr, "REGISTRY", registry), \
+                 mock.patch.object(vr, "SCHEMA", schema), \
+                 mock.patch.object(vr, "validate_schema", return_value=[]), \
+                 argv(["validate_registry.py"]), \
+                 contextlib.redirect_stdout(out):
+                rc = vr.main()
+
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        self.assertIn("desktop-only", text)
+        self.assertIn("Warnings:", text)
+        self.assertNotIn("License warnings:", text)
+        self.assertIn("1 packages validated, 0 errors, 2 warnings", text)
+
+    def test_main_marks_package_status_fail_when_errors_reference_slug(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            registry = root / "registry.json"
+            schema = root / "schema.json"
+            write_json(
+                registry,
+                {
+                    "registry_version": 2,
+                    "packages": {
+                        "bad-license": {
+                            "version": "1.0.0",
+                            "license": "AGPL-3.0-only",
+                            "verification": {
+                                "verified_version": "1.0.0",
+                                "build_status": {"Android-arm64": "pass"},
+                            },
+                            "platforms": {"Android": {}},
+                        },
+                    },
+                },
+            )
+            write_json(schema, {})
+
+            out = io.StringIO()
+            with mock.patch.object(vr, "REGISTRY", registry), \
+                 mock.patch.object(vr, "SCHEMA", schema), \
+                 mock.patch.object(vr, "validate_schema", return_value=[]), \
+                 argv(["validate_registry.py", "--check-licenses"]), \
+                 contextlib.redirect_stdout(out):
+                rc = vr.main()
+
+        self.assertEqual(rc, 1)
+        text = out.getvalue()
+        self.assertIn("bad-license", text)
+        self.assertIn("FAIL", text)
+        self.assertIn("License errors:", text)
+        self.assertIn("1 packages validated, 1 errors, 0 warnings", text)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tools/scripts/test_validate_registry_extra.py
+++ b/tools/scripts/test_validate_registry_extra.py
@@ -165,6 +165,37 @@ class ValidationHelperTests(unittest.TestCase):
         self.assertIn("custom", warnings[0])
         self.assertIn("not in known-allowed list", warnings[0])
 
+    def test_structural_validation_accepts_matching_mobile_package(self) -> None:
+        errors, warnings = vr.validate_structural(
+            {
+                "registry_version": 2,
+                "packages": {
+                    "good-mobile": {
+                        "version": "1.2.3",
+                        "verification": {
+                            "verified_version": "1.2.3",
+                            "build_status": {"Android-arm64": "pass"},
+                        },
+                        "platforms": {"Android": {}, "iOS": {}},
+                    },
+                },
+            }
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(warnings, [])
+
+    def test_license_validation_warns_for_missing_license(self) -> None:
+        errors, warnings = vr.validate_licenses(
+            {"packages": {"missing-license": {"version": "1.0.0"}}}
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            warnings,
+            ["  missing-license: license '' not in known-allowed list — review required"],
+        )
+
 
 class MainTests(unittest.TestCase):
     def test_script_entrypoint_invokes_main_for_help(self) -> None:

--- a/tools/scripts/test_version_bump_check_extra.py
+++ b/tools/scripts/test_version_bump_check_extra.py
@@ -128,6 +128,58 @@ class VersionFileIoTests(unittest.TestCase):
             self.assertIsNone(vbc.read_version(repo, vbc.VersionFile("plain.txt", "unknown")))
             self.assertFalse(vbc.write_version(repo, vbc.VersionFile("plain.txt", "unknown"), "1.0.0"))
 
+    def test_json_path_rejects_bad_array_segments_and_scalar_walks(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo = pathlib.Path(td)
+            (repo / "marketplace.json").write_text(
+                '{"plugins": [{"version": "1.0.0"}], "scalar": "value"}\n',
+                encoding="utf-8",
+            )
+
+            bad_index = vbc.VersionFile("marketplace.json", "json_path", "plugins.first.version")
+            scalar = vbc.VersionFile("marketplace.json", "json_path", "scalar.version")
+
+            self.assertIsNone(vbc.read_version(repo, bad_index))
+            self.assertFalse(vbc.write_version(repo, bad_index, "2.0.0"))
+            self.assertIsNone(vbc.read_version(repo, scalar))
+            self.assertFalse(vbc.write_version(repo, scalar, "2.0.0"))
+
+    def test_load_config_strips_metadata_and_defaults_trailer_key(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            cfg_path = pathlib.Path(td) / "versioning.json"
+            cfg_path.write_text(
+                json.dumps(
+                    {
+                        "$schema": "https://example.invalid/schema.json",
+                        "_comment": "ignored",
+                        "generated_globs": ["build/**"],
+                        "surfaces": {
+                            "sdk": {
+                                "_comment": "ignored",
+                                "label": "SDK",
+                                "version_files": [
+                                    {
+                                        "_comment": "ignored",
+                                        "path": "sdk.json",
+                                        "kind": "json_field",
+                                        "field": "version",
+                                    }
+                                ],
+                                "trigger_paths": ["src/**"],
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            cfg = vbc.load_config(cfg_path)
+
+        self.assertEqual(cfg.generated_globs, ["build/**"])
+        self.assertEqual(cfg.trailer_version_bump, "Version-Bump")
+        self.assertEqual(cfg.surfaces[0].name, "sdk")
+        self.assertEqual(cfg.surfaces[0].version_files[0].field, "version")
+
     def test_script_entrypoint_help_exits_zero(self) -> None:
         script = pathlib.Path(vbc.__file__).resolve()
         with mock.patch.object(sys, "argv", [str(script), "--help"]), \
@@ -688,6 +740,18 @@ class AssessmentReportApplyTests(unittest.TestCase):
             vbc,
             "git_log_subjects_and_bodies",
             return_value=[("sha", "chore(versions): bump SDK", "")],
+        ):
+            self.assertTrue(vbc._range_has_bump_commit("base", "head"))
+        with mock.patch.object(
+            vbc,
+            "git_log_subjects_and_bodies",
+            return_value=[("sha", "chore: bump SDK to v1.2.3", "")],
+        ):
+            self.assertFalse(vbc._range_has_bump_commit("base", "head"))
+        with mock.patch.object(
+            vbc,
+            "git_log_subjects_and_bodies",
+            return_value=[("sha", "chore: bump versions for release", "")],
         ):
             self.assertTrue(vbc._range_has_bump_commit("base", "head"))
 


### PR DESCRIPTION
## Summary

Adds one batched Phase 3 Codecov coverage tranche for ship/package/release/local-CI helpers instead of sending many small PRs. This is test-only coverage across Android packaging, appcast/NSIS/codesign, package CLI/release helpers, runner selection, registry validation, local CI helpers, and Python/Cobertura coverage tooling.

## Validation

- python3 tools/scripts/test_package_cli.py && python3 tools/scripts/test_package_cli_extra.py && python3 tools/scripts/test_fetch_skia_for_release.py && python3 tools/scripts/test_auto_release_decision.py && python3 tools/scripts/test_version_bump_check_extra.py && python3 tools/scripts/test_release_workflow_test_step.py
- python3 tools/scripts/test_coverage_tier_check.py && python3 tools/scripts/test_coverage_tier_check_extra.py && python3 tools/scripts/test_coverage_diff_comment.py && python3 tools/scripts/test_coverage_diff_comment_extra.py && python3 tools/scripts/test_run_python_coverage_extra.py && python3 tools/scripts/test_merge_cobertura_extra.py && python3 tools/scripts/test_resolve_runs_on.py && python3 tools/scripts/test_resolve_runs_on_extra.py
- python3 tools/scripts/test_android_target.py && python3 tools/scripts/test_build_migration_index_extra.py && python3 tools/scripts/test_validate_hosts.py && python3 tools/scripts/test_validate_registry_extra.py && python3 tools/local-ci/test_local_ci_extra.py
- cmake --build build --target pulp-test-android-package pulp-test-appcast pulp-test-codesign pulp-test-nsis-installer -j$(sysctl -n hw.ncpu)
- ctest --test-dir build --output-on-failure -R "Android|Appcast|codesign|NSIS" (55/55 passed)
- git diff --check

Note: local pre-push diff-cover advisory still hits the unrelated local FetchContent mbedtls v3.6.2 checkout failure in fresh build-cov; focused and broad validations above passed.

CI policy for this PR: GitHub-hosted runners only; no Namespace dispatch.