### PR TITLE
test: batch events coverage

### DIFF
--- a/core/events/include/pulp/events/async_updater.hpp
+++ b/core/events/include/pulp/events/async_updater.hpp
@@ -106,8 +106,13 @@ public:
 
     /// Send an action to all listeners
     void send_action(std::string_view action) {
-        for (auto& [id, fn] : listeners_) {
+        std::vector<ActionCallback> callbacks;
+        callbacks.reserve(listeners_.size());
+        for (const auto& [id, fn] : listeners_) {
             (void)id;
+            callbacks.push_back(fn);
+        }
+        for (auto& fn : callbacks) {
             if (fn) fn(action);
         }
     }

--- a/core/events/include/pulp/events/async_updater.hpp
+++ b/core/events/include/pulp/events/async_updater.hpp
@@ -106,8 +106,10 @@ public:
 
     /// Send an action to all listeners
     void send_action(std::string_view action) {
-        for (auto& [id, fn] : listeners_)
-            fn(action);
+        for (auto& [id, fn] : listeners_) {
+            (void)id;
+            if (fn) fn(action);
+        }
     }
 
     /// Add a listener. Returns an ID for removal.

--- a/core/events/include/pulp/events/volume_detector.hpp
+++ b/core/events/include/pulp/events/volume_detector.hpp
@@ -42,6 +42,8 @@ public:
 private:
     std::atomic<bool> running_{false};
     std::thread thread_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
     std::vector<std::string> last_volumes_;
 };
 

--- a/core/events/src/event_loop.cpp
+++ b/core/events/src/event_loop.cpp
@@ -86,7 +86,7 @@ void EventLoop::run() {
 
         // Execute outside the lock
         for (auto& task : tasks) {
-            task();
+            if (task) task();
         }
     }
 }

