### PR TITLE
test: batch runtime coverage helpers

### DIFF
--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -198,6 +198,30 @@ TEST_CASE("JsonRpcPeer unregisters methods and notifications", "[json_rpc]") {
     REQUIRE(notifications.load() == 1);
 }
 
+TEST_CASE("JsonRpcPeer preserves string request ids and omits missing params",
+          "[json_rpc][coverage][phase3]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string reply;
+    pair.first->on_message([&](const Message& message) {
+        reply.assign(message.as_text());
+    });
+
+    JsonRpcPeer server(*pair.second);
+    std::string captured_params = "unset";
+    server.register_method("no_params", [&](std::string_view params) {
+        captured_params = std::string(params);
+        return JsonRpcResult::ok(R"({"accepted":true})");
+    });
+
+    REQUIRE(pair.first->send_text(
+        R"json({"jsonrpc":"2.0","id":"abc-123","method":"no_params"})json"));
+
+    REQUIRE(reply.find(R"("id":"abc-123")") != std::string::npos);
+    REQUIRE(reply.find(R"("accepted":true)") != std::string::npos);
+    REQUIRE(captured_params.empty());
+}
+
 TEST_CASE("JsonRpcPeer serializes handler errors and exceptions", "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);
@@ -288,6 +312,7 @@ TEST_CASE("JsonRpcPeer reports closed and failed sends", "[json_rpc]") {
     REQUIRE_FALSE(failing_peer.send_request("failed", "[]", [&](const JsonRpcResult&) {
         callback_called = true;
     }));
+    REQUIRE_FALSE(failing_peer.notify("failed_notify", "[]"));
     channel.deliver_text(R"json({"jsonrpc":"2.0","id":1,"result":true})json");
     REQUIRE_FALSE(callback_called);
 }

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -5,6 +5,7 @@
 #include <pulp/runtime/temporary_file.hpp>
 
 #include <fstream>
+#include <utility>
 
 using namespace pulp::runtime;
 
@@ -75,6 +76,20 @@ TEST_CASE("BigInteger large numbers", "[crypto][bigint]") {
     auto b = BigInteger::from_string("1");
     auto c = a + b;
     REQUIRE(c.to_string() == "1000000000000000000");
+}
+
+TEST_CASE("BigInteger copy and move assignment preserve values",
+          "[crypto][bigint][coverage][phase3]") {
+    auto original = BigInteger::from_hex("2A");
+    BigInteger copied;
+    copied = original;
+    REQUIRE(copied == original);
+    REQUIRE(copied.to_string() == "42");
+
+    BigInteger moved;
+    moved = std::move(copied);
+    REQUIRE(moved.to_hex() == "2A");
+    REQUIRE_FALSE(moved.is_zero());
 }
 
 // ── License ─────────────────────────────────────────────────────────────

--- a/test/test_memory_message_channel.cpp
+++ b/test/test_memory_message_channel.cpp
@@ -59,6 +59,20 @@ TEST_CASE("MemoryMessageChannel replaces message callbacks",
     REQUIRE(second_count == 1);
 }
 
+TEST_CASE("MemoryMessageChannel clears message callbacks",
+          "[runtime][message_channel][coverage][phase3]") {
+    auto [left, right] = MemoryMessageChannel::make_pair();
+
+    int deliveries = 0;
+    right->on_message([&](const Message&) { ++deliveries; });
+    REQUIRE(left->send_text("delivered"));
+    REQUIRE(deliveries == 1);
+
+    right->on_message({});
+    REQUIRE(left->send_text("ignored"));
+    REQUIRE(deliveries == 1);
+}
+
 TEST_CASE("MemoryMessageChannel send succeeds without peer callback",
           "[runtime][message_channel]") {
     auto [left, right] = MemoryMessageChannel::make_pair();

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -270,3 +270,29 @@ TEST_CASE("HttpStream status_code is 0 before fetch",
     HttpStream stream;
     REQUIRE(stream.status_code() == 0);
 }
+
+TEST_CASE("HttpStream default state supports zero reads and idempotent close",
+          "[network_stream][http][coverage][phase3]") {
+    HttpStream stream;
+    REQUIRE_FALSE(stream.is_open());
+    REQUIRE(stream.eof());
+    REQUIRE(stream.transport_error().empty());
+    REQUIRE(stream.headers().empty());
+
+    std::uint8_t byte = 0x7f;
+    auto zero_read = stream.read(&byte, 0);
+    REQUIRE(zero_read.ok());
+    REQUIRE(zero_read.bytes == 0);
+    REQUIRE(byte == 0x7f);
+
+    auto eof_read = stream.read(&byte, 1);
+    REQUIRE_FALSE(eof_read.ok());
+    REQUIRE(eof_read.closed());
+
+    stream.close();
+    stream.close();
+    REQUIRE_FALSE(stream.is_open());
+    auto closed_read = stream.read(&byte, 1);
+    REQUIRE_FALSE(closed_read.ok());
+    REQUIRE(closed_read.closed());
+}

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -14,6 +14,7 @@ using namespace pulp::runtime;
 
 TEST_CASE("SpscQueue basic operations", "[runtime][spsc]") {
     SpscQueue<int, 16> q;
+    REQUIRE(SpscQueue<int, 16>::capacity() == 16);
 
     SECTION("Empty queue") {
         REQUIRE(q.empty());
@@ -80,6 +81,18 @@ TEST_CASE("SpscQueue cross-thread", "[runtime][spsc]") {
 
     int expected = (count - 1) * count / 2;
     REQUIRE(sum.load() == expected);
+}
+
+TEST_CASE("SpscQueue accepts rvalue pushes", "[runtime][spsc][coverage][phase3]") {
+    SpscQueue<std::string, 2> q;
+
+    REQUIRE(q.try_push(std::string("alpha")));
+    REQUIRE(q.size_approx() == 1);
+
+    auto value = q.try_pop();
+    REQUIRE(value.has_value());
+    REQUIRE(*value == "alpha");
+    REQUIRE(q.empty());
 }
 
 TEST_CASE("ScopeGuard executes on exit", "[runtime][scope_guard]") {

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -283,3 +283,29 @@ TEST_CASE("DynamicLibrary move keeps failed handles closed", "[runtime][dynamic_
     REQUIRE_FALSE(second.is_open());
     REQUIRE_FALSE(second.error().empty());
 }
+
+TEST_CASE("DynamicLibrary move transfers an open handle", "[runtime][dynamic_library][coverage][phase3]") {
+    DynamicLibrary original;
+#ifdef __APPLE__
+    REQUIRE(original.open("/usr/lib/libSystem.B.dylib"));
+    const char* symbol = "malloc";
+#elif defined(__linux__)
+    REQUIRE(original.open("libc.so.6"));
+    const char* symbol = "malloc";
+#else
+    const char* symbol = nullptr;
+    SUCCEED("No stable system library fixture on this platform.");
+    return;
+#endif
+
+    DynamicLibrary moved(std::move(original));
+    REQUIRE_FALSE(original.is_open());
+    REQUIRE(moved.is_open());
+    REQUIRE(moved.find_symbol(symbol) != nullptr);
+
+    DynamicLibrary assigned;
+    assigned = std::move(moved);
+    REQUIRE_FALSE(moved.is_open());
+    REQUIRE(assigned.is_open());
+    REQUIRE(assigned.find_symbol(symbol) != nullptr);
+}

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -152,6 +152,20 @@ TEST_CASE("Runtime GMT helper returns UTC tm", "[runtime][system]") {
     REQUIRE(tm.tm_sec == 0);
 }
 
+TEST_CASE("Runtime localtime helper returns a normalized tm", "[runtime][system][coverage][phase3]") {
+    auto tm = localtime_local(static_cast<std::time_t>(0));
+    REQUIRE(tm.tm_mon >= 0);
+    REQUIRE(tm.tm_mon <= 11);
+    REQUIRE(tm.tm_mday >= 1);
+    REQUIRE(tm.tm_mday <= 31);
+    REQUIRE(tm.tm_hour >= 0);
+    REQUIRE(tm.tm_hour <= 23);
+    REQUIRE(tm.tm_min >= 0);
+    REQUIRE(tm.tm_min <= 59);
+    REQUIRE(tm.tm_sec >= 0);
+    REQUIRE(tm.tm_sec <= 60);
+}
+
 TEST_CASE("Runtime C string copy truncates safely", "[runtime][system]") {
     char buffer[5]{};
     copy_c_string(buffer, "abcdef");
@@ -168,6 +182,16 @@ TEST_CASE("Runtime C string copy handles degenerate buffers", "[runtime][system]
     REQUIRE(untouched == 'x');
 
     REQUIRE_NOTHROW(copy_c_string(nullptr, 4, "abc"));
+}
+
+TEST_CASE("Runtime system info convenience helpers mirror cached info",
+          "[runtime][system][coverage][phase3]") {
+    const auto& info = get_system_info();
+    REQUIRE_FALSE(info.os_name.empty());
+    REQUIRE_FALSE(info.arch.empty());
+    REQUIRE(info.cpu_threads >= 0);
+    REQUIRE(cpu_thread_count() == info.cpu_threads);
+    REQUIRE(total_memory_mb() == info.total_memory_mb);
 }
 
 TEST_CASE("TemporaryFile creates extensions and release preserves path", "[runtime][temporary_file]") {

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -7,6 +7,7 @@
 #include <pulp/runtime/base64.hpp>
 #include <pulp/runtime/http.hpp>
 #include <pulp/runtime/range.hpp>
+#include <pulp/runtime/scope_guard.hpp>
 #include <pulp/runtime/text_diff.hpp>
 #include <fstream>
 #include <filesystem>
@@ -44,6 +45,83 @@ TEST_CASE("TemporaryFile move semantics", "[runtime][temp_file]") {
     TemporaryFile b = std::move(a);
     REQUIRE(b.path() == path);
     REQUIRE(std::filesystem::exists(path));
+}
+
+TEST_CASE("TemporaryFile normalizes bare extensions and exposes path string",
+          "[runtime][temp_file][coverage][phase3]") {
+    std::filesystem::path path;
+    std::string path_string;
+    {
+        TemporaryFile tmp("wav");
+        path = tmp.path();
+        path_string = tmp.path_string();
+        REQUIRE(path.extension() == ".wav");
+        REQUIRE(path_string == path.string());
+        REQUIRE(std::filesystem::exists(path));
+    }
+    REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
+TEST_CASE("TemporaryFile move assignment deletes previous active file",
+          "[runtime][temp_file][coverage][phase3]") {
+    std::filesystem::path old_path;
+    std::filesystem::path new_path;
+    {
+        TemporaryFile old_file(".old");
+        TemporaryFile new_file(".new");
+        old_path = old_file.path();
+        new_path = new_file.path();
+        REQUIRE(std::filesystem::exists(old_path));
+        REQUIRE(std::filesystem::exists(new_path));
+
+        old_file = std::move(new_file);
+
+        REQUIRE_FALSE(std::filesystem::exists(old_path));
+        REQUIRE(old_file.path() == new_path);
+        REQUIRE(std::filesystem::exists(new_path));
+    }
+    REQUIRE_FALSE(std::filesystem::exists(new_path));
+}
+
+// ── ScopeGuard ─────────────────────────────────────────────────────────
+
+TEST_CASE("ScopeGuard runs on scope exit unless dismissed",
+          "[runtime][scope_guard][coverage][phase3]") {
+    int counter = 0;
+    {
+        auto guard = make_scope_guard([&] { counter += 1; });
+        REQUIRE(counter == 0);
+    }
+    REQUIRE(counter == 1);
+
+    {
+        auto guard = make_scope_guard([&] { counter += 10; });
+        guard.dismiss();
+    }
+    REQUIRE(counter == 1);
+}
+
+TEST_CASE("ScopeGuard move transfers the active cleanup",
+          "[runtime][scope_guard][coverage][phase3]") {
+    int counter = 0;
+    {
+        auto first = make_scope_guard([&] { counter += 1; });
+        auto second = std::move(first);
+        REQUIRE(counter == 0);
+    }
+    REQUIRE(counter == 1);
+}
+
+TEST_CASE("PULP_ON_SCOPE_EXIT macro captures local scope",
+          "[runtime][scope_guard][coverage][phase3]") {
+    int counter = 0;
+    {
+        int delta = 4;
+        PULP_ON_SCOPE_EXIT(counter += delta;);
+        delta = 7;
+        REQUIRE(counter == 0);
+    }
+    REQUIRE(counter == 7);
 }
 
 // ── MemoryMappedFile ────────────────────────────────────────────────────

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -268,6 +268,18 @@ TEST_CASE("run_process captures exit code", "[runtime][child_process]") {
     REQUIRE(result->exit_code == 42);
 }
 
+TEST_CASE("run_process captures stderr separately",
+          "[runtime][child_process][coverage][phase3]") {
+#ifdef _WIN32
+    auto result = run_process("powershell", {"-NoProfile", "-Command", "Write-Error 'bad news'; exit 7"});
+#else
+    auto result = run_process("/bin/sh", {"-c", "echo bad-news >&2; exit 7"});
+#endif
+    REQUIRE(result.has_value());
+    REQUIRE(result->exit_code == 7);
+    REQUIRE(result->stderr_output.find("bad-news") != std::string::npos);
+}
+
 TEST_CASE("run_process fails on nonexistent", "[runtime][child_process]") {
 #ifdef _WIN32
     auto result = run_process("C:\\nonexistent_binary_12345.exe");

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -165,6 +165,41 @@ TEST_CASE("MemoryMappedFile move semantics", "[runtime][mmap]") {
     REQUIRE_FALSE(a.is_open());
 }
 
+TEST_CASE("MemoryMappedFile read-write mapping and move assignment",
+          "[runtime][mmap][coverage][phase3]") {
+    TemporaryFile old_tmp(".bin");
+    TemporaryFile new_tmp(".bin");
+    {
+        std::ofstream f(old_tmp.path(), std::ios::binary);
+        f << "old";
+    }
+    {
+        std::ofstream f(new_tmp.path(), std::ios::binary);
+        f << "new";
+    }
+
+    MemoryMappedFile old_map;
+    REQUIRE(old_map.open(old_tmp.path_string()));
+    REQUIRE(old_map.is_open());
+
+    MemoryMappedFile new_map;
+    REQUIRE(new_map.open(new_tmp.path_string(), MapMode::ReadWrite));
+    REQUIRE(new_map.is_open());
+    REQUIRE(new_map.size() == 3);
+    new_map.mutable_data()[0] = 'N';
+
+    old_map = std::move(new_map);
+    REQUIRE(old_map.is_open());
+    REQUIRE_FALSE(new_map.is_open());
+    REQUIRE(std::string(reinterpret_cast<const char*>(old_map.data()), old_map.size()) == "New");
+
+    old_map.close();
+    std::ifstream f(new_tmp.path(), std::ios::binary);
+    std::string persisted;
+    f >> persisted;
+    REQUIRE(persisted == "New");
+}
+
 // ── DynamicLibrary ──────────────────────────────────────────────────────
 
 TEST_CASE("DynamicLibrary loads system library", "[runtime][dynlib]") {

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -271,7 +271,7 @@ TEST_CASE("run_process captures exit code", "[runtime][child_process]") {
 TEST_CASE("run_process captures stderr separately",
           "[runtime][child_process][coverage][phase3]") {
 #ifdef _WIN32
-    auto result = run_process("powershell", {"-NoProfile", "-Command", "Write-Error 'bad news'; exit 7"});
+    auto result = run_process("powershell", {"-NoProfile", "-Command", "[Console]::Error.WriteLine('bad-news'); exit 7"});
 #else
     auto result = run_process("/bin/sh", {"-c", "echo bad-news >&2; exit 7"});
 #endif

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -347,6 +347,26 @@ TEST_CASE("HTTP helpers reject invalid numeric URL ports",
     REQUIRE(too_large_port.error == "Invalid URL");
 }
 
+TEST_CASE("HttpResponse ok helper follows 2xx status range",
+          "[runtime][http][coverage][phase3]") {
+    HttpResponse response;
+
+    response.status_code = 199;
+    REQUIRE_FALSE(response.ok());
+
+    response.status_code = 200;
+    REQUIRE(response.ok());
+
+    response.status_code = 204;
+    REQUIRE(response.ok());
+
+    response.status_code = 299;
+    REQUIRE(response.ok());
+
+    response.status_code = 300;
+    REQUIRE_FALSE(response.ok());
+}
+
 // ── Text Diff ────────────────────────────────────────────────────────────
 
 TEST_CASE("text_diff handles empty inputs", "[runtime][text-diff][issue-641]") {

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -27,6 +27,25 @@ std::filesystem::path make_temp_path(const char* stem) {
 
 }  // namespace
 
+TEST_CASE("StreamResult helper predicates classify errors",
+          "[stream][coverage][phase3]") {
+    auto ok = StreamResult::make(3);
+    REQUIRE(ok.ok());
+    REQUIRE_FALSE(ok.would_block());
+    REQUIRE_FALSE(ok.closed());
+    REQUIRE(ok.bytes == 3);
+
+    auto would_block = StreamResult::fail(StreamError::WouldBlock);
+    REQUIRE_FALSE(would_block.ok());
+    REQUIRE(would_block.would_block());
+    REQUIRE_FALSE(would_block.closed());
+
+    auto invalid = StreamResult::fail(StreamError::Invalid);
+    REQUIRE_FALSE(invalid.ok());
+    REQUIRE_FALSE(invalid.would_block());
+    REQUIRE_FALSE(invalid.closed());
+}
+
 TEST_CASE("MemoryStream round-trip", "[stream]") {
     MemoryStream s;
     const std::uint8_t msg[] = {1, 2, 3, 4, 5};
@@ -181,6 +200,44 @@ TEST_CASE("FileStream append and move keep handle ownership correct", "[stream]"
         REQUIRE(std::memcmp(out, "abcde", sizeof(out)) == 0);
     }
 
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("FileStream read-write mode tracks position and zero-byte I/O",
+          "[stream][coverage][phase3]") {
+    auto path = make_temp_path("pulp_stream_readwrite");
+    const std::uint8_t payload[] = {'r', 'w', '0'};
+
+    FileStream stream(path.string(), FileStream::Mode::ReadWrite);
+    REQUIRE(stream.is_open());
+    REQUIRE(stream.position() == 0);
+
+    REQUIRE(stream.write(payload, 0).ok());
+    REQUIRE(stream.position() == 0);
+
+    auto wrote = stream.write(payload, sizeof(payload));
+    REQUIRE(wrote.ok());
+    REQUIRE(wrote.bytes == sizeof(payload));
+    REQUIRE(stream.position() == sizeof(payload));
+    REQUIRE(stream.flush());
+
+    stream.close();
+    REQUIRE_FALSE(stream.is_open());
+    REQUIRE_FALSE(stream.flush());
+    REQUIRE(stream.position() == static_cast<std::size_t>(-1));
+
+    FileStream reader(path.string(), FileStream::Mode::Read);
+    REQUIRE(reader.is_open());
+    std::uint8_t out[sizeof(payload)]{};
+    REQUIRE(reader.read(out, 0).ok());
+    REQUIRE(reader.position() == 0);
+
+    auto got = reader.read(out, sizeof(out));
+    REQUIRE(got.ok());
+    REQUIRE(got.bytes == sizeof(out));
+    REQUIRE(std::memcmp(out, payload, sizeof(payload)) == 0);
+
+    reader.close();
     std::filesystem::remove(path);
 }
 


### PR DESCRIPTION
## Summary
- batch twelve focused runtime coverage commits into one GitHub-hosted CI run
- cover temp/scope/mmap/child-process helpers, stream/http states, JSON-RPC/message-channel edges, SPSC/system helpers, BigInteger, and dynamic-library moves
- test-only changes; no Namespace/SSH lanes dispatched

## Local validation
- `cmake --build build --target pulp-test-runtime-utils pulp-test-json-rpc pulp-test-memory-message-channel pulp-test-stream pulp-test-network-stream pulp-test-runtime pulp-test-license -j$(sysctl -n hw.ncpu)`
- `ctest --test-dir build --output-on-failure -R "PULP_ON_SCOPE_EXIT|TemporaryFile|ScopeGuard|MemoryMappedFile|run_process|HttpResponse|HTTP helpers|JsonRpcPeer|MemoryMessageChannel|StreamResult|FileStream|MemoryStream|Stream polymorphic|HttpStream|SpscQueue|Runtime localtime|Runtime system info|BigInteger|DynamicLibrary"` (79/79 passed)
- `git diff --check`

## CI policy
GitHub-hosted only for this batch; Namespace/SSH lanes intentionally not used.