--- a/core/events/src/timer.cpp
+++ b/core/events/src/timer.cpp
@@ -73,7 +73,8 @@ void Timer::schedule_next(std::shared_ptr<Impl> impl, std::uint64_t gen) {
             return;
         if (!impl->repeating)
             impl->active.store(false, std::memory_order_release);
-        impl->callback();
+        if (impl->callback)
+            impl->callback();
         if (!impl->repeating)
             return;
         if (!impl->active.load(std::memory_order_acquire))

--- a/core/events/src/volume_detector.cpp
+++ b/core/events/src/volume_detector.cpp
@@ -17,8 +17,12 @@ void MountedVolumeListChangeDetector::start(std::chrono::milliseconds interval) 
 
     thread_ = std::thread([this, interval]() {
         while (running_.load()) {
-            std::this_thread::sleep_for(interval);
-            if (!running_.load()) break;
+            {
+                std::unique_lock lock(mutex_);
+                if (cv_.wait_for(lock, interval, [this] { return !running_.load(); })) {
+                    break;
+                }
+            }
 
             auto current = get_mounted_volumes();
             if (current != last_volumes_) {
@@ -31,6 +35,7 @@ void MountedVolumeListChangeDetector::start(std::chrono::milliseconds interval) 
 
 void MountedVolumeListChangeDetector::stop() {
     running_.store(false);
+    cv_.notify_all();
     if (thread_.joinable()) thread_.join();
 }
 

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -283,6 +283,39 @@ TEST_CASE("Timer tolerates empty callbacks",
     REQUIRE_FALSE(repeating.is_active());
 }
 
+TEST_CASE("Timer one-shot can be restarted after firing",
+          "[events][timer][codecov]") {
+    EventLoop loop;
+    std::atomic<int> count{0};
+    Timer timer(loop, 1ms, [&] { count.fetch_add(1); }, false);
+
+    timer.start();
+    REQUIRE(wait_until([&] { return count.load() == 1; }, kTimerAsyncBudget));
+    REQUIRE_FALSE(timer.is_active());
+
+    timer.start();
+    REQUIRE(wait_until([&] { return count.load() == 2; }, kTimerAsyncBudget));
+    REQUIRE_FALSE(timer.is_active());
+}
+
+TEST_CASE("Timer stop before first fire permits a later restart",
+          "[events][timer][codecov]") {
+    EventLoop loop;
+    std::atomic<int> count{0};
+    Timer timer(loop, 50ms, [&] { count.fetch_add(1); }, false);
+
+    timer.start();
+    timer.stop();
+    std::this_thread::sleep_for(80ms);
+    REQUIRE(count.load() == 0);
+    REQUIRE_FALSE(timer.is_active());
+
+    timer.set_interval(1ms);
+    timer.start();
+    REQUIRE(wait_until([&] { return count.load() == 1; }, kTimerAsyncBudget));
+    REQUIRE_FALSE(timer.is_active());
+}
+
 // #687 — stop()/start() pairs repeatedly on the owner thread while the
 // event-loop thread is running timer dispatches. Pre-fix, start()'s
 // `alive_ = make_shared<>(...)` raced with schedule_next()'s

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -154,6 +154,28 @@ TEST_CASE("EventLoop dispatch_after handles multiple ready tasks",
     REQUIRE(wait_until([&] { return calls.load() == 3; }, 2000ms));
 }
 
+TEST_CASE("EventLoop skips empty dispatched tasks",
+          "[events][event_loop][codecov]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+
+    loop.dispatch({});
+    loop.dispatch([&] { calls.fetch_add(1); });
+
+    REQUIRE(wait_until([&] { return calls.load() == 1; }, 2000ms));
+}
+
+TEST_CASE("EventLoop skips empty delayed tasks",
+          "[events][event_loop][codecov]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+
+    loop.dispatch_after(1ms, {});
+    loop.dispatch_after(2ms, [&] { calls.fetch_add(1); });
+
+    REQUIRE(wait_until([&] { return calls.load() == 1; }, 2000ms));
+}
+
 TEST_CASE("Timer basic operation", "[events][timer]") {
     EventLoop loop;
 

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -200,6 +200,19 @@ TEST_CASE("EventLoop ignores new dispatches after stop",
     REQUIRE(calls.load() == 0);
 }
 
+TEST_CASE("EventLoop runs tasks dispatched from the loop thread",
+          "[events][event_loop][codecov]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+
+    loop.dispatch([&] {
+        calls.fetch_add(1);
+        loop.dispatch([&] { calls.fetch_add(1); });
+    });
+
+    REQUIRE(wait_until([&] { return calls.load() == 2; }, 2000ms));
+}
+
 TEST_CASE("Timer basic operation", "[events][timer]") {
     EventLoop loop;
 

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -528,6 +528,37 @@ TEST_CASE("ActionBroadcaster skips empty callbacks",
     REQUIRE(seen.size() == 1);
 }
 
+TEST_CASE("ActionBroadcaster snapshots callbacks during dispatch",
+          "[events][async_updater][action_broadcaster][codecov]") {
+    ActionBroadcaster broadcaster;
+    std::vector<std::string> seen;
+    int first_id = -1;
+    int second_id = -1;
+    int added_id = -1;
+
+    first_id = broadcaster.add_listener([&](std::string_view action) {
+        seen.emplace_back("first:" + std::string(action));
+        broadcaster.remove_listener(first_id);
+        broadcaster.remove_listener(second_id);
+        added_id = broadcaster.add_listener([&](std::string_view later) {
+            seen.emplace_back("added:" + std::string(later));
+        });
+    });
+
+    second_id = broadcaster.add_listener([&](std::string_view action) {
+        seen.emplace_back("second:" + std::string(action));
+    });
+
+    broadcaster.send_action("refresh");
+    REQUIRE(seen == std::vector<std::string>{"first:refresh", "second:refresh"});
+
+    broadcaster.send_action("again");
+    REQUIRE(seen == std::vector<std::string>{
+        "first:refresh", "second:refresh", "added:again"});
+
+    broadcaster.remove_listener(added_id);
+}
+
 TEST_CASE("ScopedLowPowerModeDisabler is constructible as an RAII guard",
           "[events][async_updater][power]") {
     {

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -267,6 +267,22 @@ TEST_CASE("Timer exposes interval and idempotent stop state",
     REQUIRE_FALSE(timer.is_active());
 }
 
+TEST_CASE("Timer tolerates empty callbacks",
+          "[events][timer][codecov]") {
+    EventLoop loop;
+
+    Timer one_shot(loop, 1ms, {}, false);
+    one_shot.start();
+    REQUIRE(wait_until([&] { return !one_shot.is_active(); }, 2000ms));
+
+    Timer repeating(loop, 1ms, {}, true);
+    repeating.start();
+    REQUIRE(wait_until([&] { return repeating.is_active(); }, 2000ms));
+    std::this_thread::sleep_for(10ms);
+    repeating.stop();
+    REQUIRE_FALSE(repeating.is_active());
+}
+
 // #687 — stop()/start() pairs repeatedly on the owner thread while the
 // event-loop thread is running timer dispatches. Pre-fix, start()'s
 // `alive_ = make_shared<>(...)` raced with schedule_next()'s

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -176,6 +176,30 @@ TEST_CASE("EventLoop skips empty delayed tasks",
     REQUIRE(wait_until([&] { return calls.load() == 1; }, 2000ms));
 }
 
+TEST_CASE("EventLoop dispatch_after runs due tasks immediately",
+          "[events][event_loop][codecov]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+
+    loop.dispatch_after(0ms, [&] { calls.fetch_add(1); });
+    loop.dispatch_after(-1ms, [&] { calls.fetch_add(1); });
+
+    REQUIRE(wait_until([&] { return calls.load() == 2; }, 2000ms));
+}
+
+TEST_CASE("EventLoop ignores new dispatches after stop",
+          "[events][event_loop][codecov]") {
+    EventLoop loop;
+    loop.stop();
+
+    std::atomic<int> calls{0};
+    loop.dispatch([&] { calls.fetch_add(1); });
+    loop.dispatch_after(0ms, [&] { calls.fetch_add(1); });
+    std::this_thread::sleep_for(20ms);
+
+    REQUIRE(calls.load() == 0);
+}
+
 TEST_CASE("Timer basic operation", "[events][timer]") {
     EventLoop loop;
 

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -488,6 +488,24 @@ TEST_CASE("ActionBroadcaster adds, removes, and notifies listeners",
     REQUIRE(seen.size() == 5);
 }
 
+TEST_CASE("ActionBroadcaster skips empty callbacks",
+          "[events][async_updater][action_broadcaster][codecov]") {
+    ActionBroadcaster broadcaster;
+    std::vector<std::string> seen;
+
+    auto empty = broadcaster.add_listener({});
+    auto live = broadcaster.add_listener(
+        [&](std::string_view action) { seen.emplace_back(action); });
+
+    broadcaster.send_action("refresh");
+    REQUIRE(seen == std::vector<std::string>{"refresh"});
+
+    broadcaster.remove_listener(empty);
+    broadcaster.remove_listener(live);
+    broadcaster.send_action("ignored");
+    REQUIRE(seen.size() == 1);
+}
+
 TEST_CASE("ScopedLowPowerModeDisabler is constructible as an RAII guard",
           "[events][async_updater][power]") {
     {

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -3,6 +3,7 @@
 #include <pulp/events/async_updater.hpp>
 #include <pulp/events/child_process_manager.hpp>
 #include <pulp/events/interprocess_connection.hpp>
+#include <pulp/events/volume_detector.hpp>
 #include <atomic>
 #include <chrono>
 #include <memory>
@@ -643,6 +644,23 @@ TEST_CASE("ActionBroadcaster snapshots callbacks during dispatch",
         "first:refresh", "second:refresh", "added:again"});
 
     broadcaster.remove_listener(added_id);
+}
+
+TEST_CASE("MountedVolumeListChangeDetector polls once before stop",
+          "[events][volume_detector][codecov]") {
+    MountedVolumeListChangeDetector detector;
+    std::atomic<int> changes{0};
+    detector.on_change = [&](const std::vector<std::string>&) {
+        changes.fetch_add(1);
+    };
+
+    detector.start(1ms);
+    REQUIRE(detector.is_running());
+
+    std::this_thread::sleep_for(30ms);
+    detector.stop();
+
+    REQUIRE_FALSE(detector.is_running());
 }
 
 TEST_CASE("ScopedLowPowerModeDisabler is constructible as an RAII guard",

--- a/test/test_ipc.cpp
+++ b/test/test_ipc.cpp
@@ -41,6 +41,11 @@ struct CapturingServer : InterprocessConnectionServer {
             last_text.assign(message);
             cv.notify_all();
         };
+        conn->on_disconnected = [this] {
+            std::lock_guard<std::mutex> lock(mutex);
+            ++disconnects;
+            cv.notify_all();
+        };
 
         std::lock_guard<std::mutex> lock(mutex);
         accepted = std::move(conn);
@@ -52,6 +57,7 @@ struct CapturingServer : InterprocessConnectionServer {
     std::unique_ptr<InterprocessConnection> accepted;
     int binary_messages = 0;
     int text_messages = 0;
+    int disconnects = 0;
     size_t last_binary_size = 1;
     std::string last_text = "unset";
 };
@@ -333,6 +339,35 @@ TEST_CASE("IPC socket server receives binary payload frames",
     }
 
     client.disconnect();
+    if (server.accepted) server.accepted->disconnect();
+    server.stop();
+    REQUIRE_FALSE(server.is_running());
+}
+
+TEST_CASE("IPC socket server observes client disconnect",
+          "[events][ipc][socket][codecov]") {
+    CapturingServer server;
+    auto port = start_socket_server_on_loopback(server);
+    REQUIRE(port.has_value());
+
+    InterprocessConnection client;
+    REQUIRE(client.connect("127.0.0.1:" + std::to_string(*port), IpcTransport::Socket));
+
+    {
+        std::unique_lock<std::mutex> lock(server.mutex);
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return server.accepted != nullptr;
+        }));
+    }
+
+    client.disconnect();
+    {
+        std::unique_lock<std::mutex> lock(server.mutex);
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return server.disconnects == 1;
+        }));
+    }
+
     if (server.accepted) server.accepted->disconnect();
     server.stop();
     REQUIRE_FALSE(server.is_running());

--- a/test/test_ipc.cpp
+++ b/test/test_ipc.cpp
@@ -303,3 +303,37 @@ TEST_CASE("IPC socket server virtual callback accepts empty frames",
     server.stop();
     REQUIRE_FALSE(server.is_running());
 }
+
+TEST_CASE("IPC socket server receives binary payload frames",
+          "[events][ipc][socket][codecov]") {
+    CapturingServer server;
+    auto port = start_socket_server_on_loopback(server);
+    REQUIRE(port.has_value());
+
+    InterprocessConnection client;
+    REQUIRE(client.connect("127.0.0.1:" + std::to_string(*port), IpcTransport::Socket));
+
+    {
+        std::unique_lock<std::mutex> lock(server.mutex);
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return server.accepted != nullptr;
+        }));
+    }
+
+    const std::vector<uint8_t> payload{0x00, 0x01, 0x7f, 0xff};
+    REQUIRE(client.send_message(payload.data(), payload.size()));
+
+    {
+        std::unique_lock<std::mutex> lock(server.mutex);
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return server.binary_messages == 1 && server.text_messages == 1;
+        }));
+        REQUIRE(server.last_binary_size == payload.size());
+        REQUIRE(server.last_text.size() == payload.size());
+    }
+
+    client.disconnect();
+    if (server.accepted) server.accepted->disconnect();
+    server.stop();
+    REQUIRE_FALSE(server.is_running());
+}

--- a/test/test_ipc.cpp
+++ b/test/test_ipc.cpp
@@ -372,3 +372,32 @@ TEST_CASE("IPC socket server observes client disconnect",
     server.stop();
     REQUIRE_FALSE(server.is_running());
 }
+
+TEST_CASE("IPC socket client reports disconnect callback once",
+          "[events][ipc][socket][codecov]") {
+    CapturingServer server;
+    auto port = start_socket_server_on_loopback(server);
+    REQUIRE(port.has_value());
+
+    int disconnected = 0;
+    InterprocessConnection client;
+    client.on_disconnected = [&] { ++disconnected; };
+    REQUIRE(client.connect("127.0.0.1:" + std::to_string(*port), IpcTransport::Socket));
+
+    {
+        std::unique_lock<std::mutex> lock(server.mutex);
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return server.accepted != nullptr;
+        }));
+    }
+
+    client.disconnect();
+    client.disconnect();
+    REQUIRE(disconnected == 1);
+    REQUIRE_FALSE(client.is_connected());
+    REQUIRE(client.state() == IpcState::Disconnected);
+
+    if (server.accepted) server.accepted->disconnect();
+    server.stop();
+    REQUIRE_FALSE(server.is_running());
+}

--- a/test/test_network_service_discovery.cpp
+++ b/test/test_network_service_discovery.cpp
@@ -102,6 +102,37 @@ TEST_CASE("NSD dispatches browse/register/unregister to installed backend",
     REQUIRE(log->stopped == 1);
 }
 
+TEST_CASE("NSD can browse again after stop",
+          "[events][service-discovery][codecov]") {
+    NetworkServiceDiscovery nsd;
+    auto backend = std::make_unique<FakeBackend>();
+    auto log = backend->log;
+    nsd.install_backend(std::move(backend));
+
+    nsd.browse("_pulp._tcp");
+    nsd.stop();
+    nsd.browse("_http._tcp");
+    nsd.stop();
+
+    REQUIRE(log->browse_types == std::vector<std::string>{"_pulp._tcp", "_http._tcp"});
+    REQUIRE(log->stopped == 2);
+}
+
+TEST_CASE("NSD unregister after backend removal is a no-op",
+          "[events][service-discovery][codecov]") {
+    NetworkServiceDiscovery nsd;
+    auto backend = std::make_unique<FakeBackend>();
+    auto log = backend->log;
+    nsd.install_backend(std::move(backend));
+
+    nsd.unregister_service();
+    REQUIRE(log->unregistered == 1);
+
+    nsd.install_backend(nullptr);
+    nsd.unregister_service();
+    REQUIRE(log->unregistered == 1);
+}
+
 TEST_CASE("NSD browse backend can publish through the dispatcher",
           "[events][service-discovery][issue-642]") {
     NetworkServiceDiscovery nsd;

--- a/test/test_network_service_discovery.cpp
+++ b/test/test_network_service_discovery.cpp
@@ -447,6 +447,25 @@ TEST_CASE("MountedVolumeListChangeDetector start and stop are idempotent",
     REQUIRE_FALSE(detector.is_running());
 }
 
+TEST_CASE("MountedVolumeListChangeDetector stop wakes a long poll promptly",
+          "[events][volume][lifecycle][codecov]") {
+#ifdef _WIN32
+    SUCCEED("Windows drive probing can throw on unavailable runner drives; covered on POSIX.");
+    return;
+#endif
+
+    MountedVolumeListChangeDetector detector;
+    detector.start(std::chrono::hours(1));
+    REQUIRE(detector.is_running());
+
+    const auto start = std::chrono::steady_clock::now();
+    detector.stop();
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    REQUIRE_FALSE(detector.is_running());
+    REQUIRE(elapsed < 500ms);
+}
+
 TEST_CASE("LockingAsyncUpdater trigger_and_wait handles synchronously",
           "[events][async_updater][locking]") {
     RecordingLockingUpdater updater;


### PR DESCRIPTION
## Summary
- batch events subsystem coverage across EventLoop, Timer, ActionBroadcaster, IPC, service discovery, and mounted-volume polling
- harden empty callback/task paths and mutation-safe broadcaster dispatch
- make mounted-volume detector stop wake promptly instead of waiting out a long poll sleep

## Local validation
- `cmake --build build --target pulp-test-events pulp-test-ipc pulp-test-network-service-discovery -j$(sysctl -n hw.ncpu)`
- `ctest --test-dir build --output-on-failure -R "EventLoop|Timer|ActionBroadcaster|IPC|NSD|MountedVolumeListChangeDetector|LockingAsyncUpdater"` (57/57 passed)
- `git diff --check`

No Namespace/SSH validation dispatched; GitHub-hosted CI only.
