### PR TITLE
test: consolidate phase 3 codecov coverage queue

### DIFF
--- a/core/audio/include/pulp/audio/buffering_reader.hpp
+++ b/core/audio/include/pulp/audio/buffering_reader.hpp
@@ -82,6 +82,7 @@ public:
     /// @param num_channels Number of channels (must match start()).
     /// @return Number of frames actually copied (may be less if buffer underrun).
     int read(float* dest, int num_frames, int num_channels) {
+        if (dest == nullptr || num_frames <= 0) return 0;
         if (num_channels != num_channels_ || buffer_.empty()) return 0;
 
         int samples_requested = num_frames * num_channels;

--- a/core/audio/include/pulp/audio/subsection_reader.hpp
+++ b/core/audio/include/pulp/audio/subsection_reader.hpp
@@ -38,6 +38,7 @@ public:
 
     /// Copy frames from this subsection into a destination buffer
     void read_frames(float* dest, uint32_t channel, uint64_t start, uint64_t count) const {
+        if (dest == nullptr) return;
         if (!source_ || channel >= num_channels()) return;
         uint64_t actual_start = start_ + std::min(start, length_);
         uint64_t actual_count = std::min(count, length_ - std::min(start, length_));

--- a/core/audio/src/mmap_reader.cpp
+++ b/core/audio/src/mmap_reader.cpp
@@ -30,7 +30,6 @@ void MemoryMappedAudioReader::close() {
 bool MemoryMappedAudioReader::read_frames(float** dest_channels, uint32_t num_channels,
                                            uint64_t start_frame, uint64_t num_frames) {
     if (!is_open()) return false;
-    if (dest_channels == nullptr) return false;
 
     // For now, read the full file and extract the range
     // A more optimized version would decode only the requested range
@@ -41,10 +40,6 @@ bool MemoryMappedAudioReader::read_frames(float** dest_channels, uint32_t num_ch
     uint64_t avail = data->num_frames();
     uint64_t start = std::min(start_frame, avail);
     uint64_t count = std::min(num_frames, avail - start);
-
-    for (uint32_t c = 0; c < ch_count; ++c) {
-        if (dest_channels[c] == nullptr) return false;
-    }
 
     for (uint32_t c = 0; c < ch_count; ++c)
         for (uint64_t f = 0; f < count; ++f)

--- a/core/audio/src/mmap_reader.cpp
+++ b/core/audio/src/mmap_reader.cpp
@@ -30,6 +30,7 @@ void MemoryMappedAudioReader::close() {
 bool MemoryMappedAudioReader::read_frames(float** dest_channels, uint32_t num_channels,
                                            uint64_t start_frame, uint64_t num_frames) {
     if (!is_open()) return false;
+    if (dest_channels == nullptr) return false;
 
     // For now, read the full file and extract the range
     // A more optimized version would decode only the requested range
@@ -40,6 +41,10 @@ bool MemoryMappedAudioReader::read_frames(float** dest_channels, uint32_t num_ch
     uint64_t avail = data->num_frames();
     uint64_t start = std::min(start_frame, avail);
     uint64_t count = std::min(num_frames, avail - start);
+
+    for (uint32_t c = 0; c < ch_count; ++c) {
+        if (dest_channels[c] == nullptr) return false;
+    }
 
     for (uint32_t c = 0; c < ch_count; ++c)
         for (uint64_t f = 0; f < count; ++f)

--- a/core/events/include/pulp/events/async_updater.hpp
+++ b/core/events/include/pulp/events/async_updater.hpp
@@ -106,8 +106,13 @@ public:
 
     /// Send an action to all listeners
     void send_action(std::string_view action) {
-        for (auto& [id, fn] : listeners_) {
+        std::vector<ActionCallback> callbacks;
+        callbacks.reserve(listeners_.size());
+        for (const auto& [id, fn] : listeners_) {
             (void)id;
+            callbacks.push_back(fn);
+        }
+        for (auto& fn : callbacks) {
             if (fn) fn(action);
         }
     }

--- a/core/events/include/pulp/events/async_updater.hpp
+++ b/core/events/include/pulp/events/async_updater.hpp
@@ -106,8 +106,10 @@ public:
 
     /// Send an action to all listeners
     void send_action(std::string_view action) {
-        for (auto& [id, fn] : listeners_)
-            fn(action);
+        for (auto& [id, fn] : listeners_) {
+            (void)id;
+            if (fn) fn(action);
+        }
     }
 
     /// Add a listener. Returns an ID for removal.

--- a/core/events/include/pulp/events/volume_detector.hpp
+++ b/core/events/include/pulp/events/volume_detector.hpp
@@ -42,6 +42,8 @@ public:
 private:
     std::atomic<bool> running_{false};
     std::thread thread_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
     std::vector<std::string> last_volumes_;
 };
 

--- a/core/events/src/event_loop.cpp
+++ b/core/events/src/event_loop.cpp
@@ -86,7 +86,7 @@ void EventLoop::run() {
 
         // Execute outside the lock
         for (auto& task : tasks) {
-            task();
+            if (task) task();
         }
     }
 }

--- a/core/events/src/timer.cpp
+++ b/core/events/src/timer.cpp
@@ -73,7 +73,8 @@ void Timer::schedule_next(std::shared_ptr<Impl> impl, std::uint64_t gen) {
             return;
         if (!impl->repeating)
             impl->active.store(false, std::memory_order_release);
-        impl->callback();
+        if (impl->callback)
+            impl->callback();
         if (!impl->repeating)
             return;
         if (!impl->active.load(std::memory_order_acquire))

--- a/core/events/src/volume_detector.cpp
+++ b/core/events/src/volume_detector.cpp
@@ -17,8 +17,12 @@ void MountedVolumeListChangeDetector::start(std::chrono::milliseconds interval) 
 
     thread_ = std::thread([this, interval]() {
         while (running_.load()) {
-            std::this_thread::sleep_for(interval);
-            if (!running_.load()) break;
+            {
+                std::unique_lock lock(mutex_);
+                if (cv_.wait_for(lock, interval, [this] { return !running_.load(); })) {
+                    break;
+                }
+            }
 
             auto current = get_mounted_volumes();
             if (current != last_volumes_) {
@@ -31,6 +35,7 @@ void MountedVolumeListChangeDetector::start(std::chrono::milliseconds interval) 
 
 void MountedVolumeListChangeDetector::stop() {
     running_.store(false);
+    cv_.notify_all();
     if (thread_.joinable()) thread_.join();
 }
 

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -109,6 +109,9 @@ public:
     NodeId add_input_node(int channels, const std::string& name = "Input");
     NodeId add_output_node(int channels, const std::string& name = "Output");
     NodeId add_plugin_node(const PluginInfo& info);
+    NodeId add_unresolved_plugin_node(const PluginInfo& info,
+                                      int num_inputs, int num_outputs,
+                                      const std::string& name);
 
     // Add a plugin node wrapping a caller-provided slot. Useful for tests
     // (mock latency, mock processing) and for hosts that build their own

--- a/core/host/src/graph_serializer.cpp
+++ b/core/host/src/graph_serializer.cpp
@@ -253,7 +253,7 @@ GraphSerializer::LoadResult GraphSerializer::from_json(SignalGraph& graph, const
                             std::string(format_str(info.format)) + ":" + info.unique_id);
                         // Still create a placeholder Plugin node with no slot so
                         // connection IDs remain stable.
-                        new_id = graph.add_plugin_node(info);
+                        new_id = graph.add_unresolved_plugin_node(info, in_ch, out_ch, name);
                     } else {
                         if (pv.hasObjectMember("state_b64")) {
                             auto blob = b64_decode(pv["state_b64"].getString());

--- a/core/host/src/graph_serializer.cpp
+++ b/core/host/src/graph_serializer.cpp
@@ -253,7 +253,7 @@ GraphSerializer::LoadResult GraphSerializer::from_json(SignalGraph& graph, const
                             std::string(format_str(info.format)) + ":" + info.unique_id);
                         // Still create a placeholder Plugin node with no slot so
                         // connection IDs remain stable.
-                        new_id = graph.add_plugin_node(std::unique_ptr<PluginSlot>{}, in_ch, out_ch, name);
+                        new_id = graph.add_plugin_node(info);
                     } else {
                         if (pv.hasObjectMember("state_b64")) {
                             auto blob = b64_decode(pv["state_b64"].getString());

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -53,6 +53,24 @@ NodeId SignalGraph::add_plugin_node(const PluginInfo& info) {
     return nodes_.back().id;
 }
 
+NodeId SignalGraph::add_unresolved_plugin_node(const PluginInfo& info,
+                                               int num_inputs,
+                                               int num_outputs,
+                                               const std::string& name) {
+    GraphNode node;
+    node.id = next_id_++;
+    node.type = NodeType::Plugin;
+    node.name = name;
+    node.num_input_ports = num_inputs;
+    node.num_output_ports = num_outputs;
+    node.plugin_info = info;
+    node.plugin_info.num_inputs = num_inputs;
+    node.plugin_info.num_outputs = num_outputs;
+    nodes_.push_back(std::move(node));
+    invalidate_live_();
+    return nodes_.back().id;
+}
+
 NodeId SignalGraph::add_plugin_node(std::unique_ptr<PluginSlot> slot,
                                     int num_inputs, int num_outputs,
                                     const std::string& name) {

--- a/core/runtime/src/analytics.cpp
+++ b/core/runtime/src/analytics.cpp
@@ -4,6 +4,26 @@
 
 namespace pulp::runtime {
 
+namespace {
+
+std::string json_escape(std::string_view value) {
+    std::string escaped;
+    escaped.reserve(value.size());
+    for (char c : value) {
+        switch (c) {
+            case '\\': escaped += "\\\\"; break;
+            case '"': escaped += "\\\""; break;
+            case '\n': escaped += "\\n"; break;
+            case '\r': escaped += "\\r"; break;
+            case '\t': escaped += "\\t"; break;
+            default: escaped += c; break;
+        }
+    }
+    return escaped;
+}
+
+}  // namespace
+
 // ── FileAnalyticsDestination ────────────────────────────────────────────
 
 FileAnalyticsDestination::FileAnalyticsDestination(std::string_view path)
@@ -28,13 +48,13 @@ void FileAnalyticsDestination::flush() {
     if (!file) return;
 
     for (auto& event : buffer_) {
-        file << "{\"event\":\"" << event.name << "\",\"time\":" << event.timestamp;
+        file << "{\"event\":\"" << json_escape(event.name) << "\",\"time\":" << event.timestamp;
         if (!event.properties.empty()) {
             file << ",\"props\":{";
             bool first = true;
             for (auto& [k, v] : event.properties) {
                 if (!first) file << ",";
-                file << "\"" << k << "\":\"" << v << "\"";
+                file << "\"" << json_escape(k) << "\":\"" << json_escape(v) << "\"";
                 first = false;
             }
             file << "}";

--- a/core/runtime/src/analytics.cpp
+++ b/core/runtime/src/analytics.cpp
@@ -10,13 +10,18 @@ std::string json_escape(std::string_view value) {
     std::string escaped;
     escaped.reserve(value.size());
     for (char c : value) {
-        switch (c) {
-            case '\\': escaped += "\\\\"; break;
-            case '"': escaped += "\\\""; break;
-            case '\n': escaped += "\\n"; break;
-            case '\r': escaped += "\\r"; break;
-            case '\t': escaped += "\\t"; break;
-            default: escaped += c; break;
+        if (c == '\\') {
+            escaped += "\\\\";
+        } else if (c == '"') {
+            escaped += "\\\"";
+        } else if (c == '\n') {
+            escaped += "\\n";
+        } else if (c == '\r') {
+            escaped += "\\r";
+        } else if (c == '\t') {
+            escaped += "\\t";
+        } else {
+            escaped += c;
         }
     }
     return escaped;

--- a/core/runtime/src/identity.cpp
+++ b/core/runtime/src/identity.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <iomanip>
 #include <charconv>
+#include <cctype>
 
 namespace pulp::runtime {
 
@@ -40,12 +41,21 @@ Uuid Uuid::from_string(std::string_view str) {
     // Parse "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" (36 chars)
     // or compact "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" (32 chars)
     Uuid id;
+    if (str.size() != 32 && str.size() != 36) return id;
+    if (str.size() == 36 &&
+        (str[8] != '-' || str[13] != '-' || str[18] != '-' || str[23] != '-')) {
+        return id;
+    }
+
     std::string hex;
     hex.reserve(32);
     for (char c : str) {
         if (c != '-') hex += c;
     }
     if (hex.size() != 32) return id; // nil on parse failure
+    for (char c : hex) {
+        if (!std::isxdigit(static_cast<unsigned char>(c))) return id;
+    }
 
     for (int i = 0; i < 8; ++i) {
         id.hi = (id.hi << 8) | (hex_digit(hex[i * 2]) << 4 | hex_digit(hex[i * 2 + 1]));

--- a/core/view/include/pulp/view/preset_browser.hpp
+++ b/core/view/include/pulp/view/preset_browser.hpp
@@ -213,6 +213,8 @@ public:
 
         // Click in list area
         float list_y = header_h + (filter_text_.empty() ? 4.0f : 22.0f);
+        if (event.position.y < list_y)
+            return;
         float click_y = event.position.y - list_y + scroll_offset_;
         int index = static_cast<int>(click_y / row_height_);
 

--- a/core/view/src/asset_manager.cpp
+++ b/core/view/src/asset_manager.cpp
@@ -206,15 +206,8 @@ FontData AssetManager::load_font(const std::string& path) {
     FontData font;
     font.data = std::move(blob.data);
 
-    // Extract family name from path
-    auto slash = path.rfind('/');
-    auto dot = path.rfind('.');
-    if (slash != std::string::npos && dot != std::string::npos && dot > slash)
-        font.family_name = path.substr(slash + 1, dot - slash - 1);
-    else if (dot != std::string::npos)
-        font.family_name = path.substr(0, dot);
-    else
-        font.family_name = path;
+    // Extract family name from path using platform separators.
+    font.family_name = std::filesystem::path(path).stem().string();
 
     CacheEntry entry;
     entry.type = CacheEntry::Type::font;

--- a/core/view/src/table.cpp
+++ b/core/view/src/table.cpp
@@ -104,6 +104,11 @@ void TableListBox::paint(canvas::Canvas& canvas) {
 void TableListBox::on_mouse_down(Point pos) {
     float header_h = header_height_;
 
+    if (pos.x < 0.0f || pos.y < 0.0f || pos.x >= bounds().width ||
+        pos.y >= bounds().height) {
+        return;
+    }
+
     if (pos.y < header_h) {
         // Click on header — sort by column
         float col_x = 0;

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -186,6 +186,7 @@ find "${PROFRAW_DIR}" -name '*.profraw' -print0 \
 # External SDK archives (libausdk.a, libvst3-sdk.a) are excluded because
 # they're built from third-party sources not instrumented by our flags.
 BINARIES=()
+TEST_BINARIES=()
 
 # First-party static libraries — expose every instrumented TU regardless
 # of whether a test links it. Pattern is `libpulp-*.a` on macOS/Linux
@@ -213,7 +214,10 @@ while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
 # CTest can run `.exe` files whose Unix executable bit is not visible to
 # `find -perm -u+x`; include `.exe` explicitly so their coverage maps reach
 # llvm-cov.
-while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
+while IFS= read -r f; do
+    TEST_BINARIES+=("$f")
+    BINARIES+=("-object" "$f")
+done < <(
     find "${BUILD_DIR}/test" -maxdepth 2 -type f \
          \( -perm -u+x -o -name '*.exe' \) \
          ! -name '*.cmake' ! -name '*.txt' 2>/dev/null || true
@@ -223,7 +227,10 @@ while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
 # binaries in the llvm-cov object set. The embedded Python bindings
 # smoke target is built under bindings/python/, not build/test/, so
 # without this pass its profile data never contributes to report/show.
-while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
+while IFS= read -r f; do
+    TEST_BINARIES+=("$f")
+    BINARIES+=("-object" "$f")
+done < <(
     find "${BUILD_DIR}" -type f \
          \( -perm -u+x -o -name '*.exe' \) \
          -name 'pulp-test-*' \
@@ -234,7 +241,7 @@ while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
          2>/dev/null || true
 )
 
-if [[ ${#BINARIES[@]} -eq 0 ]]; then
+if [[ ${#TEST_BINARIES[@]} -eq 0 ]]; then
     echo "run_coverage.sh: no test binaries found under ${BUILD_DIR}/test" >&2
     exit 1
 fi

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -187,10 +187,32 @@ find "${PROFRAW_DIR}" -name '*.profraw' -print0 \
 # they're built from third-party sources not instrumented by our flags.
 BINARIES=()
 
-# Test executables — first, these drive the actual coverage hits. On
-# Windows/MSYS, CTest can run `.exe` files whose Unix executable bit is
-# not visible to `find -perm -u+x`; include `.exe` explicitly so their
-# coverage maps reach llvm-cov.
+# First-party static libraries — expose every instrumented TU regardless
+# of whether a test links it. Pattern is `libpulp-*.a` on macOS/Linux
+# and `pulp-*.lib` on Windows (clang-cl's MSVC-style driver emits `.lib`
+# archives, not `.a`). Without the `.lib` branch the Windows coverage
+# matrix leg silently skips the full-surface expansion, so the Windows
+# Codecov upload has only test-linked TUs — same narrow view this fix
+# was meant to close everywhere. Deliberately does not pick up
+# libausdk.a / libvst3-sdk.a (external SDKs, not our code); the
+# `pulp-*.lib` prefix is narrow enough to skip third-party .lib files
+# that also appear under the build tree.
+#
+# Keep archives before executables. Files compiled into both a static
+# archive and a test binary need the executed test binary's coverage map
+# to win; adding archives after tests can leave diff-cover with the
+# archive's zero-hit record for source that tests did exercise.
+while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
+    find "${BUILD_DIR}" -type f \
+         \( -name 'libpulp-*.a' -o -name 'pulp-*.lib' \) \
+         ! -path "${BUILD_DIR}/test/*" \
+         2>/dev/null || true
+)
+
+# Test executables — these drive the actual coverage hits. On Windows/MSYS,
+# CTest can run `.exe` files whose Unix executable bit is not visible to
+# `find -perm -u+x`; include `.exe` explicitly so their coverage maps reach
+# llvm-cov.
 while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
     find "${BUILD_DIR}/test" -maxdepth 2 -type f \
          \( -perm -u+x -o -name '*.exe' \) \
@@ -216,23 +238,6 @@ if [[ ${#BINARIES[@]} -eq 0 ]]; then
     echo "run_coverage.sh: no test binaries found under ${BUILD_DIR}/test" >&2
     exit 1
 fi
-
-# First-party static libraries — expose every instrumented TU regardless
-# of whether a test links it. Pattern is `libpulp-*.a` on macOS/Linux
-# and `pulp-*.lib` on Windows (clang-cl's MSVC-style driver emits `.lib`
-# archives, not `.a`). Without the `.lib` branch the Windows coverage
-# matrix leg silently skips the full-surface expansion, so the Windows
-# Codecov upload has only test-linked TUs — same narrow view this fix
-# was meant to close everywhere. Deliberately does not pick up
-# libausdk.a / libvst3-sdk.a (external SDKs, not our code); the
-# `pulp-*.lib` prefix is narrow enough to skip third-party .lib files
-# that also appear under the build tree.
-while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
-    find "${BUILD_DIR}" -type f \
-         \( -name 'libpulp-*.a' -o -name 'pulp-*.lib' \) \
-         ! -path "${BUILD_DIR}/test/*" \
-         2>/dev/null || true
-)
 
 # First-party non-test executables — CLI, standalone host, inspector.
 # Test binaries under build/test/ are already included above; exclude

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1567,6 +1567,23 @@ catch_discover_tests(pulp-test-render-loop
     PROPERTIES
         LABELS coverage)
 
+add_executable(pulp-test-sdl3-surface
+    test_sdl3_surface.cpp
+    ${CMAKE_SOURCE_DIR}/core/render/src/sdl3_surface.cpp)
+target_include_directories(pulp-test-sdl3-surface PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/render/include)
+target_link_libraries(pulp-test-sdl3-surface PRIVATE
+    pulp::runtime
+    Catch2::Catch2WithMain)
+if(PULP_HAS_SDL3)
+    target_link_libraries(pulp-test-sdl3-surface PRIVATE
+        $<BUILD_INTERFACE:SDL3::SDL3-static>)
+    target_compile_definitions(pulp-test-sdl3-surface PRIVATE PULP_HAS_SDL3=1)
+endif()
+catch_discover_tests(pulp-test-sdl3-surface
+    PROPERTIES
+        LABELS coverage)
+
 # GPU-stack tests — pulp::render only exists when PULP_ENABLE_GPU=ON.
 # The sanitizer matrix builds with GPU off; without the guard configure
 # fails with "Target ... links to: pulp::render but the target was not

--- a/test/test_aax_model.cpp
+++ b/test/test_aax_model.cpp
@@ -392,10 +392,16 @@ TEST_CASE("AAX model validates fourcc and native plugin id derivation helpers", 
     REQUIRE(pulp::format::aax::fourcc("abc") == 0);
     REQUIRE(pulp::format::aax::fourcc("abcde") == 0);
     REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::fourcc("Pulp")) == "Pulp");
+    REQUIRE(pulp::format::aax::parameter_id_string(0) == "p00000000");
+    REQUIRE(pulp::format::aax::parameter_id_string(42) == "p0000002A");
+    REQUIRE(pulp::format::aax::parameter_id_string(0xffffffffu) == "pFFFFFFFF");
 
     const auto base = pulp::format::aax::fourcc("ABCD");
     REQUIRE(pulp::format::aax::derive_native_plugin_id(base, 0) == base);
     REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::derive_native_plugin_id(base, 1)) == "ABC1");
+    REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::derive_native_plugin_id(base, 10)) == "ABCA");
+    REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::derive_native_plugin_id(base, 35)) == "ABCZ");
+    REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::derive_native_plugin_id(base, 36)) == "ABCa");
     REQUIRE(pulp::format::aax::fourcc_string(pulp::format::aax::derive_native_plugin_id(base, 61)) == "ABCz");
 
     const auto hashed = pulp::format::aax::derive_native_plugin_id(base, 62);
@@ -415,9 +421,67 @@ TEST_CASE("AAX model exposes stem mapping helpers for supported and unknown layo
     REQUIRE(pulp::format::aax::stem_kind_for_channels(9) == pulp::format::aax::StemKind::none);
 
     REQUIRE(pulp::format::aax::stem_channel_count(pulp::format::aax::StemKind::stereo) == 2);
+    REQUIRE(pulp::format::aax::stem_channel_count(pulp::format::aax::StemKind::surround_7_1) == 8);
     REQUIRE(std::string(pulp::format::aax::stem_signature(pulp::format::aax::StemKind::surround_5_1)) == "5.1");
+    REQUIRE(std::string(pulp::format::aax::stem_signature(pulp::format::aax::StemKind::surround_7_1)) == "7.1");
     REQUIRE(pulp::format::aax::stem_channel_count(pulp::format::aax::StemKind::lcrs) == 0);
     REQUIRE(std::string(pulp::format::aax::stem_signature(pulp::format::aax::StemKind::lcrs)) == "unknown");
+    REQUIRE(pulp::format::aax::stem_channel_count(pulp::format::aax::StemKind::surround_6_0) == 0);
+    REQUIRE(std::string(pulp::format::aax::stem_signature(pulp::format::aax::StemKind::surround_6_0)) == "unknown");
+}
+
+TEST_CASE("AAX model carries descriptor and parameter metadata into definitions", "[aax][model][coverage][issue-648]") {
+    auto codes = valid_codes();
+    auto descriptor = descriptor_with_buses(
+        {{"Main In", 2, false}},
+        {{"Main Out", 2, false}},
+        pulp::format::PluginCategory::Effect,
+        true,
+        true);
+    descriptor.name = "MetadataEffect";
+
+    ConfigurableProcessor::configure(
+        std::move(descriptor),
+        {
+            {
+                .id = 7,
+                .name = "Blend",
+                .unit = "%",
+                .range = {0.0f, 100.0f, 25.0f, 0.0f},
+                .to_string = [](float value) { return std::to_string(static_cast<int>(value)) + "%"; },
+                .from_string = [](const std::string& text) { return std::stof(text); },
+            },
+            {
+                .id = 8,
+                .name = "Shape",
+                .unit = "",
+                .range = {0.0f, 1.0f, 0.0f, 0.25f},
+            },
+        },
+        128);
+
+    auto result = pulp::format::aax::build_plugin_definition(make_configured_processor, codes);
+    REQUIRE(result.ok);
+    REQUIRE(result.definition.codes.manufacturer_id == codes.manufacturer_id);
+    REQUIRE(result.definition.supports_midi_input);
+    REQUIRE(result.definition.supports_midi_output);
+    REQUIRE(result.definition.uses_transport);
+    REQUIRE(result.definition.latency_samples == 128);
+    REQUIRE(result.definition.packet_float_count == 3);
+    REQUIRE(result.definition.parameters.size() == 2);
+    REQUIRE(result.definition.parameters[0].id == 7);
+    REQUIRE(result.definition.parameters[0].aax_id == "p00000007");
+    REQUIRE(result.definition.parameters[0].name == "Blend");
+    REQUIRE(result.definition.parameters[0].unit == "%");
+    REQUIRE(result.definition.parameters[0].range.default_value == 25.0f);
+    REQUIRE(result.definition.parameters[0].to_string(42.0f) == "42%");
+    REQUIRE(result.definition.parameters[0].from_string("64") == 64.0f);
+    REQUIRE_FALSE(result.definition.parameters[0].discrete);
+    REQUIRE(result.definition.parameters[1].discrete);
+    REQUIRE(result.definition.parameters[1].step_count == 5);
+    REQUIRE(result.definition.components.size() == 1);
+    REQUIRE(result.definition.components[0].native_plugin_id == codes.native_id_base);
+    REQUIRE(result.definition.components[0].description == "MetadataEffect stereo -> stereo");
 }
 
 TEST_CASE("AAX model truncates long labels and falls back for empty parameter names", "[aax][model]") {

--- a/test/test_accessibility_tree.cpp
+++ b/test/test_accessibility_tree.cpp
@@ -7,6 +7,9 @@
 #include <pulp/view/accessibility_tree.hpp>
 #include <pulp/view/view.hpp>
 
+#include <string>
+#include <utility>
+
 using namespace pulp::view;
 
 namespace {
@@ -24,6 +27,46 @@ public:
 
 private:
     double current_ = 0.0;
+};
+
+class DegenerateRangeProbe : public View, public AccessibilityValueInterface {
+public:
+    explicit DegenerateRangeProbe(double current) : current_(current) {}
+
+    double get_current_value() const override { return current_; }
+    void set_current_value(double value) override { current_ = value; }
+    double get_minimum_value() const override { return 5.0; }
+    double get_maximum_value() const override { return 5.0; }
+
+private:
+    double current_ = 0.0;
+};
+
+class TextProbe : public AccessibilityTextInterface {
+public:
+    explicit TextProbe(std::string text) : text_(std::move(text)) {}
+
+    std::string get_text() const override { return text_; }
+    void set_text(std::string_view text) override { text_ = std::string(text); }
+
+private:
+    std::string text_;
+};
+
+class TableProbe : public AccessibilityTableInterface {
+public:
+    int get_row_count() const override { return 3; }
+    int get_column_count() const override { return 2; }
+    std::string get_column_header(int column) const override {
+        return column == 0 ? "Name" : "Value";
+    }
+};
+
+class CellProbe : public AccessibilityCellInterface {
+public:
+    std::string get_cell_text(int row, int column) const override {
+        return std::to_string(row) + ":" + std::to_string(column);
+    }
 };
 
 } // namespace
@@ -205,4 +248,58 @@ TEST_CASE("Accessibility snapshot surfaces ARIA state attributes",
 
     REQUIRE(nodes[2].label == "Decorative icon");
     REQUIRE(nodes[2].hidden == "true");
+}
+
+TEST_CASE("Accessibility value interface default strings clamp and fall back",
+          "[a11y][coverage][issue-654]") {
+    Probe root;
+
+    auto high = std::make_unique<RangeProbe>(30.0);
+    high->set_access_role(View::AccessRole::slider);
+    high->set_access_label("High");
+    root.add_child(std::move(high));
+
+    auto low = std::make_unique<RangeProbe>(-30.0);
+    low->set_access_role(View::AccessRole::slider);
+    low->set_access_label("Low");
+    root.add_child(std::move(low));
+
+    auto flat = std::make_unique<DegenerateRangeProbe>(7.25);
+    flat->set_access_role(View::AccessRole::meter);
+    flat->set_access_label("Flat");
+    root.add_child(std::move(flat));
+
+    auto nodes = snapshot_accessibility_tree(root);
+    REQUIRE(nodes.size() == 3);
+    REQUIRE(nodes[0].has_value);
+    REQUIRE(nodes[0].value_string == "100%");
+    REQUIRE(nodes[1].value_string == "0%");
+    REQUIRE(nodes[2].value_string == "7.25");
+}
+
+TEST_CASE("Accessibility helper interfaces expose default selection behavior",
+          "[a11y][coverage][issue-654]") {
+    TextProbe text("abcdef");
+    REQUIRE(text.get_character_count() == 6);
+    REQUIRE(text.get_selection() == std::pair<int, int>{0, 0});
+    REQUIRE_FALSE(text.is_editable());
+    REQUIRE(text.get_text_range(-5, 3) == "abc");
+    REQUIRE(text.get_text_range(2, 99) == "cdef");
+    REQUIRE(text.get_text_range(4, 2).empty());
+    text.set_selection(1, 4);
+    REQUIRE(text.get_selection() == std::pair<int, int>{0, 0});
+    text.set_text("xy");
+    REQUIRE(text.get_character_count() == 2);
+
+    TableProbe table;
+    REQUIRE(table.get_selected_row() == -1);
+    REQUIRE(table.get_selected_rows().empty());
+    REQUIRE_FALSE(table.supports_multi_selection());
+    table.select_row(1);
+    REQUIRE(table.get_selected_row() == -1);
+
+    CellProbe cell;
+    REQUIRE(cell.get_cell_text(2, 1) == "2:1");
+    REQUIRE_FALSE(cell.is_cell_editable(0, 0));
+    REQUIRE(cell.get_cell_span(0, 0) == std::pair<int, int>{1, 1});
 }

--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -148,6 +148,62 @@ TEST_CASE("FileAnalyticsDestination escapes JSON strings", "[runtime][analytics]
     REQUIRE(line.find("\",\"return\"") != std::string::npos);
 }
 
+TEST_CASE("FileAnalyticsDestination escapes each special JSON character",
+          "[runtime][analytics][coverage][issue-656]") {
+    struct Case {
+        std::string input;
+        std::string expected;
+    };
+
+    const Case cases[] = {
+        {"back\\slash", "back\\\\slash"},
+        {"double\"quote", "double\\\"quote"},
+        {"new\nline", "new\\nline"},
+        {"carriage\rreturn", "carriage\\rreturn"},
+        {"tab\tchar", "tab\\tchar"},
+    };
+
+    for (const auto& c : cases) {
+        TemporaryFile tmp(".jsonl");
+        FileAnalyticsDestination dest(tmp.path_string());
+
+        AnalyticsEvent event;
+        event.name = c.input;
+        event.timestamp = 1.0;
+        dest.log_event(event);
+        dest.flush();
+
+        std::ifstream f(tmp.path());
+        std::string line;
+        REQUIRE(std::getline(f, line));
+        REQUIRE(line.find("\"event\":\"" + c.expected + "\"") != std::string::npos);
+    }
+}
+
+TEST_CASE("FileAnalyticsDestination escapes special JSON property keys and values",
+          "[runtime][analytics][coverage][issue-656]") {
+    TemporaryFile tmp(".jsonl");
+    FileAnalyticsDestination dest(tmp.path_string());
+
+    AnalyticsEvent event;
+    event.name = "props";
+    event.timestamp = 1.0;
+    event.properties = {
+        {"slash\\key", "quote\"value"},
+        {"line\nkey", "return\rvalue"},
+        {"tab\tkey", "tab\tvalue"},
+    };
+    dest.log_event(event);
+    dest.flush();
+
+    std::ifstream f(tmp.path());
+    std::string line;
+    REQUIRE(std::getline(f, line));
+    REQUIRE(line.find("\"slash\\\\key\":\"quote\\\"value\"") != std::string::npos);
+    REQUIRE(line.find("\"line\\nkey\":\"return\\rvalue\"") != std::string::npos);
+    REQUIRE(line.find("\"tab\\tkey\":\"tab\\tvalue\"") != std::string::npos);
+}
+
 TEST_CASE("FileAnalyticsDestination empty flush does not create output", "[runtime][analytics][coverage][issue-656]") {
     TemporaryFile tmp(".jsonl");
     auto path = tmp.path();

--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -2,6 +2,7 @@
 #include <pulp/runtime/analytics.hpp>
 #include <pulp/runtime/temporary_file.hpp>
 #include <fstream>
+#include <filesystem>
 #include <memory>
 #include <vector>
 
@@ -73,6 +74,21 @@ TEST_CASE("Analytics forwards event details and flushes destinations", "[runtime
 
     a.flush();
     REQUIRE(*flushes == 1);
+}
+
+TEST_CASE("Analytics flush reaches destinations even when disabled", "[runtime][analytics][issue-641]") {
+    auto events = std::make_shared<std::vector<AnalyticsEvent>>();
+    auto flushes = std::make_shared<int>(0);
+
+    auto& a = Analytics::instance();
+    a.add_destination(std::make_unique<RecordingDestination>(events, flushes));
+
+    a.set_enabled(false);
+    a.flush();
+    REQUIRE(*flushes == 1);
+    REQUIRE(events->empty());
+
+    a.set_enabled(true);
 }
 
 TEST_CASE("Analytics disabled skips destinations", "[runtime][analytics]") {
@@ -148,6 +164,33 @@ TEST_CASE("FileAnalyticsDestination appends multiple flushes", "[runtime][analyt
     REQUIRE(content.find("\"event\":\"second\"") != std::string::npos);
 }
 
+TEST_CASE("FileAnalyticsDestination empty flush does not create output", "[runtime][analytics][issue-641]") {
+    TemporaryFile tmp(".jsonl");
+    auto path = tmp.path();
+    std::filesystem::remove(path);
+
+    FileAnalyticsDestination dest(tmp.path_string());
+    dest.flush();
+
+    REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
+TEST_CASE("FileAnalyticsDestination writes property map in key order", "[runtime][analytics][issue-641]") {
+    TemporaryFile tmp(".jsonl");
+    FileAnalyticsDestination dest(tmp.path_string());
+
+    AnalyticsEvent event;
+    event.name = "ordered";
+    event.properties = {{"z", "last"}, {"a", "first"}};
+    dest.log_event(event);
+    dest.flush();
+
+    std::ifstream f(tmp.path());
+    std::string line;
+    REQUIRE(std::getline(f, line));
+    REQUIRE(line.find("\"a\":\"first\"") < line.find("\"z\":\"last\""));
+}
+
 TEST_CASE("WidgetTracker logs events", "[runtime][analytics]") {
     auto& a = Analytics::instance();
     a.set_enabled(true);
@@ -158,4 +201,27 @@ TEST_CASE("WidgetTracker logs events", "[runtime][analytics]") {
     WidgetTracker::track_preset_select("Default");
 
     REQUIRE(a.event_count() == before + 3);
+}
+
+TEST_CASE("WidgetTracker forwards expected event names and properties",
+          "[runtime][analytics][issue-641]") {
+    auto events = std::make_shared<std::vector<AnalyticsEvent>>();
+    auto flushes = std::make_shared<int>(0);
+
+    auto& a = Analytics::instance();
+    a.set_enabled(true);
+    a.add_destination(std::make_unique<RecordingDestination>(events, flushes));
+
+    WidgetTracker::track_click("bypass");
+    WidgetTracker::track_value_change("gain", "-6");
+    WidgetTracker::track_preset_select("Init");
+
+    REQUIRE(events->size() == 3);
+    REQUIRE((*events)[0].name == "widget_click");
+    REQUIRE((*events)[0].properties.at("widget") == "bypass");
+    REQUIRE((*events)[1].name == "value_change");
+    REQUIRE((*events)[1].properties.at("widget") == "gain");
+    REQUIRE((*events)[1].properties.at("value") == "-6");
+    REQUIRE((*events)[2].name == "preset_select");
+    REQUIRE((*events)[2].properties.at("preset") == "Init");
 }

--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -132,7 +132,10 @@ TEST_CASE("FileAnalyticsDestination escapes JSON strings", "[runtime][analytics]
     AnalyticsEvent event;
     event.name = "quote\"and\nline";
     event.timestamp = 1.0;
-    event.properties = {{"key\"name", "value\\path\tend"}};
+    event.properties = {
+        {"key\"name", "value\\path\tend"},
+        {"return", "line\rend"},
+    };
     dest.log_event(event);
     dest.flush();
 
@@ -141,6 +144,8 @@ TEST_CASE("FileAnalyticsDestination escapes JSON strings", "[runtime][analytics]
     REQUIRE(std::getline(f, line));
     REQUIRE(line.find("\"event\":\"quote\\\"and\\nline\"") != std::string::npos);
     REQUIRE(line.find("\"key\\\"name\":\"value\\\\path\\tend\"") != std::string::npos);
+    REQUIRE(line.find("\"return\":\"line\\rend\"") != std::string::npos);
+    REQUIRE(line.find("\",\"return\"") != std::string::npos);
 }
 
 TEST_CASE("FileAnalyticsDestination empty flush does not create output", "[runtime][analytics][coverage][issue-656]") {

--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -2,6 +2,7 @@
 #include <pulp/runtime/analytics.hpp>
 #include <pulp/runtime/temporary_file.hpp>
 #include <fstream>
+#include <filesystem>
 #include <memory>
 #include <vector>
 
@@ -107,6 +108,35 @@ TEST_CASE("FileAnalyticsDestination writes JSON", "[runtime][analytics]") {
     REQUIRE(std::getline(f, line));
     REQUIRE(line.find("\"event\":\"test\"") != std::string::npos);
     REQUIRE(line.find("\"key\":\"value\"") != std::string::npos);
+}
+
+TEST_CASE("FileAnalyticsDestination escapes JSON strings", "[runtime][analytics][coverage][issue-656]") {
+    TemporaryFile tmp(".jsonl");
+    FileAnalyticsDestination dest(tmp.path_string());
+
+    AnalyticsEvent event;
+    event.name = "quote\"and\nline";
+    event.timestamp = 1.0;
+    event.properties = {{"key\"name", "value\\path\tend"}};
+    dest.log_event(event);
+    dest.flush();
+
+    std::ifstream f(tmp.path());
+    std::string line;
+    REQUIRE(std::getline(f, line));
+    REQUIRE(line.find("\"event\":\"quote\\\"and\\nline\"") != std::string::npos);
+    REQUIRE(line.find("\"key\\\"name\":\"value\\\\path\\tend\"") != std::string::npos);
+}
+
+TEST_CASE("FileAnalyticsDestination empty flush does not create output", "[runtime][analytics][coverage][issue-656]") {
+    TemporaryFile tmp(".jsonl");
+    auto path = tmp.path();
+    tmp.release();
+    std::filesystem::remove(path);
+
+    FileAnalyticsDestination dest(path.string());
+    dest.flush();
+    REQUIRE_FALSE(std::filesystem::exists(path));
 }
 
 TEST_CASE("FileAnalyticsDestination auto flushes at batch threshold", "[runtime][analytics]") {

--- a/test/test_android_package.cpp
+++ b/test/test_android_package.cpp
@@ -228,6 +228,16 @@ void write_fake_gradlew(const fs::path& project_dir, const fs::path& log_path) {
 #endif
 }
 
+void write_failing_gradlew(const fs::path& project_dir, int exit_code) {
+#ifdef _WIN32
+    write_tool(project_dir / "gradlew.bat",
+        "exit /b " + std::to_string(exit_code) + "\r\n");
+#else
+    write_tool(project_dir / "gradlew",
+        "exit " + std::to_string(exit_code) + "\n");
+#endif
+}
+
 void write_fake_bundletool(const fs::path& path, const fs::path& log_path) {
 #ifdef _WIN32
     write_tool(path,
@@ -304,6 +314,108 @@ TEST_CASE("Android SDK discovery falls back to SDK root and dedicated NDK home",
     REQUIRE(find_android_ndk() == standalone_ndk);
 }
 
+TEST_CASE("Android SDK discovery returns empty for invalid env roots",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto invalid_home = temp.path / "not-an-sdk";
+    fs::create_directories(invalid_home);
+
+    ScopedEnvVar android_home("ANDROID_HOME", invalid_home.string());
+    ScopedEnvVar android_sdk_root("ANDROID_SDK_ROOT", invalid_home.string());
+    ScopedEnvVar android_ndk_home("ANDROID_NDK_HOME", (temp.path / "not-an-ndk").string());
+    ScopedEnvVar home("HOME", (temp.path / "home").string());
+    ScopedUnsetEnvVar userprofile("USERPROFILE");
+
+    REQUIRE(detect_android_sdk().empty());
+    REQUIRE(find_android_ndk().empty());
+    REQUIRE(android_build_tools_version().empty());
+    REQUIRE(find_android_build_tool("apksigner").empty());
+}
+
+TEST_CASE("Android SDK discovery ignores empty tool directories",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto sdk = temp.path / "sdk";
+    fs::create_directories(sdk / "build-tools");
+    fs::create_directories(sdk / "ndk");
+
+    ScopedEnvVar android_home("ANDROID_HOME", sdk.string());
+    ScopedUnsetEnvVar android_sdk_root("ANDROID_SDK_ROOT");
+    ScopedUnsetEnvVar android_ndk_home("ANDROID_NDK_HOME");
+
+    REQUIRE(detect_android_sdk() == sdk);
+    REQUIRE(android_build_tools_version().empty());
+    REQUIRE(find_android_ndk().empty());
+}
+
+TEST_CASE("Android SDK discovery treats malformed revisions as zero",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto sdk = temp.path / "sdk";
+    fs::create_directories(sdk / "build-tools" / "preview");
+    fs::create_directories(sdk / "build-tools" / "1.preview");
+    fs::create_directories(sdk / "build-tools" / "1.0.1");
+    fs::create_directories(sdk / "ndk" / "beta" / "toolchains");
+    fs::create_directories(sdk / "ndk" / "1.0.1" / "toolchains");
+
+    ScopedEnvVar android_home("ANDROID_HOME", sdk.string());
+    ScopedUnsetEnvVar android_sdk_root("ANDROID_SDK_ROOT");
+    ScopedUnsetEnvVar android_ndk_home("ANDROID_NDK_HOME");
+
+    REQUIRE(android_build_tools_version() == "1.0.1");
+    REQUIRE(find_android_ndk() == sdk / "ndk" / "1.0.1");
+}
+
+TEST_CASE("Android Java version detection parses quoted java output",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto bin_dir = temp.path / "bin";
+    fs::create_directories(bin_dir);
+
+#ifdef _WIN32
+    write_tool(tool_path(bin_dir, "java"),
+        "echo openjdk version \"21.0.2\" 2026-01-16\r\n"
+        "exit /b 0\r\n");
+#else
+    write_tool(bin_dir / "java",
+        "echo 'openjdk version \"21.0.2\" 2026-01-16' >&2\n");
+#endif
+
+    auto old_path = read_env_var("PATH").value_or("");
+#ifdef _WIN32
+    ScopedEnvVar path_env("PATH", bin_dir.string() + ";" + old_path);
+#else
+    ScopedEnvVar path_env("PATH", bin_dir.string() + ":" + old_path);
+#endif
+
+    REQUIRE(detect_java_version() == "21.0.2");
+}
+
+TEST_CASE("Android Java version detection returns empty for unquoted output",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto bin_dir = temp.path / "bin";
+    fs::create_directories(bin_dir);
+
+#ifdef _WIN32
+    write_tool(tool_path(bin_dir, "java"),
+        "echo openjdk version 21.0.2\r\n"
+        "exit /b 0\r\n");
+#else
+    write_tool(bin_dir / "java",
+        "echo 'openjdk version 21.0.2' >&2\n");
+#endif
+
+    auto old_path = read_env_var("PATH").value_or("");
+#ifdef _WIN32
+    ScopedEnvVar path_env("PATH", bin_dir.string() + ";" + old_path);
+#else
+    ScopedEnvVar path_env("PATH", bin_dir.string() + ":" + old_path);
+#endif
+
+    REQUIRE(detect_java_version().empty());
+}
+
 TEST_CASE("Android signing helpers use SDK tools and parse APK verification output", "[ship][android]") {
     TempDir temp;
     auto sdk = make_fake_sdk(temp.path);
@@ -342,6 +454,30 @@ TEST_CASE("Android signing helpers use SDK tools and parse APK verification outp
     REQUIRE_THAT(log, ContainsSubstring("sign"));
     REQUIRE_THAT(log, ContainsSubstring("--ks-key-alias"));
     REQUIRE_THAT(log, ContainsSubstring("verify --print-certs --verbose"));
+}
+
+TEST_CASE("Android signing helpers fail cleanly when SDK tools are unavailable",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    ScopedEnvVar android_home("ANDROID_HOME", (temp.path / "missing-sdk").string());
+    ScopedUnsetEnvVar android_sdk_root("ANDROID_SDK_ROOT");
+    ScopedEnvVar home("HOME", (temp.path / "home").string());
+    ScopedUnsetEnvVar userprofile("USERPROFILE");
+
+    auto apk = temp.path / "app.apk";
+    std::ofstream(apk) << "apk";
+
+    AndroidKeystoreConfig keystore;
+    keystore.keystore_path = temp.path / "release.jks";
+    keystore.store_password = "store-pass";
+    keystore.key_alias = "release";
+
+    REQUIRE_FALSE(zipalign_apk(apk, temp.path / "aligned.apk"));
+    REQUIRE_FALSE(sign_apk(apk, keystore));
+
+    auto info = check_android_signing(apk);
+    REQUIRE_FALSE(info.is_signed);
+    REQUIRE_THAT(info.error, ContainsSubstring("apksigner not found"));
 }
 
 TEST_CASE("Android AAB signing and verification use jarsigner on PATH", "[ship][android]") {
@@ -413,6 +549,47 @@ TEST_CASE("Android Gradle packaging collects APK and AAB artifacts", "[ship][and
     REQUIRE_THAT(args, ContainsSubstring("-Pandroid.injected.signing.key.alias=release"));
 }
 
+TEST_CASE("Android Gradle packaging supports APK-only and AAB-only builds",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto project = temp.path / "android";
+    fs::create_directories(project);
+    auto gradle_log = temp.path / "gradle.args";
+    write_fake_gradlew(project, gradle_log);
+
+    auto apk_only = build_android_package(project, {}, nullptr, false, true);
+    INFO(apk_only.error);
+    REQUIRE(apk_only.success);
+    REQUIRE(apk_only.apk_path.filename() == "app-release.apk");
+    REQUIRE(apk_only.aab_path.empty());
+    REQUIRE_THAT(read_text(gradle_log), ContainsSubstring("assembleRelease"));
+    REQUIRE(read_text(gradle_log).find("bundleRelease") == std::string::npos);
+
+    fs::remove_all(project / "app" / "build" / "outputs");
+    auto aab_only = build_android_package(project, {}, nullptr, true, false);
+    INFO(aab_only.error);
+    REQUIRE(aab_only.success);
+    REQUIRE(aab_only.apk_path.empty());
+    REQUIRE(aab_only.aab_path.filename() == "app-release.aab");
+    REQUIRE_THAT(read_text(gradle_log), ContainsSubstring("bundleRelease"));
+    REQUIRE(read_text(gradle_log).find("assembleRelease") == std::string::npos);
+}
+
+TEST_CASE("Android Gradle packaging reports command failures",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto project = temp.path / "android";
+    fs::create_directories(project);
+    write_failing_gradlew(project, 7);
+
+    auto result = build_android_package(project, {"arm64-v8a"}, nullptr, true, true);
+
+    REQUIRE_FALSE(result.success);
+    REQUIRE(result.apk_path.empty());
+    REQUIRE(result.aab_path.empty());
+    REQUIRE_THAT(result.error, ContainsSubstring("Gradle build failed (exit code 7)"));
+}
+
 TEST_CASE("Android Gradle packaging reports missing wrapper and missing artifacts", "[ship][android]") {
     TempDir temp;
     auto missing_wrapper = build_android_package(temp.path / "missing", {}, nullptr, true, true);
@@ -461,4 +638,38 @@ TEST_CASE("Android bundletool conversion passes optional signing config", "[ship
     REQUIRE_THAT(args, ContainsSubstring("--bundle=" + aab.string()));
     REQUIRE_THAT(args, ContainsSubstring("--output=" + apks.string()));
     REQUIRE_THAT(args, ContainsSubstring("--ks-key-alias=release"));
+}
+
+TEST_CASE("Android bundletool conversion supports unsigned output",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto bundletool = tool_path(temp.path, "bundletool");
+    auto bundletool_log = temp.path / "bundletool-unsigned.args";
+    write_fake_bundletool(bundletool, bundletool_log);
+    ScopedEnvVar bundletool_env("BUNDLETOOL", bundletool.string());
+
+    auto aab = temp.path / "app-release.aab";
+    auto apks = temp.path / "app-release.apks";
+    std::ofstream(aab) << "aab";
+
+    REQUIRE(aab_to_apks(aab, apks, nullptr));
+    REQUIRE(fs::exists(apks));
+
+    auto args = read_text(bundletool_log);
+    REQUIRE_THAT(args, ContainsSubstring("build-apks"));
+    REQUIRE_THAT(args, ContainsSubstring("--overwrite"));
+    REQUIRE(args.find("--ks=") == std::string::npos);
+}
+
+TEST_CASE("Android bundletool conversion reports missing command",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    ScopedEnvVar bundletool_env("BUNDLETOOL", (temp.path / "missing-bundletool").string());
+
+    auto aab = temp.path / "app-release.aab";
+    auto apks = temp.path / "app-release.apks";
+    std::ofstream(aab) << "aab";
+
+    REQUIRE_FALSE(aab_to_apks(aab, apks, nullptr));
+    REQUIRE_FALSE(fs::exists(apks));
 }

--- a/test/test_android_package.cpp
+++ b/test/test_android_package.cpp
@@ -314,6 +314,23 @@ TEST_CASE("Android SDK discovery falls back to SDK root and dedicated NDK home",
     REQUIRE(find_android_ndk() == standalone_ndk);
 }
 
+TEST_CASE("Android SDK discovery skips invalid primary env roots",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto sdk = make_fake_sdk(temp.path);
+    auto invalid_sdk = temp.path / "invalid-sdk";
+    auto invalid_ndk = temp.path / "invalid-ndk";
+    fs::create_directories(invalid_sdk);
+    fs::create_directories(invalid_ndk);
+
+    ScopedEnvVar android_home("ANDROID_HOME", invalid_sdk.string());
+    ScopedEnvVar android_sdk_root("ANDROID_SDK_ROOT", sdk.string());
+    ScopedEnvVar android_ndk_home("ANDROID_NDK_HOME", invalid_ndk.string());
+
+    REQUIRE(detect_android_sdk() == sdk);
+    REQUIRE(find_android_ndk() == sdk / "ndk" / "27.0.12077973");
+}
+
 TEST_CASE("Android SDK discovery returns empty for invalid env roots",
           "[ship][android][coverage][issue-644]") {
     TempDir temp;
@@ -364,6 +381,24 @@ TEST_CASE("Android SDK discovery treats malformed revisions as zero",
 
     REQUIRE(android_build_tools_version() == "1.0.1");
     REQUIRE(find_android_ndk() == sdk / "ndk" / "1.0.1");
+}
+
+TEST_CASE("Android SDK discovery handles very large revision components",
+          "[ship][android][coverage][issue-644]") {
+    TempDir temp;
+    auto sdk = temp.path / "sdk";
+    const std::string huge = "999999999999999999999999999999";
+    fs::create_directories(sdk / "build-tools" / "100.0.0");
+    fs::create_directories(sdk / "build-tools" / huge);
+    fs::create_directories(sdk / "ndk" / "100.0.0" / "toolchains");
+    fs::create_directories(sdk / "ndk" / huge / "toolchains");
+
+    ScopedEnvVar android_home("ANDROID_HOME", sdk.string());
+    ScopedUnsetEnvVar android_sdk_root("ANDROID_SDK_ROOT");
+    ScopedUnsetEnvVar android_ndk_home("ANDROID_NDK_HOME");
+
+    REQUIRE(android_build_tools_version() == huge);
+    REQUIRE(find_android_ndk() == sdk / "ndk" / huge);
 }
 
 TEST_CASE("Android Java version detection parses quoted java output",

--- a/test/test_appcast.cpp
+++ b/test/test_appcast.cpp
@@ -236,6 +236,58 @@ TEST_CASE("Appcast from_xml ignores malformed enclosure length", "[ship][appcast
     REQUIRE(parsed->items[1].file_size == 0);
 }
 
+TEST_CASE("Appcast XML uses short version as build number when build is empty",
+          "[ship][appcast][coverage][issue-644]") {
+    Appcast feed;
+    feed.title = "Fallback Feed";
+    feed.link = "https://example.com/appcast.xml";
+    feed.description = "Fallback build number";
+
+    AppcastItem item;
+    item.version = "6.2.1";
+    item.title = "Version 6.2.1";
+    item.pub_date = "Sat, 06 Jun 2026 12:00:00 +0000";
+    item.download_url = "https://example.com/Pulp-6.2.1.pkg";
+    item.file_size = 621;
+    feed.items.push_back(item);
+
+    auto xml = feed.to_xml();
+
+    REQUIRE(xml.find("<sparkle:version>6.2.1</sparkle:version>") != std::string::npos);
+    REQUIRE(xml.find("<sparkle:shortVersionString>6.2.1</sparkle:shortVersionString>") != std::string::npos);
+}
+
+TEST_CASE("Appcast from_xml accepts rss with item-only metadata",
+          "[ship][appcast][coverage][issue-644]") {
+    auto parsed = Appcast::from_xml(R"(<rss version="2.0">
+  <channel>
+    <item>
+      <title>Nameless Release</title>
+      <sparkle:version>700</sparkle:version>
+      <sparkle:shortVersionString>7.0.0</sparkle:shortVersionString>
+      <enclosure url="https://example.com/Pulp-7.0.0.pkg" length="700" />
+    </item>
+  </channel>
+</rss>)");
+
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->title == "Nameless Release");
+    REQUIRE(parsed->link.empty());
+    REQUIRE(parsed->description.empty());
+    REQUIRE(parsed->items.size() == 1);
+    REQUIRE(parsed->items[0].title == "Nameless Release");
+    REQUIRE(parsed->items[0].build_number == "700");
+    REQUIRE(parsed->items[0].version == "7.0.0");
+}
+
+TEST_CASE("Appcast from_xml only requires rss marker",
+          "[ship][appcast][coverage][issue-644]") {
+    auto parsed = Appcast::from_xml("<rss version=\"2.0\"></rss>");
+
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->items.empty());
+}
+
 TEST_CASE("Version comparison", "[ship][version]") {
     REQUIRE(compare_versions("1.0.0", "1.0.0") == 0);
     REQUIRE(compare_versions("1.0.0", "1.0.1") == -1);
@@ -249,6 +301,15 @@ TEST_CASE("Version comparison tolerates non-numeric segments", "[ship][version]"
     REQUIRE(compare_versions("01.002.0003", "1.2.3") == 0);
     REQUIRE(compare_versions("1.beta.5", "1.0.7") == -1);
     REQUIRE(compare_versions("1..5", "1.0.4") == 1);
+}
+
+TEST_CASE("Version comparison pads and orders long mixed versions",
+          "[ship][version][coverage][issue-644]") {
+    REQUIRE(compare_versions("", "0") == 0);
+    REQUIRE(compare_versions("1.0.0", "1.0.0.0.0") == 0);
+    REQUIRE(compare_versions("1.0.0.0.1", "1.0.0.0") == 1);
+    REQUIRE(compare_versions("2.alpha.0", "2.0.1") == -1);
+    REQUIRE(compare_versions("2026.05.15", "2026.5.14") == 1);
 }
 
 // #295 P0 regression: sign_file_ed25519 MUST NOT silently return an

--- a/test/test_appearance_tracker.cpp
+++ b/test/test_appearance_tracker.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/view/appearance_tracker.hpp>
+#include <vector>
 
 using namespace pulp::view;
 
@@ -38,6 +39,31 @@ TEST_CASE("AppearanceTracker callback fires on lock", "[view][appearance]") {
     tracker.lock(Appearance::light);
 
     REQUIRE(received == Appearance::light);
+}
+
+TEST_CASE("AppearanceTracker callbacks follow repeated locks and locked poll no-op",
+          "[view][appearance][coverage][issue-493]") {
+    AppearanceTracker tracker;
+    std::vector<Appearance> received;
+
+    tracker.on_appearance_changed([&](Appearance a) { received.push_back(a); });
+    tracker.lock(Appearance::light);
+    tracker.lock(Appearance::dark);
+
+    REQUIRE(tracker.is_locked());
+    REQUIRE(tracker.locked_appearance() == Appearance::dark);
+    REQUIRE(tracker.current_appearance() == Appearance::dark);
+    REQUIRE_FALSE(tracker.poll());
+    REQUIRE(received == std::vector<Appearance>{Appearance::light, Appearance::dark});
+
+    const auto count_before_unlock = received.size();
+    tracker.unlock();
+    REQUIRE_FALSE(tracker.is_locked());
+    REQUIRE((tracker.current_appearance() == Appearance::light ||
+             tracker.current_appearance() == Appearance::dark));
+
+    if (received.size() > count_before_unlock)
+        REQUIRE(received.back() == tracker.current_appearance());
 }
 
 // ── ThemeManager ────────────────────────────────────────────────────────────
@@ -85,4 +111,43 @@ TEST_CASE("ThemeManager callback fires on theme change", "[view][appearance]") {
     mgr.lock_appearance(Appearance::light);
 
     REQUIRE(called);
+}
+
+TEST_CASE("ThemeManager callbacks cover locked theme poll and unlock",
+          "[view][appearance][coverage][issue-493]") {
+    ThemeManager mgr;
+
+    Theme light;
+    light.colors["bg.primary"] = color_from_hex(0x110000);
+    Theme dark;
+    dark.colors["bg.primary"] = color_from_hex(0x220000);
+    Theme locked;
+    locked.colors["bg.primary"] = color_from_hex(0x330000);
+    mgr.set_theme_pair(light, dark);
+
+    std::vector<uint8_t> callback_red;
+    mgr.on_theme_changed([&](const Theme& theme) {
+        callback_red.push_back(theme.color("bg.primary")->r8());
+    });
+
+    mgr.lock_theme(locked);
+    REQUIRE(mgr.is_locked());
+    REQUIRE(mgr.active_theme().color("bg.primary")->r8() == 0x33);
+    REQUIRE(callback_red == std::vector<uint8_t>{0x33});
+    REQUIRE_FALSE(mgr.poll());
+    REQUIRE(callback_red == std::vector<uint8_t>{0x33});
+
+    mgr.lock_appearance(Appearance::light);
+    REQUIRE(mgr.is_locked());
+    REQUIRE(mgr.active_theme().color("bg.primary")->r8() == 0x11);
+
+    mgr.lock_appearance(Appearance::dark);
+    REQUIRE(mgr.active_theme().color("bg.primary")->r8() == 0x22);
+
+    mgr.unlock();
+    REQUIRE_FALSE(mgr.is_locked());
+    REQUIRE(callback_red.size() == 4);
+    REQUIRE(callback_red[0] == 0x33);
+    REQUIRE(callback_red[1] == 0x11);
+    REQUIRE(callback_red[2] == 0x22);
 }

--- a/test/test_ara.cpp
+++ b/test/test_ara.cpp
@@ -38,6 +38,29 @@ TEST_CASE("AraDocumentController subclass overrides work", "[ara]") {
     REQUIRE((c.supported_roles() & static_cast<int>(AraRole::EditorView)) != 0);
 }
 
+TEST_CASE("AraDocumentController defaults are inert and non-ARA", "[ara][coverage][issue-648]") {
+    AraDocumentController controller;
+    controller.begin_editing();
+    controller.notify_audio_source_content_changed(123);
+    controller.end_editing();
+    REQUIRE(controller.supported_roles() == static_cast<int>(AraRole::None));
+    REQUIRE(controller.is_ara_supported() == false);
+    REQUIRE(controller.ara_factory_name().empty());
+}
+
+TEST_CASE("AraRole bit values remain stable for adapter metadata", "[ara][coverage][issue-648]") {
+    REQUIRE(static_cast<int>(AraRole::None) == 0);
+    REQUIRE(static_cast<int>(AraRole::PlaybackRenderer) == 1);
+    REQUIRE(static_cast<int>(AraRole::EditorRenderer) == 2);
+    REQUIRE(static_cast<int>(AraRole::EditorView) == 4);
+
+    const auto render_and_view =
+        static_cast<int>(AraRole::PlaybackRenderer)
+        | static_cast<int>(AraRole::EditorRenderer)
+        | static_cast<int>(AraRole::EditorView);
+    REQUIRE(render_and_view == 7);
+}
+
 TEST_CASE("ara_sdk_generation reflects SDK headers", "[ara]") {
 #ifdef PULP_HAS_ARA
     // Compiled with the Celemony SDK — generation constant is at least

--- a/test/test_asset_manager.cpp
+++ b/test/test_asset_manager.cpp
@@ -69,6 +69,31 @@ TEST_CASE("AssetManager cache clear", "[view][assets]") {
     REQUIRE(mgr.cache_count() == 0);
 }
 
+TEST_CASE("Asset data wrappers report validity and byte size",
+          "[view][assets][coverage][issue-651]") {
+    ImageData image;
+    image.pixels = {1, 2, 3, 4};
+    image.width = 1;
+    image.height = 1;
+    REQUIRE(image.valid());
+    REQUIRE(image.byte_size() == 4);
+
+    FontData font;
+    font.data = {0, 1};
+    REQUIRE(font.valid());
+    REQUIRE(font.byte_size() == 2);
+
+    ShaderData shader{"void main() {}", ""};
+    REQUIRE(shader.valid());
+    REQUIRE(shader.byte_size() == shader.source.size());
+    shader.error = "compile failed";
+    REQUIRE_FALSE(shader.valid());
+
+    BlobData blob{{5, 6, 7}};
+    REQUIRE(blob.valid());
+    REQUIRE(blob.byte_size() == 3);
+}
+
 TEST_CASE("AssetManager max cache size", "[view][assets]") {
     auto& mgr = AssetManager::instance();
     size_t old_max = mgr.max_cache_size();
@@ -246,6 +271,24 @@ TEST_CASE("AssetManager load image from memory with PNG header", "[view][assets]
     REQUIRE(img.height == 8);
 }
 
+TEST_CASE("AssetManager image memory loading handles invalid and short buffers",
+          "[view][assets][coverage][issue-651]") {
+    auto& mgr = AssetManager::instance();
+
+    static const uint8_t short_png[] = {0x89, 0x50, 0x4E};
+    auto too_short = mgr.load_image_from_memory(short_png, sizeof(short_png));
+    REQUIRE_FALSE(too_short.valid());
+    REQUIRE(too_short.byte_size() == 0);
+
+    static const uint8_t not_png[] = {
+        'n', 'o', 't', 'p', 'n', 'g', '!', '!',
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1,
+    };
+    auto decoded = mgr.load_image_from_memory(not_png, sizeof(not_png));
+    REQUIRE_FALSE(decoded.valid());
+    REQUIRE(decoded.byte_size() == sizeof(not_png));
+}
+
 TEST_CASE("AssetManager load image from embedded", "[view][assets]") {
     auto& mgr = AssetManager::instance();
 
@@ -335,6 +378,18 @@ TEST_CASE("AssetManager data URI base64 decode", "[view][assets]") {
     // Should decode the base64 and attempt PNG parse
     // Won't be a valid image but should not crash
     // The decoded bytes would be the PNG signature (8 bytes)
+}
+
+TEST_CASE("AssetManager data URI decodes PNG dimensions with ignored characters",
+          "[view][assets][coverage][issue-651]") {
+    auto& mgr = AssetManager::instance();
+
+    auto img = mgr.load_image_from_data_uri(
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAAFCAYAAAA=\n!?");
+
+    REQUIRE(img.valid());
+    REQUIRE(img.width == 3);
+    REQUIRE(img.height == 5);
 }
 
 TEST_CASE("AssetManager rejects malformed data URIs", "[view][assets]") {
@@ -433,6 +488,38 @@ TEST_CASE("AssetManager blob file cache and misses", "[view][assets]") {
     REQUIRE_FALSE(missing_embedded.valid());
 
     mgr.clear_cache();
+    mgr.set_max_cache_size(old_max);
+}
+
+TEST_CASE("AssetManager font file loading derives family names and uses cache",
+          "[view][assets][coverage][issue-651]") {
+    auto& mgr = AssetManager::instance();
+    const auto old_max = mgr.max_cache_size();
+    mgr.clear_cache();
+    mgr.set_max_cache_size(1024 * 1024);
+
+    auto path = make_temp_asset_path("Pulp Test Font", ".ttf");
+    const std::vector<uint8_t> bytes = {0x00, 0x01, 0x00, 0x00, 0x66};
+    write_bytes(path, bytes);
+
+    auto font = mgr.load_font(path.string());
+    REQUIRE(font.valid());
+    REQUIRE(font.data == bytes);
+    REQUIRE(font.family_name == path.stem().string());
+    REQUIRE(mgr.cache_count() == 1);
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+
+    auto cached = mgr.load_font(path.string());
+    REQUIRE(cached.valid());
+    REQUIRE(cached.data == bytes);
+    REQUIRE(cached.family_name == font.family_name);
+
+    mgr.clear_cache();
+    auto missing = mgr.load_font(path.string());
+    REQUIRE_FALSE(missing.valid());
+
     mgr.set_max_cache_size(old_max);
 }
 

--- a/test/test_attributed_string.cpp
+++ b/test/test_attributed_string.cpp
@@ -116,6 +116,34 @@ TEST_CASE("AttributedString empty span has zero text length but remains a span",
     REQUIRE(str.spans().size() == 1);
 }
 
+TEST_CASE("AttributedString bulk style setters are no-ops on empty strings",
+          "[canvas][text][issue-644]") {
+    AttributedString str;
+    str.set_font("mono", 22.0f);
+    str.set_color(Color::rgba(1, 2, 3));
+
+    REQUIRE(str.empty());
+    REQUIRE(str.length() == 0);
+    REQUIRE(str.plain_text().empty());
+}
+
+TEST_CASE("AttributedString clear drops spans and accepts reuse",
+          "[canvas][text][issue-644]") {
+    AttributedString str("before");
+    str.append(" after", Color::rgba(9, 8, 7));
+    REQUIRE(str.spans().size() == 2);
+
+    str.clear();
+    REQUIRE(str.empty());
+
+    str.append("again", 18.0f, Color::rgba(1, 2, 3));
+    REQUIRE_FALSE(str.empty());
+    REQUIRE(str.plain_text() == "again");
+    REQUIRE(str.spans().size() == 1);
+    REQUIRE(str.spans()[0].font_size == 18.0f);
+    REQUIRE(str.spans()[0].color.g == 2);
+}
+
 // ── TextLayout word wrapping ────────────────────────────────────────────
 
 TEST_CASE("TextLayout empty string", "[canvas][layout]") {
@@ -221,6 +249,18 @@ TEST_CASE("TextLayout empty span creates blank line", "[canvas][layout]") {
     REQUIRE(layout.lines[0].width == 0);
     REQUIRE_THAT(layout.lines[0].height, WithinAbs(12.0f, 1e-5));
     REQUIRE_THAT(layout.total_height, WithinAbs(12.0f, 1e-5));
+}
+
+TEST_CASE("TextLayout skips the delimiter that triggered word wrapping",
+          "[canvas][layout][issue-644]") {
+    AttributedString str("alpha beta gamma");
+    auto layout = layout_attributed_string(str, 48.0f, 10.0f);
+
+    REQUIRE(layout.lines.size() == 3);
+    REQUIRE(layout.lines[0].spans[0].text == "alpha");
+    REQUIRE(layout.lines[1].spans[0].text == "beta");
+    REQUIRE(layout.lines[2].spans[0].text == "gamma");
+    REQUIRE_THAT(layout.total_height, WithinAbs(30.0f, 1e-5));
 }
 
 TEST_CASE("TextLayout narrow width forces word break", "[canvas][layout]") {

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/audio/audio.hpp>
+#include <pulp/audio/audio_file.hpp>
 #include <pulp/audio/channel_set.hpp>
 #include <cmath>
 #include <numbers>
@@ -142,6 +143,84 @@ TEST_CASE("Buffer resize and views expose contiguous channel storage",
 
     buf.resize(2, 0);
     REQUIRE(buf.view().empty());
+}
+
+TEST_CASE("Buffer zero-channel and zero-sample states remain well formed",
+          "[audio][buffer][codecov]") {
+    Buffer<float> zero_channels(0, 8);
+    REQUIRE(zero_channels.num_channels() == 0);
+    REQUIRE(zero_channels.num_samples() == 8);
+    REQUIRE(zero_channels.view().empty());
+    zero_channels.clear();
+
+    Buffer<float> zero_samples(2, 0);
+    REQUIRE(zero_samples.num_channels() == 2);
+    REQUIRE(zero_samples.num_samples() == 0);
+    auto empty_view = zero_samples.view();
+    REQUIRE(empty_view.empty());
+    REQUIRE(empty_view.num_channels() == 2);
+    REQUIRE(empty_view.num_samples() == 0);
+    zero_samples.clear();
+
+    BufferView<float> default_view;
+    REQUIRE(default_view.empty());
+    REQUIRE(default_view.num_channels() == 0);
+    REQUIRE(default_view.num_samples() == 0);
+    default_view.clear();
+}
+
+TEST_CASE("AudioFileData reports shape from first channel",
+          "[audio][file][codecov]") {
+    AudioFileData empty;
+    REQUIRE(empty.sample_rate == 0);
+    REQUIRE(empty.num_channels() == 0);
+    REQUIRE(empty.num_frames() == 0);
+    REQUIRE(empty.empty());
+
+    AudioFileData first_channel_empty;
+    first_channel_empty.sample_rate = 44100;
+    first_channel_empty.channels = {{}, {1.0f, 2.0f}};
+    REQUIRE(first_channel_empty.num_channels() == 2);
+    REQUIRE(first_channel_empty.num_frames() == 0);
+    REQUIRE(first_channel_empty.empty());
+
+    AudioFileData stereo;
+    stereo.sample_rate = 48000;
+    stereo.channels = {{0.0f, 0.25f, -0.25f}, {1.0f}};
+    REQUIRE(stereo.num_channels() == 2);
+    REQUIRE(stereo.num_frames() == 3);
+    REQUIRE_FALSE(stereo.empty());
+}
+
+TEST_CASE("Device metadata defaults and custom configs are stable",
+          "[audio][device][codecov]") {
+    DeviceInfo info;
+    REQUIRE(info.id.empty());
+    REQUIRE(info.name.empty());
+    REQUIRE(info.max_input_channels == 0);
+    REQUIRE(info.max_output_channels == 0);
+    REQUIRE(info.sample_rates.empty());
+    REQUIRE(info.buffer_sizes.empty());
+    REQUIRE_FALSE(info.is_default_input);
+    REQUIRE_FALSE(info.is_default_output);
+
+    DeviceConfig config;
+    REQUIRE(config.device_id.empty());
+    REQUIRE(config.sample_rate == 48000.0);
+    REQUIRE(config.buffer_size == 256);
+    REQUIRE(config.input_channels == 0);
+    REQUIRE(config.output_channels == 2);
+
+    config.device_id = "external-device";
+    config.sample_rate = 96000.0;
+    config.buffer_size = 128;
+    config.input_channels = 2;
+    config.output_channels = 6;
+    REQUIRE(config.device_id == "external-device");
+    REQUIRE(config.sample_rate == 96000.0);
+    REQUIRE(config.buffer_size == 128);
+    REQUIRE(config.input_channels == 2);
+    REQUIRE(config.output_channels == 6);
 }
 
 TEST_CASE("ChannelSet maps standard layouts by count and name",

--- a/test/test_audio_bridge.cpp
+++ b/test/test_audio_bridge.cpp
@@ -47,6 +47,15 @@ TEST_CASE("AudioBridge pop_latest drains queue", "[view][bridge]") {
     REQUIRE_THAT(out.peak[0], WithinAbs(0.3, 0.001));
 }
 
+TEST_CASE("AudioBridge pop_latest reports empty before first meter",
+          "[view][bridge][issue-493]") {
+    AudioBridge bridge;
+
+    MeterData out;
+    REQUIRE_FALSE(bridge.pop_latest_meter(out));
+    REQUIRE(out.num_channels == 0);
+}
+
 TEST_CASE("AudioBridge analyze_and_push", "[view][bridge]") {
     AudioBridge bridge;
 
@@ -79,6 +88,43 @@ TEST_CASE("AudioBridge analyze_and_push", "[view][bridge]") {
     // ch1 should be silent
     REQUIRE_THAT(out.peak[1], WithinAbs(0.0, 0.001));
     REQUIRE_THAT(out.rms[1], WithinAbs(0.0, 0.001));
+}
+
+TEST_CASE("AudioBridge analyze clamps channels and handles zero sample blocks",
+          "[view][bridge][issue-493]") {
+    AudioBridge bridge;
+
+    std::vector<std::vector<float>> samples(10, std::vector<float>(4));
+    std::vector<const float*> channels(samples.size());
+    for (std::size_t ch = 0; ch < samples.size(); ++ch) {
+        float base = 0.05f * static_cast<float>(ch + 1);
+        samples[ch] = {base, -2.0f * base, 0.5f * base, 0.0f};
+        channels[ch] = samples[ch].data();
+    }
+
+    bridge.analyze_and_push(channels.data(), static_cast<int>(channels.size()), 4);
+
+    MeterData out;
+    REQUIRE(bridge.pop_latest_meter(out));
+    REQUIRE(out.num_channels == MeterData::max_channels);
+    for (int ch = 0; ch < out.num_channels; ++ch) {
+        float base = 0.05f * static_cast<float>(ch + 1);
+        REQUIRE_THAT(out.peak[ch], WithinAbs(2.0f * base, 0.0001));
+        REQUIRE_THAT(out.rms[ch],
+                     WithinAbs(std::sqrt((base * base +
+                                          4.0f * base * base +
+                                          0.25f * base * base) /
+                                         4.0f),
+                               0.0001));
+    }
+
+    bridge.analyze_and_push(channels.data(), static_cast<int>(channels.size()), 0);
+    REQUIRE(bridge.pop_latest_meter(out));
+    REQUIRE(out.num_channels == MeterData::max_channels);
+    for (int ch = 0; ch < out.num_channels; ++ch) {
+        REQUIRE_THAT(out.peak[ch], WithinAbs(0.0, 0.0001));
+        REQUIRE_THAT(out.rms[ch], WithinAbs(0.0, 0.0001));
+    }
 }
 
 TEST_CASE("MeterBallistics smooth response", "[view][bridge]") {
@@ -118,4 +164,16 @@ TEST_CASE("MeterBallistics peak hold", "[view][bridge]") {
         ballistics.update(0.0f, 0.0f, 1.0f / 60.0f);
     }
     REQUIRE(ballistics.held_peak < 0.9f); // Should have decayed
+}
+
+TEST_CASE("MeterBallistics releases tiny values to exact zero",
+          "[view][bridge][issue-493]") {
+    MeterBallistics ballistics;
+
+    ballistics.display_peak = 5e-7f;
+    ballistics.display_rms = 4e-7f;
+    ballistics.update(0.0f, 0.0f, 1.0f / 60.0f);
+
+    REQUIRE(ballistics.display_peak == 0.0f);
+    REQUIRE(ballistics.display_rms == 0.0f);
 }

--- a/test/test_audio_excerpt.cpp
+++ b/test/test_audio_excerpt.cpp
@@ -262,3 +262,18 @@ TEST_CASE("AudioSubsectionReader handles empty and past-end ranges",
     REQUIRE(dest[0] == 7.0f);
     REQUIRE(dest[1] == 8.0f);
 }
+
+TEST_CASE("AudioSubsectionReader ignores invalid read destinations",
+          "[audio][subsection][codecov]") {
+    AudioFileData audio;
+    audio.sample_rate = 48000;
+    audio.channels = {{0.0f, 0.5f}, {1.0f, 1.5f}};
+
+    AudioSubsectionReader reader(audio, 0, 2);
+    reader.read_frames(nullptr, 0, 0, 2);
+
+    float dest[] = {-1.0f, -2.0f};
+    reader.read_frames(dest, 2, 0, 2);
+    REQUIRE(dest[0] == -1.0f);
+    REQUIRE(dest[1] == -2.0f);
+}

--- a/test/test_audio_file.cpp
+++ b/test/test_audio_file.cpp
@@ -608,6 +608,33 @@ TEST_CASE("MemoryMappedAudioReader leaves destinations untouched past EOF",
     std::filesystem::remove(path);
 }
 
+TEST_CASE("MemoryMappedAudioReader rejects invalid destination buffers",
+          "[audio][file][mmap][codecov]") {
+    auto path = unique_temp_audio_path("_mmap_invalid_dest.wav");
+    std::filesystem::remove(path);
+
+    AudioFileData data;
+    data.sample_rate = 44100;
+    data.channels = {
+        {0.0f, 0.25f},
+        {0.5f, 0.75f},
+    };
+    REQUIRE(write_wav_file(path.string(), data));
+
+    MemoryMappedAudioReader reader;
+    REQUIRE(reader.open(path.string()));
+
+    REQUIRE_FALSE(reader.read_frames(nullptr, 2, 0, 1));
+
+    float left[1] = {-1.0f};
+    float* missing_right[] = {left, nullptr};
+    REQUIRE_FALSE(reader.read_frames(missing_right, 2, 0, 1));
+    REQUIRE(left[0] == -1.0f);
+
+    reader.close();
+    std::filesystem::remove(path);
+}
+
 TEST_CASE("offline processing handles guards, block tails, and file dispatch",
           "[audio][file][offline][issue-640]") {
     AudioFileData input;

--- a/test/test_audio_file.cpp
+++ b/test/test_audio_file.cpp
@@ -608,33 +608,6 @@ TEST_CASE("MemoryMappedAudioReader leaves destinations untouched past EOF",
     std::filesystem::remove(path);
 }
 
-TEST_CASE("MemoryMappedAudioReader rejects invalid destination buffers",
-          "[audio][file][mmap][codecov]") {
-    auto path = unique_temp_audio_path("_mmap_invalid_dest.wav");
-    std::filesystem::remove(path);
-
-    AudioFileData data;
-    data.sample_rate = 44100;
-    data.channels = {
-        {0.0f, 0.25f},
-        {0.5f, 0.75f},
-    };
-    REQUIRE(write_wav_file(path.string(), data));
-
-    MemoryMappedAudioReader reader;
-    REQUIRE(reader.open(path.string()));
-
-    REQUIRE_FALSE(reader.read_frames(nullptr, 2, 0, 1));
-
-    float left[1] = {-1.0f};
-    float* missing_right[] = {left, nullptr};
-    REQUIRE_FALSE(reader.read_frames(missing_right, 2, 0, 1));
-    REQUIRE(left[0] == -1.0f);
-
-    reader.close();
-    std::filesystem::remove(path);
-}
-
 TEST_CASE("offline processing handles guards, block tails, and file dispatch",
           "[audio][file][offline][issue-640]") {
     AudioFileData input;

--- a/test/test_audio_file.cpp
+++ b/test/test_audio_file.cpp
@@ -425,6 +425,30 @@ TEST_CASE("Read nonexistent file returns nullopt", "[audio][file]") {
     REQUIRE_FALSE(info.has_value());
 }
 
+TEST_CASE("AudioFileData shape helpers and WAV writer reject first-channel empties",
+          "[audio][file][issue-640]") {
+    AudioFileData data;
+    REQUIRE(data.num_channels() == 0);
+    REQUIRE(data.num_frames() == 0);
+    REQUIRE(data.empty());
+
+    data.sample_rate = 44100;
+    data.channels = {{}, {0.25f, 0.5f}};
+    REQUIRE(data.num_channels() == 2);
+    REQUIRE(data.num_frames() == 0);
+    REQUIRE(data.empty());
+
+    auto path = unique_temp_audio_path("_empty_first_channel.wav");
+    std::filesystem::remove(path);
+    REQUIRE_FALSE(write_wav_file(path.string(), data));
+    REQUIRE_FALSE(std::filesystem::exists(path));
+
+    data.channels = {{0.0f, 0.5f, 1.0f}, {-0.5f}};
+    REQUIRE(data.num_channels() == 2);
+    REQUIRE(data.num_frames() == 3);
+    REQUIRE_FALSE(data.empty());
+}
+
 TEST_CASE("WAV helpers write deinterleaved channel data and reject malformed input",
           "[audio][file][issue-640]") {
     auto path = unique_temp_audio_path("_helper_edges.wav");
@@ -719,6 +743,31 @@ TEST_CASE("StreamingWriter rejects invalid opens and closed writes",
     REQUIRE(writer.frames_written() == 0);
 
     writer.close();
+    writer.close();
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("StreamingWriter finalizes the active file before a failed reopen",
+          "[audio][file][streaming][issue-640]") {
+    auto path = unique_temp_audio_path("_stream_reopen_fail.wav");
+    std::filesystem::remove(path);
+
+    StreamingWriter writer;
+    REQUIRE(writer.open(path.string(), 44100, 1, 16));
+
+    const float frames[] = {-0.25f, 0.25f};
+    REQUIRE(writer.write_frames(frames, 2) == 2);
+    REQUIRE(writer.frames_written() == 2);
+
+    REQUIRE_FALSE(writer.open(std::filesystem::temp_directory_path().string(), 44100, 1, 16));
+    REQUIRE_FALSE(writer.is_open());
+    REQUIRE(writer.frames_written() == 0);
+
+    auto bytes = read_binary_file(path);
+    require_wav_header(bytes, 1, 44100, 16, 4);
+    REQUIRE(static_cast<int16_t>(read_le16(bytes, 44)) == -8191);
+    REQUIRE(static_cast<int16_t>(read_le16(bytes, 46)) == 8191);
+
     writer.close();
     std::filesystem::remove(path);
 }
@@ -1147,4 +1196,58 @@ TEST_CASE("AIFF reader rejects truncated PCM payloads", "[audio][file][registry]
     REQUIRE_FALSE(registry.read(tmp_path.string()).has_value());
 
     std::filesystem::remove(tmp_path);
+}
+
+TEST_CASE("AIFF reader rejects invalid COMM metadata and unsupported PCM depths",
+          "[audio][file][registry][aiff][issue-640]") {
+    auto& registry = FormatRegistry::instance();
+
+    SECTION("zero sample rate") {
+        auto tmp_path = unique_temp_audio_path("_aiff_zero_rate.aiff");
+        auto comm = make_comm_chunk(1, 1, 16);
+        std::fill(comm.begin() + 8, comm.begin() + 18, 0);
+
+        write_aiff_fixture(tmp_path,
+                           "AIFF",
+                           {
+                               {"COMM", comm},
+                               {"SSND", make_ssnd_chunk({0x40, 0x00})},
+                           });
+
+        REQUIRE_FALSE(registry.read_info(tmp_path.string()).has_value());
+        REQUIRE_FALSE(registry.read(tmp_path.string()).has_value());
+        std::filesystem::remove(tmp_path);
+    }
+
+    SECTION("zero channels") {
+        auto tmp_path = unique_temp_audio_path("_aiff_zero_channels.aiff");
+
+        write_aiff_fixture(tmp_path,
+                           "AIFF",
+                           {
+                               {"COMM", make_comm_chunk(0, 1, 16)},
+                               {"SSND", make_ssnd_chunk({0x40, 0x00})},
+                           });
+
+        REQUIRE_FALSE(registry.read_info(tmp_path.string()).has_value());
+        REQUIRE_FALSE(registry.read(tmp_path.string()).has_value());
+        std::filesystem::remove(tmp_path);
+    }
+
+    SECTION("unsupported PCM bit depth") {
+        auto tmp_path = unique_temp_audio_path("_aiff_20bit.aiff");
+
+        write_aiff_fixture(tmp_path,
+                           "AIFF",
+                           {
+                               {"COMM", make_comm_chunk(1, 1, 20)},
+                               {"SSND", make_ssnd_chunk({0x40, 0x00})},
+                           });
+
+        auto info = registry.read_info(tmp_path.string());
+        REQUIRE(info.has_value());
+        REQUIRE(info->bits_per_sample == 20);
+        REQUIRE_FALSE(registry.read(tmp_path.string()).has_value());
+        std::filesystem::remove(tmp_path);
+    }
 }

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -383,6 +383,69 @@ TEST_CASE("excerpt bundle reader fails clearly without manifest", "[audio][tools
     REQUIRE(result.error.find("bundle path does not exist") != std::string::npos);
 }
 
+TEST_CASE("excerpt bundle reader uses defaults and model/result fallbacks",
+          "[audio][tools][codecov]") {
+    TempDir temp;
+    auto bundle = temp.path / "bundle";
+    fs::create_directories(bundle);
+
+    write_text(bundle / "manifest.json", R"JSON({
+  "tool": "pulp audio excerpt-find",
+  "bundle_version": 1
+}
+)JSON");
+    write_text(bundle / "model.json", R"JSON({
+  "model_id": "clap_music_audioset_v1",
+  "backend": "null"
+}
+)JSON");
+    write_text(bundle / "ranked_results.json", R"JSON({
+  "results": [
+    "ignored",
+    {
+      "score": 0.25,
+      "source_path": "legacy-source.wav",
+      "start_ms": 10,
+      "end_ms": 20
+    }
+  ]
+}
+)JSON");
+
+    auto result = read_excerpt_bundle(bundle);
+
+    REQUIRE(result.ok);
+    REQUIRE(result.model_path == bundle / "model.json");
+    REQUIRE(result.ranked_results_path == bundle / "ranked_results.json");
+    REQUIRE(result.requested_model_id == "clap_music_audioset_v1");
+    REQUIRE(result.loaded_model_id == "clap_music_audioset_v1");
+    REQUIRE(result.backend == "null");
+    REQUIRE(result.result_count == 1);
+    REQUIRE(result.results.size() == 1);
+    REQUIRE(result.results[0].rank == 2);
+    REQUIRE(result.results[0].source_file == "legacy-source.wav");
+}
+
+TEST_CASE("excerpt bundle reader reports empty and missing ranked inputs",
+          "[audio][tools][codecov]") {
+    auto empty = read_excerpt_bundle({});
+    REQUIRE_FALSE(empty.ok);
+    REQUIRE(empty.error == "bundle path is required");
+
+    TempDir temp;
+    auto bundle = temp.path / "bundle";
+    fs::create_directories(bundle);
+    write_text(bundle / "manifest.json", R"JSON({
+  "ranked_results_file": "missing.json"
+}
+)JSON");
+
+    auto missing_ranked = read_excerpt_bundle(bundle);
+    REQUIRE_FALSE(missing_ranked.ok);
+    REQUIRE(missing_ranked.error.find("missing ranked results file")
+            != std::string::npos);
+}
+
 TEST_CASE("excerpt find writes a deterministic WAV-first bundle", "[audio][tools]") {
     TempDir temp;
     auto checkpoint = temp.path / "models" / "clap.pt";

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -124,6 +124,30 @@ TEST_CASE("audio model list reports registry and install state", "[audio][tools]
     REQUIRE(result.models[0].active);
 }
 
+TEST_CASE("audio model registry resolves checkpoint URLs and lookup misses",
+          "[audio][tools][codecov]") {
+    const auto& models = registered_models();
+    REQUIRE_FALSE(models.empty());
+    REQUIRE(models[0].model_id == "clap_music_audioset_v1");
+    REQUIRE(models[0].auto_downloadable);
+    REQUIRE(models[0].download_url.find("https://huggingface.co/")
+            == 0);
+
+    auto* model = find_registered_model("clap_music_audioset_v1");
+    REQUIRE(model != nullptr);
+    REQUIRE(model->backend == "clap");
+    REQUIRE(find_registered_model("missing_model") == nullptr);
+
+    REQUIRE(resolve_checkpoint_url("hf://user/repo/path/to/file.pt")
+            == "https://huggingface.co/user/repo/resolve/main/path/to/file.pt");
+    REQUIRE(resolve_checkpoint_url("https://example.com/model.pt")
+            == "https://example.com/model.pt");
+    REQUIRE(resolve_checkpoint_url("http://example.com/model.pt")
+            == "http://example.com/model.pt");
+    REQUIRE(resolve_checkpoint_url("hf://user-only").empty());
+    REQUIRE(resolve_checkpoint_url("manual://model.pt").empty());
+}
+
 TEST_CASE("audio model status reports missing config cleanly", "[audio][tools]") {
     TempDir temp;
 

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -68,6 +68,23 @@ pulp::audio::AudioFileData make_audio(uint32_t sample_rate, uint64_t frame_count
     return data;
 }
 
+fs::path install_active_clap_model(const TempDir& temp) {
+    auto checkpoint = temp.path / "models" / "clap.pt";
+    write_text(checkpoint, "stub");
+    write_text(temp.path / "audio" / "models" / "clap_music_audioset_v1.json", R"JSON({
+  "model_id": "clap_music_audioset_v1",
+  "backend": "clap",
+  "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
+  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+}
+)JSON");
+    write_text(temp.path / "audio" / "model-state.json", R"JSON({
+  "active_model_id": "clap_music_audioset_v1"
+}
+)JSON");
+    return checkpoint;
+}
+
 uint64_t stable_hash64(std::string_view text) {
     constexpr uint64_t offset_basis = 14695981039346656037ull;
     constexpr uint64_t prime = 1099511628211ull;
@@ -511,6 +528,83 @@ TEST_CASE("excerpt find JSON serializer includes results and skipped files",
     REQUIRE(json.find("\"excerpt_file\": \"excerpts/rank-01.wav\"")
             != std::string::npos);
     REQUIRE(json.find("notes.txt (unsupported; WAV only)") != std::string::npos);
+}
+
+TEST_CASE("excerpt find reports explicit unknown models",
+          "[audio][tools][codecov]") {
+    TempDir temp;
+    auto input = temp.path / "input.wav";
+    REQUIRE(pulp::audio::write_wav_file(input.string(), make_audio(48000, 48000)));
+
+    ExcerptFindRequest request;
+    request.text = "texture";
+    request.input_path = input;
+    request.model_id = "not_a_model";
+
+    auto result = run_excerpt_find(request, temp.path);
+
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.error == "unknown model_id: not_a_model");
+}
+
+TEST_CASE("excerpt find collects uppercase WAV files and records unsupported siblings",
+          "[audio][tools][codecov]") {
+    TempDir temp;
+    install_active_clap_model(temp);
+
+    auto wav = temp.path / "Upper.WAV";
+    REQUIRE(pulp::audio::write_wav_file(wav.string(), make_audio(48000, 48000)));
+    write_text(temp.path / "notes.mp3", "not really mp3");
+    fs::create_directories(temp.path / "nested");
+    REQUIRE(pulp::audio::write_wav_file(
+        (temp.path / "nested" / "ignored.wav").string(),
+        make_audio(48000, 48000)));
+
+    ExcerptFindRequest request;
+    request.text = "texture";
+    request.input_path = temp.path;
+    request.recursive = false;
+    request.top_k = 1;
+    request.window_ms = 1000;
+    request.hop_ms = 1000;
+    request.max_candidates_per_file = 1;
+    request.dry_run = true;
+
+    auto result = run_excerpt_find(request, temp.path);
+
+    REQUIRE(result.ok);
+    REQUIRE(result.scanned_file_count == 1);
+    REQUIRE(result.results.size() == 1);
+    REQUIRE(result.results[0].source_file == wav.string());
+    REQUIRE(result.skipped_files.size() == 1);
+    REQUIRE(result.skipped_files[0].find("notes.mp3") != std::string::npos);
+    REQUIRE(result.skipped_files[0].find("unsupported; WAV only") != std::string::npos);
+}
+
+TEST_CASE("excerpt find can dry-run with all candidates below min score",
+          "[audio][tools][codecov]") {
+    TempDir temp;
+    install_active_clap_model(temp);
+    auto input = temp.path / "input.wav";
+    REQUIRE(pulp::audio::write_wav_file(input.string(), make_audio(48000, 48000)));
+
+    ExcerptFindRequest request;
+    request.text = "texture";
+    request.input_path = input;
+    request.top_k = 3;
+    request.window_ms = 1000;
+    request.hop_ms = 1000;
+    request.max_candidates_per_file = 2;
+    request.min_score = 2.0;
+    request.dry_run = true;
+
+    auto result = run_excerpt_find(request, temp.path);
+
+    REQUIRE(result.ok);
+    REQUIRE(result.bundle_path.empty());
+    REQUIRE(result.scanned_file_count == 1);
+    REQUIRE(result.results.empty());
+    REQUIRE(result.skipped_files.empty());
 }
 
 TEST_CASE("excerpt find deterministic scores use a stable hash", "[audio][tools]") {

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -417,6 +417,102 @@ TEST_CASE("excerpt find writes a deterministic WAV-first bundle", "[audio][tools
     REQUIRE(bundle.results.size() == result.results.size());
 }
 
+TEST_CASE("excerpt find validates required request fields before model loading",
+          "[audio][tools][codecov]") {
+    TempDir temp;
+    auto input = temp.path / "input.wav";
+    REQUIRE(pulp::audio::write_wav_file(input.string(), make_audio(48000, 48000)));
+
+    ExcerptFindRequest request;
+    request.input_path = input;
+
+    auto missing_text = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(missing_text.ok);
+    REQUIRE(missing_text.error == "text query is required");
+
+    request.text = "kick";
+    request.input_path.clear();
+    auto missing_input = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(missing_input.ok);
+    REQUIRE(missing_input.error == "input path is required");
+
+    request.input_path = input;
+    request.top_k = 0;
+    auto bad_top = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(bad_top.ok);
+    REQUIRE(bad_top.error == "top and max_candidates_per_file must be >= 1");
+
+    request.top_k = 1;
+    request.max_candidates_per_file = 0;
+    auto bad_max = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(bad_max.ok);
+    REQUIRE(bad_max.error == "top and max_candidates_per_file must be >= 1");
+
+    request.max_candidates_per_file = 1;
+    request.window_ms = 0;
+    auto bad_window = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(bad_window.ok);
+    REQUIRE(bad_window.error == "window_ms and hop_ms must be >= 1");
+}
+
+TEST_CASE("excerpt find reports unsupported inputs after resolving a model",
+          "[audio][tools][codecov]") {
+    TempDir temp;
+    auto checkpoint = temp.path / "models" / "clap.pt";
+    write_text(checkpoint, "stub");
+    write_text(temp.path / "audio" / "models" / "clap_music_audioset_v1.json", R"JSON({
+  "model_id": "clap_music_audioset_v1",
+  "backend": "clap",
+  "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
+  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+}
+)JSON");
+    write_text(temp.path / "audio" / "model-state.json", R"JSON({
+  "active_model_id": "clap_music_audioset_v1"
+}
+)JSON");
+
+    auto text_file = temp.path / "notes.txt";
+    write_text(text_file, "not audio");
+
+    ExcerptFindRequest request;
+    request.text = "texture";
+    request.input_path = text_file;
+
+    auto result = run_excerpt_find(request, temp.path);
+
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.error == "no supported WAV inputs found");
+    REQUIRE(result.scanned_file_count == 0);
+    REQUIRE(result.skipped_files.size() == 1);
+    REQUIRE(result.skipped_files[0].find("unsupported; WAV only") != std::string::npos);
+}
+
+TEST_CASE("excerpt find JSON serializer includes results and skipped files",
+          "[audio][tools][codecov]") {
+    ExcerptFindResult result;
+    result.ok = true;
+    result.bundle_path = "/tmp/bundle";
+    result.query = "kick";
+    result.requested_model_id = "clap_music_audioset_v1";
+    result.loaded_model_id = "clap_music_audioset_v1";
+    result.backend = "null";
+    result.resolved_checkpoint_path = "/tmp/model.pt";
+    result.scanned_file_count = 2;
+    result.results.push_back({1, 0.75, "input.wav", 1000.0, 0.0, 500.0,
+                              "excerpts/rank-01.wav"});
+    result.skipped_files.push_back("notes.txt (unsupported; WAV only)");
+
+    auto json = to_json(result);
+
+    REQUIRE(json.find("\"ok\": true") != std::string::npos);
+    REQUIRE(json.find("\"query\": \"kick\"") != std::string::npos);
+    REQUIRE(json.find("\"scanned_file_count\": 2") != std::string::npos);
+    REQUIRE(json.find("\"excerpt_file\": \"excerpts/rank-01.wav\"")
+            != std::string::npos);
+    REQUIRE(json.find("notes.txt (unsupported; WAV only)") != std::string::npos);
+}
+
 TEST_CASE("excerpt find deterministic scores use a stable hash", "[audio][tools]") {
     TempDir temp;
     auto checkpoint = temp.path / "models" / "clap.pt";

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -198,6 +198,102 @@ TEST_CASE("audio model activate rejects installed metadata with missing checkpoi
     REQUIRE(activation.error.find("checkpoint does not exist") != std::string::npos);
 }
 
+TEST_CASE("audio model store accepts overrides and legacy checkpoint metadata",
+          "[audio][tools][codecov]") {
+    TempDir temp;
+    auto checkpoint = temp.path / "models" / "legacy-clap.pt";
+    write_text(checkpoint, "stub");
+
+    REQUIRE(resolve_pulp_home(temp.path) == temp.path);
+    REQUIRE(audio_model_state_path(temp.path)
+            == temp.path / "audio" / "model-state.json");
+    REQUIRE(audio_model_install_path("clap_music_audioset_v1", temp.path)
+            == temp.path / "audio" / "models" / "clap_music_audioset_v1.json");
+
+    write_text(temp.path / "audio" / "models" / "clap_music_audioset_v1.json", R"JSON({
+  "model_id": "clap_music_audioset_v1",
+  "backend": "legacy-clap",
+  "checkpoint_ref": "manual://legacy",
+  "checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+}
+)JSON");
+    auto installed = read_installed_model("clap_music_audioset_v1", temp.path);
+    REQUIRE(installed.metadata_found);
+    REQUIRE(installed.loadable());
+    REQUIRE(installed.backend == "legacy-clap");
+    REQUIRE(installed.checkpoint_ref == "manual://legacy");
+    REQUIRE(installed.resolved_checkpoint_path == checkpoint);
+
+    write_text(temp.path / "audio" / "model-state.json", R"JSON({
+  "requested_model_id": "clap_music_audioset_v1"
+}
+)JSON");
+    REQUIRE(read_active_model_id(temp.path) == "clap_music_audioset_v1");
+}
+
+TEST_CASE("audio model and bundle JSON serializers include stable fields",
+          "[audio][tools][codecov]") {
+    ModelListResult list;
+    list.pulp_home = "/tmp/pulp-home";
+    list.active_model_id = "clap_music_audioset_v1";
+    list.error = "sample error";
+    ListedModel listed;
+    listed.model.model_id = "clap_music_audioset_v1";
+    listed.model.display_name = "CLAP Music";
+    listed.model.backend = "clap";
+    listed.model.checkpoint_ref = "hf://example/model.pt";
+    listed.model.task_tags = {"music", "embedding"};
+    listed.model.size_bytes = 1234;
+    listed.status = "installed";
+    listed.active = true;
+    listed.resolved_checkpoint_path = "/tmp/model.pt";
+    list.models.push_back(listed);
+
+    auto list_json = to_json(list);
+    REQUIRE(list_json.find("\"active_model_id\": \"clap_music_audioset_v1\"")
+            != std::string::npos);
+    REQUIRE(list_json.find("\"status\": \"installed\"") != std::string::npos);
+    REQUIRE(list_json.find("\"active\": true") != std::string::npos);
+    REQUIRE(list_json.find("\"error\": \"sample error\"") != std::string::npos);
+
+    ActivateModelResult activation;
+    activation.ok = true;
+    activation.state_path = "/tmp/state.json";
+    activation.active_model_id = "clap_music_audioset_v1";
+    activation.backend = "clap";
+    activation.checkpoint_ref = "hf://example/model.pt";
+    activation.resolved_checkpoint_path = "/tmp/model.pt";
+    auto activation_json = to_json(activation);
+    REQUIRE(activation_json.find("\"ok\": true") != std::string::npos);
+    REQUIRE(activation_json.find("\"state_path\": \"/tmp/state.json\"")
+            != std::string::npos);
+
+    ModelStatus status;
+    status.state_path = "/tmp/state.json";
+    status.state_file_found = true;
+    status.configured_model_id = "clap_music_audioset_v1";
+    status.resolved_checkpoint_path = "/tmp/model.pt";
+    status.checkpoint_exists = true;
+    status.message = "configured model is loadable";
+    auto status_json = to_json(status);
+    REQUIRE(status_json.find("\"loadable\": true") != std::string::npos);
+    REQUIRE(status_json.find("\"message\": \"configured model is loadable\"")
+            != std::string::npos);
+
+    BundleReadResult bundle;
+    bundle.ok = true;
+    bundle.bundle_path = "/tmp/bundle";
+    bundle.bundle_version = 1;
+    bundle.tool = "pulp audio excerpt-find";
+    bundle.result_count = 1;
+    bundle.results.push_back({1, 0.5, "input.wav", 1000.0, 100.0, 200.0,
+                              "excerpts/rank-01.wav"});
+    auto bundle_json = to_json(bundle);
+    REQUIRE(bundle_json.find("\"result_count\": 1") != std::string::npos);
+    REQUIRE(bundle_json.find("\"excerpt_file\": \"excerpts/rank-01.wav\"")
+            != std::string::npos);
+}
+
 TEST_CASE("excerpt bundle reader summarizes manifest and ranked results", "[audio][tools]") {
     TempDir temp;
     auto bundle = temp.path / "bundle";

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/tools/audio/excerpt_service.hpp>
+#include <pulp/tools/audio/model_registry.hpp>
 #include <pulp/tools/audio/model_store.hpp>
 #include <pulp/tools/audio/service.hpp>
 
@@ -10,6 +11,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <string>
 #include <string_view>
 
 #ifdef _WIN32
@@ -79,7 +81,115 @@ uint64_t stable_hash64(std::string_view text) {
     return hash;
 }
 
+void write_installed_model_metadata(const fs::path& pulp_home,
+                                    const fs::path& checkpoint,
+                                    std::string_view checkpoint_key = "resolved_checkpoint_path") {
+    write_text(pulp_home / "audio" / "models" / "clap_music_audioset_v1.json", R"JSON({
+  "model_id": "clap_music_audioset_v1",
+  "backend": "clap",
+  "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
+  ")JSON" + std::string(checkpoint_key) + R"JSON(": ")JSON" + checkpoint.generic_string() + R"JSON("
+}
+)JSON");
+}
+
 } // namespace
+
+TEST_CASE("audio model registry resolves known models and checkpoint URLs",
+          "[audio][tools][issue-643]") {
+    const auto& models = registered_models();
+    REQUIRE_FALSE(models.empty());
+
+    auto* model = find_registered_model("clap_music_audioset_v1");
+    REQUIRE(model != nullptr);
+    REQUIRE(model->backend == "clap");
+    REQUIRE(model->auto_downloadable);
+    REQUIRE(find_registered_model("not_a_model") == nullptr);
+
+    REQUIRE(resolve_checkpoint_url("hf://user/repo/path/to/model.pt")
+            == "https://huggingface.co/user/repo/resolve/main/path/to/model.pt");
+    REQUIRE(resolve_checkpoint_url("https://example.test/model.bin")
+            == "https://example.test/model.bin");
+    REQUIRE(resolve_checkpoint_url("http://example.test/model.bin")
+            == "http://example.test/model.bin");
+    REQUIRE(resolve_checkpoint_url("hf://user-only").empty());
+    REQUIRE(resolve_checkpoint_url("hf://user/repo").empty());
+    REQUIRE(resolve_checkpoint_url("file:///tmp/model.pt").empty());
+}
+
+TEST_CASE("audio model store reads legacy metadata and malformed records fail closed",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    auto checkpoint = temp.path / "models" / "clap.pt";
+    write_text(checkpoint, "stub");
+    write_installed_model_metadata(temp.path, checkpoint, "checkpoint_path");
+
+    auto record = read_installed_model("clap_music_audioset_v1", temp.path);
+    REQUIRE(record.metadata_found);
+    REQUIRE(record.model_id == "clap_music_audioset_v1");
+    REQUIRE(record.backend == "clap");
+    REQUIRE(record.checkpoint_ref == "hf://lukewys/laion_clap/music.pt");
+    REQUIRE(record.resolved_checkpoint_path == checkpoint);
+    REQUIRE(record.checkpoint_exists);
+    REQUIRE(record.loadable());
+
+    write_text(temp.path / "audio" / "models" / "bad_model.json", "{");
+    auto bad = read_installed_model("bad_model", temp.path);
+    REQUIRE(bad.metadata_found);
+    REQUIRE(bad.model_id == "bad_model");
+    REQUIRE(bad.backend.empty());
+    REQUIRE_FALSE(bad.checkpoint_exists);
+    REQUIRE_FALSE(bad.loadable());
+}
+
+TEST_CASE("audio model list and activation JSON report inactive and error states",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+
+    auto list = list_models(temp.path);
+    REQUIRE(list.error.empty());
+    REQUIRE(list.active_model_id.empty());
+    REQUIRE(list.models.size() == 1);
+    REQUIRE(list.models[0].status == "not_installed");
+    REQUIRE_FALSE(list.models[0].active);
+
+    auto list_json = to_json(list);
+    REQUIRE(list_json.find("\"status\": \"not_installed\"") != std::string::npos);
+    REQUIRE(list_json.find("\"active\": false") != std::string::npos);
+
+    auto activation = activate_model("not_a_model", temp.path);
+    REQUIRE_FALSE(activation.ok);
+    auto activation_json = to_json(activation);
+    REQUIRE(activation_json.find("\"ok\": false") != std::string::npos);
+    REQUIRE(activation_json.find("unknown model_id: not_a_model") != std::string::npos);
+}
+
+TEST_CASE("audio model status falls back to legacy model.json and installed metadata",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    auto checkpoint = temp.path / "models" / "clap.pt";
+    write_text(checkpoint, "stub");
+    write_installed_model_metadata(temp.path, checkpoint, "checkpoint_path");
+    write_text(temp.path / "audio" / "model.json", R"JSON({
+  "model_id": "clap_music_audioset_v1"
+}
+)JSON");
+
+    auto status = query_model_status(temp.path);
+
+    REQUIRE(status.state_file_found);
+    REQUIRE(status.state_path.filename() == "model.json");
+    REQUIRE(status.configured_model_id == "clap_music_audioset_v1");
+    REQUIRE(status.backend == "clap");
+    REQUIRE(status.checkpoint_ref == "hf://lukewys/laion_clap/music.pt");
+    REQUIRE(status.resolved_checkpoint_path == checkpoint);
+    REQUIRE(status.checkpoint_exists);
+    REQUIRE(status.loadable());
+
+    auto json = to_json(status);
+    REQUIRE(json.find("\"loadable\": true") != std::string::npos);
+    REQUIRE(json.find("\"message\": \"configured model is loadable\"") != std::string::npos);
+}
 
 TEST_CASE("audio model list reports registry and install state", "[audio][tools]") {
     TempDir temp;
@@ -270,6 +380,76 @@ TEST_CASE("excerpt bundle reader fails clearly without manifest", "[audio][tools
     REQUIRE(result.error.find("bundle path does not exist") != std::string::npos);
 }
 
+TEST_CASE("excerpt bundle reader fills defaults from model and ranked result files",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    auto bundle = temp.path / "bundle";
+    fs::create_directories(bundle);
+
+    write_text(bundle / "manifest.json", R"JSON({
+  "tool": "pulp audio excerpt-find",
+  "bundle_version": 1
+}
+)JSON");
+
+    write_text(bundle / "model.json", R"JSON({
+  "model_id": "clap_music_audioset_v1",
+  "backend": "clap"
+}
+)JSON");
+
+    write_text(bundle / "ranked_results.json", R"JSON({
+  "results": [
+    {
+      "score": 0.25,
+      "source_path": "/tmp/source.wav",
+      "end_ms": 100
+    },
+    42,
+    {
+      "rank": 5,
+      "source_file": "/tmp/other.wav"
+    }
+  ]
+}
+)JSON");
+
+    auto result = read_excerpt_bundle(bundle);
+
+    REQUIRE(result.ok);
+    REQUIRE(result.requested_model_id == "clap_music_audioset_v1");
+    REQUIRE(result.loaded_model_id == "clap_music_audioset_v1");
+    REQUIRE(result.backend == "clap");
+    REQUIRE(result.result_count == 2);
+    REQUIRE(result.results.size() == 2);
+    REQUIRE(result.results[0].rank == 1);
+    REQUIRE(result.results[0].score == Catch::Approx(0.25));
+    REQUIRE(result.results[0].source_file == "/tmp/source.wav");
+    REQUIRE(result.results[1].rank == 5);
+
+    auto json = to_json(result);
+    REQUIRE(json.find("\"result_count\": 2") != std::string::npos);
+    REQUIRE(json.find("\"source_file\": \"/tmp/source.wav\"") != std::string::npos);
+}
+
+TEST_CASE("excerpt bundle reader rejects missing ranked result file",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    auto bundle = temp.path / "bundle";
+    fs::create_directories(bundle);
+
+    write_text(bundle / "manifest.json", R"JSON({
+  "tool": "pulp audio excerpt-find",
+  "bundle_version": 1
+}
+)JSON");
+
+    auto result = read_excerpt_bundle(bundle);
+
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.error.find("missing ranked results file") != std::string::npos);
+}
+
 TEST_CASE("excerpt find writes a deterministic WAV-first bundle", "[audio][tools]") {
     TempDir temp;
     auto checkpoint = temp.path / "models" / "clap.pt";
@@ -356,6 +536,93 @@ TEST_CASE("excerpt find deterministic scores use a stable hash", "[audio][tools]
     const auto key = request.text + "|" + input.string() + "|0|48000";
     const auto expected = static_cast<double>(stable_hash64(key) % 1000000ULL) / 1000000.0;
     REQUIRE(result.results.front().score == Catch::Approx(expected));
+}
+
+TEST_CASE("excerpt find validates request guard fields before model resolution",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    ExcerptFindRequest request;
+    request.input_path = temp.path;
+    request.top_k = 1;
+    request.max_candidates_per_file = 1;
+    request.window_ms = 1000;
+    request.hop_ms = 1000;
+
+    auto empty_text = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(empty_text.ok);
+    REQUIRE(empty_text.error == "text query is required");
+
+    request.text = "query";
+    request.input_path = fs::path{};
+    auto empty_input = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(empty_input.ok);
+    REQUIRE(empty_input.error == "input path is required");
+
+    request.input_path = temp.path / "missing.wav";
+    auto missing_input = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(missing_input.ok);
+    REQUIRE(missing_input.error.find("input path does not exist") != std::string::npos);
+
+    request.input_path = temp.path;
+    request.top_k = 0;
+    auto zero_top = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(zero_top.ok);
+    REQUIRE(zero_top.error == "top and max_candidates_per_file must be >= 1");
+
+    request.top_k = 1;
+    request.max_candidates_per_file = 0;
+    auto zero_candidates = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(zero_candidates.ok);
+    REQUIRE(zero_candidates.error == "top and max_candidates_per_file must be >= 1");
+
+    request.max_candidates_per_file = 1;
+    request.window_ms = 0;
+    auto zero_window = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(zero_window.ok);
+    REQUIRE(zero_window.error == "window_ms and hop_ms must be >= 1");
+
+    request.window_ms = 1000;
+    request.hop_ms = 0;
+    auto zero_hop = run_excerpt_find(request, temp.path);
+    REQUIRE_FALSE(zero_hop.ok);
+    REQUIRE(zero_hop.error == "window_ms and hop_ms must be >= 1");
+}
+
+TEST_CASE("excerpt find reports unsupported inputs after model resolution",
+          "[audio][tools][issue-643]") {
+    TempDir temp;
+    auto checkpoint = temp.path / "models" / "clap.pt";
+    write_text(checkpoint, "stub");
+    write_installed_model_metadata(temp.path, checkpoint);
+    write_text(temp.path / "audio" / "model-state.json", R"JSON({
+  "active_model_id": "clap_music_audioset_v1"
+}
+)JSON");
+
+    auto unsupported = temp.path / "notes.txt";
+    write_text(unsupported, "not audio");
+
+    ExcerptFindRequest request;
+    request.text = "query";
+    request.input_path = unsupported;
+    request.top_k = 1;
+    request.max_candidates_per_file = 1;
+    request.window_ms = 1000;
+    request.hop_ms = 1000;
+    request.dry_run = true;
+
+    auto result = run_excerpt_find(request, temp.path);
+
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.requested_model_id == "clap_music_audioset_v1");
+    REQUIRE(result.error == "no supported WAV inputs found");
+    REQUIRE(result.scanned_file_count == 0);
+    REQUIRE(result.skipped_files.size() == 1);
+    REQUIRE(result.skipped_files[0].find("unsupported; WAV only") != std::string::npos);
+
+    auto json = to_json(result);
+    REQUIRE(json.find("\"ok\": false") != std::string::npos);
+    REQUIRE(json.find("unsupported; WAV only") != std::string::npos);
 }
 
 #if !defined(_WIN32)

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -181,6 +181,47 @@ TEST_CASE("audio model status reports configured checkpoint loadability", "[audi
     REQUIRE(status.message == "configured model is loadable");
 }
 
+TEST_CASE("audio model status reports malformed state files",
+          "[audio][tools][codecov]") {
+    TempDir temp;
+    write_text(temp.path / "audio" / "model-state.json", "{ not-json");
+
+    auto status = query_model_status(temp.path);
+
+    REQUIRE(status.state_file_found);
+    REQUIRE(status.state_path == temp.path / "audio" / "model-state.json");
+    REQUIRE_FALSE(status.loadable());
+    REQUIRE(status.message.find("failed to parse") != std::string::npos);
+}
+
+TEST_CASE("audio model status reads legacy model.json and installed metadata fallbacks",
+          "[audio][tools][codecov]") {
+    TempDir temp;
+    auto checkpoint = temp.path / "models" / "clap.pt";
+    write_text(checkpoint, "stub");
+    write_text(temp.path / "audio" / "models" / "clap_music_audioset_v1.json", R"JSON({
+  "model_id": "clap_music_audioset_v1",
+  "backend": "clap",
+  "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
+  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+}
+)JSON");
+    write_text(temp.path / "audio" / "model.json", R"JSON({
+  "model_id": "clap_music_audioset_v1"
+}
+)JSON");
+
+    auto status = query_model_status(temp.path);
+
+    REQUIRE(status.state_file_found);
+    REQUIRE(status.state_path == temp.path / "audio" / "model.json");
+    REQUIRE(status.configured_model_id == "clap_music_audioset_v1");
+    REQUIRE(status.backend == "clap");
+    REQUIRE(status.checkpoint_ref == "hf://lukewys/laion_clap/music.pt");
+    REQUIRE(status.resolved_checkpoint_path == checkpoint);
+    REQUIRE(status.loadable());
+}
+
 TEST_CASE("audio model activate writes state from installed metadata", "[audio][tools]") {
     TempDir temp;
     auto checkpoint = temp.path / "models" / "clap.pt";

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -246,6 +246,30 @@ TEST_CASE("audio model activate writes state from installed metadata", "[audio][
     REQUIRE(status.checkpoint_exists);
 }
 
+TEST_CASE("audio model activate falls back to registered metadata",
+          "[audio][tools][codecov]") {
+    TempDir temp;
+    auto checkpoint = temp.path / "models" / "clap.pt";
+    write_text(checkpoint, "stub");
+    write_text(temp.path / "audio" / "models" / "clap_music_audioset_v1.json", R"JSON({
+  "model_id": "clap_music_audioset_v1",
+  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+}
+)JSON");
+
+    auto activation = activate_model("clap_music_audioset_v1", temp.path);
+
+    REQUIRE(activation.ok);
+    REQUIRE(activation.backend == "clap");
+    REQUIRE(activation.checkpoint_ref == "hf://lukewys/laion_clap/music.pt");
+    REQUIRE(activation.resolved_checkpoint_path == checkpoint);
+
+    auto status = query_model_status(temp.path);
+    REQUIRE(status.loadable());
+    REQUIRE(status.backend == "clap");
+    REQUIRE(status.checkpoint_ref == "hf://lukewys/laion_clap/music.pt");
+}
+
 TEST_CASE("audio model activate rejects unknown or uninstalled models", "[audio][tools]") {
     TempDir temp;
 

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -337,6 +337,21 @@ TEST_CASE("audio model store accepts overrides and legacy checkpoint metadata",
     REQUIRE(read_active_model_id(temp.path) == "clap_music_audioset_v1");
 }
 
+TEST_CASE("audio model store treats malformed install metadata as unloadable",
+          "[audio][tools][codecov]") {
+    TempDir temp;
+    write_text(temp.path / "audio" / "models" / "clap_music_audioset_v1.json",
+               "{ not-json");
+
+    auto installed = read_installed_model("clap_music_audioset_v1", temp.path);
+
+    REQUIRE(installed.metadata_found);
+    REQUIRE(installed.model_id == "clap_music_audioset_v1");
+    REQUIRE(installed.backend.empty());
+    REQUIRE_FALSE(installed.checkpoint_exists);
+    REQUIRE_FALSE(installed.loadable());
+}
+
 TEST_CASE("audio model and bundle JSON serializers include stable fields",
           "[audio][tools][codecov]") {
     ModelListResult list;

--- a/test/test_auto_ui.cpp
+++ b/test/test_auto_ui.cpp
@@ -1,16 +1,58 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/view/auto_ui.hpp>
+#include <pulp/canvas/canvas.hpp>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
 
 using namespace pulp::view;
 using namespace pulp::state;
 using Catch::Matchers::WithinAbs;
 
+namespace {
+
+ParamInfo make_param(ParamID id, std::string name, std::string unit, ParamRange range) {
+    ParamInfo info;
+    info.id = id;
+    info.name = std::move(name);
+    info.unit = std::move(unit);
+    info.range = range;
+    return info;
+}
+
+template <typename Widget>
+Widget* find_widget(View& view, std::string_view id) {
+    if (view.id() == id) {
+        if (auto* widget = dynamic_cast<Widget*>(&view)) return widget;
+    }
+    for (size_t i = 0; i < view.child_count(); ++i) {
+        if (auto* widget = find_widget<Widget>(*view.child_at(i), id)) return widget;
+    }
+    return nullptr;
+}
+
+bool paints_text(View& view, std::string_view text) {
+    pulp::canvas::RecordingCanvas canvas;
+    view.paint(canvas);
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::fill_text &&
+            cmd.text == text) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
 TEST_CASE("AutoUi builds from parameter store", "[view][auto_ui]") {
     StateStore store;
-    store.add_parameter({1, "Gain", "dB", {-60.0f, 12.0f, 0.0f}});
-    store.add_parameter({2, "Mix", "%", {0.0f, 100.0f, 100.0f}});
-    store.add_parameter({3, "Bypass", "", {0.0f, 1.0f, 0.0f, 1.0f}}); // step=1 → toggle
+    store.add_parameter(make_param(1, "Gain", "dB", {-60.0f, 12.0f, 0.0f}));
+    store.add_parameter(make_param(2, "Mix", "%", {0.0f, 100.0f, 100.0f}));
+    store.add_parameter(make_param(3, "Bypass", "", {0.0f, 1.0f, 0.0f, 1.0f}));
 
     auto root = AutoUi::build(store);
     REQUIRE(root != nullptr);
@@ -132,7 +174,7 @@ TEST_CASE("AutoUi scales from 1 param up to 16 without losing structure",
 
 TEST_CASE("AutoUi sync updates widgets", "[view][auto_ui]") {
     StateStore store;
-    store.add_parameter({1, "Gain", "dB", {-60.0f, 12.0f, 0.0f}});
+    store.add_parameter(make_param(1, "Gain", "dB", {-60.0f, 12.0f, 0.0f}));
 
     auto root = AutoUi::build(store);
     REQUIRE(root != nullptr);
@@ -155,4 +197,66 @@ TEST_CASE("AutoUi sync updates widgets", "[view][auto_ui]") {
     auto* knob = find_knob(*root);
     REQUIRE(knob != nullptr);
     REQUIRE_THAT(knob->value(), WithinAbs(0.8, 0.01));
+}
+
+TEST_CASE("AutoUi generated controls expose toggle state and formatted values",
+          "[view][auto_ui][coverage][issue-493]") {
+    StateStore store;
+    store.add_parameter(make_param(1, "Frequency", "Hz", {0.0f, 1000.0f, 500.0f}));
+    store.add_parameter(make_param(2, "Drive", "dB", {0.0f, 80.0f, 50.0f}));
+    store.add_parameter(make_param(3, "Fine", "", {0.0f, 8.0f, 5.0f}));
+    store.add_parameter(make_param(4, "Bypass", "", {0.0f, 1.0f, 1.0f, 1.0f}));
+
+    auto root = AutoUi::build(store);
+    REQUIRE(root != nullptr);
+
+    auto* frequency = find_widget<Knob>(*root, "Frequency");
+    auto* drive = find_widget<Knob>(*root, "Drive");
+    auto* fine = find_widget<Knob>(*root, "Fine");
+    auto* bypass = find_widget<Toggle>(*root, "Bypass");
+
+    REQUIRE(frequency != nullptr);
+    REQUIRE(drive != nullptr);
+    REQUIRE(fine != nullptr);
+    REQUIRE(bypass != nullptr);
+    REQUIRE(bypass->is_on());
+    REQUIRE(bypass->label() == "Bypass");
+
+    frequency->set_bounds({0, 0, 80, 80});
+    drive->set_bounds({0, 0, 80, 80});
+    fine->set_bounds({0, 0, 80, 80});
+
+    REQUIRE(paints_text(*frequency, "500 Hz"));
+    REQUIRE(paints_text(*drive, "50.0 dB"));
+    REQUIRE(paints_text(*fine, "5.00"));
+}
+
+TEST_CASE("AutoUi sync updates generated toggles and existing faders",
+          "[view][auto_ui][coverage][issue-493]") {
+    StateStore store;
+    store.add_parameter(make_param(1, "Bypass", "", {0.0f, 1.0f, 0.0f, 1.0f}));
+    store.add_parameter(make_param(2, "Level", "", {0.0f, 1.0f, 0.0f}));
+
+    auto root = AutoUi::build(store);
+    REQUIRE(root != nullptr);
+
+    auto* bypass = find_widget<Toggle>(*root, "Bypass");
+    REQUIRE(bypass != nullptr);
+    REQUIRE_FALSE(bypass->is_on());
+
+    auto fader = std::make_unique<Fader>();
+    auto* fader_ptr = fader.get();
+    fader->set_id("Level");
+    root->add_child(std::move(fader));
+
+    store.set_normalized(1, 1.0f);
+    store.set_normalized(2, 0.35f);
+    AutoUi::sync(*root, store);
+
+    REQUIRE(bypass->is_on());
+    REQUIRE_THAT(fader_ptr->value(), WithinAbs(0.35f, 0.001f));
+
+    store.set_normalized(1, 0.0f);
+    AutoUi::sync(*root, store);
+    REQUIRE_FALSE(bypass->is_on());
 }

--- a/test/test_binding.cpp
+++ b/test/test_binding.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/state/binding.hpp>
+#include <vector>
 
 using namespace pulp::state;
 using Catch::Matchers::WithinAbs;
@@ -61,6 +62,41 @@ TEST_CASE("Binding normalized", "[binding]") {
     REQUIRE_THAT(b.get(), WithinAbs(24.0, 0.1));
 }
 
+TEST_CASE("Binding unknown parameter operations stay inert",
+          "[binding][coverage][issue-646]") {
+    auto store = make_store();
+    Binding b(*store,999);
+    int call_count = 0;
+    b.on_change([&](float) { ++call_count; });
+
+    REQUIRE(b.is_bound());
+    REQUIRE(b.id() == 999);
+    REQUIRE(b.info() == nullptr);
+    REQUIRE_THAT(b.get(), WithinAbs(0.0, 0.01));
+    REQUIRE_THAT(b.get_normalized(), WithinAbs(0.0, 0.01));
+
+    b.set(12.0f);
+    b.set_normalized(0.75f);
+    REQUIRE_FALSE(b.poll());
+    REQUIRE(call_count == 0);
+}
+
+TEST_CASE("Binding set_normalized clamps and quantizes through store",
+          "[binding][coverage][issue-646]") {
+    auto store = make_store();
+    Binding b(*store,1); // range -60..24, step 0.1
+
+    b.set_normalized(-0.25f);
+    REQUIRE_THAT(b.get(), WithinAbs(-60.0, 0.01));
+
+    b.set_normalized(1.25f);
+    REQUIRE_THAT(b.get(), WithinAbs(24.0, 0.01));
+
+    b.set_normalized(0.1234f);
+    REQUIRE_THAT(b.get(), WithinAbs(-49.6, 0.01));
+    REQUIRE_THAT(b.get_normalized(), WithinAbs(0.1238, 0.001));
+}
+
 TEST_CASE("Binding set_normalized only notifies when value changes", "[binding]") {
     auto store = make_store();
     Binding b(*store,2); // range 0..100, default 50
@@ -85,6 +121,29 @@ TEST_CASE("Binding on_change fires", "[binding]") {
 
     b.set(6.0f);
     REQUIRE_THAT(received, WithinAbs(6.0, 0.01));
+}
+
+TEST_CASE("Binding on_change callbacks fire in registration order",
+          "[binding][coverage][issue-646]") {
+    auto store = make_store();
+    Binding b(*store,1);
+    std::vector<int> calls;
+    std::vector<float> values;
+
+    b.on_change([&](float v) {
+        calls.push_back(1);
+        values.push_back(v);
+    });
+    b.on_change([&](float v) {
+        calls.push_back(2);
+        values.push_back(v);
+    });
+
+    b.set(3.5f);
+    REQUIRE(calls == std::vector<int>{1, 2});
+    REQUIRE(values.size() == 2);
+    REQUIRE_THAT(values[0], WithinAbs(3.5, 0.01));
+    REQUIRE_THAT(values[1], WithinAbs(3.5, 0.01));
 }
 
 TEST_CASE("Binding on_change does not fire for same value", "[binding]") {

--- a/test/test_buffering_reader.cpp
+++ b/test/test_buffering_reader.cpp
@@ -363,3 +363,23 @@ TEST_CASE("BufferingReader channel mismatch returns 0", "[audio][buffering]") {
 
     reader.stop();
 }
+
+TEST_CASE("BufferingReader invalid read destinations are no-ops",
+          "[audio][buffering][codecov]") {
+    BufferingReader reader;
+
+    REQUIRE(reader.read(nullptr, 16, 1) == 0);
+
+    float buf[4] = {-1.0f, -2.0f, -3.0f, -4.0f};
+    REQUIRE(reader.read(buf, 0, 1) == 0);
+    REQUIRE(reader.read(buf, -1, 1) == 0);
+    REQUIRE(buf[0] == -1.0f);
+    REQUIRE(buf[1] == -2.0f);
+
+    reader.set_read_callback([](float*, int, int) {
+        return 0;
+    });
+    reader.start(1, 1024);
+    REQUIRE(reader.read(nullptr, 16, 1) == 0);
+    reader.stop();
+}

--- a/test/test_child_process.cpp
+++ b/test/test_child_process.cpp
@@ -161,6 +161,35 @@ TEST_CASE("wait and read before start return default results",
     REQUIRE_FALSE(r.was_cancelled);
 }
 
+TEST_CASE("read_available_output drains stdout while process is running",
+          "[child_process][edge][issue-640]") {
+    ChildProcess cp;
+
+#ifdef _WIN32
+    REQUIRE(cp.start("cmd",
+                     {"/c", "<nul set /p dummy=available& ping -n 3 127.0.0.1 >nul"}));
+#else
+    REQUIRE(cp.start("/bin/sh", {"-c", "printf available; sleep 1"}));
+#endif
+
+    std::string observed;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (observed.find("available") == std::string::npos
+           && std::chrono::steady_clock::now() < deadline) {
+        observed += cp.read_available_output();
+        if (observed.find("available") == std::string::npos) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+
+    REQUIRE(observed.find("available") != std::string::npos);
+
+    auto r = cp.wait();
+    REQUIRE(r.exit_code == 0);
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE_FALSE(r.was_cancelled);
+}
+
 TEST_CASE("run honors working directory",
           "[child_process][edge][issue-640]") {
     auto dir = std::filesystem::temp_directory_path()

--- a/test/test_cli_fetchcontent_cache.cpp
+++ b/test/test_cli_fetchcontent_cache.cpp
@@ -88,6 +88,14 @@ std::string json_field_fragment(const std::string& key,
 
 }  // namespace
 
+TEST_CASE("status and fix labels fall back to unknown",
+          "[fetchcontent_cache][issue-643]") {
+    CHECK(std::string(fcc::status_label(fcc::CacheStatus::Healthy)) == "healthy");
+    CHECK(std::string(fcc::fix_outcome_label(fcc::FixOutcome::Removed)) == "removed");
+    CHECK(std::string(fcc::status_label(static_cast<fcc::CacheStatus>(99))) == "unknown");
+    CHECK(std::string(fcc::fix_outcome_label(static_cast<fcc::FixOutcome>(99))) == "unknown");
+}
+
 // ── Acceptance scenario 1: healthy ──────────────────────────────────────────
 
 TEST_CASE("discover: healthy entries report Healthy and exit 0",
@@ -268,6 +276,75 @@ TEST_CASE("discover: missing cache root returns empty and renders OK",
     CHECK(out.str().find("no entries") != std::string::npos);
 }
 
+TEST_CASE("discover: undeclared entries use fallback splitting and stable order",
+          "[fetchcontent_cache][issue-643]") {
+    fs::path root = "/fake/cache";
+    fs::path plain = root / "zlib";
+    fs::path split = root / "foo-bar-baz";
+    fs::path alpha = root / "alpha-v1";
+    MockState state;
+    state.children = {plain, split, alpha};
+
+    fcc::StatInfo info;
+    info.exists = true;
+    info.is_symlink = false;
+    info.is_directory = true;
+    info.is_user_writable = true;
+    state.lstat_results[plain] = info;
+    state.lstat_results[split] = info;
+    state.lstat_results[alpha] = info;
+
+    auto env = make_mock_env(root, {}, state);
+    auto entries = fcc::discover_fetchcontent_cache(env);
+
+    REQUIRE(entries.size() == 3);
+    CHECK(entries[0].name == "alpha-v1");
+    CHECK(entries[0].dep_name == "alpha");
+    CHECK(entries[0].cached_ref == "v1");
+    CHECK(entries[1].name == "foo-bar-baz");
+    CHECK(entries[1].dep_name == "foo-bar");
+    CHECK(entries[1].cached_ref == "baz");
+    CHECK(entries[2].name == "zlib");
+    CHECK(entries[2].dep_name == "zlib");
+    CHECK(entries[2].cached_ref.empty());
+    for (const auto& entry : entries) {
+        CHECK(entry.status == fcc::CacheStatus::Healthy);
+    }
+}
+
+TEST_CASE("discover: live symlink follows target and stays healthy",
+          "[fetchcontent_cache][issue-643]") {
+    fs::path root = "/fake/cache";
+    fs::path entry = root / "threejs-077dd13c0e869d9f3dbe55875686f920367de457";
+    MockState state;
+    state.children = {entry};
+
+    fcc::StatInfo link_info;
+    link_info.exists = true;
+    link_info.is_symlink = true;
+    link_info.symlink_target = "/Users/me/Code/three.js";
+    link_info.is_user_writable = true;
+    state.lstat_results[entry] = link_info;
+
+    fcc::StatInfo target_info;
+    target_info.exists = true;
+    target_info.is_directory = true;
+    target_info.is_user_writable = true;
+    state.stat_follow_results[entry] = target_info;
+
+    fcc::DeclaredRefs refs{
+        {"threejs", "077dd13c0e869d9f3dbe55875686f920367de457"}};
+    auto env = make_mock_env(root, refs, state);
+
+    auto entries = fcc::discover_fetchcontent_cache(env);
+    REQUIRE(entries.size() == 1);
+    CHECK(entries[0].status == fcc::CacheStatus::Healthy);
+    CHECK(entries[0].is_symlink);
+    CHECK(entries[0].resolved_target == fs::path("/Users/me/Code/three.js"));
+    CHECK_FALSE(fcc::any_unhealthy(entries));
+    CHECK_FALSE(fcc::blocks_preflight(entries));
+}
+
 TEST_CASE("discover: lstat miss reports Unknown and blocks preflight",
           "[fetchcontent_cache][issue-643]") {
     fs::path root = "/fake/cache";
@@ -348,6 +425,39 @@ TEST_CASE("apply_fixes: removes a real fixable entry from a tempdir",
     fs::remove_all(tmp, ec);
 }
 
+TEST_CASE("apply_fixes: removes symlinks without deleting their targets",
+          "[fetchcontent_cache][issue-643]") {
+#ifdef _WIN32
+    SKIP("symlink creation requires privileges on Windows");
+#else
+    auto tmp = fs::temp_directory_path() / "pulp-fcc-symlink-test-643";
+    std::error_code ec;
+    fs::remove_all(tmp, ec);
+    fs::create_directories(tmp / "target");
+    auto link = tmp / "stale-link";
+    fs::create_directory_symlink(tmp / "target", link, ec);
+    if (ec) {
+        fs::remove_all(tmp, ec);
+        SKIP("symlink creation unavailable in this filesystem");
+    }
+    REQUIRE(fs::is_symlink(fs::symlink_status(link)));
+    REQUIRE(fs::exists(tmp / "target"));
+
+    fcc::CacheEntry e;
+    e.name = "stale-link";
+    e.path = link;
+    e.status = fcc::CacheStatus::Dangling;
+    e.fixable = true;
+
+    auto results = fcc::apply_fixes({e}, /*dry_run=*/false);
+    REQUIRE(results.size() == 1);
+    CHECK(results[0].outcome == fcc::FixOutcome::Removed);
+    CHECK_FALSE(fs::exists(fs::symlink_status(link)));
+    CHECK(fs::exists(tmp / "target"));
+    fs::remove_all(tmp, ec);
+#endif
+}
+
 // ── parse_declared_refs_from_text: handles the real CMakeLists shape ───────
 
 TEST_CASE("parse_declared_refs_from_text: extracts name → REF map",
@@ -371,6 +481,27 @@ TEST_CASE("parse_declared_refs_from_text: extracts name → REF map",
     // is what protects stale-commit detection from false positives on
     // example/documentation snippets in CMakeLists.
     CHECK(refs.count("commented") == 0);
+}
+
+TEST_CASE("parse_declared_refs_from_file reads files and ignores missing paths",
+          "[fetchcontent_cache][issue-643]") {
+    auto tmp = fs::temp_directory_path() / "pulp-fcc-parse-file-643";
+    std::error_code ec;
+    fs::remove_all(tmp, ec);
+    fs::create_directories(tmp);
+    auto cmake = tmp / "CMakeLists.txt";
+    {
+        std::ofstream out(cmake);
+        out << "pulp_register_fetchcontent_source(Yoga REF release/3.2.12)\n";
+        out << "pulp_register_fetchcontent_source(no_ref URL https://example.invalid)\n";
+    }
+
+    auto refs = fcc::parse_declared_refs_from_file(cmake);
+    REQUIRE(refs.size() == 1);
+    CHECK(refs.at("yoga") == "release/3.2.12");
+    CHECK(refs.count("no_ref") == 0);
+    CHECK(fcc::parse_declared_refs_from_file(tmp / "missing.txt").empty());
+    fs::remove_all(tmp, ec);
 }
 
 // ── Multi-hyphen dep names split correctly ─────────────────────────────────

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -593,6 +593,90 @@ TEST_CASE("pulp status reports shipyard version and pin health",
 }
 #endif
 
+TEST_CASE("pulp config set/get/list round-trips isolated update settings",
+          "[cli][shellout][config][issue-643]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto home = unique_temp_dir("pulp-config-roundtrip");
+    fs::remove_all(home);
+    fs::create_directories(home);
+    write_text(home / "update-snooze", "dismissed\n");
+
+    ScopedEnvVar pulp_home("PULP_HOME");
+    pulp_home.set(home.string());
+    ScopedEnvVar update_disabled("PULP_UPDATE_CHECK_DISABLED");
+    update_disabled.set("1");
+
+    auto set_mode = run_pulp({"config", "set", "update.mode", "manual"}, 10000);
+    REQUIRE_FALSE(set_mode.timed_out);
+    REQUIRE(set_mode.exit_code == 0);
+    REQUIRE(set_mode.stdout_output.find("Set update.mode = manual") != std::string::npos);
+    REQUIRE_FALSE(fs::exists(home / "update-snooze"));
+
+    auto get_mode = run_pulp({"config", "get", "update.mode"}, 10000);
+    REQUIRE_FALSE(get_mode.timed_out);
+    REQUIRE(get_mode.exit_code == 0);
+    REQUIRE(get_mode.stdout_output == "manual\n");
+
+    auto set_channel = run_pulp({"config", "set", "update.channel", "beta"}, 10000);
+    REQUIRE_FALSE(set_channel.timed_out);
+    REQUIRE(set_channel.exit_code == 0);
+    REQUIRE(set_channel.stdout_output.find("Set update.channel = beta") != std::string::npos);
+
+    auto list = run_pulp({"config", "list"}, 10000);
+    const auto config_body = read_file(home / "config.toml");
+    fs::remove_all(home);
+
+    REQUIRE_FALSE(list.timed_out);
+    REQUIRE(list.exit_code == 0);
+    REQUIRE(list.stdout_output.find("update.mode = manual") != std::string::npos);
+    REQUIRE(list.stdout_output.find("update.check_interval_hours = 24") != std::string::npos);
+    REQUIRE(list.stdout_output.find("update.channel = beta") != std::string::npos);
+    REQUIRE(list.stdout_output.find("update.bump_projects = prompt") != std::string::npos);
+    REQUIRE(config_body.find("[update]") != std::string::npos);
+    REQUIRE(config_body.find("mode = \"manual\"") != std::string::npos);
+    REQUIRE(config_body.find("channel = \"beta\"") != std::string::npos);
+}
+
+TEST_CASE("pulp config rejects malformed and invalid update keys",
+          "[cli][shellout][config][issue-643]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto home = unique_temp_dir("pulp-config-invalid");
+    fs::remove_all(home);
+    fs::create_directories(home);
+
+    ScopedEnvVar pulp_home("PULP_HOME");
+    pulp_home.set(home.string());
+    ScopedEnvVar update_disabled("PULP_UPDATE_CHECK_DISABLED");
+    update_disabled.set("1");
+
+    auto malformed_get = run_pulp({"config", "get", "update"}, 10000);
+    REQUIRE_FALSE(malformed_get.timed_out);
+    REQUIRE(malformed_get.exit_code != 0);
+    REQUIRE(malformed_get.stderr_output.find("key must be dotted") != std::string::npos);
+
+    auto unknown_key = run_pulp({"config", "set", "update.not_a_key", "value"}, 10000);
+    REQUIRE_FALSE(unknown_key.timed_out);
+    REQUIRE(unknown_key.exit_code != 0);
+    REQUIRE(unknown_key.stderr_output.find("unknown config key") != std::string::npos);
+
+    auto bad_mode = run_pulp({"config", "set", "update.mode", "weekly"}, 10000);
+    REQUIRE_FALSE(bad_mode.timed_out);
+    REQUIRE(bad_mode.exit_code != 0);
+    REQUIRE(bad_mode.stderr_output.find("update.mode must be one of") != std::string::npos);
+
+    auto bad_interval =
+        run_pulp({"config", "set", "update.check_interval_hours", "-1"}, 10000);
+    const bool config_written = fs::exists(home / "config.toml");
+    fs::remove_all(home);
+
+    REQUIRE_FALSE(bad_interval.timed_out);
+    REQUIRE(bad_interval.exit_code != 0);
+    REQUIRE(bad_interval.stderr_output.find("non-negative integer") != std::string::npos);
+    REQUIRE_FALSE(config_written);
+}
+
 TEST_CASE("pulp version subcommand runs and mentions the SDK",
           "[cli][shellout][version]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -1123,29 +1123,24 @@ TEST_CASE("pulp doctor android|ios are recognized subcommands",
 
     const auto bin = fs::absolute(pulp_binary());
 
-    // Doctor walks xcode-select / xcrun / simctl on macOS and the Android
-    // SDK probe on non-macOS; under CI load (github-hosted ARM64 runners
-    // especially) these can stretch well past a minute. This test only
-    // validates subcommand recognition, so allow extra headroom and let
-    // exit-code assertions catch real parser regressions.
-    constexpr int doctor_timeout_ms = 180000;
-    auto android = exec(bin.string(), {"doctor", "android"}, doctor_timeout_ms);
-    auto ios     = exec(bin.string(), {"doctor", "ios"},     doctor_timeout_ms);
-    auto bogus   = exec(bin.string(), {"doctor", "potato"},  10000);
+    // Use --versions so the parser still has to accept the mobile
+    // subcommand before the diagnostic short-circuit, without running the
+    // slow host SDK probes that can hang on saturated CI runners.
+    auto android = exec(bin.string(), {"doctor", "android", "--versions"}, 10000);
+    auto ios     = exec(bin.string(), {"doctor", "ios", "--versions"},     10000);
+    auto bogus   = exec(bin.string(), {"doctor", "potato", "--versions"},  10000);
 
     REQUIRE_FALSE(android.timed_out);
     REQUIRE_FALSE(ios.timed_out);
     REQUIRE_FALSE(bogus.timed_out);
 
-    // android + ios run the new check sets — exit 0 when the host
-    // has the tooling, exit 1 when something's missing. Either is
-    // fine here; we're verifying the SUBCOMMAND is recognized, not
-    // that the dev host is fully provisioned. exit 2 is the
-    // "unknown subcommand" failure path we're guarding against.
-    REQUIRE(android.exit_code != 2);
-    REQUIRE(ios.exit_code != 2);
-    REQUIRE(android.stdout_output.find("Pulp Doctor") != std::string::npos);
-    REQUIRE(ios.stdout_output.find("Pulp Doctor") != std::string::npos);
+    // android + ios are recognized before --versions short-circuits the
+    // doctor pipeline. exit 2 is the "unknown subcommand" failure path
+    // we're guarding against.
+    REQUIRE(android.exit_code == 0);
+    REQUIRE(ios.exit_code == 0);
+    REQUIRE(android.stdout_output.find("Pulp Version Diagnostics") != std::string::npos);
+    REQUIRE(ios.stdout_output.find("Pulp Version Diagnostics") != std::string::npos);
 
     // bogus subcommand: rejected at the parser with a helpful Usage line.
     REQUIRE(bogus.exit_code == 2);

--- a/test/test_code_editor.cpp
+++ b/test/test_code_editor.cpp
@@ -200,6 +200,36 @@ TEST_CASE("FileBasedDocument handles save and load edge paths",
     REQUIRE_FALSE(last_dirty);
 }
 
+TEST_CASE("FileBasedDocument handles successful load and save_as paths",
+          "[gui][code-editor][coverage]") {
+    TestDoc doc;
+    int dirty_callback_count = 0;
+    bool last_dirty = true;
+    doc.on_dirty_changed = [&](bool dirty) {
+        ++dirty_callback_count;
+        last_dirty = dirty;
+    };
+
+    doc.set_dirty(true);
+    REQUIRE(doc.load("/tmp/session.pulp"));
+    REQUIRE(doc.load_calls == 1);
+    REQUIRE(doc.loaded_path == "/tmp/session.pulp");
+    REQUIRE(doc.file_path() == "/tmp/session.pulp");
+    REQUIRE(doc.title() == "session");
+    REQUIRE_FALSE(doc.is_dirty());
+    REQUIRE(dirty_callback_count == 0);
+
+    doc.set_dirty(true);
+    REQUIRE(doc.save_as("/tmp/renamed.project"));
+    REQUIRE(doc.save_calls == 1);
+    REQUIRE(doc.saved_path == "/tmp/renamed.project");
+    REQUIRE(doc.file_path() == "/tmp/renamed.project");
+    REQUIRE(doc.title() == "renamed");
+    REQUIRE_FALSE(doc.is_dirty());
+    REQUIRE(dirty_callback_count == 1);
+    REQUIRE_FALSE(last_dirty);
+}
+
 TEST_CASE("RecentlyOpenedFilesList MRU behavior", "[gui][code-editor]") {
     RecentlyOpenedFilesList mru;
     mru.add("/path/a.txt");
@@ -217,6 +247,28 @@ TEST_CASE("RecentlyOpenedFilesList MRU behavior", "[gui][code-editor]") {
     // Max entries
     mru.set_max_entries(2);
     REQUIRE(mru.files().size() == 2);
+}
+
+TEST_CASE("RecentlyOpenedFilesList removes entries and ignores missing paths",
+          "[gui][code-editor][coverage]") {
+    RecentlyOpenedFilesList mru;
+    mru.add("/path/a.txt");
+    mru.add("/path/b.txt");
+    mru.add("/path/c.txt");
+
+    mru.remove("/path/b.txt");
+    REQUIRE(mru.files().size() == 2);
+    REQUIRE(mru.files()[0] == "/path/c.txt");
+    REQUIRE(mru.files()[1] == "/path/a.txt");
+
+    mru.remove("/path/missing.txt");
+    REQUIRE(mru.files().size() == 2);
+    REQUIRE(mru.files()[0] == "/path/c.txt");
+    REQUIRE(mru.files()[1] == "/path/a.txt");
+
+    mru.remove("/path/c.txt");
+    mru.remove("/path/a.txt");
+    REQUIRE(mru.files().empty());
 }
 
 TEST_CASE("RecentlyOpenedFilesList persists trims and handles I/O misses",

--- a/test/test_code_editor.cpp
+++ b/test/test_code_editor.cpp
@@ -94,6 +94,20 @@ TEST_CASE("CodeEditor insert text", "[gui][code-editor]") {
     REQUIRE(editor.text() == "hello world");
 }
 
+TEST_CASE("CodeEditor insert appends in read-only fallback mode",
+          "[gui][code-editor][coverage][issue-655]") {
+    CodeEditor editor;
+    editor.set_read_only(true);
+    editor.set_text("alpha");
+    editor.insert_text("\nbeta");
+    editor.go_to_line(99);
+
+    REQUIRE(editor.text() == "alpha\nbeta");
+    REQUIRE(editor.cursor_line() == 99);
+    REQUIRE(editor.cursor_column() == 1);
+    REQUIRE(editor.selected_text().empty());
+}
+
 TEST_CASE("CodeEditor go to line", "[gui][code-editor]") {
     CodeEditor editor;
     editor.set_text("line1\nline2\nline3");
@@ -310,4 +324,26 @@ TEST_CASE("RecentlyOpenedFilesList persists trims and handles I/O misses",
     REQUIRE(reloaded.files()[1] == "/saved/a.txt");
 
     std::filesystem::remove_all(dir);
+}
+
+TEST_CASE("RecentlyOpenedFilesList remove and max-entry edge paths",
+          "[gui][code-editor][coverage][issue-655]") {
+    RecentlyOpenedFilesList mru;
+    mru.add("/a.txt");
+    mru.add("/b.txt");
+    mru.add("/c.txt");
+
+    mru.remove("/b.txt");
+    REQUIRE(mru.files().size() == 2);
+    REQUIRE(mru.files()[0] == "/c.txt");
+    REQUIRE(mru.files()[1] == "/a.txt");
+
+    mru.remove("/missing.txt");
+    REQUIRE(mru.files().size() == 2);
+
+    mru.set_max_entries(0);
+    REQUIRE(mru.files().empty());
+
+    mru.add("/d.txt");
+    REQUIRE(mru.files().empty());
 }

--- a/test/test_codesign.cpp
+++ b/test/test_codesign.cpp
@@ -33,6 +33,32 @@ TEST_CASE("check_notarization on nonexistent path is false", "[ship][codesign]")
     REQUIRE_FALSE(check_notarization("/nonexistent/binary"));
 }
 
+TEST_CASE("codesign rejects nonexistent path and identity",
+          "[ship][codesign][coverage][issue-644]") {
+    REQUIRE_FALSE(codesign("/nonexistent/binary", "Developer ID Application: Missing"));
+}
+
+TEST_CASE("codesign includes entitlements path on failure path",
+          "[ship][codesign][coverage][issue-644]") {
+    REQUIRE_FALSE(codesign("/nonexistent/binary",
+                           "Developer ID Application: Missing",
+                           "/nonexistent/entitlements.plist"));
+}
+
+TEST_CASE("notarization staple on nonexistent path is false",
+          "[ship][codesign][coverage][issue-644]") {
+    REQUIRE_FALSE(notarize_staple("/nonexistent/binary"));
+}
+
+TEST_CASE("create_pkg on nonexistent component is false",
+          "[ship][codesign][coverage][issue-644]") {
+    auto output = (fs::temp_directory_path() / "pulp-missing-component.pkg").string();
+    REQUIRE_FALSE(create_pkg("/nonexistent/component.vst3",
+                             output,
+                             "dev.pulp.missing",
+                             "1.0.0"));
+}
+
 TEST_CASE("list_signing_identities does not crash", "[ship][codesign]") {
     auto ids = list_signing_identities();
     // May be empty on CI, but should not crash

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/runtime/crypto.hpp>
+#include <algorithm>
+#include <cctype>
 #include <cstring>
 #include <vector>
 
@@ -23,6 +25,20 @@ TEST_CASE("SHA-256 binary data", "[crypto][sha256]") {
     REQUIRE(digest.size() == 32);
 }
 
+TEST_CASE("SHA-256 pointer overload preserves embedded NUL bytes",
+          "[crypto][sha256][coverage][issue-641]") {
+    const std::vector<uint8_t> data = {'a', 'b', 'c', 0x00, 'd', 'e', 'f'};
+
+    auto digest = sha256(data.data(), data.size());
+    auto hex = sha256_hex(data.data(), data.size());
+
+    REQUIRE(digest.size() == 32);
+    REQUIRE(hex == "516a5e926ce20c5f4d80f00e1a01abdf14986def6588d6abeed9fce090bc660c");
+    REQUIRE(std::all_of(hex.begin(), hex.end(), [](unsigned char c) {
+        return std::isdigit(c) || (c >= 'a' && c <= 'f');
+    }));
+}
+
 // ── SHA-1 ───────────────────────────────────────────────────────────────
 
 TEST_CASE("SHA-1 known value", "[crypto][sha1]") {
@@ -35,6 +51,17 @@ TEST_CASE("SHA-1 known value", "[crypto][sha1]") {
     REQUIRE(digest == expected);
 }
 
+TEST_CASE("SHA-1 pointer overload preserves embedded NUL bytes",
+          "[crypto][sha1][coverage][issue-641]") {
+    const std::vector<uint8_t> data = {'w', 's', 0x00, 'k', 'e', 'y'};
+    const std::vector<uint8_t> expected = {
+        0xb1, 0x24, 0x2e, 0x4b, 0x0c, 0x53, 0x4d, 0x49, 0x0f, 0x5e,
+        0xf7, 0xee, 0x67, 0xb8, 0x80, 0xf0, 0xa2, 0xb8, 0x8a, 0x6b,
+    };
+
+    REQUIRE(sha1(data.data(), data.size()) == expected);
+}
+
 // ── MD5 ─────────────────────────────────────────────────────────────────
 
 TEST_CASE("MD5 empty string", "[crypto][md5]") {
@@ -45,6 +72,17 @@ TEST_CASE("MD5 empty string", "[crypto][md5]") {
 TEST_CASE("MD5 known value", "[crypto][md5]") {
     auto hex = md5_hex("hello");
     REQUIRE(hex == "5d41402abc4b2a76b9719d911017c592");
+}
+
+TEST_CASE("MD5 binary data returns raw digest bytes",
+          "[crypto][md5][coverage][issue-641]") {
+    const std::vector<uint8_t> data = {0x00, 0xff, 0x10, 0x20, 0x00};
+    const std::vector<uint8_t> expected = {
+        0x96, 0x26, 0x6b, 0xae, 0xb1, 0xeb, 0x57, 0x35,
+        0xd5, 0x51, 0xca, 0xc2, 0xd9, 0xa8, 0x27, 0x75,
+    };
+
+    REQUIRE(md5(data.data(), data.size()) == expected);
 }
 
 // ── AES-256-CBC ─────────────────────────────────────────────────────────
@@ -86,6 +124,27 @@ TEST_CASE("AES empty plaintext", "[crypto][aes]") {
     REQUIRE(decrypted->empty());
 }
 
+TEST_CASE("AES exact block plaintext adds and removes full padding block",
+          "[crypto][aes][coverage][issue-641]") {
+    uint8_t key[32] = {};
+    uint8_t iv[16] = {};
+    std::memset(key, 0x21, 32);
+    std::memset(iv, 0x43, 16);
+
+    std::string plaintext = "sixteen byte txt";
+    REQUIRE(plaintext.size() == 16);
+
+    auto encrypted = aes_encrypt(
+        reinterpret_cast<const uint8_t*>(plaintext.data()),
+        plaintext.size(), key, iv);
+    REQUIRE(encrypted.has_value());
+    REQUIRE(encrypted->size() == 32);
+
+    auto decrypted = aes_decrypt(encrypted->data(), encrypted->size(), key, iv);
+    REQUIRE(decrypted.has_value());
+    REQUIRE(std::string(decrypted->begin(), decrypted->end()) == plaintext);
+}
+
 TEST_CASE("AES decrypt invalid data", "[crypto][aes]") {
     uint8_t key[32] = {};
     uint8_t iv[16] = {};
@@ -103,6 +162,24 @@ TEST_CASE("AES decrypt rejects non-block-aligned ciphertext", "[crypto][aes]") {
     uint8_t ciphertext[15] = {};
 
     auto result = aes_decrypt(ciphertext, sizeof(ciphertext), key, iv);
+    REQUIRE_FALSE(result.has_value());
+}
+
+TEST_CASE("AES decrypt rejects invalid PKCS7 padding bytes",
+          "[crypto][aes][coverage][issue-641]") {
+    uint8_t key[32] = {};
+    uint8_t iv[16] = {};
+    std::memset(key, 0x5c, 32);
+    std::memset(iv, 0xa7, 16);
+
+    std::string plaintext = "padding check";
+    auto encrypted = aes_encrypt(
+        reinterpret_cast<const uint8_t*>(plaintext.data()),
+        plaintext.size(), key, iv);
+    REQUIRE(encrypted.has_value());
+
+    encrypted->back() ^= 0x01;
+    auto result = aes_decrypt(encrypted->data(), encrypted->size(), key, iv);
     REQUIRE_FALSE(result.has_value());
 }
 

--- a/test/test_descriptor_validation.cpp
+++ b/test/test_descriptor_validation.cpp
@@ -248,3 +248,44 @@ TEST_CASE("DescriptorValidation: reverse-DNS bundle_id passes",
         REQUIRE(i.field != "bundle_id");
     }
 }
+
+TEST_CASE("DescriptorValidation: mixed warnings and errors remain invalid",
+          "[format][descriptor-validation][issue-493]") {
+    auto d = well_formed_effect();
+    d.name.clear();
+    d.bundle_id = "Not Reverse DNS";
+    d.output_buses = {{"Broken Out", 0, false}};
+
+    auto issues = validate_descriptor(d);
+    REQUIRE(has_error_on(issues, "name"));
+    REQUIRE(has_warning_on(issues, "bundle_id"));
+    REQUIRE(has_error_on(issues, "output_buses"));
+    REQUIRE_FALSE(descriptor_is_valid(issues));
+}
+
+TEST_CASE("DescriptorValidation: optional zero-channel side inputs are accepted",
+          "[format][descriptor-validation][issue-493]") {
+    auto d = well_formed_effect();
+    d.input_buses = {
+        {"Main In", 2, false},
+        {"Sidechain", 0, true},
+    };
+    d.output_buses = {{"Main Out", 2, false}};
+
+    auto issues = validate_descriptor(d);
+    REQUIRE_FALSE(has_error_on(issues, "input_buses"));
+    REQUIRE(descriptor_is_valid(issues));
+}
+
+TEST_CASE("DescriptorValidation: MIDI sidecar capabilities are warning-only without MIDI input",
+          "[format][descriptor-validation][issue-493]") {
+    auto d = well_formed_effect();
+    d.accepts_midi = false;
+    d.produces_midi = true;
+    d.supports_mpe = true;
+    d.supports_ump = true;
+
+    auto issues = validate_descriptor(d);
+    REQUIRE(has_warning_on(issues, "accepts_midi"));
+    REQUIRE(descriptor_is_valid(issues));
+}

--- a/test/test_descriptor_validation.cpp
+++ b/test/test_descriptor_validation.cpp
@@ -35,6 +35,16 @@ bool has_warning_on(const std::vector<DescriptorIssue>& issues,
     return false;
 }
 
+std::size_t warning_count_on(const std::vector<DescriptorIssue>& issues,
+                             const std::string& field) {
+    std::size_t count = 0;
+    for (const auto& i : issues) {
+        if (i.severity == DescriptorIssueSeverity::Warning && i.field == field)
+            ++count;
+    }
+    return count;
+}
+
 } // namespace
 
 TEST_CASE("DescriptorValidation: well-formed effect passes with no issues",
@@ -221,6 +231,19 @@ TEST_CASE("DescriptorValidation: supports_ump follows the accepts_midi sidecar w
         REQUIRE_FALSE(has_warning_on(issues, "accepts_midi"));
         REQUIRE(descriptor_is_valid(issues));
     }
+}
+
+TEST_CASE("DescriptorValidation: MIDI capability warnings accumulate without invalidating descriptor",
+          "[format][descriptor-validation][coverage][issue-646]") {
+    auto d = well_formed_effect();
+    d.category = PluginCategory::MidiEffect;
+    d.accepts_midi = false;
+    d.supports_mpe = true;
+    d.supports_ump = true;
+
+    auto issues = validate_descriptor(d);
+    REQUIRE(warning_count_on(issues, "accepts_midi") == 2);
+    REQUIRE(descriptor_is_valid(issues));
 }
 
 TEST_CASE("DescriptorValidation: MidiEffect without audio output is valid",

--- a/test/test_diagnostic_reporter.cpp
+++ b/test/test_diagnostic_reporter.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/format/diagnostic_reporter.hpp>
+#include <pulp/format/host_type.hpp>
 #include <pulp/state/store.hpp>
 
 using namespace pulp::format;
@@ -135,4 +136,60 @@ TEST_CASE("DiagnosticReporter instrument type", "[format][diagnostic]") {
 
     auto report = diag.generate_report();
     REQUIRE(report.find("Instrument") != std::string::npos);
+}
+
+TEST_CASE("DiagnosticReporter default report omits optional sections until set",
+          "[format][diagnostic][issue-493]") {
+    DiagnosticReporter diag;
+    auto report = diag.generate_report();
+    auto json = diag.generate_json();
+
+    REQUIRE(report.find("--- Plugin ---") != std::string::npos);
+    REQUIRE(report.find("Format:") == std::string::npos);
+    REQUIRE(report.find("Host:") == std::string::npos);
+    REQUIRE(report.find("CPU Load:") == std::string::npos);
+    REQUIRE(report.find("--- Custom ---") == std::string::npos);
+    REQUIRE(report.find("--- Parameters (0) ---") != std::string::npos);
+    REQUIRE(json.find("\"parameters\": [") != std::string::npos);
+    REQUIRE(json.find("\"name\": \"\"") != std::string::npos);
+}
+
+TEST_CASE("DiagnosticReporter JSON reflects instrument/effect type and parameter values",
+          "[format][diagnostic][issue-493]") {
+    DiagnosticReporter diag;
+    auto desc = make_desc();
+    desc.category = PluginCategory::Instrument;
+    StateStore store;
+    setup_store(store);
+    store.set_value(1, -18.0f);
+    store.set_value(2, 25.0f);
+
+    diag.set_plugin_info(desc, store);
+    diag.set_audio_config(96000, 128, 0, 2);
+
+    auto json = diag.generate_json();
+    REQUIRE(json.find("\"type\": \"instrument\"") != std::string::npos);
+    REQUIRE(json.find("\"sampleRate\": 96000") != std::string::npos);
+    REQUIRE(json.find("\"bufferSize\": 128") != std::string::npos);
+    REQUIRE(json.find("\"inputChannels\": 0") != std::string::npos);
+    REQUIRE(json.find("\"outputChannels\": 2") != std::string::npos);
+    REQUIRE(json.find("\"value\": -18.0000") != std::string::npos);
+    REQUIRE(json.find("\"value\": 25.0000") != std::string::npos);
+}
+
+TEST_CASE("HostType names and feature heuristics cover fixed-size and no-sidechain hosts",
+          "[format][host-type][issue-493]") {
+    REQUIRE(host_type_name(HostType::Unknown) == "Unknown");
+    REQUIRE(host_type_name(HostType::Other) == "Other");
+    REQUIRE(host_type_name(static_cast<HostType>(255)) == "Unknown");
+
+    REQUIRE_FALSE(host_supports_resize(HostType::ProTools));
+    REQUIRE_FALSE(host_supports_resize(HostType::GarageBand));
+    REQUIRE(host_supports_resize(HostType::LogicPro));
+    REQUIRE(host_supports_resize(HostType::Unknown));
+
+    REQUIRE_FALSE(host_supports_sidechain(HostType::GarageBand));
+    REQUIRE_FALSE(host_supports_sidechain(HostType::AudacityTenacity));
+    REQUIRE(host_supports_sidechain(HostType::Reaper));
+    REQUIRE(host_supports_sidechain(HostType::Unknown));
 }

--- a/test/test_dirty_tracker.cpp
+++ b/test/test_dirty_tracker.cpp
@@ -70,6 +70,24 @@ TEST_CASE("DirtyTracker invalidate_all forces full repaint", "[render][dirty]") 
     REQUIRE(dt.dirty_rects().empty());
 }
 
+TEST_CASE("DirtyTracker full repaint keeps empty partial bounds",
+          "[render][dirty][issue-644]") {
+    DirtyTracker dt;
+    dt.clear();
+    dt.invalidate(1, 2, 3, 4);
+    REQUIRE_FALSE(dt.dirty_rects().empty());
+
+    dt.invalidate_all();
+    REQUIRE(dt.is_dirty());
+    REQUIRE(dt.needs_full_repaint());
+    REQUIRE(dt.dirty_rects().empty());
+    auto b = dt.bounds();
+    REQUIRE(b.x == Catch::Approx(0.0f));
+    REQUIRE(b.y == Catch::Approx(0.0f));
+    REQUIRE(b.w == Catch::Approx(0.0f));
+    REQUIRE(b.h == Catch::Approx(0.0f));
+}
+
 TEST_CASE("DirtyTracker frame counter increments", "[render][dirty]") {
     DirtyTracker dt;
     REQUIRE(dt.frame_count() == 0);
@@ -129,6 +147,30 @@ TEST_CASE("DirtyTracker threshold sums partial dirty regions", "[render][dirty][
     dt.invalidate(50, 50, 30, 30);
     REQUIRE(dt.needs_full_repaint());
     REQUIRE(dt.dirty_rects().empty());
+}
+
+TEST_CASE("DirtyTracker threshold equality remains partial repaint",
+          "[render][dirty][issue-644]") {
+    DirtyTracker dt;
+    dt.set_viewport(100, 100, 0.25f);
+    dt.clear();
+
+    dt.invalidate(0, 0, 50, 50);
+    REQUIRE(dt.is_dirty());
+    REQUIRE_FALSE(dt.needs_full_repaint());
+    REQUIRE(dt.dirty_rects().size() == 1);
+}
+
+TEST_CASE("DirtyTracker ignores invalid viewport dimensions for promotion",
+          "[render][dirty][issue-644]") {
+    DirtyTracker dt;
+    dt.set_viewport(-100, 100, 0.01f);
+    dt.clear();
+    dt.invalidate(0, 0, 1000, 1000);
+
+    REQUIRE(dt.is_dirty());
+    REQUIRE_FALSE(dt.needs_full_repaint());
+    REQUIRE(dt.dirty_rects().size() == 1);
 }
 
 TEST_CASE("DirtyTracker does not promote to full repaint without viewport", "[render][dirty][issue-646]") {

--- a/test/test_dsp_expansion.cpp
+++ b/test/test_dsp_expansion.cpp
@@ -75,6 +75,23 @@ TEST_CASE("FirFilter order returns tap count", "[signal][fir]") {
     REQUIRE(fir.order() == 3);
 }
 
+TEST_CASE("FirFilter empty coefficients pass samples through and reset safely",
+          "[signal][fir][issue-645]") {
+    FirFilter fir;
+    REQUIRE(fir.order() == 0);
+    REQUIRE_THAT(fir.process(-0.25f), WithinAbs(-0.25f, 1e-6f));
+
+    float buffer[] = {0.25f, -0.5f, 0.75f};
+    fir.process(buffer, 3);
+    REQUIRE_THAT(buffer[0], WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(buffer[1], WithinAbs(-0.5f, 1e-6f));
+    REQUIRE_THAT(buffer[2], WithinAbs(0.75f, 1e-6f));
+
+    fir.reset();
+    REQUIRE(fir.order() == 0);
+    REQUIRE_THAT(fir.process(0.5f), WithinAbs(0.5f, 1e-6f));
+}
+
 // ── BallisticsFilter ─────────────────────────────────────────────────────
 
 TEST_CASE("BallisticsFilter tracks rising signal", "[signal][ballistics]") {
@@ -370,6 +387,28 @@ TEST_CASE("LookupTable buffer processing", "[signal][lookup]") {
     REQUIRE_THAT(buf[0], WithinAbs(0.0, 0.01));
     REQUIRE_THAT(buf[1], WithinAbs(1.0, 0.01));
     REQUIRE_THAT(buf[2], WithinAbs(1.0, 0.01));
+}
+
+TEST_CASE("LookupTable indexed access clamps and zero-length buffers are no-ops",
+          "[signal][lookup][issue-645]") {
+    LookupTable table(5, 0.0f, 1.0f, [](float x) { return 10.0f + x; });
+
+    REQUIRE_THAT(table[-100], WithinAbs(10.0f, 1e-6f));
+    REQUIRE_THAT(table[0], WithinAbs(10.0f, 1e-6f));
+    REQUIRE_THAT(table[2], WithinAbs(10.5f, 1e-6f));
+    REQUIRE_THAT(table[99], WithinAbs(11.0f, 1e-6f));
+
+    float samples[] = {-1.0f, 0.5f, 2.0f};
+    table.process(samples, 0);
+    table.process(samples, -3);
+    REQUIRE_THAT(samples[0], WithinAbs(-1.0f, 1e-6f));
+    REQUIRE_THAT(samples[1], WithinAbs(0.5f, 1e-6f));
+    REQUIRE_THAT(samples[2], WithinAbs(2.0f, 1e-6f));
+
+    table.process(samples, 3);
+    REQUIRE_THAT(samples[0], WithinAbs(10.0f, 1e-6f));
+    REQUIRE_THAT(samples[1], WithinAbs(10.5f, 1e-6f));
+    REQUIRE_THAT(samples[2], WithinAbs(11.0f, 1e-6f));
 }
 
 // ── TptFilter ────────────────────────────────────────────────────────────

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -191,6 +191,22 @@ TEST_CASE("Environment: token move assignment replaces prior subscription",
     REQUIRE(second_calls == 1);
 }
 
+TEST_CASE("Environment: token self move assignment preserves subscription",
+          "[environment][issue-640]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+    REQUIRE(token.valid());
+
+    Environment::Token& alias = token;
+    token = std::move(alias);
+    REQUIRE(token.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(calls == 1);
+}
+
 TEST_CASE("Environment: keyboard inset change propagates separately",
           "[environment]") {
     Environment::reset_for_test();
@@ -438,6 +454,63 @@ TEST_CASE("Environment: listener unsubscribed mid-dispatch is not invoked "
     Environment::inject_for_test(make_state(ColorScheme::light));
     REQUIRE(a_calls == 2);
     REQUIRE(b_calls == 1);
+}
+
+TEST_CASE("Environment: listener removed before its dispatch turn is skipped",
+          "[environment][issue-640]") {
+    Environment::reset_for_test();
+
+    int victim_calls = 0;
+    int survivor_calls = 0;
+    Environment::Token victim;
+
+    auto killer = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { victim.reset(); });
+    victim = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++victim_calls; });
+    auto survivor = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++survivor_calls; });
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+
+    REQUIRE(killer.valid());
+    REQUIRE_FALSE(victim.valid());
+    REQUIRE(survivor.valid());
+    REQUIRE(victim_calls == 0);
+    REQUIRE(survivor_calls == 1);
+}
+
+TEST_CASE("Environment: reset during dispatch clears later callbacks",
+          "[environment][issue-640]") {
+    Environment::reset_for_test();
+
+    int resetter_calls = 0;
+    int later_calls = 0;
+    auto resetter = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) {
+            ++resetter_calls;
+            Environment::reset_for_test();
+        });
+    auto later = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++later_calls; });
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+
+    REQUIRE(resetter_calls == 1);
+    REQUIRE(later_calls == 0);
+    REQUIRE(resetter.valid());
+    REQUIRE(later.valid());
+    REQUIRE(Environment::instance().snapshot().color_scheme
+            == ColorScheme::unknown);
+
+    resetter.reset();
+    later.reset();
+    REQUIRE_FALSE(resetter.valid());
+    REQUIRE_FALSE(later.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(resetter_calls == 1);
+    REQUIRE(later_calls == 0);
 }
 
 TEST_CASE("Environment: snapshot is consistent with last publish",

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -87,6 +87,24 @@ TEST_CASE("EnvironmentChange: any reflects individual flags",
     REQUIRE(change.any());
 }
 
+TEST_CASE("SafeAreaInsets zero detection checks all edges",
+          "[environment][coverage][issue-640]") {
+    SafeAreaInsets insets;
+    REQUIRE(insets.is_zero());
+
+    insets.top = 1.0f;
+    REQUIRE_FALSE(insets.is_zero());
+    insets = {};
+    insets.bottom = 1.0f;
+    REQUIRE_FALSE(insets.is_zero());
+    insets = {};
+    insets.left = 1.0f;
+    REQUIRE_FALSE(insets.is_zero());
+    insets = {};
+    insets.right = 1.0f;
+    REQUIRE_FALSE(insets.is_zero());
+}
+
 TEST_CASE("Environment: subscribe receives publish + correct change mask",
           "[environment]") {
     Environment::reset_for_test();
@@ -149,6 +167,32 @@ TEST_CASE("Environment: reset clears listeners held by live tokens",
 
     Environment::inject_for_test(make_state(ColorScheme::light));
     REQUIRE(calls == 0);
+}
+
+TEST_CASE("Environment: token reset is idempotent and preserves other listeners",
+          "[environment][coverage][issue-640]") {
+    Environment::reset_for_test();
+    int first_calls = 0;
+    int second_calls = 0;
+
+    auto first = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++first_calls; });
+    auto second = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++second_calls; });
+
+    first.reset();
+    first.reset();
+    REQUIRE_FALSE(first.valid());
+    REQUIRE(second.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(first_calls == 0);
+    REQUIRE(second_calls == 1);
+
+    second.reset();
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(first_calls == 0);
+    REQUIRE(second_calls == 1);
 }
 
 TEST_CASE("Environment: token move transfers ownership", "[environment]") {

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -166,6 +166,46 @@ TEST_CASE("Environment: token move transfers ownership", "[environment]") {
     REQUIRE(calls == 1);
 }
 
+TEST_CASE("Environment: publish without listeners still updates snapshot",
+          "[environment][coverage][issue-649]") {
+    Environment::reset_for_test();
+
+    auto state = make_state(ColorScheme::light, 1.25f, 48.0f);
+    state.safe_area.bottom = 12.0f;
+    state.memory_pressure = MemoryPressure::moderate;
+    Environment::instance().publish(state);
+
+    auto got = Environment::instance().snapshot();
+    REQUIRE(got.color_scheme == ColorScheme::light);
+    REQUIRE(got.display.scale == 1.25f);
+    REQUIRE(got.keyboard.bottom == 48.0f);
+    REQUIRE(got.safe_area.bottom == 12.0f);
+    REQUIRE(got.memory_pressure == MemoryPressure::moderate);
+}
+
+TEST_CASE("Environment: token reset and self-move assignment are idempotent",
+          "[environment][coverage][issue-649]") {
+    Environment::reset_for_test();
+    int calls = 0;
+
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+    REQUIRE(token.valid());
+
+    auto* same_token = &token;
+    token = std::move(*same_token);
+    REQUIRE(token.valid());
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(calls == 1);
+
+    token.reset();
+    REQUIRE_FALSE(token.valid());
+    token.reset();
+    REQUIRE_FALSE(token.valid());
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(calls == 1);
+}
+
 TEST_CASE("Environment: token move assignment replaces prior subscription",
           "[environment][issue-640]") {
     Environment::reset_for_test();

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -283,6 +283,39 @@ TEST_CASE("Timer tolerates empty callbacks",
     REQUIRE_FALSE(repeating.is_active());
 }
 
+TEST_CASE("Timer one-shot can be restarted after firing",
+          "[events][timer][codecov]") {
+    EventLoop loop;
+    std::atomic<int> count{0};
+    Timer timer(loop, 1ms, [&] { count.fetch_add(1); }, false);
+
+    timer.start();
+    REQUIRE(wait_until([&] { return count.load() == 1; }, kTimerAsyncBudget));
+    REQUIRE_FALSE(timer.is_active());
+
+    timer.start();
+    REQUIRE(wait_until([&] { return count.load() == 2; }, kTimerAsyncBudget));
+    REQUIRE_FALSE(timer.is_active());
+}
+
+TEST_CASE("Timer stop before first fire permits a later restart",
+          "[events][timer][codecov]") {
+    EventLoop loop;
+    std::atomic<int> count{0};
+    Timer timer(loop, 50ms, [&] { count.fetch_add(1); }, false);
+
+    timer.start();
+    timer.stop();
+    std::this_thread::sleep_for(80ms);
+    REQUIRE(count.load() == 0);
+    REQUIRE_FALSE(timer.is_active());
+
+    timer.set_interval(1ms);
+    timer.start();
+    REQUIRE(wait_until([&] { return count.load() == 1; }, kTimerAsyncBudget));
+    REQUIRE_FALSE(timer.is_active());
+}
+
 // #687 — stop()/start() pairs repeatedly on the owner thread while the
 // event-loop thread is running timer dispatches. Pre-fix, start()'s
 // `alive_ = make_shared<>(...)` raced with schedule_next()'s

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -154,6 +154,28 @@ TEST_CASE("EventLoop dispatch_after handles multiple ready tasks",
     REQUIRE(wait_until([&] { return calls.load() == 3; }, 2000ms));
 }
 
+TEST_CASE("EventLoop skips empty dispatched tasks",
+          "[events][event_loop][codecov]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+
+    loop.dispatch({});
+    loop.dispatch([&] { calls.fetch_add(1); });
+
+    REQUIRE(wait_until([&] { return calls.load() == 1; }, 2000ms));
+}
+
+TEST_CASE("EventLoop skips empty delayed tasks",
+          "[events][event_loop][codecov]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+
+    loop.dispatch_after(1ms, {});
+    loop.dispatch_after(2ms, [&] { calls.fetch_add(1); });
+
+    REQUIRE(wait_until([&] { return calls.load() == 1; }, 2000ms));
+}
+
 TEST_CASE("Timer basic operation", "[events][timer]") {
     EventLoop loop;
 

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -200,6 +200,19 @@ TEST_CASE("EventLoop ignores new dispatches after stop",
     REQUIRE(calls.load() == 0);
 }
 
+TEST_CASE("EventLoop runs tasks dispatched from the loop thread",
+          "[events][event_loop][codecov]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+
+    loop.dispatch([&] {
+        calls.fetch_add(1);
+        loop.dispatch([&] { calls.fetch_add(1); });
+    });
+
+    REQUIRE(wait_until([&] { return calls.load() == 2; }, 2000ms));
+}
+
 TEST_CASE("Timer basic operation", "[events][timer]") {
     EventLoop loop;
 

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -528,6 +528,37 @@ TEST_CASE("ActionBroadcaster skips empty callbacks",
     REQUIRE(seen.size() == 1);
 }
 
+TEST_CASE("ActionBroadcaster snapshots callbacks during dispatch",
+          "[events][async_updater][action_broadcaster][codecov]") {
+    ActionBroadcaster broadcaster;
+    std::vector<std::string> seen;
+    int first_id = -1;
+    int second_id = -1;
+    int added_id = -1;
+
+    first_id = broadcaster.add_listener([&](std::string_view action) {
+        seen.emplace_back("first:" + std::string(action));
+        broadcaster.remove_listener(first_id);
+        broadcaster.remove_listener(second_id);
+        added_id = broadcaster.add_listener([&](std::string_view later) {
+            seen.emplace_back("added:" + std::string(later));
+        });
+    });
+
+    second_id = broadcaster.add_listener([&](std::string_view action) {
+        seen.emplace_back("second:" + std::string(action));
+    });
+
+    broadcaster.send_action("refresh");
+    REQUIRE(seen == std::vector<std::string>{"first:refresh", "second:refresh"});
+
+    broadcaster.send_action("again");
+    REQUIRE(seen == std::vector<std::string>{
+        "first:refresh", "second:refresh", "added:again"});
+
+    broadcaster.remove_listener(added_id);
+}
+
 TEST_CASE("ScopedLowPowerModeDisabler is constructible as an RAII guard",
           "[events][async_updater][power]") {
     {

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -267,6 +267,22 @@ TEST_CASE("Timer exposes interval and idempotent stop state",
     REQUIRE_FALSE(timer.is_active());
 }
 
+TEST_CASE("Timer tolerates empty callbacks",
+          "[events][timer][codecov]") {
+    EventLoop loop;
+
+    Timer one_shot(loop, 1ms, {}, false);
+    one_shot.start();
+    REQUIRE(wait_until([&] { return !one_shot.is_active(); }, 2000ms));
+
+    Timer repeating(loop, 1ms, {}, true);
+    repeating.start();
+    REQUIRE(wait_until([&] { return repeating.is_active(); }, 2000ms));
+    std::this_thread::sleep_for(10ms);
+    repeating.stop();
+    REQUIRE_FALSE(repeating.is_active());
+}
+
 // #687 — stop()/start() pairs repeatedly on the owner thread while the
 // event-loop thread is running timer dispatches. Pre-fix, start()'s
 // `alive_ = make_shared<>(...)` raced with schedule_next()'s

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -176,6 +176,30 @@ TEST_CASE("EventLoop skips empty delayed tasks",
     REQUIRE(wait_until([&] { return calls.load() == 1; }, 2000ms));
 }
 
+TEST_CASE("EventLoop dispatch_after runs due tasks immediately",
+          "[events][event_loop][codecov]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+
+    loop.dispatch_after(0ms, [&] { calls.fetch_add(1); });
+    loop.dispatch_after(-1ms, [&] { calls.fetch_add(1); });
+
+    REQUIRE(wait_until([&] { return calls.load() == 2; }, 2000ms));
+}
+
+TEST_CASE("EventLoop ignores new dispatches after stop",
+          "[events][event_loop][codecov]") {
+    EventLoop loop;
+    loop.stop();
+
+    std::atomic<int> calls{0};
+    loop.dispatch([&] { calls.fetch_add(1); });
+    loop.dispatch_after(0ms, [&] { calls.fetch_add(1); });
+    std::this_thread::sleep_for(20ms);
+
+    REQUIRE(calls.load() == 0);
+}
+
 TEST_CASE("Timer basic operation", "[events][timer]") {
     EventLoop loop;
 

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -488,6 +488,24 @@ TEST_CASE("ActionBroadcaster adds, removes, and notifies listeners",
     REQUIRE(seen.size() == 5);
 }
 
+TEST_CASE("ActionBroadcaster skips empty callbacks",
+          "[events][async_updater][action_broadcaster][codecov]") {
+    ActionBroadcaster broadcaster;
+    std::vector<std::string> seen;
+
+    auto empty = broadcaster.add_listener({});
+    auto live = broadcaster.add_listener(
+        [&](std::string_view action) { seen.emplace_back(action); });
+
+    broadcaster.send_action("refresh");
+    REQUIRE(seen == std::vector<std::string>{"refresh"});
+
+    broadcaster.remove_listener(empty);
+    broadcaster.remove_listener(live);
+    broadcaster.send_action("ignored");
+    REQUIRE(seen.size() == 1);
+}
+
 TEST_CASE("ScopedLowPowerModeDisabler is constructible as an RAII guard",
           "[events][async_updater][power]") {
     {

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -3,6 +3,7 @@
 #include <pulp/events/async_updater.hpp>
 #include <pulp/events/child_process_manager.hpp>
 #include <pulp/events/interprocess_connection.hpp>
+#include <pulp/events/volume_detector.hpp>
 #include <atomic>
 #include <chrono>
 #include <memory>
@@ -643,6 +644,23 @@ TEST_CASE("ActionBroadcaster snapshots callbacks during dispatch",
         "first:refresh", "second:refresh", "added:again"});
 
     broadcaster.remove_listener(added_id);
+}
+
+TEST_CASE("MountedVolumeListChangeDetector polls once before stop",
+          "[events][volume_detector][codecov]") {
+    MountedVolumeListChangeDetector detector;
+    std::atomic<int> changes{0};
+    detector.on_change = [&](const std::vector<std::string>&) {
+        changes.fetch_add(1);
+    };
+
+    detector.start(1ms);
+    REQUIRE(detector.is_running());
+
+    std::this_thread::sleep_for(30ms);
+    detector.stop();
+
+    REQUIRE_FALSE(detector.is_running());
 }
 
 TEST_CASE("ScopedLowPowerModeDisabler is constructible as an RAII guard",

--- a/test/test_events_async_helpers.cpp
+++ b/test/test_events_async_helpers.cpp
@@ -140,6 +140,26 @@ TEST_CASE("ActionBroadcaster ignores missing listener removals",
     REQUIRE(seen.size() == 3);
 }
 
+TEST_CASE("ActionBroadcaster handles empty actions and no-listener sends",
+          "[events][async_updater][action_broadcaster][issue-642]") {
+    ActionBroadcaster broadcaster;
+
+    broadcaster.send_action("");
+    broadcaster.remove_listener(123);
+
+    std::vector<std::string> seen;
+    auto listener = broadcaster.add_listener(
+        [&](std::string_view action) { seen.emplace_back(action); });
+
+    broadcaster.send_action("");
+    broadcaster.send_action("named");
+    REQUIRE(seen == std::vector<std::string>{"", "named"});
+
+    broadcaster.remove_listener(listener);
+    broadcaster.send_action("ignored");
+    REQUIRE(seen.size() == 2);
+}
+
 TEST_CASE("MultiTimer stop all permits selective restart",
           "[events][async_updater][multi_timer][issue-642]") {
     RecordingMultiTimer timers;
@@ -161,6 +181,26 @@ TEST_CASE("MultiTimer stop all permits selective restart",
     timers.stop_timer(42);
     REQUIRE_FALSE(timers.is_timer_running(1));
     REQUIRE_FALSE(timers.is_timer_running(2));
+}
+
+TEST_CASE("MultiTimer restart keeps one running entry per id",
+          "[events][async_updater][multi_timer][issue-642]") {
+    RecordingMultiTimer timers;
+
+    timers.start_timer(7, 20);
+    timers.start_timer(7, 10);
+    timers.start_timer(7, 5);
+    REQUIRE(timers.is_timer_running(7));
+
+    timers.stop_timer(7);
+    REQUIRE_FALSE(timers.is_timer_running(7));
+
+    timers.start_timer(7, 1);
+    REQUIRE(timers.is_timer_running(7));
+
+    timers.stop_all_timers();
+    timers.stop_all_timers();
+    REQUIRE_FALSE(timers.is_timer_running(7));
 }
 
 TEST_CASE("ScopedLowPowerModeDisabler has no observable test-lane side effects",

--- a/test/test_file_browser.cpp
+++ b/test/test_file_browser.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/canvas/canvas.hpp>
 #include <pulp/view/file_browser.hpp>
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -56,6 +57,10 @@ int index_containing(const std::vector<std::string>& texts, const std::string& n
 
 bool contains_text(const std::vector<std::string>& texts, const std::string& needle) {
     return index_containing(texts, needle) >= 0;
+}
+
+int exact_text_count(const std::vector<std::string>& texts, const std::string& text) {
+    return static_cast<int>(std::count(texts.begin(), texts.end(), text));
 }
 
 float x_for_exact_text(const RecordingCanvas& canvas, const std::string& text) {
@@ -120,6 +125,29 @@ TEST_CASE("FileBrowser filters hidden files and sorts directories before files",
     browser.paint(canvas);
     texts = fill_texts(canvas);
     REQUIRE(contains_text(texts, ".hidden.wav"));
+}
+
+TEST_CASE("FileBrowser paint clips rows and keeps directories through filters",
+          "[view][file-browser][coverage][issue-655]") {
+    TempDir tmp("filter-clip");
+    std::filesystem::create_directory(tmp.path / "Samples");
+    write_file(tmp.path / "alpha.wav");
+    write_file(tmp.path / "beta.txt");
+    write_file(tmp.path / "gamma.wav");
+
+    FileBrowser browser;
+    browser.set_bounds({0, 0, 320, 40});
+    browser.set_filters({"*.wav"});
+    browser.set_root(tmp.path);
+
+    RecordingCanvas clipped;
+    browser.paint(clipped);
+    auto texts = fill_texts(clipped);
+
+    REQUIRE(contains_text(texts, "Samples"));
+    REQUIRE(contains_text(texts, "alpha.wav"));
+    REQUIRE_FALSE(contains_text(texts, "beta.txt"));
+    REQUIRE_FALSE(contains_text(texts, "gamma.wav"));
 }
 
 TEST_CASE("FileTree skips hidden nodes and paints one expanded directory level",
@@ -221,4 +249,29 @@ TEST_CASE("MultiDocumentPanel remove_document preserves active document callback
         REQUIRE(closed == std::vector<int>({0, 1, 0}));
         REQUIRE(active_changes == std::vector<int>({0, 2, 1, 0, -1}));
     }
+}
+
+TEST_CASE("MultiDocumentPanel paint reflects active tab and empty state",
+          "[view][multi-document][coverage][issue-655]") {
+    MultiDocumentPanel empty;
+    empty.set_bounds({0, 0, 200, 80});
+    RecordingCanvas empty_canvas;
+    empty.paint(empty_canvas);
+    REQUIRE(empty_canvas.count(DrawCommand::Type::fill_text) == 0);
+    REQUIRE(empty_canvas.count(DrawCommand::Type::fill_rect) == 0);
+
+    MultiDocumentPanel panel;
+    panel.set_bounds({0, 0, 260, 100});
+    panel.add_document("Main", std::make_unique<View>());
+    panel.add_document("Aux", std::make_unique<View>());
+    panel.set_active(1);
+
+    RecordingCanvas canvas;
+    panel.paint(canvas);
+    auto texts = fill_texts(canvas);
+
+    REQUIRE(panel.active_index() == 1);
+    REQUIRE(exact_text_count(texts, "Main") == 1);
+    REQUIRE(exact_text_count(texts, "Aux") == 1);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rect) == 2);
 }

--- a/test/test_graph_editor_view.cpp
+++ b/test/test_graph_editor_view.cpp
@@ -5,6 +5,8 @@
 #include <pulp/view/input_events.hpp>
 #include <pulp/view/widgets/graph_editor_view.hpp>
 
+#include <algorithm>
+
 using pulp::canvas::DrawCommand;
 using pulp::canvas::RecordingCanvas;
 using pulp::host::SignalGraph;
@@ -30,6 +32,34 @@ MouseEvent modifier_event(uint16_t modifiers) {
     MouseEvent event;
     event.modifiers = modifiers;
     return event;
+}
+
+bool has_fill_rect(const RecordingCanvas& canvas, float x, float y, float w, float h) {
+    return std::any_of(canvas.commands().begin(),
+                       canvas.commands().end(),
+                       [&](const DrawCommand& cmd) {
+                           return cmd.type == DrawCommand::Type::fill_rect &&
+                                  cmd.f[0] == x && cmd.f[1] == y &&
+                                  cmd.f[2] == w && cmd.f[3] == h;
+                       });
+}
+
+bool has_text(const RecordingCanvas& canvas, const std::string& text) {
+    return std::any_of(canvas.commands().begin(),
+                       canvas.commands().end(),
+                       [&](const DrawCommand& cmd) {
+                           return cmd.type == DrawCommand::Type::fill_text &&
+                                  cmd.text == text;
+                       });
+}
+
+bool has_stroke_color(const RecordingCanvas& canvas, pulp::canvas::Color color) {
+    return std::any_of(canvas.commands().begin(),
+                       canvas.commands().end(),
+                       [&](const DrawCommand& cmd) {
+                           return cmd.type == DrawCommand::Type::set_stroke_color &&
+                                  cmd.color == color;
+                       });
 }
 
 } // namespace
@@ -58,6 +88,58 @@ TEST_CASE("GraphEditorView paints graph nodes connections and drag ghost",
     RecordingCanvas drag_canvas;
     editor.paint(drag_canvas);
     REQUIRE(drag_canvas.count(DrawCommand::Type::cubic_to) == 2);
+}
+
+TEST_CASE("GraphEditorView auto layout preserves positions and paints unnamed ports",
+          "[view][graph_editor][issue-493]") {
+    SignalGraph graph;
+    const auto unnamed_input = graph.add_input_node(2, "");
+    graph.add_output_node(2, "Output");
+
+    GraphEditorView editor(graph);
+    editor.set_node_position(unnamed_input, 100.0f, 20.0f);
+    graph.add_gain_node("Gain");
+    editor.auto_layout();
+
+    RecordingCanvas canvas;
+    editor.paint(canvas);
+
+    REQUIRE(has_fill_rect(canvas, 100.0f, 20.0f, 160.0f, 80.0f));
+    REQUIRE(has_fill_rect(canvas, 260.0f, 40.0f, 160.0f, 80.0f));
+    REQUIRE(has_fill_rect(canvas, 480.0f, 40.0f, 160.0f, 80.0f));
+    REQUIRE(has_text(canvas, "(unnamed)"));
+    REQUIRE(has_text(canvas, "Output"));
+    REQUIRE(has_text(canvas, "Gain"));
+    REQUIRE(canvas.count(DrawCommand::Type::fill_circle) == 8);
+}
+
+TEST_CASE("GraphEditorView paints feedback and midi edge colors",
+          "[view][graph_editor][issue-493]") {
+    SignalGraph feedback_graph;
+    const auto feedback_input = feedback_graph.add_input_node(1, "Input");
+    const auto feedback_output = feedback_graph.add_output_node(1, "Output");
+    REQUIRE(feedback_graph.connect_feedback(feedback_input, 0, feedback_output, 0));
+
+    GraphEditorView feedback(feedback_graph);
+    feedback.set_node_position(feedback_input, 10.0f, 10.0f);
+    feedback.set_node_position(feedback_output, 240.0f, 10.0f);
+
+    RecordingCanvas feedback_canvas;
+    feedback.paint(feedback_canvas);
+    REQUIRE(has_stroke_color(feedback_canvas, {0.95f, 0.40f, 0.40f, 1.0f}));
+
+    SignalGraph midi_graph;
+    const auto midi_in = midi_graph.add_midi_input_node("Keys");
+    const auto midi_out = midi_graph.add_midi_output_node("Sink");
+    REQUIRE(midi_graph.connect_midi(midi_in, midi_out));
+
+    GraphEditorView midi(midi_graph);
+    midi.set_node_position(midi_in, 10.0f, 10.0f);
+    midi.set_node_position(midi_out, 240.0f, 10.0f);
+
+    RecordingCanvas midi_canvas;
+    midi.paint(midi_canvas);
+    REQUIRE(has_stroke_color(midi_canvas, {0.30f, 0.85f, 0.45f, 1.0f}));
 }
 
 TEST_CASE("GraphEditorView drag connects output to input and reverse",

--- a/test/test_graph_editor_view.cpp
+++ b/test/test_graph_editor_view.cpp
@@ -204,6 +204,35 @@ TEST_CASE("GraphEditorView modifier drags create feedback and midi edges",
     REQUIRE_FALSE(midi_graph.connections()[0].feedback);
 }
 
+TEST_CASE("GraphEditorView reverse modifier drags create feedback and midi edges",
+          "[view][graph_editor][coverage][issue-655]") {
+    SignalGraph feedback_graph;
+    const auto feedback_input = feedback_graph.add_input_node(1, "Input");
+    const auto feedback_output = feedback_graph.add_output_node(1, "Output");
+    GraphEditorView feedback(feedback_graph);
+    feedback.set_node_position(feedback_input, 10.0f, 10.0f);
+    feedback.set_node_position(feedback_output, 240.0f, 10.0f);
+
+    feedback.on_mouse_down(input_port(240.0f));
+    feedback.on_mouse_event(modifier_event(kModShift));
+    feedback.on_mouse_up(output_port(10.0f));
+    REQUIRE(feedback_graph.connections().size() == 1);
+    REQUIRE(feedback_graph.connections()[0].feedback);
+
+    SignalGraph midi_graph;
+    const auto midi_in = midi_graph.add_midi_input_node("Keys");
+    const auto midi_out = midi_graph.add_midi_output_node("Sink");
+    GraphEditorView midi(midi_graph);
+    midi.set_node_position(midi_in, 10.0f, 10.0f);
+    midi.set_node_position(midi_out, 240.0f, 10.0f);
+
+    midi.on_mouse_down(input_port(240.0f));
+    midi.on_mouse_event(modifier_event(kModAlt));
+    midi.on_mouse_up(output_port(10.0f));
+    REQUIRE(midi_graph.connections().size() == 1);
+    REQUIRE(midi_graph.connections()[0].midi);
+}
+
 TEST_CASE("GraphEditorView selection and miss handling are stable",
           "[view][graph_editor][issue-493]") {
     SignalGraph graph;
@@ -223,4 +252,32 @@ TEST_CASE("GraphEditorView selection and miss handling are stable",
     editor.on_mouse_drag({1000.0f, 1000.0f});
     editor.on_mouse_up({1000.0f, 1000.0f});
     REQUIRE(graph.connections().empty());
+}
+
+TEST_CASE("GraphEditorView paints unnamed nodes and clears drag ghost after miss",
+          "[view][graph_editor][coverage][issue-655]") {
+    SignalGraph graph;
+    const auto input = graph.add_input_node(1, "");
+    const auto output = graph.add_output_node(1, "Output");
+
+    GraphEditorView editor(graph);
+    editor.set_node_position(input, 10.0f, 10.0f);
+    editor.set_node_position(output, 240.0f, 10.0f);
+
+    RecordingCanvas initial;
+    editor.paint(initial);
+    REQUIRE(has_text(initial, "(unnamed)"));
+
+    editor.on_mouse_down(output_port(10.0f));
+    editor.on_mouse_drag({180.0f, 90.0f});
+    RecordingCanvas dragging;
+    editor.paint(dragging);
+    REQUIRE(dragging.count(DrawCommand::Type::cubic_to) == 1);
+
+    editor.on_mouse_up({900.0f, 900.0f});
+    REQUIRE(graph.connections().empty());
+
+    RecordingCanvas released;
+    editor.paint(released);
+    REQUIRE(released.count(DrawCommand::Type::cubic_to) == 0);
 }

--- a/test/test_graph_serializer.cpp
+++ b/test/test_graph_serializer.cpp
@@ -474,6 +474,52 @@ TEST_CASE("GraphSerializer preserves unresolved plugin identity when reserializi
     REQUIRE(second_json.find("\"state_b64\"") == std::string::npos);
 }
 
+TEST_CASE("GraphSerializer preserves unresolved plugin display name",
+          "[host][serializer][issue-493]") {
+    const auto json = R"({
+      "format_version": 1,
+      "nodes": [
+        {
+          "id": 7,
+          "type": "plugin",
+          "name": "User Label",
+          "num_input_ports": 1,
+          "num_output_ports": 1,
+          "plugin": {
+            "format": "clap",
+            "unique_id": "pulp.test.renamed.missing",
+            "name": "Plugin Metadata Name",
+            "manufacturer": "PulpTest",
+            "version": "1.0.0",
+            "last_path": "/nonexistent/Plugin Metadata Name.clap"
+          }
+        }
+      ],
+      "connections": []
+    })";
+
+    SignalGraph dst;
+    auto result = GraphSerializer::from_json(dst, json);
+    REQUIRE(result.ok);
+    REQUIRE(missing_plugins_contain(result, "clap:pulp.test.renamed.missing"));
+    REQUIRE(dst.nodes().size() == 1);
+
+    const auto& node = dst.nodes().front();
+    REQUIRE(node.type == NodeType::Plugin);
+    REQUIRE(node.plugin == nullptr);
+    REQUIRE(node.name == "User Label");
+    REQUIRE(node.plugin_info.name == "Plugin Metadata Name");
+    REQUIRE(node.plugin_info.unique_id == "pulp.test.renamed.missing");
+
+    const auto second_json = GraphSerializer::to_json(dst);
+    REQUIRE(second_json.find("\"name\": \"User Label\"") != std::string::npos);
+    REQUIRE(second_json.find("\"name\": \"Plugin Metadata Name\"") !=
+            std::string::npos);
+    REQUIRE(second_json.find("\"unique_id\": \"pulp.test.renamed.missing\"") !=
+            std::string::npos);
+    REQUIRE(second_json.find("\"state_b64\"") == std::string::npos);
+}
+
 TEST_CASE("GraphSerializer clears partially loaded graphs after plugin field errors",
           "[host][serializer][issue-493]") {
     SignalGraph dst;

--- a/test/test_graph_serializer.cpp
+++ b/test/test_graph_serializer.cpp
@@ -445,6 +445,75 @@ TEST_CASE("GraphSerializer serializes plugin formats and state blobs",
     }
 }
 
+TEST_CASE("GraphSerializer preserves unresolved plugin identity when reserializing",
+          "[host][serializer][issue-493]") {
+    SignalGraph src;
+    auto info = make_fake_plugin_info("MissingEcho", "pulp.test.missing.echo",
+                                      PluginFormat::CLAP, 2, 2);
+    src.add_plugin_node(info);
+
+    const auto first_json = GraphSerializer::to_json(src);
+    REQUIRE(first_json.find("\"unique_id\": \"pulp.test.missing.echo\"") !=
+            std::string::npos);
+    REQUIRE(first_json.find("\"state_b64\"") == std::string::npos);
+
+    SignalGraph dst;
+    auto result = GraphSerializer::from_json(dst, first_json);
+    REQUIRE(result.ok);
+    REQUIRE(missing_plugins_contain(result, "clap:pulp.test.missing.echo"));
+    REQUIRE(dst.nodes().size() == 1);
+    REQUIRE(dst.nodes().front().type == NodeType::Plugin);
+    REQUIRE(dst.nodes().front().plugin == nullptr);
+
+    const auto second_json = GraphSerializer::to_json(dst);
+    REQUIRE(second_json.find("\"format\": \"clap\"") != std::string::npos);
+    REQUIRE(second_json.find("\"unique_id\": \"pulp.test.missing.echo\"") !=
+            std::string::npos);
+    REQUIRE(second_json.find("\"last_path\": \"/nonexistent/MissingEcho.clap\"") !=
+            std::string::npos);
+    REQUIRE(second_json.find("\"state_b64\"") == std::string::npos);
+}
+
+TEST_CASE("GraphSerializer clears partially loaded graphs after plugin field errors",
+          "[host][serializer][issue-493]") {
+    SignalGraph dst;
+    auto result = GraphSerializer::from_json(dst, R"({
+  "format_version": 1,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "audio_in",
+      "name": "Input",
+      "num_input_ports": 0,
+      "num_output_ports": 1,
+      "gain": 1
+    },
+    {
+      "id": 2,
+      "type": "plugin",
+      "name": "Broken plugin",
+      "num_input_ports": 1,
+      "num_output_ports": 1,
+      "gain": 1,
+      "plugin": {
+        "format": "clap",
+        "unique_id": 123,
+        "name": "Broken plugin",
+        "manufacturer": "PulpTest",
+        "version": "1.0.0",
+        "last_path": "/missing/broken.clap"
+      }
+    }
+  ],
+  "connections": []
+})");
+
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.error.find("field deserialization failed") != std::string::npos);
+    REQUIRE(dst.nodes().empty());
+    REQUIRE(dst.connections().empty());
+}
+
 TEST_CASE("GraphSerializer round-trips MIDI routing", "[host][serializer]") {
     SignalGraph src;
     auto midi_in = src.add_midi_input_node();

--- a/test/test_gui_components.cpp
+++ b/test/test_gui_components.cpp
@@ -283,6 +283,9 @@ TEST_CASE("Toolbar enable/disable", "[gui][toolbar]") {
 
     toolbar.set_enabled("save", false);
     // Disabled items shouldn't trigger (tested via on_mouse_down in real usage)
+    toolbar.set_enabled("missing", false);
+    toolbar.on_mouse_down({10, 10});
+    REQUIRE_FALSE(clicked);
 }
 
 TEST_CASE("Toolbar remove item", "[gui][toolbar]") {
@@ -291,8 +294,34 @@ TEST_CASE("Toolbar remove item", "[gui][toolbar]") {
     toolbar.add_button("b", "B", []() {});
     REQUIRE(toolbar.item_count() == 2);
 
+    toolbar.remove_item("missing");
+    REQUIRE(toolbar.item_count() == 2);
+
     toolbar.remove_item("a");
     REQUIRE(toolbar.item_count() == 1);
+}
+
+TEST_CASE("Toolbar missing ids and sizing fallbacks are stable",
+          "[gui][toolbar][coverage][issue-653]") {
+    Toolbar toolbar;
+    toolbar.add_toggle("solo", "Solo", [](bool) {});
+
+    toolbar.set_toggled("missing", true);
+    toolbar.set_enabled("missing", false);
+    REQUIRE_FALSE(toolbar.is_toggled("missing"));
+    REQUIRE_FALSE(toolbar.is_toggled("solo"));
+
+    toolbar.set_item_size(18.0f);
+    toolbar.set_spacing(2.0f);
+    REQUIRE(toolbar.intrinsic_height() == 26.0f);
+
+    toolbar.set_orientation(Toolbar::Orientation::vertical);
+    REQUIRE(toolbar.intrinsic_height() == 0.0f);
+
+    int clicks = 0;
+    toolbar.add_button("go", "Go", [&] { ++clicks; });
+    toolbar.on_mouse_down({40, 40});
+    REQUIRE(clicks == 0);
 }
 
 TEST_CASE("Toolbar mouse interaction skips separators and disabled items",

--- a/test/test_gui_components.cpp
+++ b/test/test_gui_components.cpp
@@ -30,6 +30,68 @@ public:
     }
 };
 
+class PanelProbeView final : public View {
+public:
+    explicit PanelProbeView(float intrinsic_height) : intrinsic_height_(intrinsic_height) {}
+
+    int paint_count = 0;
+
+    float intrinsic_height() const override { return intrinsic_height_; }
+
+    void paint(pulp::canvas::Canvas& canvas) override {
+        ++paint_count;
+        canvas.set_fill_color(pulp::canvas::Color::rgba8(4, 5, 6));
+        canvas.fill_rect(0, 0, bounds().width, bounds().height);
+    }
+
+private:
+    float intrinsic_height_ = 0.0f;
+};
+
+class TrackingTableModel final : public TableModel {
+public:
+    explicit TrackingTableModel(std::vector<std::vector<std::string>> rows)
+        : rows_(std::move(rows)) {}
+
+    int sort_calls = 0;
+    int selected_calls = 0;
+    int last_sort_column = -1;
+    int last_selected_row = -1;
+    bool last_sort_ascending = false;
+
+    int row_count() const override { return static_cast<int>(rows_.size()); }
+
+    std::string cell_text(int row, int column) const override {
+        if (row < 0 || row >= row_count())
+            return "";
+        const auto& row_values = rows_[static_cast<size_t>(row)];
+        if (column < 0 || column >= static_cast<int>(row_values.size()))
+            return "";
+        return row_values[static_cast<size_t>(column)];
+    }
+
+    bool sort(int column, bool ascending) override {
+        ++sort_calls;
+        last_sort_column = column;
+        last_sort_ascending = ascending;
+        const auto col = static_cast<size_t>(column);
+        std::sort(rows_.begin(), rows_.end(), [col, ascending](const auto& a, const auto& b) {
+            const std::string av = col < a.size() ? a[col] : "";
+            const std::string bv = col < b.size() ? b[col] : "";
+            return ascending ? av < bv : av > bv;
+        });
+        return true;
+    }
+
+    void row_selected(int row) override {
+        ++selected_calls;
+        last_selected_row = row;
+    }
+
+private:
+    std::vector<std::vector<std::string>> rows_;
+};
+
 }  // namespace
 
 // ── SimpleTableModel ────────────────────────────────────────────────────
@@ -94,6 +156,101 @@ TEST_CASE("TableListBox column management", "[gui][table]") {
 
     table.clear_columns();
     REQUIRE(table.column_count() == 0);
+}
+
+TEST_CASE("TableListBox header sorting and row selection edge paths",
+          "[gui][table][issue-493]") {
+    TrackingTableModel model({
+        {"Charlie", "Synth", "3"},
+        {"Alice", "Bass", "1"},
+        {"Bob", "Lead", "2"},
+    });
+
+    TableListBox table;
+    table.set_bounds({0, 0, 180, 120});
+    table.set_model(&model);
+    table.add_column({"Name", 120.0f, true});
+    table.add_column({"Type", 120.0f, false});
+    table.add_column({"Rank", 60.0f, true});
+
+    table.on_mouse_down({20, 8});
+    REQUIRE(model.sort_calls == 1);
+    REQUIRE(model.last_sort_column == 0);
+    REQUIRE(model.last_sort_ascending);
+    REQUIRE(model.cell_text(0, 0) == "Alice");
+
+    table.on_mouse_down({20, 8});
+    REQUIRE(model.sort_calls == 2);
+    REQUIRE(model.last_sort_column == 0);
+    REQUIRE_FALSE(model.last_sort_ascending);
+    REQUIRE(model.cell_text(0, 0) == "Charlie");
+
+    table.on_mouse_down({90, 8});
+    REQUIRE(model.sort_calls == 2);
+
+    table.on_mouse_down({160, 8});
+    REQUIRE(model.sort_calls == 3);
+    REQUIRE(model.last_sort_column == 2);
+    REQUIRE(model.last_sort_ascending);
+
+    int selected = -1;
+    table.on_selection_changed = [&](int row) { selected = row; };
+    table.on_mouse_down({15, 58});
+    REQUIRE(table.selected_row() == 1);
+    REQUIRE(selected == 1);
+    REQUIRE(model.selected_calls == 1);
+    REQUIRE(model.last_selected_row == 1);
+
+    table.on_mouse_down({15, 400});
+    REQUIRE(table.selected_row() == 1);
+    REQUIRE(model.selected_calls == 1);
+}
+
+TEST_CASE("TableListBox paint covers empty guards scaled columns and alignment",
+          "[gui][table][issue-493]") {
+    TableListBox empty;
+    empty.set_bounds({0, 0, 120, 80});
+    RecordingCanvas canvas;
+    empty.paint(canvas);
+    REQUIRE(canvas.command_count() == 0);
+
+    TrackingTableModel model({
+        {"Alice", "Bass", "10"},
+        {"Bob", "Lead", "2"},
+        {"Charlie", "Pad", "30"},
+    });
+
+    TableListBox table;
+    table.set_bounds({0, 0, 160, 86});
+    table.set_model(&model);
+    table.add_column({"Name", 120.0f, true, true, TableColumn::Align::left});
+    table.add_column({"Type", 100.0f, true, true, TableColumn::Align::center});
+    table.add_column({"Rank", 100.0f, true, true, TableColumn::Align::right});
+    table.set_selected_row(1);
+    table.on_mouse_down({12, 8});
+
+    table.paint(canvas);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rect) >= 4);
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_line) >= 4);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_text) >= 13);
+
+    bool saw_name_header = false;
+    bool saw_rank_header = false;
+    bool saw_selected_cell = false;
+    bool saw_sort_indicator = false;
+    for (const auto& command : canvas.commands()) {
+        if (command.type != DrawCommand::Type::fill_text)
+            continue;
+        saw_name_header = saw_name_header || command.text == "Name";
+        saw_rank_header = saw_rank_header || command.text == "Rank";
+        saw_selected_cell = saw_selected_cell || command.text == "Bob";
+        saw_sort_indicator = saw_sort_indicator || command.text == "\xe2\x96\xb2";
+    }
+
+    REQUIRE(saw_name_header);
+    REQUIRE(saw_rank_header);
+    REQUIRE(saw_selected_cell);
+    REQUIRE(saw_sort_indicator);
 }
 
 // ── Toolbar ─────────────────────────────────────────────────────────────
@@ -283,6 +440,74 @@ TEST_CASE("ConcertinaPanel exclusive mode", "[gui][concertina]") {
     panel.expand(1);
     REQUIRE_FALSE(panel.is_expanded(0));  // Auto-collapsed
     REQUIRE(panel.is_expanded(1));
+}
+
+TEST_CASE("ConcertinaPanel guards indices and syncs content visibility",
+          "[gui][concertina][issue-493]") {
+    ConcertinaPanel panel;
+    auto first = std::make_unique<PanelProbeView>(24.0f);
+    auto* first_ptr = first.get();
+    auto second = std::make_unique<PanelProbeView>(0.0f);
+    auto* second_ptr = second.get();
+
+    panel.add_section("First", std::move(first), true);
+    panel.add_section("Second", std::move(second), false);
+
+    REQUIRE(first_ptr->visible());
+    REQUIRE_FALSE(second_ptr->visible());
+    REQUIRE_FALSE(panel.is_expanded(-1));
+    REQUIRE_FALSE(panel.is_expanded(99));
+
+    panel.expand(-1);
+    panel.collapse(99);
+    panel.toggle(99);
+    REQUIRE(panel.is_expanded(0));
+    REQUIRE_FALSE(panel.is_expanded(1));
+
+    panel.expand(1);
+    REQUIRE(second_ptr->visible());
+    panel.collapse(0);
+    REQUIRE_FALSE(first_ptr->visible());
+
+    panel.layout_sections();
+    REQUIRE(second_ptr->bounds().height == 100.0f);
+}
+
+TEST_CASE("ConcertinaPanel paint and mouse hit testing cover content offsets",
+          "[gui][concertina][issue-493]") {
+    ConcertinaPanel panel;
+    panel.set_bounds({0, 0, 180, 160});
+    panel.set_header_height(20.0f);
+
+    auto first = std::make_unique<PanelProbeView>(40.0f);
+    auto* first_ptr = first.get();
+    auto second = std::make_unique<PanelProbeView>(30.0f);
+    auto* second_ptr = second.get();
+
+    panel.add_section("First", std::move(first), true);
+    panel.add_section("Second", std::move(second), false);
+
+    RecordingCanvas canvas;
+    panel.paint(canvas);
+    REQUIRE(first_ptr->paint_count == 1);
+    REQUIRE(second_ptr->paint_count == 0);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rect) >= 4);
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_line) == 2);
+    REQUIRE(canvas.count(DrawCommand::Type::save) == 1);
+    REQUIRE(canvas.count(DrawCommand::Type::restore) == 1);
+
+    panel.on_mouse_down({10, 35});
+    REQUIRE(panel.is_expanded(0));
+    REQUIRE_FALSE(panel.is_expanded(1));
+
+    panel.on_mouse_down({10, 65});
+    REQUIRE(panel.is_expanded(1));
+
+    canvas.clear();
+    panel.paint(canvas);
+    REQUIRE(second_ptr->paint_count == 1);
+    REQUIRE(canvas.count(DrawCommand::Type::save) == 2);
+    REQUIRE(canvas.count(DrawCommand::Type::restore) == 2);
 }
 
 // ── TextButton ──────────────────────────────────────────────────────────

--- a/test/test_headless.cpp
+++ b/test/test_headless.cpp
@@ -34,15 +34,27 @@ public:
         });
     }
 
-    void prepare(const pulp::format::PrepareContext&) override {}
+    void prepare(const pulp::format::PrepareContext& context) override {
+        ++prepare_calls;
+        last_prepare_context = context;
+    }
+
+    void release() override { ++release_calls; }
 
     void process(
         pulp::audio::BufferView<float>& output,
         const pulp::audio::BufferView<const float>& input,
-        pulp::midi::MidiBuffer&, pulp::midi::MidiBuffer&,
+        pulp::midi::MidiBuffer& midi_in, pulp::midi::MidiBuffer&,
         const pulp::format::ProcessContext& context) override
     {
         last_context = context;
+        ++process_calls;
+        midi_in_events = 0;
+        for (const auto& event : midi_in) {
+            if (event.is_note_on()) ++midi_note_ons;
+            ++midi_in_events;
+        }
+
         float db = state().get_value(1);
         float gain = std::pow(10.0f, db / 20.0f);
         for (std::size_t ch = 0; ch < output.num_channels() && ch < input.num_channels(); ++ch) {
@@ -63,6 +75,12 @@ public:
     }
 
     std::string plugin_state;
+    pulp::format::PrepareContext last_prepare_context{};
+    int prepare_calls = 0;
+    int release_calls = 0;
+    int process_calls = 0;
+    int midi_in_events = 0;
+    int midi_note_ons = 0;
 };
 
 std::unique_ptr<pulp::format::Processor> create_test_gain() {
@@ -100,6 +118,41 @@ TEST_CASE("HeadlessHost processes audio at unity gain", "[headless]") {
 
     // 0 dB = unity gain
     REQUIRE_THAT(out.channel(0)[0], WithinAbs(0.5, 0.001));
+}
+
+TEST_CASE("HeadlessHost forwards prepare context and release",
+          "[headless][coverage][issue-647]") {
+    pulp::format::HeadlessHost host(create_test_gain);
+    REQUIRE(last_processor != nullptr);
+    auto* processor = last_processor;
+
+    host.prepare(96000.0, 1024, 1, 4);
+    REQUIRE(processor->prepare_calls == 1);
+    REQUIRE_THAT(processor->last_prepare_context.sample_rate,
+                 WithinAbs(96000.0, 0.001));
+    REQUIRE(processor->last_prepare_context.max_buffer_size == 1024);
+    REQUIRE(processor->last_prepare_context.input_channels == 1);
+    REQUIRE(processor->last_prepare_context.output_channels == 4);
+
+    host.release();
+    REQUIRE(processor->release_calls == 1);
+}
+
+TEST_CASE("HeadlessHost fills default process context",
+          "[headless][coverage][issue-647]") {
+    pulp::format::HeadlessHost host(create_test_gain);
+    host.prepare(44100.0, 512);
+
+    pulp::audio::Buffer<float> in(2, 32), out(2, 32);
+    const float* in_ptrs[2] = {in.channel(0).data(), in.channel(1).data()};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 2, 32);
+    auto out_view = out.view();
+
+    last_context = {};
+    host.process(out_view, in_view);
+
+    REQUIRE_THAT(last_context.sample_rate, WithinAbs(44100.0, 0.001));
+    REQUIRE(last_context.num_samples == 32);
 }
 
 TEST_CASE("HeadlessHost applies parameter changes", "[headless]") {
@@ -152,6 +205,47 @@ TEST_CASE("HeadlessHost accepts explicit transport context for offline stepping"
     REQUIRE(last_context.position_samples == 2048);
     REQUIRE(last_context.time_sig_numerator == 7);
     REQUIRE(last_context.time_sig_denominator == 8);
+}
+
+TEST_CASE("HeadlessHost forwards explicit MIDI buffers",
+          "[headless][coverage][issue-647]") {
+    pulp::format::HeadlessHost host(create_test_gain);
+    host.prepare(48000.0, 256);
+    REQUIRE(last_processor != nullptr);
+    auto* processor = last_processor;
+
+    pulp::audio::Buffer<float> in(2, 16), out(2, 16);
+    const float* in_ptrs[2] = {in.channel(0).data(), in.channel(1).data()};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 2, 16);
+    auto out_view = out.view();
+    pulp::midi::MidiBuffer midi_in;
+    pulp::midi::MidiBuffer midi_out;
+    midi_in.add(pulp::midi::MidiEvent::note_on(0, 64, 100));
+
+    host.process(out_view, in_view, midi_in, midi_out);
+
+    REQUIRE(processor->process_calls == 1);
+    REQUIRE(processor->midi_in_events == 1);
+    REQUIRE(processor->midi_note_ons == 1);
+}
+
+TEST_CASE("HeadlessHost null processor process and release are no-ops",
+          "[headless][coverage][issue-647]") {
+    pulp::format::HeadlessHost host(create_null_processor);
+    host.prepare(48000.0, 64);
+
+    pulp::audio::Buffer<float> in(1, 4), out(1, 4);
+    for (std::size_t i = 0; i < 4; ++i) out.channel(0)[i] = 7.0f;
+    const float* in_ptrs[1] = {in.channel(0).data()};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 1, 4);
+    auto out_view = out.view();
+
+    host.process(out_view, in_view);
+    host.release();
+
+    for (std::size_t i = 0; i < 4; ++i) {
+        REQUIRE_THAT(out.channel(0)[i], WithinAbs(7.0, 0.001));
+    }
 }
 
 TEST_CASE("HeadlessHost state round-trip", "[headless]") {

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -481,6 +481,35 @@ TEST_CASE("SignalGraph connections", "[host][graph]") {
     REQUIRE(graph.connections().size() == 1);
 }
 
+TEST_CASE("SignalGraph rejects missing-node and duplicate edge variants",
+          "[host][graph][issue-493]") {
+    SignalGraph graph;
+    auto input = graph.add_input_node(2);
+    auto gain = graph.add_gain_node("Gain");
+    auto output = graph.add_output_node(2);
+    auto midi_in = graph.add_midi_input_node("MIDI In");
+    auto midi_out = graph.add_midi_output_node("MIDI Out");
+
+    REQUIRE_FALSE(graph.connect(999, 0, gain, 0));
+    REQUIRE_FALSE(graph.connect(input, 0, 999, 0));
+    REQUIRE_FALSE(graph.disconnect(input, 0, gain, 0));
+
+    REQUIRE(graph.connect(input, 0, gain, 0));
+    REQUIRE_FALSE(graph.connect(input, 0, gain, 0));
+    REQUIRE(graph.disconnect(input, 0, gain, 0));
+    REQUIRE_FALSE(graph.disconnect(input, 0, gain, 0));
+
+    REQUIRE_FALSE(graph.connect_feedback(999, 0, output, 0));
+    REQUIRE_FALSE(graph.connect_feedback(gain, 0, 999, 0));
+    REQUIRE(graph.connect_feedback(gain, 0, output, 0));
+    REQUIRE_FALSE(graph.connect_feedback(gain, 0, output, 0));
+
+    REQUIRE_FALSE(graph.connect_midi(999, midi_out));
+    REQUIRE_FALSE(graph.connect_midi(midi_in, 999));
+    REQUIRE(graph.connect_midi(midi_in, midi_out));
+    REQUIRE_FALSE(graph.connect_midi(midi_in, midi_out));
+}
+
 TEST_CASE("SignalGraph cycle detection", "[host][graph]") {
     SignalGraph graph;
     auto a = graph.add_input_node(2);
@@ -567,6 +596,71 @@ TEST_CASE("SignalGraph routes input -> gain -> output", "[host][graph][routing]"
         REQUIRE(std::abs(out_r[i] - 0.2f) < 1e-6f);
     }
     graph.release();
+}
+
+TEST_CASE("SignalGraph live gain updates and release silence output",
+          "[host][graph][routing][issue-493]") {
+    SignalGraph graph;
+    auto in  = graph.add_input_node(1, "in");
+    auto gain = graph.add_gain_node("gain");
+    auto out = graph.add_output_node(1, "out");
+
+    REQUIRE(graph.connect(in, 0, gain, 0));
+    REQUIRE(graph.connect(gain, 0, out, 0));
+    REQUIRE(graph.prepare(48000.0, 16));
+
+    std::vector<float> input(16, 0.8f);
+    std::vector<float> output(16, -1.0f);
+    const float* in_ptrs[1] = {input.data()};
+    float* out_ptrs[1] = {output.data()};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 1, 16);
+    pulp::audio::BufferView<float> out_view(out_ptrs, 1, 16);
+
+    graph.process(out_view, in_view, 16);
+    for (float sample : output) REQUIRE_THAT(sample, WithinAbs(0.8f, 1e-6f));
+
+    REQUIRE(graph.set_node_gain(gain, 0.25f));
+    REQUIRE(graph.node_gain(gain) == 0.25f);
+    std::fill(output.begin(), output.end(), -1.0f);
+    graph.process(out_view, in_view, 16);
+    for (float sample : output) REQUIRE_THAT(sample, WithinAbs(0.2f, 1e-6f));
+
+    graph.release();
+    std::fill(output.begin(), output.end(), -1.0f);
+    graph.process(out_view, in_view, 16);
+    for (float sample : output) REQUIRE(sample == 0.0f);
+    REQUIRE(graph.latency_samples() == 0);
+    REQUIRE(graph.node_latency_samples(gain) == 0);
+}
+
+TEST_CASE("SignalGraph query helpers handle non-plugin and cleared nodes",
+          "[host][graph][issue-493]") {
+    SignalGraph graph;
+    auto input = graph.add_input_node(2);
+    auto gain = graph.add_gain_node("Gain");
+    auto output = graph.add_output_node(2);
+
+    REQUIRE_FALSE(graph.prepare(48000.0, 0));
+    REQUIRE_FALSE(graph.prepare(48000.0, -16));
+    REQUIRE_FALSE(graph.set_node_gain(999, 0.5f));
+    REQUIRE(graph.node_gain(999) == 1.0f);
+    REQUIRE_FALSE(graph.set_node_parameter(gain, 7, 0.25f));
+    REQUIRE(graph.get_node_parameter(gain, 7) == 0.0f);
+    REQUIRE_FALSE(graph.set_node_parameter(999, 7, 0.25f));
+    REQUIRE(graph.get_node_parameter(999, 7) == 0.0f);
+    REQUIRE(graph.node_latency_samples(999) == 0);
+
+    REQUIRE(graph.connect(input, 0, gain, 0));
+    REQUIRE(graph.connect(gain, 0, output, 0));
+    REQUIRE(graph.prepare(48000.0, 16));
+    REQUIRE(graph.node_latency_samples(gain) == 0);
+
+    graph.clear();
+    REQUIRE(graph.nodes().empty());
+    REQUIRE(graph.connections().empty());
+    REQUIRE(graph.latency_samples() == 0);
+    REQUIRE(graph.node_latency_samples(gain) == 0);
+    REQUIRE(graph.node_gain(gain) == 1.0f);
 }
 
 TEST_CASE("SignalGraph disconnected output stays silent", "[host][graph][routing]") {

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -15,6 +15,15 @@ TEST_CASE("i18n add and translate", "[runtime][i18n]") {
     REQUIRE(strings.count() == 1);
 }
 
+TEST_CASE("i18n add overwrites existing translation", "[runtime][i18n][issue-641]") {
+    LocalisedStrings strings;
+    strings.add("mode", "Old");
+    strings.add("mode", "New");
+
+    REQUIRE(strings.count() == 1);
+    REQUIRE(strings.translate("mode") == "New");
+}
+
 TEST_CASE("i18n translate missing key returns key", "[runtime][i18n]") {
     LocalisedStrings strings;
     REQUIRE(strings.translate("missing_key") == "missing_key");
@@ -40,6 +49,12 @@ TEST_CASE("i18n argument substitution leaves unmatched placeholders", "[runtime]
 
     REQUIRE(strings.translate("mixed", {"left", "right"}) == "left/{2}/right/left");
     REQUIRE(strings.translate("empty", {""}) == "beforeafter");
+}
+
+TEST_CASE("i18n argument substitution also applies to missing-key fallback",
+          "[runtime][i18n][issue-641]") {
+    LocalisedStrings strings;
+    REQUIRE(strings.translate("missing {0}/{1}/{2}", {"a", "b"}) == "missing a/b/{2}");
 }
 
 TEST_CASE("i18n clear removes all translations", "[runtime][i18n]") {
@@ -96,6 +111,22 @@ TEST_CASE("i18n .strings parser ignores malformed lines", "[runtime][i18n]") {
     REQUIRE_FALSE(strings.has("missing_value"));
 }
 
+TEST_CASE("i18n .strings parser overwrites duplicate keys", "[runtime][i18n][issue-641]") {
+    TemporaryFile tmp(".strings");
+    {
+        std::ofstream f(tmp.path());
+        f << "\"name\" = \"Old\";\n";
+        f << "\"other\" = \"Kept\";\n";
+        f << "\"name\" = \"New\";\n";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_strings_file(tmp.path_string()));
+    REQUIRE(strings.count() == 2);
+    REQUIRE(strings.translate("name") == "New");
+    REQUIRE(strings.translate("other") == "Kept");
+}
+
 // ── .po file format ─────────────────────────────────────────────────────
 
 TEST_CASE("i18n load .po file", "[runtime][i18n]") {
@@ -139,6 +170,24 @@ TEST_CASE("i18n .po parser handles continuations and empty entries", "[runtime][
     REQUIRE(strings.count() == 1);
     REQUIRE(strings.translate("long_key") == "lange_wert");
     REQUIRE_FALSE(strings.has("empty_translation"));
+}
+
+TEST_CASE("i18n .po parser commits previous entry when new msgid starts",
+          "[runtime][i18n][issue-641]") {
+    TemporaryFile tmp(".po");
+    {
+        std::ofstream f(tmp.path());
+        f << "msgid \"first\"\n";
+        f << "msgstr \"one\"\n";
+        f << "msgid \"second\"\n";
+        f << "msgstr \"two\"\n";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_po_file(tmp.path_string()));
+    REQUIRE(strings.count() == 2);
+    REQUIRE(strings.translate("first") == "one");
+    REQUIRE(strings.translate("second") == "two");
 }
 
 // ── JSON file format ────────────────────────────────────────────────────
@@ -205,6 +254,25 @@ TEST_CASE("i18n JSON parser rejects missing object opener", "[runtime][i18n]") {
     REQUIRE(strings.count() == 0);
 }
 
+TEST_CASE("i18n JSON parser allows duplicate keys and trailing comma",
+          "[runtime][i18n][issue-641]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << "{\n";
+        f << "  \"name\": \"Old\",\n";
+        f << "  \"name\": \"New\",\n";
+        f << "  \"last\": \"value\",\n";
+        f << "}\n";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_json_file(tmp.path_string()));
+    REQUIRE(strings.count() == 2);
+    REQUIRE(strings.translate("name") == "New");
+    REQUIRE(strings.translate("last") == "value");
+}
+
 // ── File load failures ──────────────────────────────────────────────────
 
 TEST_CASE("i18n load nonexistent file returns false", "[runtime][i18n]") {
@@ -220,6 +288,16 @@ TEST_CASE("i18n global instance", "[runtime][i18n]") {
     auto& inst = LocalisedStrings::instance();
     inst.add("test_global", "works");
     REQUIRE(tr("test_global") == "works");
+    inst.clear();
+}
+
+TEST_CASE("i18n global tr supports argument substitution", "[runtime][i18n][issue-641]") {
+    auto& inst = LocalisedStrings::instance();
+    inst.clear();
+    inst.add("global_args", "{0}:{1}");
+
+    REQUIRE(tr("global_args", {"left", "right"}) == "left:right");
+
     inst.clear();
 }
 

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -11,8 +11,17 @@ TEST_CASE("i18n add and translate", "[runtime][i18n]") {
     LocalisedStrings strings;
     strings.add("greeting", "Hello");
     REQUIRE(strings.translate("greeting") == "Hello");
+    REQUIRE(strings.t("greeting") == "Hello");
     REQUIRE(strings.has("greeting"));
     REQUIRE(strings.count() == 1);
+}
+
+TEST_CASE("i18n duplicate keys overwrite previous values", "[runtime][i18n][coverage][issue-656]") {
+    LocalisedStrings strings;
+    strings.add("mode", "old");
+    strings.add("mode", "new");
+    REQUIRE(strings.count() == 1);
+    REQUIRE(strings.translate("mode") == "new");
 }
 
 TEST_CASE("i18n translate missing key returns key", "[runtime][i18n]") {
@@ -94,6 +103,22 @@ TEST_CASE("i18n .strings parser ignores malformed lines", "[runtime][i18n]") {
     REQUIRE(strings.count() == 1);
     REQUIRE(strings.translate("valid") == "kept");
     REQUIRE_FALSE(strings.has("missing_value"));
+}
+
+TEST_CASE("i18n .strings parser lets later entries replace earlier ones",
+          "[runtime][i18n][coverage][issue-656]") {
+    TemporaryFile tmp(".strings");
+    {
+        std::ofstream f(tmp.path());
+        f << "\"label\" = \"First\";\n";
+        f << "\"label\" = \"Second\";\n";
+        f << "\"other\" = \"Value\";\n";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_strings_file(tmp.path_string()));
+    REQUIRE(strings.count() == 2);
+    REQUIRE(strings.translate("label") == "Second");
 }
 
 // ── .po file format ─────────────────────────────────────────────────────
@@ -184,6 +209,24 @@ TEST_CASE("i18n JSON parser handles escapes and keyless entries", "[runtime][i18
     REQUIRE(strings.translate("slash") == "path\\file");
 }
 
+TEST_CASE("i18n JSON parser accepts commas and duplicate keys", "[runtime][i18n][coverage][issue-656]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << "{\n";
+        f << "  \"mode\": \"old\",\n";
+        f << "  \"mode\": \"new\",\n";
+        f << "  \"tail\": \"kept\",\n";
+        f << "}\n";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_json_file(tmp.path_string()));
+    REQUIRE(strings.count() == 2);
+    REQUIRE(strings.translate("mode") == "new");
+    REQUIRE(strings.translate("tail") == "kept");
+}
+
 TEST_CASE("i18n JSON parser rejects missing object opener", "[runtime][i18n]") {
     TemporaryFile tmp(".json");
 
@@ -220,6 +263,8 @@ TEST_CASE("i18n global instance", "[runtime][i18n]") {
     auto& inst = LocalisedStrings::instance();
     inst.add("test_global", "works");
     REQUIRE(tr("test_global") == "works");
+    inst.add("test_global_args", "{0} works");
+    REQUIRE(tr("test_global_args", {"also"}) == "also works");
     inst.clear();
 }
 

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -116,12 +116,9 @@ TEST_CASE("i18n .strings parser lets later entries replace earlier ones",
     TemporaryFile tmp(".strings");
     {
         std::ofstream f(tmp.path());
-        f << ""label" = "First";
-";
-        f << ""label" = "Second";
-";
-        f << ""other" = "Value";
-";
+        f << "\"label\" = \"First\";\n";
+        f << "\"label\" = \"Second\";\n";
+        f << "\"other\" = \"Value\";\n";
     }
 
     LocalisedStrings strings;

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -88,6 +88,7 @@ TEST_CASE("Uuid string round-trip", "[runtime][identity]") {
         REQUIRE(Uuid::from_string("00112233-4455-6677-8899-aabbccddeefg").is_nil());
         REQUIRE(Uuid::from_string("00112233445566778899aabb-ccddeeff").is_nil());
         REQUIRE(Uuid::from_string("001122334455-6677-8899-aabbccddeeff").is_nil());
+        REQUIRE(Uuid::from_string("0011223344556677-8899-aabb-ccdd-eeff").is_nil());
         REQUIRE(Uuid::from_string("00112233445566778899aabbccddeeff00").is_nil());
     }
 }

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -107,6 +107,12 @@ TEST_CASE("Uuid ordering and hashing cover deterministic values", "[runtime][ide
     REQUIRE(ids.size() == 2);
 }
 
+TEST_CASE("Uuid parsing rejects malformed dashed layout",
+          "[runtime][identity][coverage][issue-656]") {
+    auto parsed = Uuid::from_string("0011223344556677-8899-aabb-ccdd-eeff");
+    REQUIRE(parsed.is_nil());
+}
+
 TEST_CASE("Uuid parsing accepts uppercase dashed and compact hex",
           "[runtime][identity][issue-641]") {
     Uuid id;

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -67,6 +67,12 @@ TEST_CASE("Uuid string round-trip", "[runtime][identity]") {
         REQUIRE(parsed == original);
     }
 
+    SECTION("from_string accepts uppercase hex") {
+        auto parsed = Uuid::from_string("00112233-4455-6677-8899-AABBCCDDEEFF");
+        REQUIRE_FALSE(parsed.is_nil());
+        REQUIRE(parsed.to_string() == "00112233-4455-6677-8899-aabbccddeeff");
+    }
+
     SECTION("Nil UUID") {
         Uuid nil;
         REQUIRE(nil.is_nil());
@@ -77,6 +83,26 @@ TEST_CASE("Uuid string round-trip", "[runtime][identity]") {
         auto parsed = Uuid::from_string("not-a-uuid");
         REQUIRE(parsed.is_nil());
     }
+
+    SECTION("Invalid hex digits and misplaced dashes return nil") {
+        REQUIRE(Uuid::from_string("00112233-4455-6677-8899-aabbccddeefg").is_nil());
+        REQUIRE(Uuid::from_string("001122334455-6677-8899-aabbccddeeff").is_nil());
+        REQUIRE(Uuid::from_string("00112233445566778899aabbccddeeff00").is_nil());
+    }
+}
+
+TEST_CASE("Uuid ordering and hashing cover deterministic values", "[runtime][identity][coverage][issue-656]") {
+    auto low = Uuid::from_string("00000000-0000-0000-0000-000000000001");
+    auto high = Uuid::from_string("00000000-0000-0000-0000-000000000002");
+
+    REQUIRE(low < high);
+    REQUIRE_FALSE(high < low);
+
+    std::unordered_set<Uuid> ids;
+    ids.insert(low);
+    ids.insert(high);
+    ids.insert(Uuid::from_string(low.to_hex()));
+    REQUIRE(ids.size() == 2);
 }
 
 TEST_CASE("Typed identity wrappers", "[runtime][identity]") {

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -86,6 +86,7 @@ TEST_CASE("Uuid string round-trip", "[runtime][identity]") {
 
     SECTION("Invalid hex digits and misplaced dashes return nil") {
         REQUIRE(Uuid::from_string("00112233-4455-6677-8899-aabbccddeefg").is_nil());
+        REQUIRE(Uuid::from_string("00112233445566778899aabb-ccddeeff").is_nil());
         REQUIRE(Uuid::from_string("001122334455-6677-8899-aabbccddeeff").is_nil());
         REQUIRE(Uuid::from_string("00112233445566778899aabbccddeeff00").is_nil());
     }

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -79,6 +79,27 @@ TEST_CASE("Uuid string round-trip", "[runtime][identity]") {
     }
 }
 
+TEST_CASE("Uuid parsing accepts uppercase dashed and compact hex",
+          "[runtime][identity][issue-641]") {
+    Uuid id;
+    id.hi = 0x0123456789abcdefULL;
+    id.lo = 0xfedcba9876543210ULL;
+
+    REQUIRE(Uuid::from_string("01234567-89AB-CDEF-FEDC-BA9876543210") == id);
+    REQUIRE(Uuid::from_string("0123456789ABCDEFFEDCBA9876543210") == id);
+}
+
+TEST_CASE("Uuid ordering sorts by high word before low word",
+          "[runtime][identity][issue-641]") {
+    Uuid low{1, 999};
+    Uuid middle{2, 1};
+    Uuid high{2, 2};
+
+    REQUIRE(low < middle);
+    REQUIRE(middle < high);
+    REQUIRE_FALSE(high < middle);
+}
+
 TEST_CASE("Typed identity wrappers", "[runtime][identity]") {
     SECTION("SessionId") {
         auto sid = SessionId::generate();
@@ -121,6 +142,19 @@ TEST_CASE("Typed identity wrappers", "[runtime][identity]") {
         REQUIRE(sessions.size() == 1);
         REQUIRE(objects.size() == 1);
     }
+}
+
+TEST_CASE("Typed identity nil and hashing are stable", "[runtime][identity][issue-641]") {
+    REQUIRE(SessionId::nil() == SessionId::nil());
+    REQUIRE(RunId::nil() == RunId::nil());
+    REQUIRE(ObjectId::nil() == ObjectId::from_string("00000000000000000000000000000000"));
+    REQUIRE(CorrelationId::nil() == CorrelationId::nil());
+
+    auto object = ObjectId::generate();
+    std::unordered_set<ObjectId> objects;
+    objects.insert(object);
+    objects.insert(object);
+    REQUIRE(objects.size() == 1);
 }
 
 TEST_CASE("EventEnvelope", "[runtime][identity]") {

--- a/test/test_image_cache.cpp
+++ b/test/test_image_cache.cpp
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <vector>
 
 using namespace pulp::view;
 
@@ -133,6 +134,39 @@ TEST_CASE("zero budget disables trimming", "[view][image-cache]") {
     for (int i = 0; i < 100; ++i) c.get("u" + std::to_string(i));
     REQUIRE(c.stats().entry_count == 100);
     REQUIRE(c.stats().evictions == 0);
+}
+
+TEST_CASE("lowering byte budget trims least recently used entries",
+          "[view][image-cache][coverage][issue-493]") {
+    ImageCache c;
+    std::atomic<int> calls{0};
+    std::vector<void*> released;
+    c.set_decoder(make_fake_decoder(calls));
+    c.set_releaser([&](DecodedImage& img) { released.push_back(img.native_handle); });
+
+    const auto* a = c.get("a");
+    const auto* b = c.get("bb");
+    const auto* ccc = c.get("ccc");
+    REQUIRE(a != nullptr);
+    REQUIRE(b != nullptr);
+    REQUIRE(ccc != nullptr);
+    auto* b_handle = b->native_handle;
+    REQUIRE(c.stats().entry_count == 3);
+
+    REQUIRE(c.get("a") == a);
+    c.set_byte_budget(64 * 2);
+
+    auto s = c.stats();
+    REQUIRE(s.entry_count == 2);
+    REQUIRE(s.total_bytes == 64 * 2);
+    REQUIRE(s.evictions == 1);
+    REQUIRE(released.size() == 1);
+    REQUIRE(released[0] == b_handle);
+
+    calls = 0;
+    REQUIRE(c.get("a") != nullptr);
+    REQUIRE(c.get("ccc") != nullptr);
+    REQUIRE(calls.load() == 0);
 }
 
 TEST_CASE("stats track hits/misses/evictions",

--- a/test/test_input_events.cpp
+++ b/test/test_input_events.cpp
@@ -128,6 +128,29 @@ TEST_CASE("MouseEvent is_cancelled flag", "[view][input][pointer]") {
     REQUIRE(e.is_cancelled);
 }
 
+TEST_CASE("MouseEvent wheel and meta helper edge paths",
+          "[view][input][issue-493]") {
+    MouseEvent e;
+    REQUIRE(e.button == MouseButton::left);
+    REQUIRE_FALSE(e.isWheel());
+    REQUIRE_FALSE(e.isMetaDown());
+
+    e.button = MouseButton::none;
+    e.modifiers = kModMeta | kModCtrl;
+    e.is_wheel = true;
+    e.scroll_delta_x = -3.0f;
+    e.scroll_delta_y = 7.0f;
+    e.pointer_id = 2;
+
+    REQUIRE(e.button == MouseButton::none);
+    REQUIRE(e.isWheel());
+    REQUIRE(e.isMetaDown());
+    REQUIRE(e.isCtrlDown());
+    REQUIRE_FALSE(e.isPrimary());
+    REQUIRE(e.scroll_delta_x == -3.0f);
+    REQUIRE(e.scroll_delta_y == 7.0f);
+}
+
 // ── Gesture event tests (P4) ───────────────────────────────────────────
 
 TEST_CASE("GestureEvent defaults", "[view][input][gesture]") {
@@ -147,6 +170,53 @@ TEST_CASE("GestureEvent pinch", "[view][input][gesture]") {
 
     REQUIRE(ge.scale == 1.5f);
     REQUIRE(ge.position.x == 100.0f);
+}
+
+TEST_CASE("GestureEvent ended and cancelled phases carry deltas",
+          "[view][input][gesture][issue-493]") {
+    GestureEvent ended;
+    ended.phase = GesturePhase::ended;
+    ended.rotation = 0.75f;
+    ended.delta_rotation = 0.25f;
+    ended.position = {12, 34};
+
+    REQUIRE(ended.phase == GesturePhase::ended);
+    REQUIRE(ended.rotation == 0.75f);
+    REQUIRE(ended.delta_rotation == 0.25f);
+    REQUIRE(ended.position.y == 34.0f);
+
+    GestureEvent cancelled;
+    cancelled.phase = GesturePhase::cancelled;
+    cancelled.scale = 0.8f;
+    cancelled.delta_scale = -0.2f;
+
+    REQUIRE(cancelled.phase == GesturePhase::cancelled);
+    REQUIRE(cancelled.scale == 0.8f);
+    REQUIRE(cancelled.delta_scale == -0.2f);
+}
+
+TEST_CASE("KeyEvent main modifier release and repeat edge paths",
+          "[view][input][issue-493]") {
+    KeyEvent e;
+    e.key = KeyCode::enter;
+    e.is_down = false;
+    e.is_repeat = true;
+    REQUIRE(e.key == KeyCode::enter);
+    REQUIRE_FALSE(e.is_down);
+    REQUIRE(e.is_repeat);
+    REQUIRE_FALSE(e.isCtrlDown());
+    REQUIRE_FALSE(e.isCmdDown());
+    REQUIRE_FALSE(e.isMainModifier());
+
+#ifdef __APPLE__
+    e.modifiers = kModCmd;
+    REQUIRE(e.isCmdDown());
+    REQUIRE(e.isMainModifier());
+#else
+    e.modifiers = kModCtrl;
+    REQUIRE(e.isCtrlDown());
+    REQUIRE(e.isMainModifier());
+#endif
 }
 
 // ── Pointer capture tests (P2b) ────────────────────────────────────────
@@ -174,4 +244,20 @@ TEST_CASE("View pointer capture duplicate is no-op", "[view][input][capture]") {
     REQUIRE(v.has_pointer_capture(0));
     v.release_pointer_capture(0);
     REQUIRE_FALSE(v.has_pointer_capture(0)); // single release clears it
+}
+
+TEST_CASE("View pointer capture ignores missing release ids",
+          "[view][input][capture][issue-493]") {
+    View v;
+    v.set_pointer_capture(1);
+    v.set_pointer_capture(2);
+
+    v.release_pointer_capture(99);
+    REQUIRE(v.has_pointer_capture(1));
+    REQUIRE(v.has_pointer_capture(2));
+
+    v.release_pointer_capture(1);
+    v.release_pointer_capture(1);
+    REQUIRE_FALSE(v.has_pointer_capture(1));
+    REQUIRE(v.has_pointer_capture(2));
 }

--- a/test/test_ios_audio_session.cpp
+++ b/test/test_ios_audio_session.cpp
@@ -88,6 +88,54 @@ TEST_CASE("C ABI entry routes to the C++ listener",
     pulp_ios_audio_session_set_callback(nullptr, nullptr);
 }
 
+TEST_CASE("C ABI ignores null events and prefers C++ listeners over raw callbacks",
+          "[ios][audio-session][c-abi][coverage][issue-648]") {
+    int c_calls = 0;
+    pulp_ios_audio_session_set_callback(
+        [](const PulpIosAudioSessionEvent*, void* ud) {
+            ++(*static_cast<int*>(ud));
+        },
+        &c_calls);
+    pulp_ios_audio_session_emit(nullptr);
+    REQUIRE(c_calls == 0);
+
+    int cpp_calls = 0;
+    set_ios_audio_session_listener(
+        [&](const PulpIosAudioSessionEvent&) { ++cpp_calls; });
+
+    PulpIosAudioSessionEvent e{};
+    e.event = PULP_IOS_AUDIO_EVENT_ROUTE_CHANGED;
+    e.reason = PULP_IOS_ROUTE_CHANGE_CATEGORY_CHANGE;
+    pulp_ios_audio_session_emit(&e);
+    REQUIRE(cpp_calls == 1);
+    REQUIRE(c_calls == 0);
+
+    set_ios_audio_session_listener({});
+    pulp_ios_audio_session_emit(&e);
+    REQUIRE(c_calls == 1);
+
+    pulp_ios_audio_session_set_callback(nullptr, nullptr);
+}
+
+TEST_CASE("audio session listener replacement detaches the previous sink",
+          "[ios][audio-session][coverage][issue-648]") {
+    int first_calls = 0;
+    int second_calls = 0;
+    set_ios_audio_session_listener(
+        [&](const PulpIosAudioSessionEvent&) { ++first_calls; });
+    set_ios_audio_session_listener(
+        [&](const PulpIosAudioSessionEvent&) { ++second_calls; });
+
+    PulpIosAudioSessionEvent e{};
+    e.event = PULP_IOS_AUDIO_EVENT_INTERRUPTION_ENDED;
+    REQUIRE(emit_ios_audio_session_event(e));
+    REQUIRE(first_calls == 0);
+    REQUIRE(second_calls == 1);
+
+    set_ios_audio_session_listener({});
+    REQUIRE_FALSE(emit_ios_audio_session_event(e));
+}
+
 TEST_CASE("to_string covers every event code",
           "[ios][audio-session]") {
     REQUIRE(to_string(PULP_IOS_AUDIO_EVENT_NONE) == "none");

--- a/test/test_ipc.cpp
+++ b/test/test_ipc.cpp
@@ -41,6 +41,11 @@ struct CapturingServer : InterprocessConnectionServer {
             last_text.assign(message);
             cv.notify_all();
         };
+        conn->on_disconnected = [this] {
+            std::lock_guard<std::mutex> lock(mutex);
+            ++disconnects;
+            cv.notify_all();
+        };
 
         std::lock_guard<std::mutex> lock(mutex);
         accepted = std::move(conn);
@@ -52,6 +57,7 @@ struct CapturingServer : InterprocessConnectionServer {
     std::unique_ptr<InterprocessConnection> accepted;
     int binary_messages = 0;
     int text_messages = 0;
+    int disconnects = 0;
     size_t last_binary_size = 1;
     std::string last_text = "unset";
 };
@@ -333,6 +339,35 @@ TEST_CASE("IPC socket server receives binary payload frames",
     }
 
     client.disconnect();
+    if (server.accepted) server.accepted->disconnect();
+    server.stop();
+    REQUIRE_FALSE(server.is_running());
+}
+
+TEST_CASE("IPC socket server observes client disconnect",
+          "[events][ipc][socket][codecov]") {
+    CapturingServer server;
+    auto port = start_socket_server_on_loopback(server);
+    REQUIRE(port.has_value());
+
+    InterprocessConnection client;
+    REQUIRE(client.connect("127.0.0.1:" + std::to_string(*port), IpcTransport::Socket));
+
+    {
+        std::unique_lock<std::mutex> lock(server.mutex);
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return server.accepted != nullptr;
+        }));
+    }
+
+    client.disconnect();
+    {
+        std::unique_lock<std::mutex> lock(server.mutex);
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return server.disconnects == 1;
+        }));
+    }
+
     if (server.accepted) server.accepted->disconnect();
     server.stop();
     REQUIRE_FALSE(server.is_running());

--- a/test/test_ipc.cpp
+++ b/test/test_ipc.cpp
@@ -303,3 +303,37 @@ TEST_CASE("IPC socket server virtual callback accepts empty frames",
     server.stop();
     REQUIRE_FALSE(server.is_running());
 }
+
+TEST_CASE("IPC socket server receives binary payload frames",
+          "[events][ipc][socket][codecov]") {
+    CapturingServer server;
+    auto port = start_socket_server_on_loopback(server);
+    REQUIRE(port.has_value());
+
+    InterprocessConnection client;
+    REQUIRE(client.connect("127.0.0.1:" + std::to_string(*port), IpcTransport::Socket));
+
+    {
+        std::unique_lock<std::mutex> lock(server.mutex);
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return server.accepted != nullptr;
+        }));
+    }
+
+    const std::vector<uint8_t> payload{0x00, 0x01, 0x7f, 0xff};
+    REQUIRE(client.send_message(payload.data(), payload.size()));
+
+    {
+        std::unique_lock<std::mutex> lock(server.mutex);
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return server.binary_messages == 1 && server.text_messages == 1;
+        }));
+        REQUIRE(server.last_binary_size == payload.size());
+        REQUIRE(server.last_text.size() == payload.size());
+    }
+
+    client.disconnect();
+    if (server.accepted) server.accepted->disconnect();
+    server.stop();
+    REQUIRE_FALSE(server.is_running());
+}

--- a/test/test_ipc.cpp
+++ b/test/test_ipc.cpp
@@ -372,3 +372,32 @@ TEST_CASE("IPC socket server observes client disconnect",
     server.stop();
     REQUIRE_FALSE(server.is_running());
 }
+
+TEST_CASE("IPC socket client reports disconnect callback once",
+          "[events][ipc][socket][codecov]") {
+    CapturingServer server;
+    auto port = start_socket_server_on_loopback(server);
+    REQUIRE(port.has_value());
+
+    int disconnected = 0;
+    InterprocessConnection client;
+    client.on_disconnected = [&] { ++disconnected; };
+    REQUIRE(client.connect("127.0.0.1:" + std::to_string(*port), IpcTransport::Socket));
+
+    {
+        std::unique_lock<std::mutex> lock(server.mutex);
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return server.accepted != nullptr;
+        }));
+    }
+
+    client.disconnect();
+    client.disconnect();
+    REQUIRE(disconnected == 1);
+    REQUIRE_FALSE(client.is_connected());
+    REQUIRE(client.state() == IpcState::Disconnected);
+
+    if (server.accepted) server.accepted->disconnect();
+    server.stop();
+    REQUIRE_FALSE(server.is_running());
+}

--- a/test/test_ipc_endpoints.cpp
+++ b/test/test_ipc_endpoints.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/events/interprocess_connection.hpp>
 
+#include <string_view>
+#include <vector>
+
 using namespace pulp::events;
 
 TEST_CASE("IPC socket endpoints reject empty ports without opening connections",
@@ -31,4 +34,92 @@ TEST_CASE("IPC socket listener rejects empty endpoint strings",
 
     server.stop();
     REQUIRE_FALSE(server.is_running());
+}
+
+TEST_CASE("IPC socket client rejects malformed port strings without connecting",
+          "[events][ipc][endpoint][issue-642]") {
+    const std::vector<std::string_view> endpoints = {
+        "127.0.0.1:not-a-port",
+        "127.0.0.1:12x",
+        "127.0.0.1:+12",
+        "127.0.0.1:-1",
+        "127.0.0.1: 12",
+        "127.0.0.1:12 ",
+        "127.0.0.1:65536",
+        "127.0.0.1:999999999999",
+    };
+
+    for (auto endpoint : endpoints) {
+        InterprocessConnection client;
+        REQUIRE_FALSE(client.connect(endpoint, IpcTransport::Socket));
+        REQUIRE(client.state() == IpcState::Error);
+        REQUIRE_FALSE(client.is_connected());
+    }
+}
+
+TEST_CASE("IPC socket connection-server rejects malformed port strings",
+          "[events][ipc][endpoint][issue-642]") {
+    const std::vector<std::string_view> endpoints = {
+        "127.0.0.1:not-a-port",
+        "127.0.0.1:12x",
+        "127.0.0.1:+12",
+        "127.0.0.1:-1",
+        "127.0.0.1: 12",
+        "127.0.0.1:12 ",
+        "127.0.0.1:65536",
+        "127.0.0.1:999999999999",
+    };
+
+    for (auto endpoint : endpoints) {
+        InterprocessConnection connection;
+        REQUIRE_FALSE(connection.create_server(endpoint, IpcTransport::Socket));
+        REQUIRE(connection.state() == IpcState::Error);
+        REQUIRE_FALSE(connection.is_connected());
+    }
+}
+
+TEST_CASE("IPC socket listener rejects malformed port strings without staying running",
+          "[events][ipc][endpoint][issue-642]") {
+    const std::vector<std::string_view> endpoints = {
+        "not-a-port",
+        "12x",
+        "+12",
+        "-1",
+        " 12",
+        "12 ",
+        "127.0.0.1:not-a-port",
+        "127.0.0.1:12x",
+        "127.0.0.1:+12",
+        "127.0.0.1:-1",
+        "127.0.0.1: 12",
+        "127.0.0.1:12 ",
+        "127.0.0.1:65536",
+        "127.0.0.1:999999999999",
+    };
+
+    for (auto endpoint : endpoints) {
+        InterprocessConnectionServer server;
+        REQUIRE_FALSE(server.start(endpoint, IpcTransport::Socket));
+        REQUIRE_FALSE(server.is_running());
+        server.stop();
+        REQUIRE_FALSE(server.is_running());
+    }
+}
+
+TEST_CASE("IPC socket endpoint failure can be reset with disconnect",
+          "[events][ipc][endpoint][issue-642]") {
+    InterprocessConnection connection;
+
+    REQUIRE_FALSE(connection.connect("127.0.0.1:bad", IpcTransport::Socket));
+    REQUIRE(connection.state() == IpcState::Error);
+
+    connection.disconnect();
+    REQUIRE(connection.state() == IpcState::Disconnected);
+    REQUIRE_FALSE(connection.is_connected());
+
+    REQUIRE_FALSE(connection.create_server("127.0.0.1:bad", IpcTransport::Socket));
+    REQUIRE(connection.state() == IpcState::Error);
+
+    connection.disconnect();
+    REQUIRE(connection.state() == IpcState::Disconnected);
 }

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -291,3 +291,81 @@ TEST_CASE("JsonRpcPeer reports closed and failed sends", "[json_rpc]") {
     channel.deliver_text(R"json({"jsonrpc":"2.0","id":1,"result":true})json");
     REQUIRE_FALSE(callback_called);
 }
+
+TEST_CASE("JsonRpcPeer omits params for empty request payloads",
+          "[json_rpc][coverage][issue-641]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string outbound_request;
+    pair.second->on_message([&](const Message& message) {
+        outbound_request.assign(message.as_text());
+    });
+
+    JsonRpcPeer client(*pair.first);
+    std::atomic<int> callbacks{0};
+    std::string result;
+    REQUIRE(client.send_request("noParams", "", [&](const JsonRpcResult& response) {
+        result = response.result_json;
+        callbacks.fetch_add(1);
+    }));
+
+    REQUIRE(outbound_request.find(R"("method":"noParams")") != std::string::npos);
+    REQUIRE(outbound_request.find(R"("params")") == std::string::npos);
+
+    pair.second->send_text(R"json({"jsonrpc":"2.0","id":1,"result":{"ok":true}})json");
+    REQUIRE(wait_until([&] { return callbacks.load() == 1; }));
+    REQUIRE(result.find(R"("ok")") != std::string::npos);
+    REQUIRE(result.find("true") != std::string::npos);
+}
+
+TEST_CASE("JsonRpcPeer preserves string request ids in responses",
+          "[json_rpc][coverage][issue-641]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string reply;
+    pair.first->on_message([&](const Message& message) {
+        reply.assign(message.as_text());
+    });
+
+    JsonRpcPeer server(*pair.second);
+    server.register_method("echo", [](std::string_view params) {
+        return JsonRpcResult::ok(std::string(params));
+    });
+
+    pair.first->send_text(
+        R"json({"jsonrpc":"2.0","id":"abc-123","method":"echo","params":{"value":7}})json");
+
+    REQUIRE(reply.find(R"("id":"abc-123")") != std::string::npos);
+    REQUIRE(reply.find(R"("value")") != std::string::npos);
+    REQUIRE(reply.find("7") != std::string::npos);
+}
+
+TEST_CASE("JsonRpcPeer dispatches incoming error responses with data",
+          "[json_rpc][coverage][issue-641]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string outbound_request;
+    pair.second->on_message([&](const Message& message) {
+        outbound_request.assign(message.as_text());
+    });
+
+    JsonRpcPeer client(*pair.first);
+    std::atomic<bool> done{false};
+    std::optional<JsonRpcError> error;
+
+    REQUIRE(client.send_request("willFail", "[]", [&](const JsonRpcResult& response) {
+        error = response.error;
+        done.store(true);
+    }));
+    REQUIRE(outbound_request.find(R"("id":1)") != std::string::npos);
+
+    pair.second->send_text(
+        R"json({"jsonrpc":"2.0","id":1,"error":{"code":-32099,"message":"custom","data":{"retry":false}}})json");
+
+    REQUIRE(wait_until([&] { return done.load(); }));
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == -32099);
+    REQUIRE(error->message == "custom");
+    REQUIRE(error->data_json.find(R"("retry")") != std::string::npos);
+    REQUIRE(error->data_json.find("false") != std::string::npos);
+}

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -198,6 +198,30 @@ TEST_CASE("JsonRpcPeer unregisters methods and notifications", "[json_rpc]") {
     REQUIRE(notifications.load() == 1);
 }
 
+TEST_CASE("JsonRpcPeer preserves string request ids and omits missing params",
+          "[json_rpc][coverage][phase3]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string reply;
+    pair.first->on_message([&](const Message& message) {
+        reply.assign(message.as_text());
+    });
+
+    JsonRpcPeer server(*pair.second);
+    std::string captured_params = "unset";
+    server.register_method("no_params", [&](std::string_view params) {
+        captured_params = std::string(params);
+        return JsonRpcResult::ok(R"({"accepted":true})");
+    });
+
+    REQUIRE(pair.first->send_text(
+        R"json({"jsonrpc":"2.0","id":"abc-123","method":"no_params"})json"));
+
+    REQUIRE(reply.find(R"("id":"abc-123")") != std::string::npos);
+    REQUIRE(reply.find(R"("accepted":true)") != std::string::npos);
+    REQUIRE(captured_params.empty());
+}
+
 TEST_CASE("JsonRpcPeer serializes handler errors and exceptions", "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);
@@ -288,6 +312,7 @@ TEST_CASE("JsonRpcPeer reports closed and failed sends", "[json_rpc]") {
     REQUIRE_FALSE(failing_peer.send_request("failed", "[]", [&](const JsonRpcResult&) {
         callback_called = true;
     }));
+    REQUIRE_FALSE(failing_peer.notify("failed_notify", "[]"));
     channel.deliver_text(R"json({"jsonrpc":"2.0","id":1,"result":true})json");
     REQUIRE_FALSE(callback_called);
 }

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -144,9 +144,9 @@ TEST_CASE("LicenseValidator validate_and_parse includes optional machine and exp
           "[crypto][license][coverage][issue-656]") {
     LicenseValidator validator;
 
-    std::string payload = "{"product_id":"PulpSuite","email":"user@example.com","
-                          ""machine_id":"machine-1","edition":"team","
-                          ""issued":1700000000,"expiry":1800000000}";
+    std::string payload = "{\"product_id\":\"PulpSuite\",\"email\":\"user@example.com\","
+                          "\"machine_id\":\"machine-1\",\"edition\":\"team\","
+                          "\"issued\":1700000000,\"expiry\":1800000000}";
     auto info = validator.validate_and_parse(base64_encode(payload) + ".sig");
     REQUIRE(info.has_value());
     REQUIRE(info->product_id == "PulpSuite");

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -5,6 +5,7 @@
 #include <pulp/runtime/temporary_file.hpp>
 
 #include <fstream>
+#include <utility>
 
 using namespace pulp::runtime;
 
@@ -75,6 +76,20 @@ TEST_CASE("BigInteger large numbers", "[crypto][bigint]") {
     auto b = BigInteger::from_string("1");
     auto c = a + b;
     REQUIRE(c.to_string() == "1000000000000000000");
+}
+
+TEST_CASE("BigInteger copy and move assignment preserve values",
+          "[crypto][bigint][coverage][phase3]") {
+    auto original = BigInteger::from_hex("2A");
+    BigInteger copied;
+    copied = original;
+    REQUIRE(copied == original);
+    REQUIRE(copied.to_string() == "42");
+
+    BigInteger moved;
+    moved = std::move(copied);
+    REQUIRE(moved.to_hex() == "2A");
+    REQUIRE_FALSE(moved.is_zero());
 }
 
 // ── License ─────────────────────────────────────────────────────────────

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -119,6 +119,25 @@ TEST_CASE("LicenseValidator validate_and_parse extracts info", "[crypto][license
     REQUIRE(info->edition == "pro");
 }
 
+TEST_CASE("LicenseValidator validate_and_parse extracts optional machine and expiry",
+          "[crypto][license][issue-641]") {
+    LicenseValidator validator;
+
+    std::string payload =
+        "{\"product_id\":\"PulpSynth\",\"email\":\"user@example.com\","
+        "\"machine_id\":\"machine-1\",\"edition\":\"studio\","
+        "\"issued\":1700000000,\"expiry\":1800000000}";
+    auto info = validator.validate_and_parse(base64_encode(payload) + ".sig");
+
+    REQUIRE(info.has_value());
+    REQUIRE(info->product_id == "PulpSynth");
+    REQUIRE(info->user_email == "user@example.com");
+    REQUIRE(info->machine_id == "machine-1");
+    REQUIRE(info->edition == "studio");
+    REQUIRE(info->issued_timestamp == 1700000000);
+    REQUIRE(info->expiry_timestamp == 1800000000);
+}
+
 TEST_CASE("LicenseValidator validate_and_parse rejects malformed payloads", "[crypto][license]") {
     LicenseValidator validator;
 
@@ -166,6 +185,28 @@ TEST_CASE("LicenseValidator validate_file trims line endings", "[crypto][license
 
     LicenseValidator validator;
     REQUIRE(validator.validate_file(tmp.path_string()) == LicenseStatus::InvalidSignature);
+}
+
+TEST_CASE("LicenseValidator validate_file accepts file without trailing newline",
+          "[crypto][license][issue-641]") {
+    TemporaryFile tmp(".license");
+    std::string payload = "{\"product_id\":\"PulpSynth\",\"issued\":1700000000}";
+    std::string key = base64_encode(payload) + "." + base64_encode("signature");
+
+    {
+        std::ofstream out(tmp.path());
+        REQUIRE(out.good());
+        out << key;
+    }
+
+    LicenseValidator validator;
+    REQUIRE(validator.validate_file(tmp.path_string()) == LicenseStatus::InvalidSignature);
+}
+
+TEST_CASE("LicenseValidator validate rejects empty payload section",
+          "[crypto][license][issue-641]") {
+    LicenseValidator validator;
+    REQUIRE(validator.validate(".sig") == LicenseStatus::InvalidSignature);
 }
 
 TEST_CASE("LicenseGenerator requires a usable private key", "[crypto][license]") {

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -77,6 +77,27 @@ TEST_CASE("BigInteger large numbers", "[crypto][bigint]") {
     REQUIRE(c.to_string() == "1000000000000000000");
 }
 
+TEST_CASE("BigInteger copy move hex and bit-count helpers", "[crypto][bigint][coverage][issue-656]") {
+    auto value = BigInteger::from_hex("0100");
+    REQUIRE(value.to_string() == "256");
+    REQUIRE(value.to_hex() == "0100");
+    REQUIRE(value.bit_count() == 9);
+
+    BigInteger copied(value);
+    REQUIRE(copied == value);
+
+    BigInteger assigned;
+    assigned = copied;
+    REQUIRE(assigned == value);
+
+    BigInteger moved(std::move(assigned));
+    REQUIRE(moved == value);
+
+    BigInteger move_assigned;
+    move_assigned = std::move(moved);
+    REQUIRE(move_assigned.to_string() == "256");
+}
+
 // ── License ─────────────────────────────────────────────────────────────
 
 TEST_CASE("LicenseValidator invalid format", "[crypto][license]") {
@@ -117,6 +138,23 @@ TEST_CASE("LicenseValidator validate_and_parse extracts info", "[crypto][license
     REQUIRE(info->product_id == "PulpGain");
     REQUIRE(info->user_email == "user@example.com");
     REQUIRE(info->edition == "pro");
+}
+
+TEST_CASE("LicenseValidator validate_and_parse includes optional machine and expiry fields",
+          "[crypto][license][coverage][issue-656]") {
+    LicenseValidator validator;
+
+    std::string payload = "{\"product_id\":\"PulpSuite\",\"email\":\"user@example.com\","
+                          "\"machine_id\":\"machine-1\",\"edition\":\"team\","
+                          "\"issued\":1700000000,\"expiry\":1800000000}";
+    auto info = validator.validate_and_parse(base64_encode(payload) + ".sig");
+    REQUIRE(info.has_value());
+    REQUIRE(info->product_id == "PulpSuite");
+    REQUIRE(info->user_email == "user@example.com");
+    REQUIRE(info->machine_id == "machine-1");
+    REQUIRE(info->edition == "team");
+    REQUIRE(info->issued_timestamp == 1700000000);
+    REQUIRE(info->expiry_timestamp == 1800000000);
 }
 
 TEST_CASE("LicenseValidator validate_and_parse rejects malformed payloads", "[crypto][license]") {
@@ -179,4 +217,10 @@ TEST_CASE("LicenseGenerator requires a usable private key", "[crypto][license]")
 
     generator.set_private_key("not a pem key");
     REQUIRE_FALSE(generator.generate(info).has_value());
+}
+
+TEST_CASE("OnlineActivation rejects malformed server URLs without network", "[crypto][license][coverage][issue-656]") {
+    REQUIRE_FALSE(OnlineActivation::activate("not-a-url", "serial", "product").has_value());
+    REQUIRE_FALSE(OnlineActivation::deactivate("not-a-url", "license"));
+    REQUIRE(OnlineActivation::check_status("not-a-url", "license") == LicenseStatus::NotFound);
 }

--- a/test/test_memory_message_channel.cpp
+++ b/test/test_memory_message_channel.cpp
@@ -68,6 +68,64 @@ TEST_CASE("MemoryMessageChannel send succeeds without peer callback",
     REQUIRE(left->send_text("nobody-listens"));
 }
 
+TEST_CASE("MemoryMessageChannel delivers zero-length binary and text payloads",
+          "[runtime][message_channel][coverage][issue-641]") {
+    auto [left, right] = MemoryMessageChannel::make_pair();
+
+    std::vector<Message> received;
+    right->on_message([&](const Message& message) {
+        received.push_back(message);
+    });
+
+    std::uint8_t empty = 0;
+    REQUIRE(left->send(&empty, 0));
+    REQUIRE(left->send_text(""));
+
+    REQUIRE(received.size() == 2);
+    REQUIRE(received[0].kind == MessageKind::Binary);
+    REQUIRE(received[0].payload.empty());
+    REQUIRE(received[1].kind == MessageKind::Text);
+    REQUIRE(received[1].payload.empty());
+    REQUIRE(received[1].as_text().empty());
+}
+
+TEST_CASE("MemoryMessageChannel can clear callbacks while remaining open",
+          "[runtime][message_channel][coverage][issue-641]") {
+    auto [left, right] = MemoryMessageChannel::make_pair();
+
+    int calls = 0;
+    right->on_message([&](const Message&) { ++calls; });
+    REQUIRE(left->send_text("before-clear"));
+    REQUIRE(calls == 1);
+
+    right->on_message({});
+    REQUIRE(left->send_text("after-clear"));
+    REQUIRE(calls == 1);
+    REQUIRE(left->is_open());
+    REQUIRE(right->is_open());
+}
+
+TEST_CASE("MemoryMessageChannel text views preserve embedded NUL bytes",
+          "[runtime][message_channel][coverage][issue-641]") {
+    auto [left, right] = MemoryMessageChannel::make_pair();
+
+    std::string text = "prefix";
+    text.push_back('\0');
+    text += "suffix";
+
+    std::string_view view;
+    Message received;
+    right->on_message([&](const Message& message) {
+        received = message;
+        view = received.as_text();
+    });
+
+    REQUIRE(left->send_text(text));
+    REQUIRE(received.kind == MessageKind::Text);
+    REQUIRE(view.size() == text.size());
+    REQUIRE(std::string(view) == text);
+}
+
 TEST_CASE("MemoryMessageChannel close is peer-wide and idempotent",
           "[runtime][message_channel]") {
     auto [left, right] = MemoryMessageChannel::make_pair();

--- a/test/test_memory_message_channel.cpp
+++ b/test/test_memory_message_channel.cpp
@@ -59,6 +59,20 @@ TEST_CASE("MemoryMessageChannel replaces message callbacks",
     REQUIRE(second_count == 1);
 }
 
+TEST_CASE("MemoryMessageChannel clears message callbacks",
+          "[runtime][message_channel][coverage][phase3]") {
+    auto [left, right] = MemoryMessageChannel::make_pair();
+
+    int deliveries = 0;
+    right->on_message([&](const Message&) { ++deliveries; });
+    REQUIRE(left->send_text("delivered"));
+    REQUIRE(deliveries == 1);
+
+    right->on_message({});
+    REQUIRE(left->send_text("ignored"));
+    REQUIRE(deliveries == 1);
+}
+
 TEST_CASE("MemoryMessageChannel send succeeds without peer callback",
           "[runtime][message_channel]") {
     auto [left, right] = MemoryMessageChannel::make_pair();

--- a/test/test_midi_buffer_ump.cpp
+++ b/test/test_midi_buffer_ump.cpp
@@ -41,3 +41,26 @@ TEST_CASE("plugin-side consumer can iterate UMP packets via the sidecar",
     REQUIRE(buf.ump()->size() == 2);     // UMP sidecar visible
     REQUIRE((*buf.ump())[0].packet.message_type() == UmpMessageType::Midi2ChannelVoice);
 }
+
+TEST_CASE("attached UMP sidecar remains externally owned across MidiBuffer edits",
+          "[midi][buffer][ump][issue-645]") {
+    MidiBuffer buf;
+    UmpBuffer first;
+    UmpBuffer second;
+    first.add(UmpPacket::note_on_2(0, 1, 60, 0x8000), 32);
+    second.add(UmpPacket::note_on_2(0, 2, 67, 0x4000), 64);
+
+    buf.attach_ump(&first);
+    buf.add(MidiEvent::note_on(0, 60, 100));
+    REQUIRE(buf.ump() == &first);
+    REQUIRE(buf.ump()->size() == 1);
+
+    buf.clear();
+    REQUIRE(buf.empty());
+    REQUIRE(buf.ump() == &first);
+    REQUIRE(buf.ump()->size() == 1);
+
+    buf.attach_ump(&second);
+    REQUIRE(buf.ump() == &second);
+    REQUIRE((*buf.ump())[0].packet.channel() == 2);
+}

--- a/test/test_midi_ci.cpp
+++ b/test/test_midi_ci.cpp
@@ -21,6 +21,13 @@ uint32_t read_muid_at(const std::vector<uint8_t>& msg, std::size_t offset) {
         | (static_cast<uint32_t>(msg[offset + 3]) << 21);
 }
 
+uint32_t read_uint7_at(const std::vector<uint8_t>& msg, std::size_t offset, std::size_t bytes) {
+    uint32_t value = 0;
+    for (std::size_t i = 0; i < bytes; ++i)
+        value |= static_cast<uint32_t>(msg[offset + i]) << (7 * i);
+    return value;
+}
+
 std::vector<uint8_t> make_ci_header(CiMessageType type, MUID source, MUID destination) {
     std::vector<uint8_t> msg{0xF0, 0x7E, 0x7F, 0x0D,
                              static_cast<uint8_t>(type), 0x02};
@@ -56,6 +63,34 @@ TEST_CASE("CiDiscovery creates valid inquiry", "[midi][ci]") {
     REQUIRE(msg[4] == 0x70);       // Discovery inquiry
 }
 
+TEST_CASE("CiDiscovery discovery inquiry encodes local identity fields",
+          "[midi][ci][issue-645]") {
+    CiDiscovery ci;
+    CiDeviceInfo info;
+    info.muid = MUID{0x01234567};
+    info.manufacturer_id = 0x00123456;
+    info.family_id = 0x2345;
+    info.model_id = 0x3456;
+    info.software_version = 0x01234567;
+    info.ci_version = 3;
+    info.max_sysex_size = 96;
+    ci.set_device_info(info);
+
+    auto msg = ci.create_discovery_inquiry();
+
+    REQUIRE(msg.size() == 31);
+    REQUIRE(msg[4] == static_cast<uint8_t>(CiMessageType::DiscoveryInquiry));
+    REQUIRE(msg[5] == 3);
+    REQUIRE(read_muid_at(msg, 6) == info.muid.value);
+    REQUIRE(read_muid_at(msg, 10) == MUID::broadcast().value);
+    REQUIRE(read_uint7_at(msg, 14, 3) == info.manufacturer_id);
+    REQUIRE(read_uint7_at(msg, 17, 2) == info.family_id);
+    REQUIRE(read_uint7_at(msg, 19, 2) == info.model_id);
+    REQUIRE(read_uint7_at(msg, 21, 4) == info.software_version);
+    REQUIRE(msg[25] == 0x07);
+    REQUIRE(read_uint7_at(msg, 26, 4) == info.max_sysex_size);
+}
+
 TEST_CASE("CiDiscovery profile inquiry encodes destination",
           "[midi][ci][issue-645]") {
     CiDiscovery ci;
@@ -81,6 +116,39 @@ TEST_CASE("CiDiscovery responds to inquiry", "[midi][ci]") {
     REQUIRE_FALSE(reply.empty());
     REQUIRE(reply.front() == 0xF0);
     REQUIRE(reply[4] == 0x71);  // Discovery reply
+}
+
+TEST_CASE("CiDiscovery discovery reply addresses source and encodes responder identity",
+          "[midi][ci][issue-645]") {
+    CiDiscovery responder;
+    CiDeviceInfo info;
+    info.muid = MUID{0x0002468A};
+    info.manufacturer_id = 0x00010203;
+    info.family_id = 0x0203;
+    info.model_id = 0x0304;
+    info.software_version = 0x00040506;
+    info.ci_version = 4;
+    info.max_sysex_size = 120;
+    responder.set_device_info(info);
+
+    MUID peer{0x00013579};
+    auto inquiry = make_ci_header(CiMessageType::DiscoveryInquiry,
+                                  peer, MUID::broadcast());
+    inquiry.push_back(0xF7);
+
+    auto reply = responder.process_message(inquiry.data(), inquiry.size());
+
+    REQUIRE(reply.size() == 31);
+    REQUIRE(reply[4] == static_cast<uint8_t>(CiMessageType::DiscoveryReply));
+    REQUIRE(reply[5] == info.ci_version);
+    REQUIRE(read_muid_at(reply, 6) == info.muid.value);
+    REQUIRE(read_muid_at(reply, 10) == peer.value);
+    REQUIRE(read_uint7_at(reply, 14, 3) == info.manufacturer_id);
+    REQUIRE(read_uint7_at(reply, 17, 2) == info.family_id);
+    REQUIRE(read_uint7_at(reply, 19, 2) == info.model_id);
+    REQUIRE(read_uint7_at(reply, 21, 4) == info.software_version);
+    REQUIRE(read_uint7_at(reply, 26, 4) == info.max_sysex_size);
+    REQUIRE(reply.back() == 0xF7);
 }
 
 TEST_CASE("CiDiscovery ignores malformed and unhandled messages",
@@ -194,6 +262,21 @@ TEST_CASE("CiDiscovery property exchange", "[midi][ci]") {
     REQUIRE(*val == "PulpSynth");
 
     REQUIRE_FALSE(ci.get_property("nonexistent").has_value());
+}
+
+TEST_CASE("CiDiscovery properties accept empty and overwritten values",
+          "[midi][ci][issue-645]") {
+    CiDiscovery ci;
+
+    ci.set_property("", "");
+    REQUIRE(ci.get_property("").has_value());
+    REQUIRE(*ci.get_property("") == "");
+
+    ci.set_property("DeviceName", "First");
+    ci.set_property("DeviceName", "Second");
+    auto value = ci.get_property("DeviceName");
+    REQUIRE(value.has_value());
+    REQUIRE(*value == "Second");
 }
 
 TEST_CASE("CiDiscovery profile inquiry response", "[midi][ci]") {

--- a/test/test_midi_file.cpp
+++ b/test/test_midi_file.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -21,7 +22,9 @@ struct TempDir {
 
     TempDir() {
         const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
-        path = fs::temp_directory_path() / ("pulp-midi-file-test-" + std::to_string(stamp));
+        const auto entropy = std::random_device{}();
+        path = fs::temp_directory_path() / ("pulp-midi-file-test-"
+            + std::to_string(stamp) + "-" + std::to_string(entropy));
         fs::create_directories(path);
     }
 

--- a/test/test_modal.cpp
+++ b/test/test_modal.cpp
@@ -1,9 +1,21 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/view/modal.hpp>
 #include <pulp/canvas/canvas.hpp>
+#include <memory>
 
 using namespace pulp::view;
 using namespace pulp::canvas;
+
+namespace {
+
+MouseEvent mouse_down(float x, float y) {
+    MouseEvent event;
+    event.position = {x, y};
+    event.is_down = true;
+    return event;
+}
+
+} // namespace
 
 TEST_CASE("ModalOverlay dismiss on Escape", "[view][modal]") {
     ModalOverlay modal;
@@ -17,6 +29,21 @@ TEST_CASE("ModalOverlay dismiss on Escape", "[view][modal]") {
     REQUIRE(dismissed);
 }
 
+TEST_CASE("ModalOverlay ignores key releases and handles Escape without callback",
+          "[view][modal][coverage][issue-493]") {
+    ModalOverlay modal;
+
+    KeyEvent release;
+    release.key = KeyCode::escape;
+    release.is_down = false;
+    REQUIRE_FALSE(modal.on_key_event(release));
+
+    KeyEvent esc;
+    esc.key = KeyCode::escape;
+    esc.is_down = true;
+    REQUIRE(modal.on_key_event(esc));
+}
+
 TEST_CASE("ModalOverlay paints backdrop", "[view][modal]") {
     ModalOverlay modal;
     modal.set_bounds({0, 0, 800, 600});
@@ -24,6 +51,21 @@ TEST_CASE("ModalOverlay paints backdrop", "[view][modal]") {
 
     RecordingCanvas canvas;
     modal.paint(canvas);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rect) == 1);
+}
+
+TEST_CASE("ModalOverlay paint applies backdrop alpha to fill color",
+          "[view][modal][coverage][issue-493]") {
+    ModalOverlay modal;
+    modal.set_bounds({0, 0, 320, 200});
+    modal.backdrop_opacity = 0.25f;
+
+    RecordingCanvas canvas;
+    modal.paint(canvas);
+
+    REQUIRE(canvas.count(DrawCommand::Type::set_fill_color) == 1);
+    REQUIRE(canvas.commands().front().type == DrawCommand::Type::set_fill_color);
+    REQUIRE(canvas.commands().front().color.a8() == 63);
     REQUIRE(canvas.count(DrawCommand::Type::fill_rect) == 1);
 }
 
@@ -39,6 +81,34 @@ TEST_CASE("ModalOverlay dismiss_on_backdrop_click flag", "[view][modal]") {
 
     modal.dismiss_on_backdrop_click = false;
     REQUIRE_FALSE(modal.dismiss_on_backdrop_click);
+}
+
+TEST_CASE("ModalOverlay backdrop mouse dismissal respects hit target and flag",
+          "[view][modal][coverage][issue-493]") {
+    ModalOverlay modal;
+    modal.set_bounds({0, 0, 200, 120});
+
+    auto child = std::make_unique<View>();
+    child->set_bounds({20, 20, 80, 40});
+    modal.add_child(std::move(child));
+
+    int dismissed = 0;
+    modal.on_dismiss = [&] { ++dismissed; };
+
+    auto release = mouse_down(10.0f, 10.0f);
+    release.is_down = false;
+    modal.on_mouse_event(release);
+    REQUIRE(dismissed == 0);
+
+    modal.on_mouse_event(mouse_down(30.0f, 30.0f));
+    REQUIRE(dismissed == 0);
+
+    modal.on_mouse_event(mouse_down(150.0f, 100.0f));
+    REQUIRE(dismissed == 1);
+
+    modal.dismiss_on_backdrop_click = false;
+    modal.on_mouse_event(mouse_down(150.0f, 100.0f));
+    REQUIRE(dismissed == 1);
 }
 
 TEST_CASE("ModalOverlay non-Escape key not handled", "[view][modal]") {

--- a/test/test_modal.cpp
+++ b/test/test_modal.cpp
@@ -3,6 +3,8 @@
 #include <pulp/canvas/canvas.hpp>
 #include <memory>
 
+#include <memory>
+
 using namespace pulp::view;
 using namespace pulp::canvas;
 
@@ -121,4 +123,49 @@ TEST_CASE("ModalOverlay non-Escape key not handled", "[view][modal]") {
     enter.is_down = true;
     REQUIRE_FALSE(modal.on_key_event(enter));
     REQUIRE_FALSE(dismissed);
+}
+
+TEST_CASE("ModalOverlay backdrop click dismisses only outside children",
+          "[view][modal][coverage][issue-653]") {
+    ModalOverlay modal;
+    modal.set_bounds({0, 0, 200, 100});
+    auto child = std::make_unique<View>();
+    child->set_bounds({25, 20, 50, 40});
+    modal.add_child(std::move(child));
+
+    int dismiss_count = 0;
+    modal.on_dismiss = [&] { ++dismiss_count; };
+
+    MouseEvent child_click;
+    child_click.position = {30, 25};
+    child_click.is_down = true;
+    modal.on_mouse_event(child_click);
+    REQUIRE(dismiss_count == 0);
+
+    MouseEvent backdrop_click;
+    backdrop_click.position = {150, 80};
+    backdrop_click.is_down = true;
+    modal.on_mouse_event(backdrop_click);
+    REQUIRE(dismiss_count == 1);
+
+    modal.dismiss_on_backdrop_click = false;
+    modal.on_mouse_event(backdrop_click);
+    REQUIRE(dismiss_count == 1);
+}
+
+TEST_CASE("ModalOverlay ignores mouse-up and missing dismiss callback",
+          "[view][modal][coverage][issue-653]") {
+    ModalOverlay modal;
+    modal.set_bounds({0, 0, 80, 40});
+
+    MouseEvent up;
+    up.position = {10, 10};
+    up.is_down = false;
+    modal.on_mouse_event(up);
+
+    MouseEvent down;
+    down.position = {10, 10};
+    down.is_down = true;
+    modal.on_mouse_event(down);
+    SUCCEED("modal mouse paths tolerate missing callbacks");
 }

--- a/test/test_mpe_buffer.cpp
+++ b/test/test_mpe_buffer.cpp
@@ -3,6 +3,7 @@
 
 #include <pulp/format/processor.hpp>
 #include <pulp/midi/mpe_buffer.hpp>
+#include <vector>
 
 using namespace pulp::midi;
 using Kind = MpeExpressionEvent::Kind;
@@ -12,6 +13,16 @@ namespace {
 MidiEvent channel_pressure(uint8_t channel, uint8_t value) {
     return {choc::midi::ShortMessage(
         static_cast<uint8_t>(0xD0 | (channel & 0x0F)), value, 0), 0, 0.0};
+}
+
+UmpPacket channel_pressure_ump(uint8_t group, uint8_t channel, uint32_t value) {
+    UmpPacket p;
+    p.word_count = 2;
+    p.words[0] = (0x4u << 28)
+        | (static_cast<uint32_t>(group & 0x0F) << 24)
+        | (static_cast<uint32_t>(0xD0 | (channel & 0x0F)) << 16);
+    p.words[1] = value;
+    return p;
 }
 } // namespace
 
@@ -60,6 +71,176 @@ TEST_CASE("MpeBuffer clear and sort", "[midi][mpe]") {
 
     buffer.clear();
     REQUIRE(buffer.empty());
+}
+
+TEST_CASE("MpeBuffer groups equal sample offsets without dropping events",
+          "[midi][mpe][issue-645]") {
+    MpeBuffer buffer;
+    MpeNoteState first;
+    first.note = 60;
+    MpeNoteState second;
+    second.note = 64;
+    MpeNoteState third;
+    third.note = 67;
+
+    buffer.add({12, Kind::NoteOn, first});
+    buffer.add({12, Kind::Pressure, second});
+    buffer.add({20, Kind::Timbre, third});
+    buffer.sort();
+
+    REQUIRE(buffer.size() == 3);
+    REQUIRE(buffer[0].sample_offset == 12);
+    REQUIRE(buffer[1].sample_offset == 12);
+    REQUIRE(buffer[2].sample_offset == 20);
+    const bool saw_first_equal_offset = buffer[0].state.note == 60
+                                     || buffer[1].state.note == 60;
+    const bool saw_second_equal_offset = buffer[0].state.note == 64
+                                      || buffer[1].state.note == 64;
+    REQUIRE(saw_first_equal_offset);
+    REQUIRE(saw_second_equal_offset);
+    REQUIRE(buffer[2].state.note == 67);
+}
+
+TEST_CASE("MpeBuffer accepts moved expression events and supports const iteration",
+          "[midi][mpe][issue-645]") {
+    MpeBuffer buffer;
+    MpeExpressionEvent event;
+    event.sample_offset = 7;
+    event.kind = Kind::NoteOn;
+    event.state.channel = 3;
+    event.state.note = 72;
+    event.state.velocity = 100;
+
+    buffer.add(std::move(event));
+
+    const MpeBuffer& const_buffer = buffer;
+    int seen = 0;
+    for (const auto& e : const_buffer) {
+        REQUIRE(e.sample_offset == 7);
+        REQUIRE(e.kind == Kind::NoteOn);
+        REQUIRE(e.state.channel == 3);
+        REQUIRE(e.state.note == 72);
+        REQUIRE(e.state.velocity == 100);
+        ++seen;
+    }
+    REQUIRE(seen == 1);
+}
+
+TEST_CASE("MpeConfig identifies lower and upper zone member boundaries",
+          "[midi][mpe][issue-645]") {
+    auto cfg = MpeConfig::dual(3, 2);
+
+    REQUIRE(cfg.lower_zone.is_lower());
+    REQUIRE(cfg.upper_zone.is_upper());
+    REQUIRE(cfg.is_manager_channel(0));
+    REQUIRE(cfg.is_manager_channel(15));
+
+    REQUIRE(cfg.zone_for_channel(1) == &cfg.lower_zone);
+    REQUIRE(cfg.zone_for_channel(3) == &cfg.lower_zone);
+    REQUIRE(cfg.zone_for_channel(4) == nullptr);
+    REQUIRE(cfg.zone_for_channel(13) == &cfg.upper_zone);
+    REQUIRE(cfg.zone_for_channel(14) == &cfg.upper_zone);
+    REQUIRE(cfg.zone_for_channel(12) == nullptr);
+}
+
+TEST_CASE("MpeVoiceTracker seeds new notes from cached member expression",
+          "[midi][mpe][issue-645]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+
+    REQUIRE(tracker.process(MidiEvent::pitch_bend(2, 16383)));
+    REQUIRE(tracker.process(channel_pressure(2, 64)));
+    REQUIRE(tracker.process(MidiEvent::cc(2, 74, 100)));
+    REQUIRE(tracker.process(MidiEvent::note_on(2, 61, 90)));
+
+    const auto* note = tracker.find(2, 61);
+    REQUIRE(note != nullptr);
+    REQUIRE(note->pitch_bend_semitones == Approx(48.0f).margin(0.01f));
+    REQUIRE(note->pressure == Approx(64.0f / 127.0f).margin(1e-6f));
+    REQUIRE(note->timbre == Approx(100.0f / 127.0f).margin(1e-6f));
+}
+
+TEST_CASE("MpeVoiceTracker manager messages update zone state without notes",
+          "[midi][mpe][issue-645]") {
+    MpeVoiceTracker tracker{MpeConfig::dual(4, 3)};
+    tracker.set_manager_bend_range(2.0f);
+
+    REQUIRE(tracker.process(MidiEvent::pitch_bend(0, 16383)));
+    REQUIRE(tracker.process(channel_pressure(15, 127)));
+    REQUIRE(tracker.process(MidiEvent::cc(15, 74, 64)));
+
+    REQUIRE(tracker.active_count() == 0);
+    REQUIRE(tracker.lower_zone_state().pitch_bend_semitones == Approx(2.0f).margin(0.01f));
+    REQUIRE(tracker.upper_zone_state().pressure == Approx(1.0f).margin(1e-6f));
+    REQUIRE(tracker.upper_zone_state().timbre == Approx(64.0f / 127.0f).margin(1e-6f));
+}
+
+TEST_CASE("bind_tracker_to_buffer uses the latest referenced sample offset",
+          "[midi][mpe][issue-645]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    MpeBuffer buffer;
+    int32_t offset = 0;
+    bind_tracker_to_buffer(tracker, buffer, offset);
+
+    offset = 3;
+    REQUIRE(tracker.process(MidiEvent::note_on(1, 60, 100)));
+    offset = 99;
+    REQUIRE(tracker.process(MidiEvent::note_off(1, 60)));
+
+    REQUIRE(buffer.size() == 2);
+    REQUIRE(buffer[0].sample_offset == 3);
+    REQUIRE(buffer[0].kind == Kind::NoteOn);
+    REQUIRE(buffer[1].sample_offset == 99);
+    REQUIRE(buffer[1].kind == Kind::NoteOff);
+}
+
+TEST_CASE("MpeVoiceTracker UMP manager and member events feed callbacks",
+          "[midi][mpe][issue-645]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    MpeBuffer buffer;
+    int32_t offset = 0;
+    bind_tracker_to_buffer(tracker, buffer, offset);
+
+    offset = 5;
+    REQUIRE(tracker.process(UmpPacket::pitch_bend_2(0, 0, 0xFFFFFFFFu)));
+    REQUIRE(buffer.empty());
+    REQUIRE(tracker.lower_zone_state().pitch_bend_semitones > 1.9f);
+
+    offset = 10;
+    REQUIRE(tracker.process(UmpPacket::note_on_2(0, 3, 67, 0xFFFF)));
+    offset = 20;
+    REQUIRE(tracker.process(channel_pressure_ump(0, 3, 0xFFFFFFFFu)));
+    offset = 30;
+    REQUIRE(tracker.process(UmpPacket::registered_per_note_cc(0, 3, 67, 74,
+                                                              0xFFFFFFFFu)));
+
+    REQUIRE(buffer.size() == 3);
+    REQUIRE(buffer[0].kind == Kind::NoteOn);
+    REQUIRE(buffer[0].sample_offset == 10);
+    REQUIRE(buffer[0].state.velocity == 127);
+    REQUIRE(buffer[1].kind == Kind::Pressure);
+    REQUIRE(buffer[1].state.pressure == Approx(1.0f).margin(1e-6f));
+    REQUIRE(buffer[2].kind == Kind::Timbre);
+    REQUIRE(buffer[2].state.timbre == Approx(1.0f).margin(1e-6f));
+}
+
+TEST_CASE("MpeVoiceTracker reset and config changes clear active state",
+          "[midi][mpe][issue-645]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.process(MidiEvent::note_on(1, 60, 100));
+    tracker.process(MidiEvent::pitch_bend(1, 16383));
+    REQUIRE(tracker.active_count() == 1);
+    REQUIRE(tracker.member_bend_range() == Approx(48.0f));
+
+    tracker.set_member_bend_range(-1.0f);
+    tracker.set_manager_bend_range(0.0f);
+    REQUIRE(tracker.member_bend_range() == Approx(48.0f));
+    REQUIRE(tracker.manager_bend_range() == Approx(2.0f));
+
+    tracker.set_config(MpeConfig::dual(2, 2));
+    REQUIRE(tracker.active_count() == 0);
+    REQUIRE(tracker.find(1, 60) == nullptr);
+    REQUIRE(tracker.config().upper_zone.member_channels == 2);
+    REQUIRE(tracker.lower_zone_state().pitch_bend_semitones == Approx(0.0f));
 }
 
 TEST_CASE("Processor::supports_mpe defaults to false", "[midi][mpe]") {

--- a/test/test_msdf_atlas.cpp
+++ b/test/test_msdf_atlas.cpp
@@ -23,6 +23,26 @@ TEST_CASE("MsdfAtlas default state is empty", "[canvas][msdf][issue-641]") {
     REQUIRE(atlas.glyph(U'A') == nullptr);
 }
 
+TEST_CASE("MsdfAtlas move operations preserve channel mode and glyph lookup",
+          "[canvas][msdf][coverage][issue-650]") {
+    MsdfAtlas original;
+    REQUIRE(original.build("stub", {U'A', U'B'}, 18, 3, 128,
+                           /*include_alpha*/ true));
+    REQUIRE(original.channels() == 4);
+
+    MsdfAtlas moved(std::move(original));
+    REQUIRE(moved.channels() == 4);
+    REQUIRE(moved.glyph_count() == 2);
+    REQUIRE(moved.glyph(U'A') != nullptr);
+    REQUIRE(moved.pixels() != nullptr);
+
+    MsdfAtlas assigned;
+    assigned = std::move(moved);
+    REQUIRE(assigned.channels() == 4);
+    REQUIRE(assigned.glyph(U'B') != nullptr);
+    REQUIRE(assigned.glyph(U'Z') == nullptr);
+}
+
 TEST_CASE("MsdfAtlas packs the requested glyphs", "[canvas][msdf]") {
     MsdfAtlas atlas;
     std::vector<char32_t> chars = {U'A', U'B', U'C', U'D'};
@@ -52,6 +72,29 @@ TEST_CASE("MsdfAtlas empty build records base size and channel mode",
     REQUIRE(atlas.channels() == 4);
     REQUIRE(atlas.width() == 0);
     REQUIRE(atlas.height() == 0);
+}
+
+TEST_CASE("MsdfAtlas rebuild resets channels and overflow failure clears glyphs",
+          "[canvas][msdf][coverage][issue-650]") {
+    MsdfAtlas atlas;
+    REQUIRE(atlas.build("stub", {U'A'}, 20, 2, 128,
+                        /*include_alpha*/ true));
+    REQUIRE(atlas.channels() == 4);
+    REQUIRE(atlas.glyph_count() == 1);
+
+    REQUIRE(atlas.build("stub", {}, 12, 1, 128,
+                        /*include_alpha*/ false));
+    REQUIRE(atlas.channels() == 3);
+    REQUIRE(atlas.glyph_count() == 0);
+    REQUIRE(atlas.pixels() == nullptr);
+
+    std::vector<char32_t> many;
+    for (char32_t c = 0; c < 100; ++c) many.push_back(c);
+    REQUIRE_FALSE(atlas.build("stub", many, 128, 8, 256,
+                              /*include_alpha*/ true));
+    REQUIRE(atlas.glyph_count() == 0);
+    REQUIRE(atlas.channels() == 3);
+    REQUIRE(atlas.pixels() == nullptr);
 }
 
 TEST_CASE("MsdfAtlas packs glyphs into deterministic tile coordinates",

--- a/test/test_network_service_discovery.cpp
+++ b/test/test_network_service_discovery.cpp
@@ -102,6 +102,37 @@ TEST_CASE("NSD dispatches browse/register/unregister to installed backend",
     REQUIRE(log->stopped == 1);
 }
 
+TEST_CASE("NSD can browse again after stop",
+          "[events][service-discovery][codecov]") {
+    NetworkServiceDiscovery nsd;
+    auto backend = std::make_unique<FakeBackend>();
+    auto log = backend->log;
+    nsd.install_backend(std::move(backend));
+
+    nsd.browse("_pulp._tcp");
+    nsd.stop();
+    nsd.browse("_http._tcp");
+    nsd.stop();
+
+    REQUIRE(log->browse_types == std::vector<std::string>{"_pulp._tcp", "_http._tcp"});
+    REQUIRE(log->stopped == 2);
+}
+
+TEST_CASE("NSD unregister after backend removal is a no-op",
+          "[events][service-discovery][codecov]") {
+    NetworkServiceDiscovery nsd;
+    auto backend = std::make_unique<FakeBackend>();
+    auto log = backend->log;
+    nsd.install_backend(std::move(backend));
+
+    nsd.unregister_service();
+    REQUIRE(log->unregistered == 1);
+
+    nsd.install_backend(nullptr);
+    nsd.unregister_service();
+    REQUIRE(log->unregistered == 1);
+}
+
 TEST_CASE("NSD browse backend can publish through the dispatcher",
           "[events][service-discovery][issue-642]") {
     NetworkServiceDiscovery nsd;

--- a/test/test_network_service_discovery.cpp
+++ b/test/test_network_service_discovery.cpp
@@ -447,6 +447,25 @@ TEST_CASE("MountedVolumeListChangeDetector start and stop are idempotent",
     REQUIRE_FALSE(detector.is_running());
 }
 
+TEST_CASE("MountedVolumeListChangeDetector stop wakes a long poll promptly",
+          "[events][volume][lifecycle][codecov]") {
+#ifdef _WIN32
+    SUCCEED("Windows drive probing can throw on unavailable runner drives; covered on POSIX.");
+    return;
+#endif
+
+    MountedVolumeListChangeDetector detector;
+    detector.start(std::chrono::hours(1));
+    REQUIRE(detector.is_running());
+
+    const auto start = std::chrono::steady_clock::now();
+    detector.stop();
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    REQUIRE_FALSE(detector.is_running());
+    REQUIRE(elapsed < 500ms);
+}
+
 TEST_CASE("LockingAsyncUpdater trigger_and_wait handles synchronously",
           "[events][async_updater][locking]") {
     RecordingLockingUpdater updater;

--- a/test/test_network_service_discovery.cpp
+++ b/test/test_network_service_discovery.cpp
@@ -318,6 +318,96 @@ TEST_CASE("NSD removing backend stops old backend and evicts discoveries",
     REQUIRE_FALSE(nsd.register_service("svc", "_pulp._tcp", 1234));
 }
 
+TEST_CASE("NSD caches same-name services separately by type",
+          "[events][service-discovery][issue-642]") {
+    NetworkServiceDiscovery nsd;
+    nsd.install_backend(std::make_unique<FakeBackend>());
+
+    NetworkServiceDiscovery::Service http;
+    http.name = "pulpd";
+    http.type = "_http._tcp";
+    http.hostname = "http.local";
+    http.port = 80;
+
+    NetworkServiceDiscovery::Service pulp = http;
+    pulp.type = "_pulp._tcp";
+    pulp.hostname = "pulp.local";
+    pulp.port = 4321;
+
+    nsd.notify_service_found(http);
+    nsd.notify_service_found(pulp);
+    REQUIRE(nsd.discovered().size() == 2);
+
+    nsd.notify_service_lost(http);
+    REQUIRE(nsd.discovered().size() == 1);
+    REQUIRE(nsd.discovered().front().type == "_pulp._tcp");
+    REQUIRE(nsd.discovered().front().hostname == "pulp.local");
+}
+
+TEST_CASE("NSD install_backend nullptr without discoveries only stops old backend",
+          "[events][service-discovery][issue-642]") {
+    NetworkServiceDiscovery nsd;
+    auto backend = std::make_unique<FakeBackend>();
+    auto log = backend->log;
+    nsd.install_backend(std::move(backend));
+
+    int lost_count = 0;
+    nsd.on_service_lost = [&](const NetworkServiceDiscovery::Service&) {
+        ++lost_count;
+    };
+
+    nsd.install_backend(nullptr);
+    REQUIRE_FALSE(nsd.has_backend());
+    REQUIRE(nsd.discovered().empty());
+    REQUIRE(lost_count == 0);
+    REQUIRE(log->stopped == 1);
+    REQUIRE_FALSE(nsd.register_service("svc", "_pulp._tcp", 1234));
+}
+
+TEST_CASE("NSD stop forwards to backend even before browsing",
+          "[events][service-discovery][issue-642]") {
+    NetworkServiceDiscovery nsd;
+    auto backend = std::make_unique<FakeBackend>();
+    auto log = backend->log;
+    nsd.install_backend(std::move(backend));
+
+    nsd.stop();
+    nsd.stop();
+
+    REQUIRE(log->stopped == 2);
+    REQUIRE(nsd.has_backend());
+}
+
+TEST_CASE("NSD discovery stores entries when callbacks are absent",
+          "[events][service-discovery][issue-642]") {
+    NetworkServiceDiscovery nsd;
+    nsd.install_backend(std::make_unique<FakeBackend>());
+
+    NetworkServiceDiscovery::Service svc;
+    svc.name = "pulpd";
+    svc.type = "_pulp._tcp";
+    svc.hostname = "pulpd.local";
+    svc.address = "127.0.0.1";
+    svc.port = 4321;
+
+    nsd.notify_service_found(svc);
+    REQUIRE(nsd.discovered().size() == 1);
+
+    nsd.notify_service_lost(svc);
+    REQUIRE(nsd.discovered().empty());
+}
+
+TEST_CASE("LockingAsyncUpdater trigger_and_wait handles every call synchronously",
+          "[events][service-discovery][locking-updater][issue-642]") {
+    RecordingLockingUpdater updater;
+
+    updater.trigger_and_wait();
+    updater.trigger_and_wait();
+    updater.trigger_and_wait();
+
+    REQUIRE(updater.handles.load() == 3);
+}
+
 TEST_CASE("NSD backend swap clears discoveries without lost callback",
           "[events][service-discovery][issue-642]") {
     NetworkServiceDiscovery nsd;

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -270,3 +270,29 @@ TEST_CASE("HttpStream status_code is 0 before fetch",
     HttpStream stream;
     REQUIRE(stream.status_code() == 0);
 }
+
+TEST_CASE("HttpStream default state supports zero reads and idempotent close",
+          "[network_stream][http][coverage][phase3]") {
+    HttpStream stream;
+    REQUIRE_FALSE(stream.is_open());
+    REQUIRE(stream.eof());
+    REQUIRE(stream.transport_error().empty());
+    REQUIRE(stream.headers().empty());
+
+    std::uint8_t byte = 0x7f;
+    auto zero_read = stream.read(&byte, 0);
+    REQUIRE(zero_read.ok());
+    REQUIRE(zero_read.bytes == 0);
+    REQUIRE(byte == 0x7f);
+
+    auto eof_read = stream.read(&byte, 1);
+    REQUIRE_FALSE(eof_read.ok());
+    REQUIRE(eof_read.closed());
+
+    stream.close();
+    stream.close();
+    REQUIRE_FALSE(stream.is_open());
+    auto closed_read = stream.read(&byte, 1);
+    REQUIRE_FALSE(closed_read.ok());
+    REQUIRE(closed_read.closed());
+}

--- a/test/test_nsis_installer.cpp
+++ b/test/test_nsis_installer.cpp
@@ -193,3 +193,69 @@ TEST_CASE("NSIS script maps standalone and unknown formats to INSTDIR", "[ship][
     REQUIRE_THAT(script, ContainsSubstring("RMDir /r \"$INSTDIR\\TestPlugin.exe\""));
     REQUIRE_THAT(script, ContainsSubstring("RMDir /r \"$INSTDIR\\TestPlugin.lv2\""));
 }
+
+TEST_CASE("NSIS script handles empty plugin list with only post and uninstall sections",
+          "[ship][installer][coverage][issue-644]") {
+    auto config = make_test_config();
+    config.plugins.clear();
+    auto script = generate_nsis_script(config);
+
+    REQUIRE_THAT(script, ContainsSubstring("Name \"TestPlugin\""));
+    REQUIRE_THAT(script, ContainsSubstring("Section \"Uninstall\""));
+    REQUIRE_THAT(script, ContainsSubstring("Section \"-Post\""));
+    REQUIRE(script.find("TestPlugin (VST3)") == std::string::npos);
+    REQUIRE(script.find("TestPlugin (CLAP)") == std::string::npos);
+}
+
+TEST_CASE("NSIS script honors configured output path and install root",
+          "[ship][installer][coverage][issue-644]") {
+    auto config = make_test_config();
+    config.output_path = "dist/TestPlugin Setup.exe";
+    config.publisher = "Acme Audio";
+    auto script = generate_nsis_script(config);
+
+    REQUIRE_THAT(script, ContainsSubstring("OutFile \"dist/TestPlugin Setup.exe\""));
+    REQUIRE_THAT(script, ContainsSubstring("InstallDir \"$PROGRAMFILES\\Acme Audio\\TestPlugin\""));
+    REQUIRE_THAT(script, ContainsSubstring("InstallDirRegKey HKLM \"Software\\Acme Audio\\TestPlugin\""));
+}
+
+TEST_CASE("NSIS script installs file plugins without recursive flag",
+          "[ship][installer][coverage][issue-644]") {
+    ScopedTempDir temp;
+    auto plugin = temp.path / "TestPlugin.clap";
+    std::ofstream(plugin) << "plugin";
+
+    auto config = make_test_config();
+    config.plugins = {{plugin.string(), "", "clap"}};
+    auto script = generate_nsis_script(config);
+
+    REQUIRE_THAT(script, ContainsSubstring("File \"" + plugin.string() + "\""));
+    REQUIRE(script.find("File /r \"" + plugin.string() + "\"") == std::string::npos);
+    REQUIRE_THAT(script, ContainsSubstring("RMDir /r \"$COMMONFILES\\CLAP\\TestPlugin.clap\""));
+}
+
+TEST_CASE("NSIS script uses per-user plugin common directories",
+          "[ship][installer][coverage][issue-644]") {
+    auto config = make_test_config();
+    config.per_user_install = true;
+    auto script = generate_nsis_script(config);
+
+    REQUIRE_THAT(script, ContainsSubstring("SetOutPath \"$LOCALAPPDATA\\Programs\\Common\\VST3\""));
+    REQUIRE_THAT(script, ContainsSubstring("SetOutPath \"$LOCALAPPDATA\\Programs\\Common\\CLAP\""));
+    REQUIRE_THAT(script, ContainsSubstring("RMDir /r \"$LOCALAPPDATA\\Programs\\Common\\VST3\\TestPlugin.vst3\""));
+    REQUIRE_THAT(script, ContainsSubstring("RMDir /r \"$LOCALAPPDATA\\Programs\\Common\\CLAP\\TestPlugin.clap\""));
+}
+
+TEST_CASE("NSIS script keeps install_dir field non-authoritative for format destinations",
+          "[ship][installer][coverage][issue-644]") {
+    auto config = make_test_config();
+    config.plugins = {
+        {"/tmp/custom/TestPlugin.vst3", "C:/Ignored/VST3", "vst3"},
+        {"/tmp/custom/TestPlugin.clap", "C:/Ignored/CLAP", "clap"},
+    };
+    auto script = generate_nsis_script(config);
+
+    REQUIRE_THAT(script, ContainsSubstring("SetOutPath \"$COMMONFILES\\VST3\""));
+    REQUIRE_THAT(script, ContainsSubstring("SetOutPath \"$COMMONFILES\\CLAP\""));
+    REQUIRE(script.find("C:/Ignored") == std::string::npos);
+}

--- a/test/test_osc.cpp
+++ b/test/test_osc.cpp
@@ -43,6 +43,18 @@ TEST_CASE("OSC Message get with defaults", "[osc][message]") {
     REQUIRE(msg.get_string(0, "nope") == "nope");
 }
 
+TEST_CASE("OSC Message typed defaults cover every wrong-type accessor", "[osc][message][issue-644]") {
+    Message msg("/defaults");
+    msg.add(std::string("label"));
+    msg.add(std::vector<uint8_t>{0x01, 0x02});
+    msg.add(1.5f);
+
+    REQUIRE(msg.get_int(0, -10) == -10);
+    REQUIRE(msg.get_float(1, -2.0f) == -2.0f);
+    REQUIRE(msg.get_string(2, "fallback") == "fallback");
+    REQUIRE(msg.get_string(99, "missing") == "missing");
+}
+
 // ── Encoding/Decoding ────────────────────────────────────────────────────────
 
 TEST_CASE("OSC encode/decode round-trip int+float", "[osc][codec]") {
@@ -418,4 +430,57 @@ TEST_CASE("OSC Sender::send without connect is rejected", "[osc][udp][sender]") 
     Message msg("/x");
     msg.add(1);
     REQUIRE_FALSE(tx.send(msg));
+}
+
+TEST_CASE("OSC decode preserves empty strings and padded string arguments", "[osc][codec][issue-644]") {
+    Message msg("/strings");
+    msg.add(std::string{});
+    msg.add(std::string{"abc"});
+    msg.add(std::string{"abcd"});
+
+    auto data = encode(msg);
+    REQUIRE(data.size() % 4 == 0);
+
+    auto decoded = decode(data.data(), data.size());
+    REQUIRE(decoded.address == "/strings");
+    REQUIRE(decoded.args.size() == 3);
+    REQUIRE(decoded.get_string(0, "fallback").empty());
+    REQUIRE(decoded.get_string(1) == "abc");
+    REQUIRE(decoded.get_string(2) == "abcd");
+}
+
+TEST_CASE("OSC decode of truncated string argument returns empty string", "[osc][codec][issue-644]") {
+    std::vector<uint8_t> buf;
+    const char addr[] = "/truncated";
+    buf.insert(buf.end(), addr, addr + sizeof(addr));
+    while (buf.size() % 4 != 0) buf.push_back(0);
+    const char tags[] = ",s";
+    buf.insert(buf.end(), tags, tags + sizeof(tags));
+    while (buf.size() % 4 != 0) buf.push_back(0);
+
+    auto decoded = decode(buf.data(), buf.size());
+    REQUIRE(decoded.address == "/truncated");
+    REQUIRE(decoded.args.size() == 1);
+    REQUIRE(decoded.get_string(0, "fallback").empty());
+}
+
+TEST_CASE("OSC decode tolerates extra trailing padding bytes", "[osc][codec][issue-644]") {
+    Message msg("/trail");
+    msg.add(123);
+    auto data = encode(msg);
+    data.insert(data.end(), {0, 0, 0, 0});
+
+    auto decoded = decode(data.data(), data.size());
+    REQUIRE(decoded.address == "/trail");
+    REQUIRE(decoded.args.size() == 1);
+    REQUIRE(decoded.get_int(0) == 123);
+}
+
+TEST_CASE("OSC Sender::send_raw without connect is rejected", "[osc][udp][sender][issue-644]") {
+    Sender tx;
+    uint8_t payload[] = {0, 1, 2, 3};
+    REQUIRE_FALSE(tx.is_connected());
+    REQUIRE_FALSE(tx.send_raw(payload, sizeof(payload)));
+    tx.disconnect();
+    REQUIRE_FALSE(tx.is_connected());
 }

--- a/test/test_osc_bundle.cpp
+++ b/test/test_osc_bundle.cpp
@@ -54,6 +54,13 @@ TEST_CASE("OSC TimeTag equality", "[osc][bundle]") {
     REQUIRE(a == b);
 }
 
+TEST_CASE("OSC TimeTag keeps fractional unix seconds near one-second boundary",
+          "[osc][bundle][issue-644]") {
+    auto tt = TimeTag::from_unix(12345.999);
+    REQUIRE_THAT(tt.to_unix(), WithinAbs(12345.999, 0.001));
+    REQUIRE_FALSE(tt == TimeTag::from_unix(12345.0));
+}
+
 // ── Bundle construction ─────────────────────────────────────────────────
 
 TEST_CASE("OSC Bundle add message", "[osc][bundle]") {
@@ -81,6 +88,15 @@ TEST_CASE("OSC Bundle add nested bundle", "[osc][bundle]") {
     REQUIRE(outer.elements.size() == 1);
     REQUIRE(outer.elements[0].is_bundle());
     REQUIRE(outer.elements[0].bundle().elements.size() == 1);
+}
+
+TEST_CASE("OSC default BundleElement is an empty message element",
+          "[osc][bundle][issue-644]") {
+    BundleElement elem;
+    REQUIRE(elem.is_message());
+    REQUIRE_FALSE(elem.is_bundle());
+    REQUIRE(elem.message().address.empty());
+    REQUIRE(elem.message().args.empty());
 }
 
 // ── Bundle serialization ────────────────────────────────────────────────
@@ -146,6 +162,13 @@ TEST_CASE("OSC address wildcard ?", "[osc][bundle]") {
     REQUIRE(address_matches("/foo/ba?", "/foo/bar"));
     REQUIRE(address_matches("/foo/ba?", "/foo/baz"));
     REQUIRE_FALSE(address_matches("/foo/ba?", "/foo/ba"));
+}
+
+TEST_CASE("OSC address wildcard question mark does not cross path separator",
+          "[osc][bundle][pattern][issue-644]") {
+    REQUIRE_FALSE(address_matches("/foo/?/bar", "/foo//bar"));
+    REQUIRE_FALSE(address_matches("/foo/?", "/foo//"));
+    REQUIRE(address_matches("/foo/?", "/foo/a"));
 }
 
 // ── TimeTag edges ──────────────────────────────────────────────────────
@@ -375,4 +398,17 @@ TEST_CASE("Malformed address patterns fail closed",
     REQUIRE_FALSE(address_matches("/note/[ab", "/note/a"));
     REQUIRE_FALSE(address_matches("/note/[!0-9", "/note/a"));
     REQUIRE_FALSE(address_matches("/{foo,bar/gain", "/foo/gain"));
+}
+
+TEST_CASE("Address pattern alternatives support first and later branches",
+          "[osc][bundle][pattern][issue-644]") {
+    REQUIRE(address_matches("/{foo,bar,baz}/gain", "/foo/gain"));
+    REQUIRE(address_matches("/{foo,bar,baz}/gain", "/baz/gain"));
+    REQUIRE_FALSE(address_matches("/{foo,bar,baz}/gain", "/ba/gain"));
+}
+
+TEST_CASE("Address pattern character class negated enumeration",
+          "[osc][bundle][pattern][issue-644]") {
+    REQUIRE(address_matches("/pad/[!abc]", "/pad/z"));
+    REQUIRE_FALSE(address_matches("/pad/[!abc]", "/pad/b"));
 }

--- a/test/test_param_attachment.cpp
+++ b/test/test_param_attachment.cpp
@@ -110,3 +110,88 @@ TEST_CASE("attach_knob on_change writes to store", "[view][attachment]") {
     if (knob->on_change) knob->on_change(0.5f);
     REQUIRE_THAT(store.get_normalized(1), WithinAbs(0.5, 0.01));
 }
+
+TEST_CASE("param attachments forward fader toggle and combo edits",
+          "[view][attachment][issue-493]") {
+    StateStore store;
+    setup_store(store);
+
+    auto [fader, fader_binding] = attach_fader(store, 2);
+    REQUIRE(fader->on_change);
+    fader->on_change(0.25f);
+    REQUIRE_THAT(store.get_value(2), WithinAbs(0.25, 0.001));
+
+    auto [toggle, toggle_binding] = attach_toggle(store, 4);
+    REQUIRE(toggle->on_toggle);
+    toggle->on_toggle(true);
+    REQUIRE_THAT(store.get_value(4), WithinAbs(1.0, 0.001));
+    toggle->on_toggle(false);
+    REQUIRE_THAT(store.get_value(4), WithinAbs(0.0, 0.001));
+
+    auto [combo, combo_binding] = attach_combo(store, 3, {"LP", "HP", "BP", "Notch"});
+    combo->set_selected(3);
+    REQUIRE(combo->selected() == 3);
+    REQUIRE(combo->selected_text() == "Notch");
+    REQUIRE_THAT(store.get_value(3), WithinAbs(3.0, 0.001));
+}
+
+TEST_CASE("param attachments tolerate missing parameter ids",
+          "[view][attachment][issue-493]") {
+    StateStore store;
+    setup_store(store);
+
+    auto [knob, knob_binding] = attach_knob(store, 999, 72.0f);
+    REQUIRE(knob != nullptr);
+    REQUIRE(knob->id().empty());
+    REQUIRE_THAT(knob->value(), WithinAbs(0.0, 0.001));
+    REQUIRE(knob->on_change);
+    knob->on_change(1.0f);
+    REQUIRE_THAT(knob_binding.get(), WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(knob->flex().preferred_width, WithinAbs(72.0, 0.001));
+
+    auto [fader, fader_binding] = attach_fader(store, 999);
+    REQUIRE(fader != nullptr);
+    REQUIRE(fader->id().empty());
+    REQUIRE(fader->on_change);
+    fader->on_change(0.5f);
+    REQUIRE_THAT(fader_binding.get(), WithinAbs(0.0, 0.001));
+
+    auto [toggle, toggle_binding] = attach_toggle(store, 999);
+    REQUIRE(toggle != nullptr);
+    REQUIRE_FALSE(toggle->is_on());
+    REQUIRE(toggle->on_toggle);
+    toggle->on_toggle(true);
+    REQUIRE_THAT(toggle_binding.get(), WithinAbs(0.0, 0.001));
+
+    auto [combo, combo_binding] = attach_combo(store, 999, {"A", "B"});
+    REQUIRE(combo != nullptr);
+    combo->set_selected(1);
+    REQUIRE(combo->selected() == 1);
+    REQUIRE_THAT(combo_binding.get(), WithinAbs(0.0, 0.001));
+}
+
+TEST_CASE("poll_bindings forwards external parameter changes",
+          "[view][attachment][issue-493]") {
+    StateStore store;
+    setup_store(store);
+    auto [knob, binding] = attach_knob(store, 1);
+
+    int callback_count = 0;
+    float last_value = 0.0f;
+    binding.on_change([&](float value) {
+        ++callback_count;
+        last_value = value;
+    });
+
+    std::vector<Binding> bindings;
+    bindings.push_back(std::move(binding));
+
+    poll_bindings(bindings);
+    callback_count = 0;
+
+    store.set_value(1, 5000.0f);
+    poll_bindings(bindings);
+
+    REQUIRE(callback_count == 1);
+    REQUIRE_THAT(last_value, WithinAbs(5000.0, 0.001));
+}

--- a/test/test_path_to_sdf.cpp
+++ b/test/test_path_to_sdf.cpp
@@ -76,3 +76,18 @@ TEST_CASE("path_to_sdf: mask threshold treats 127 outside and 128 inside",
     REQUIRE(sdf[0] == 0);
     REQUIRE(sdf[1] == 255);
 }
+
+TEST_CASE("path_to_sdf: one-pixel islands saturate in both directions",
+          "[canvas][sdf][path][coverage][issue-650]") {
+    std::uint8_t mask[9] = {
+        0, 0, 0,
+        0, 255, 0,
+        0, 0, 0,
+    };
+
+    auto sdf = path_to_sdf(mask, 3, 3, 1);
+    REQUIRE(sdf.size() == 9);
+    REQUIRE(sdf[4] == 255);
+    REQUIRE(sdf[0] == 0);
+    REQUIRE(sdf[1] == 0);
+}

--- a/test/test_permissions.cpp
+++ b/test/test_permissions.cpp
@@ -162,6 +162,35 @@ TEST_CASE("nested PermissionsOverride clear exposes backend then restores outer 
     REQUIRE(query(Permission::Microphone) == outer_state);
 }
 
+TEST_CASE("PermissionsOverride clear on missing entries is a no-op",
+          "[platform][permissions][override][coverage][issue-649]") {
+    const auto backend_microphone = query(Permission::Microphone);
+    const auto backend_camera = query(Permission::Camera);
+
+    PermissionsOverride guard;
+    guard.clear(Permission::Microphone);
+    REQUIRE(query(Permission::Microphone) == backend_microphone);
+
+    guard.set(Permission::Camera, state_different_from(backend_camera));
+    guard.clear(Permission::Microphone);
+    REQUIRE(query(Permission::Microphone) == backend_microphone);
+    REQUIRE(query(Permission::Camera) == state_different_from(backend_camera));
+}
+
+TEST_CASE("empty nested PermissionsOverride preserves outer entries",
+          "[platform][permissions][override][coverage][issue-649]") {
+    const auto backend_microphone = query(Permission::Microphone);
+    const auto outer_state = state_different_from(backend_microphone);
+
+    PermissionsOverride outer;
+    outer.set(Permission::Microphone, outer_state);
+    {
+        PermissionsOverride inner;
+        REQUIRE(query(Permission::Microphone) == outer_state);
+    }
+    REQUIRE(query(Permission::Microphone) == outer_state);
+}
+
 TEST_CASE("has_platform_backend reports truthfully for the current target",
           "[platform][permissions]") {
 #if defined(PULP_PERMISSIONS_HAS_BACKEND)

--- a/test/test_phase9_widgets.cpp
+++ b/test/test_phase9_widgets.cpp
@@ -9,8 +9,35 @@
 #include <pulp/view/property_list.hpp>
 #include <pulp/view/breadcrumb.hpp>
 
+#include <algorithm>
+#include <string_view>
+
 using namespace pulp::view;
+using pulp::canvas::DrawCommand;
+using pulp::canvas::RecordingCanvas;
 using Catch::Matchers::WithinAbs;
+
+namespace {
+
+bool has_text(const RecordingCanvas& canvas, std::string_view text) {
+    return std::any_of(canvas.commands().begin(),
+                       canvas.commands().end(),
+                       [&](const DrawCommand& command) {
+                           return command.type == DrawCommand::Type::fill_text &&
+                                  command.text == text;
+                       });
+}
+
+bool has_fill_color(const RecordingCanvas& canvas, Color color) {
+    return std::any_of(canvas.commands().begin(),
+                       canvas.commands().end(),
+                       [&](const DrawCommand& command) {
+                           return command.type == DrawCommand::Type::set_fill_color &&
+                                  command.color == color;
+                       });
+}
+
+} // namespace
 
 // ── EqCurveView ─────────────────────────────────────────────────────────────
 
@@ -195,6 +222,61 @@ TEST_CASE("MidiKeyboard interaction callback", "[view][midi_keyboard]") {
     REQUIRE(last_vel > 0);
 }
 
+TEST_CASE("MidiKeyboard vertical drag releases previous notes and misses",
+          "[view][midi_keyboard][issue-493]") {
+    MidiKeyboard kb;
+    kb.set_range(60, 64);
+    kb.set_orientation(MidiKeyboard::Orientation::vertical);
+    kb.set_bounds({0, 0, 80, 300});
+
+    std::vector<int> note_ons;
+    std::vector<int> note_offs;
+    kb.on_note_on = [&](int note, float velocity) {
+        REQUIRE_THAT(velocity, WithinAbs(0.8, 0.001));
+        note_ons.push_back(note);
+    };
+    kb.on_note_off = [&](int note) { note_offs.push_back(note); };
+
+    kb.on_mouse_down({10, 20});
+    REQUIRE(note_ons.size() == 1);
+    REQUIRE(note_ons[0] == 60);
+    REQUIRE(kb.is_note_on(60));
+
+    kb.on_mouse_drag({10, 110});
+    REQUIRE(note_offs.size() == 1);
+    REQUIRE(note_offs[0] == 60);
+    REQUIRE(note_ons.size() == 2);
+    REQUIRE(note_ons[1] == 61);
+    REQUIRE_FALSE(kb.is_note_on(60));
+    REQUIRE(kb.is_note_on(61));
+
+    kb.on_mouse_drag({90, 310});
+    REQUIRE(note_offs.size() == 2);
+    REQUIRE(note_offs[1] == 61);
+    REQUIRE_FALSE(kb.is_note_on(61));
+
+    kb.on_mouse_up({90, 310});
+    REQUIRE(note_offs.size() == 2);
+}
+
+TEST_CASE("MidiKeyboard paint emits note names and active highlight color",
+          "[view][midi_keyboard][issue-493]") {
+    MidiKeyboard kb;
+    kb.set_range(60, 64);
+    kb.set_bounds({0, 0, 300, 80});
+    kb.set_show_note_names(true);
+    kb.set_highlight_color(Color::rgba8(255, 0, 0));
+    kb.note_on(60);
+
+    RecordingCanvas canvas;
+    kb.paint(canvas);
+
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rounded_rect) == 5);
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_rounded_rect) == 3);
+    REQUIRE(has_text(canvas, "C4"));
+    REQUIRE(has_fill_color(canvas, Color::rgba8(255, 0, 0)));
+}
+
 // ── ColorPicker ─────────────────────────────────────────────────────────────
 
 TEST_CASE("ColorPicker set/get color", "[view][color_picker]") {
@@ -365,6 +447,52 @@ TEST_CASE("FileDropZone empty extensions accepts all", "[view][file_drop]") {
     REQUIRE(zone.is_drag_valid());
 }
 
+TEST_CASE("FileDropZone rejected drop resets state without callback",
+          "[view][file_drop][issue-493]") {
+    FileDropZone zone;
+    zone.set_accepted_extensions({".wav"});
+
+    int drops = 0;
+    zone.on_drop = [&](const std::vector<std::string>&) { ++drops; };
+
+    zone.drag_enter({"notes.txt"});
+    REQUIRE(zone.is_drag_over());
+    REQUIRE_FALSE(zone.is_drag_valid());
+
+    zone.drop({"notes.txt"});
+    REQUIRE(drops == 0);
+    REQUIRE_FALSE(zone.is_drag_over());
+    REQUIRE_FALSE(zone.is_drag_valid());
+}
+
+TEST_CASE("FileDropZone paint covers idle valid invalid and no-icon states",
+          "[view][file_drop][issue-493]") {
+    FileDropZone zone;
+    zone.set_bounds({0, 0, 200, 120});
+    zone.set_label("Drop audio");
+    zone.set_hover_label("Release audio");
+    zone.set_accepted_extensions({".wav"});
+
+    zone.set_icon_style(FileDropZone::IconStyle::none);
+    RecordingCanvas idle;
+    zone.paint(idle);
+    REQUIRE(has_text(idle, "Drop audio"));
+    REQUIRE(idle.count(DrawCommand::Type::stroke_line) == 0);
+
+    zone.set_icon_style(FileDropZone::IconStyle::upload);
+    zone.drag_enter({"sound.wav"});
+    RecordingCanvas valid;
+    zone.paint(valid);
+    REQUIRE(has_text(valid, "Release audio"));
+    REQUIRE(valid.count(DrawCommand::Type::stroke_line) == 3);
+
+    zone.drag_enter({"sound.txt"});
+    RecordingCanvas invalid;
+    zone.paint(invalid);
+    REQUIRE(has_text(invalid, "Drop audio"));
+    REQUIRE(invalid.count(DrawCommand::Type::stroke_line) == 3);
+}
+
 // ── SplitView ───────────────────────────────────────────────────────────────
 
 TEST_CASE("SplitView basic setup", "[view][split_view]") {
@@ -404,6 +532,73 @@ TEST_CASE("SplitView orientation", "[view][split_view]") {
     REQUIRE(split.orientation() == SplitView::Orientation::vertical);
 }
 
+TEST_CASE("SplitView drag handling clamps to pane minimums and ignores misses",
+          "[view][split_view][issue-493]") {
+    SplitView split;
+    split.set_bounds({0, 0, 400, 200});
+    split.set_first(std::make_unique<View>());
+    split.set_second(std::make_unique<View>());
+    split.set_min_first_size(80.0f);
+    split.set_min_second_size(80.0f);
+    split.set_split_fraction(0.5f);
+    split.layout_children();
+
+    int changes = 0;
+    float last_fraction = 0.0f;
+    split.on_split_changed = [&](float fraction) {
+        ++changes;
+        last_fraction = fraction;
+    };
+
+    split.on_mouse_drag({10, 100});
+    REQUIRE(changes == 0);
+    REQUIRE_THAT(split.split_fraction(), WithinAbs(0.5, 0.001));
+
+    split.on_mouse_down({20, 20});
+    split.on_mouse_drag({300, 100});
+    REQUIRE(changes == 0);
+    REQUIRE_THAT(split.split_fraction(), WithinAbs(0.5, 0.001));
+
+    split.on_mouse_down({200, 100});
+    split.on_mouse_drag({10, 100});
+    REQUIRE(changes == 1);
+    REQUIRE_THAT(split.split_fraction(), WithinAbs(0.2, 0.001));
+    REQUIRE_THAT(last_fraction, WithinAbs(0.2, 0.001));
+
+    split.on_mouse_drag({390, 100});
+    REQUIRE(changes == 2);
+    REQUIRE_THAT(split.split_fraction(), WithinAbs(0.8, 0.001));
+    split.on_mouse_up({390, 100});
+
+    split.on_mouse_drag({100, 100});
+    REQUIRE(changes == 2);
+
+    split.set_orientation(SplitView::Orientation::vertical);
+    split.set_split_fraction(0.5f);
+    split.layout_children();
+    split.on_mouse_down({200, 100});
+    split.on_mouse_drag({200, 190});
+    REQUIRE(changes == 3);
+    REQUIRE_THAT(split.split_fraction(), WithinAbs(0.6, 0.001));
+}
+
+TEST_CASE("SplitView paint emits horizontal and vertical divider grips",
+          "[view][split_view][issue-493]") {
+    SplitView split;
+    split.set_bounds({0, 0, 300, 180});
+
+    pulp::canvas::RecordingCanvas canvas;
+    split.paint(canvas);
+    REQUIRE(canvas.count(pulp::canvas::DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(canvas.count(pulp::canvas::DrawCommand::Type::fill_circle) == 3);
+
+    canvas.clear();
+    split.set_orientation(SplitView::Orientation::vertical);
+    split.paint(canvas);
+    REQUIRE(canvas.count(pulp::canvas::DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(canvas.count(pulp::canvas::DrawCommand::Type::fill_circle) == 3);
+}
+
 // ── PropertyList ────────────────────────────────────────────────────────────
 
 TEST_CASE("PropertyList basic operations", "[view][property_list]") {
@@ -441,6 +636,94 @@ TEST_CASE("PropertyList intrinsic height", "[view][property_list]") {
         {"b", "B", std::string("y"), false, ""},
     });
     REQUIRE(list.intrinsic_height() > 0);
+}
+
+TEST_CASE("PropertyList mouse editing toggles writable booleans only",
+          "[view][property_list][issue-493]") {
+    PropertyList list;
+    list.set_bounds({0, 0, 240, 160});
+    list.set_properties({
+        {"enabled", "Enabled", false, false, "General"},
+        {"locked", "Locked", true, true, "General"},
+        {"name", "Name", std::string("Osc"), false, "Info"},
+    });
+
+    int changes = 0;
+    std::string changed_key;
+    bool changed_bool = false;
+    list.on_change = [&](const std::string& key, PropertyList::PropertyValue value) {
+        ++changes;
+        changed_key = key;
+        if (std::holds_alternative<bool>(value))
+            changed_bool = std::get<bool>(value);
+    };
+
+    list.on_mouse_down({12, 30});
+    auto* enabled = list.find_property("enabled");
+    REQUIRE(enabled != nullptr);
+    REQUIRE(std::get<bool>(enabled->value));
+    REQUIRE(changes == 1);
+    REQUIRE(changed_key == "enabled");
+    REQUIRE(changed_bool);
+
+    list.on_mouse_down({12, 60});
+    auto* locked = list.find_property("locked");
+    REQUIRE(locked != nullptr);
+    REQUIRE(std::get<bool>(locked->value));
+    REQUIRE(changes == 1);
+
+    list.on_mouse_down({12, 110});
+    REQUIRE(changes == 1);
+
+    list.on_mouse_down({12, 500});
+    REQUIRE(changes == 1);
+}
+
+TEST_CASE("PropertyList paints categories and scalar value variants",
+          "[view][property_list][issue-493]") {
+    PropertyList list;
+    list.set_bounds({0, 0, 260, 180});
+    list.set_row_height(20.0f);
+    list.set_label_width_fraction(0.5f);
+    list.set_properties({
+        {"name", "", std::string("Osc"), false, "General"},
+        {"gain", "Gain", 0.5f, false, "General"},
+        {"voices", "Voices", 8, false, "Synth"},
+        {"enabled", "Enabled", true, false, "Synth"},
+    });
+
+    const auto with_categories = list.intrinsic_height();
+    list.set_show_categories(false);
+    REQUIRE_THAT(list.intrinsic_height(), WithinAbs(80.0, 0.001));
+    REQUIRE(with_categories > list.intrinsic_height());
+
+    pulp::canvas::RecordingCanvas canvas;
+    list.paint(canvas);
+    REQUIRE(canvas.count(pulp::canvas::DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(canvas.count(pulp::canvas::DrawCommand::Type::stroke_line) == 4);
+    REQUIRE(canvas.count(pulp::canvas::DrawCommand::Type::fill_text) == 8);
+
+    bool saw_key_label = false;
+    bool saw_float_value = false;
+    bool saw_int_value = false;
+    bool saw_bool_value = false;
+    for (const auto& command : canvas.commands()) {
+        if (command.type != pulp::canvas::DrawCommand::Type::fill_text)
+            continue;
+        saw_key_label = saw_key_label || command.text == "name";
+        saw_float_value = saw_float_value || command.text == "0.50";
+        saw_int_value = saw_int_value || command.text == "8";
+        saw_bool_value = saw_bool_value || command.text == "true";
+    }
+    REQUIRE(saw_key_label);
+    REQUIRE(saw_float_value);
+    REQUIRE(saw_int_value);
+    REQUIRE(saw_bool_value);
+
+    canvas.clear();
+    list.set_show_categories(true);
+    list.paint(canvas);
+    REQUIRE(canvas.count(pulp::canvas::DrawCommand::Type::fill_text) == 10);
 }
 
 // ── Breadcrumb ──────────────────────────────────────────────────────────────

--- a/test/test_phase9_widgets.cpp
+++ b/test/test_phase9_widgets.cpp
@@ -8,6 +8,7 @@
 #include <pulp/view/split_view.hpp>
 #include <pulp/view/property_list.hpp>
 #include <pulp/view/breadcrumb.hpp>
+#include <pulp/view/theme_editor.hpp>
 
 #include <algorithm>
 #include <string_view>
@@ -170,6 +171,22 @@ TEST_CASE("EqCurveView empty hit does not start a drag", "[view][eq_curve][issue
     REQUIRE_THAT(eq.bands()[0].gain_db, WithinAbs(0.0, 0.001));
 }
 
+TEST_CASE("EqCurveView paint covers disabled grid and disabled band handles",
+          "[view][eq_curve][coverage][issue-652]") {
+    EqCurveView eq;
+    eq.set_bounds({0, 0, 240, 120});
+    eq.set_show_grid(false);
+    eq.add_band({500.0f, 12.0f, 1.0f, EqCurveView::FilterType::peak, false});
+
+    pulp::canvas::RecordingCanvas canvas;
+    eq.paint(canvas);
+
+    REQUIRE(canvas.count(pulp::canvas::DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(canvas.count(pulp::canvas::DrawCommand::Type::fill_circle) == 0);
+    REQUIRE(canvas.count(pulp::canvas::DrawCommand::Type::stroke_circle) == 0);
+    REQUIRE(canvas.count(pulp::canvas::DrawCommand::Type::stroke_line) > 0);
+}
+
 // ── MidiKeyboard ────────────────────────────────────────────────────────────
 
 TEST_CASE("MidiKeyboard note state", "[view][midi_keyboard]") {
@@ -257,6 +274,40 @@ TEST_CASE("MidiKeyboard vertical drag releases previous notes and misses",
 
     kb.on_mouse_up({90, 310});
     REQUIRE(note_offs.size() == 2);
+}
+
+TEST_CASE("MidiKeyboard drag releases old notes and supports vertical range",
+          "[view][midi_keyboard][coverage][issue-652]") {
+    MidiKeyboard kb;
+    kb.set_range(80, 60);
+    REQUIRE(kb.first_note() == 80);
+    REQUIRE(kb.last_note() == 80);
+
+    kb.set_range(60, 72);
+    kb.set_orientation(MidiKeyboard::Orientation::vertical);
+    kb.set_bounds({0, 0, 100, 130});
+
+    std::vector<int> note_ons;
+    std::vector<int> note_offs;
+    kb.on_note_on = [&](int note, float velocity) {
+        note_ons.push_back(note);
+        REQUIRE_THAT(velocity, WithinAbs(0.8f, 0.001f));
+    };
+    kb.on_note_off = [&](int note) { note_offs.push_back(note); };
+
+    kb.on_mouse_down({10, 12});
+    REQUIRE(note_ons == std::vector<int>{61});
+    REQUIRE(kb.is_note_on(61));
+
+    kb.on_mouse_drag({10, 120});
+    REQUIRE(note_offs == std::vector<int>{61});
+    REQUIRE_FALSE(kb.is_note_on(61));
+    REQUIRE_FALSE(note_ons.empty());
+    REQUIRE(kb.is_note_on(note_ons.back()));
+
+    kb.on_mouse_up({10, 120});
+    REQUIRE_FALSE(kb.is_note_on(note_ons.back()));
+    REQUIRE(note_offs.back() == note_ons.back());
 }
 
 TEST_CASE("MidiKeyboard paint emits note names and active highlight color",
@@ -397,6 +448,26 @@ TEST_CASE("ColorPicker paint positions alpha cursor from normalized alpha",
     REQUIRE(found_alpha_cursor);
 }
 
+TEST_CASE("ColorPicker mode and outside mouse input are stable",
+          "[view][color_picker][coverage][issue-652]") {
+    ColorPicker picker;
+    picker.set_bounds({0, 0, 200, 260});
+    picker.set_mode(ColorPicker::Mode::hex_only);
+    REQUIRE(picker.mode() == ColorPicker::Mode::hex_only);
+
+    picker.set_color(Color::rgba8(10, 20, 30));
+    auto before = picker.hex();
+    int changes = 0;
+    picker.on_change = [&](Color) { ++changes; };
+
+    picker.on_mouse_down({300, 300});
+    picker.on_mouse_drag({4, 4});
+    picker.on_mouse_up({4, 4});
+
+    REQUIRE(changes == 0);
+    REQUIRE(picker.hex() == before);
+}
+
 // ── FileDropZone ────────────────────────────────────────────────────────────
 
 TEST_CASE("FileDropZone extension filtering", "[view][file_drop]") {
@@ -447,8 +518,49 @@ TEST_CASE("FileDropZone empty extensions accepts all", "[view][file_drop]") {
     REQUIRE(zone.is_drag_valid());
 }
 
-TEST_CASE("FileDropZone rejected drop resets state without callback",
-          "[view][file_drop][issue-493]") {
+TEST_CASE("FileDropZone paint reflects idle valid and invalid drag states",
+          "[view][file_drop][coverage][issue-652]") {
+    FileDropZone zone;
+    zone.set_bounds({0, 0, 180, 120});
+    zone.set_label("Idle");
+    zone.set_hover_label("Ready");
+    zone.set_accepted_extensions({".wav"});
+    auto fill_text_count = [](const pulp::canvas::RecordingCanvas& canvas,
+                              const std::string& text) {
+        int count = 0;
+        for (const auto& command : canvas.commands()) {
+            if (command.type == pulp::canvas::DrawCommand::Type::fill_text &&
+                command.text == text) {
+                ++count;
+            }
+        }
+        return count;
+    };
+
+    pulp::canvas::RecordingCanvas idle;
+    zone.paint(idle);
+    REQUIRE(idle.count(pulp::canvas::DrawCommand::Type::fill_text) == 1);
+    REQUIRE(fill_text_count(idle, "Idle") == 1);
+    REQUIRE(idle.count(pulp::canvas::DrawCommand::Type::stroke_line) == 3);
+
+    zone.drag_enter({"take.wav"});
+    pulp::canvas::RecordingCanvas valid;
+    zone.paint(valid);
+    REQUIRE(fill_text_count(valid, "Ready") == 1);
+
+    zone.drag_enter({"take.txt"});
+    pulp::canvas::RecordingCanvas invalid;
+    zone.paint(invalid);
+    REQUIRE(fill_text_count(invalid, "Idle") == 1);
+
+    zone.set_icon_style(FileDropZone::IconStyle::none);
+    pulp::canvas::RecordingCanvas no_icon;
+    zone.paint(no_icon);
+    REQUIRE(no_icon.count(pulp::canvas::DrawCommand::Type::stroke_line) == 0);
+}
+
+TEST_CASE("FileDropZone invalid or empty drops do not call callback",
+          "[view][file_drop][coverage][issue-652]") {
     FileDropZone zone;
     zone.set_accepted_extensions({".wav"});
 
@@ -460,6 +572,7 @@ TEST_CASE("FileDropZone rejected drop resets state without callback",
     REQUIRE_FALSE(zone.is_drag_valid());
 
     zone.drop({"notes.txt"});
+    zone.drop({});
     REQUIRE(drops == 0);
     REQUIRE_FALSE(zone.is_drag_over());
     REQUIRE_FALSE(zone.is_drag_valid());
@@ -849,4 +962,34 @@ TEST_CASE("Breadcrumb paint emits background, items, and separators",
 
     REQUIRE(home_text == 1);
     REQUIRE(separator_text == 2);
+}
+
+// ── ThemeEditor ────────────────────────────────────────────────────────────
+
+TEST_CASE("ThemeEditor covers missing selection empty theme and selected paint",
+          "[view][theme-editor][coverage][issue-652]") {
+    ThemeEditor editor;
+    editor.set_bounds({0, 0, 360, 120});
+
+    editor.select_token("missing");
+    REQUIRE(editor.selected_token() == "missing");
+    REQUIRE(editor.token_names().empty());
+
+    pulp::canvas::RecordingCanvas empty;
+    editor.paint_all(empty);
+    REQUIRE(empty.count(pulp::canvas::DrawCommand::Type::fill_text) == 1);
+
+    Theme theme;
+    theme.colors["accent.primary"] = Color::rgba8(1, 2, 3);
+    theme.colors["bg.primary"] = Color::rgba8(4, 5, 6);
+    editor.set_theme(theme);
+    editor.select_token("accent.primary");
+
+    pulp::canvas::RecordingCanvas selected;
+    editor.paint_all(selected);
+
+    REQUIRE(selected.count(pulp::canvas::DrawCommand::Type::fill_rounded_rect) == 2);
+    REQUIRE(selected.count(pulp::canvas::DrawCommand::Type::stroke_rounded_rect) == 1);
+    REQUIRE(selected.count(pulp::canvas::DrawCommand::Type::fill_text) == 3);
+    REQUIRE(editor.export_json().find("accent.primary") != std::string::npos);
 }

--- a/test/test_platform.cpp
+++ b/test/test_platform.cpp
@@ -1,7 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/platform/platform.hpp>
 #include <pulp/platform/popup_menu.hpp>
+#include <pulp/platform/progress_parser.hpp>
 #include <pulp/platform/win/registry.hpp>
+
+#include <vector>
 
 using namespace pulp::platform;
 
@@ -71,6 +74,46 @@ TEST_CASE("PopupMenu records items and separators",
     REQUIRE_FALSE(items[2].enabled);
     REQUIRE(items[2].checked);
     REQUIRE_FALSE(items[2].is_separator);
+}
+
+TEST_CASE("ProgressParser accepts payloads, empty payloads, and type-only lines",
+          "[platform][progress][coverage][issue-649]") {
+    std::vector<ProgressEvent> events;
+    ProgressParser parser([&](const ProgressEvent& e) {
+        events.push_back(e);
+    });
+
+    parser.feed_line("PROGRESS:DOWNLOAD_START:https://example.test/file.zip");
+    parser.feed_line("PROGRESS:OVERALL:42");
+    parser.feed_line("PROGRESS:EMPTY:");
+    parser.feed_line("PROGRESS:TYPE_ONLY");
+
+    REQUIRE(events.size() == 4);
+    REQUIRE(events[0].type == "DOWNLOAD_START");
+    REQUIRE(events[0].payload == "https://example.test/file.zip");
+    REQUIRE(events[1].type == "OVERALL");
+    REQUIRE(events[1].payload == "42");
+    REQUIRE(events[2].type == "EMPTY");
+    REQUIRE(events[2].payload.empty());
+    REQUIRE(events[3].type == "TYPE_ONLY");
+    REQUIRE(events[3].payload.empty());
+}
+
+TEST_CASE("ProgressParser ignores non-progress lines and tolerates empty callbacks",
+          "[platform][progress][coverage][issue-649]") {
+    int calls = 0;
+    ProgressParser parser([&](const ProgressEvent&) { ++calls; });
+
+    parser.feed_line("");
+    parser.feed_line("progress:LOWERCASE:ignored");
+    parser.feed_line("INFO:PROGRESS:OVERALL:1");
+    parser.feed_line("PROGRESSISH:OVERALL:1");
+    REQUIRE(calls == 0);
+
+    ProgressParser empty_callback({});
+    empty_callback.feed_line("PROGRESS:OVERALL:100");
+    empty_callback.feed_line("PROGRESS:TYPE_ONLY");
+    SUCCEED("empty callbacks are inert");
 }
 
 #if !defined(__APPLE__)

--- a/test/test_plugin_state_io.cpp
+++ b/test/test_plugin_state_io.cpp
@@ -213,6 +213,26 @@ TEST_CASE("plugin_state_io preserves legacy raw StateStore blobs and resets plug
     REQUIRE(restored.processor.last_payload.empty());
 }
 
+TEST_CASE("plugin_state_io envelope with empty plugin payload resets plugin state",
+          "[format][plugin-state][coverage][issue-647]") {
+    TestRig source;
+    source.store.set_value(1, -15.0f);
+    auto store_blob = source.store.serialize();
+    auto envelope = make_envelope(store_blob, {});
+
+    TestRig restored;
+    restored.store.set_value(1, 6.0f);
+    restored.processor.plugin_state = "stale";
+
+    REQUIRE(pulp::format::plugin_state_io::deserialize(envelope,
+                                                       restored.store,
+                                                       restored.processor));
+    REQUIRE_THAT(restored.store.get_value(1), WithinAbs(-15.0, 0.01));
+    REQUIRE(restored.processor.plugin_state.empty());
+    REQUIRE(restored.processor.deserialize_calls == 1);
+    REQUIRE(restored.processor.last_payload.empty());
+}
+
 TEST_CASE("plugin_state_io serialize falls back to raw StateStore blobs when plugin payload is empty",
           "[format][plugin-state]") {
     TestRig source;
@@ -345,6 +365,44 @@ TEST_CASE("plugin_state_io rejects malformed blobs without touching live state",
         REQUIRE(restored.processor.plugin_state == "keep");
         REQUIRE(restored.processor.deserialize_calls == 0);
     }
+
+    SECTION("empty inner StateStore payload") {
+        const std::array<uint8_t, 4> plugin_blob = {'K', 'E', 'E', 'P'};
+        auto blob = make_envelope({}, plugin_blob);
+
+        TestRig restored;
+        restored.store.set_value(1, 3.0f);
+        restored.processor.plugin_state = "keep";
+
+        REQUIRE_FALSE(pulp::format::plugin_state_io::deserialize(blob,
+                                                                 restored.store,
+                                                                 restored.processor));
+        REQUIRE_THAT(restored.store.get_value(1), WithinAbs(3.0, 0.01));
+        REQUIRE(restored.processor.plugin_state == "keep");
+        REQUIRE(restored.processor.deserialize_calls == 0);
+    }
+}
+
+TEST_CASE("plugin_state_io rejects envelope CRC mismatch without plugin callback",
+          "[format][plugin-state][coverage][issue-647]") {
+    TestRig source;
+    source.store.set_value(1, -21.0f);
+    source.processor.plugin_state = "snapshot-c";
+    auto store_blob = source.store.serialize();
+    auto plugin_blob = source.processor.serialize_plugin_state();
+    auto blob = make_envelope(store_blob, plugin_blob);
+    blob[8] ^= 0x01; // mutate store size after CRC calculation
+
+    TestRig restored;
+    restored.store.set_value(1, 2.0f);
+    restored.processor.plugin_state = "keep";
+
+    REQUIRE_FALSE(pulp::format::plugin_state_io::deserialize(blob,
+                                                             restored.store,
+                                                             restored.processor));
+    REQUIRE_THAT(restored.store.get_value(1), WithinAbs(2.0, 0.01));
+    REQUIRE(restored.processor.plugin_state == "keep");
+    REQUIRE(restored.processor.deserialize_calls == 0);
 }
 
 TEST_CASE("plugin_state_io rolls back StateStore when plugin payload restore fails",

--- a/test/test_preset_browser.cpp
+++ b/test/test_preset_browser.cpp
@@ -350,6 +350,22 @@ TEST_CASE("PresetBrowser filtered list click uses filter offset and row height",
     REQUIRE(browser.row_height() == 30.0f);
 }
 
+TEST_CASE("PresetBrowser ignores filtered clicks before the list starts",
+          "[view][preset_browser][coverage][issue-655]") {
+    TestPresetFixture f;
+    PresetBrowser browser(*f.pm);
+    browser.set_bounds({0, 0, 180, 180});
+    browser.set_filter("clean");
+
+    int selected_count = 0;
+    browser.on_preset_selected = [&](const PresetInfo&) { ++selected_count; };
+
+    browser.on_mouse_event(mouse_down(40.0f, 41.0f));
+
+    REQUIRE(browser.selected_index() == -1);
+    REQUIRE(selected_count == 0);
+}
+
 TEST_CASE("PresetBrowser paint produces draw commands", "[view][preset_browser]") {
     TestPresetFixture f;
     PresetBrowser browser(*f.pm);

--- a/test/test_preset_browser.cpp
+++ b/test/test_preset_browser.cpp
@@ -327,6 +327,29 @@ TEST_CASE("PresetBrowser mouse list selects and double-click activates", "[view]
     REQUIRE(browser.selected_index() == 2);
 }
 
+TEST_CASE("PresetBrowser filtered list click uses filter offset and row height",
+          "[view][preset_browser][coverage][issue-655]") {
+    TestPresetFixture f;
+    PresetBrowser browser(*f.pm);
+    browser.set_bounds({0, 0, 180, 180});
+    browser.set_row_height(30.0f);
+    browser.set_filter("clean");
+
+    std::string selected_name;
+    browser.on_preset_selected = [&](const PresetInfo& p) {
+        selected_name = p.name;
+    };
+
+    browser.on_mouse_event(mouse_down(40.0f, 40.0f));
+    REQUIRE(browser.selected_index() == -1);
+    REQUIRE(selected_name.empty());
+
+    browser.on_mouse_event(mouse_down(40.0f, 58.0f));
+    REQUIRE(browser.selected_index() == 0);
+    REQUIRE(selected_name == "Clean");
+    REQUIRE(browser.row_height() == 30.0f);
+}
+
 TEST_CASE("PresetBrowser paint produces draw commands", "[view][preset_browser]") {
     TestPresetFixture f;
     PresetBrowser browser(*f.pm);

--- a/test/test_preset_manager.cpp
+++ b/test/test_preset_manager.cpp
@@ -223,6 +223,23 @@ TEST_CASE("PresetManager load skips malformed parameter values", "[state][preset
     REQUIRE(load_callbacks == 1);
 }
 
+TEST_CASE("PresetManager load clamps out-of-range parameter values",
+          "[state][preset][coverage][issue-647]") {
+    pulp::test::PresetTestSandbox sandbox("pulp-preset-load-clamp");
+    StateStore store;
+    setup_test_store(store);
+    PresetManager pm(store, "TestCo", "TestPlugin");
+
+    const auto preset_path = sandbox.root / "Clamped.json";
+    write_text_file(preset_path,
+                    R"json({"parameters":{"Gain":999,"Mix":-50}})json");
+
+    REQUIRE(pm.load(preset_path));
+    REQUIRE(store.get_value(1) == Catch::Approx(12.0f));
+    REQUIRE(store.get_value(2) == Catch::Approx(0.0f));
+    REQUIRE(pm.current_preset_name() == "Clamped");
+}
+
 TEST_CASE("PresetManager save scans subfolders and reports list changes", "[state][preset]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-save-subfolder");
     StateStore store;
@@ -247,6 +264,29 @@ TEST_CASE("PresetManager save scans subfolders and reports list changes", "[stat
     REQUIRE(presets.size() == 2);
     REQUIRE(presets[0].name == "Alpha");
     REQUIRE(presets[1].name == "Beta");
+}
+
+TEST_CASE("PresetManager user preset scan ignores non-json files and records nested folders",
+          "[state][preset][coverage][issue-647]") {
+    pulp::test::PresetTestSandbox sandbox("pulp-preset-scan-filter");
+    StateStore store;
+    setup_test_store(store);
+    PresetManager pm(store, "TestCo", "TestPlugin");
+
+    REQUIRE(pm.save("Root"));
+    write_text_file(pm.user_presets_dir() / "Bank" / "Lead.json",
+                    R"json({"parameters":{"Gain":-6}})json");
+    write_text_file(pm.user_presets_dir() / "Bank" / "Ignore.txt", "not a preset");
+    std::error_code ec;
+    fs::create_directories(pm.user_presets_dir() / "EmptyDir", ec);
+    REQUIRE_FALSE(ec);
+
+    auto presets = pm.user_presets();
+    REQUIRE(presets.size() == 2);
+    REQUIRE(presets[0].name == "Lead");
+    REQUIRE(presets[0].folder == "Bank");
+    REQUIRE(presets[1].name == "Root");
+    REQUIRE(presets[1].folder.empty());
 }
 
 TEST_CASE("PresetManager rename and delete update current preset and callbacks", "[state][preset]") {
@@ -277,6 +317,25 @@ TEST_CASE("PresetManager rename and delete update current preset and callbacks",
     REQUIRE_FALSE(pm.rename(new_preset, "Again"));
     REQUIRE_FALSE(pm.delete_preset(new_preset));
     REQUIRE(list_changes == 2);
+}
+
+TEST_CASE("PresetManager delete missing user preset is inert",
+          "[state][preset][coverage][issue-647]") {
+    pulp::test::PresetTestSandbox sandbox("pulp-preset-delete-missing");
+    StateStore store;
+    setup_test_store(store);
+    PresetManager pm(store, "TestCo", "TestPlugin");
+
+    int list_changes = 0;
+    pm.on_list_changed = [&] { ++list_changes; };
+
+    PresetInfo missing;
+    missing.name = "Missing";
+    missing.path = sandbox.root / "missing.json";
+    missing.is_factory = false;
+
+    REQUIRE_FALSE(pm.delete_preset(missing));
+    REQUIRE(list_changes == 0);
 }
 
 TEST_CASE("PresetManager import copies external presets into the user directory", "[state][preset]") {
@@ -327,4 +386,16 @@ TEST_CASE("PresetManager navigation wraps sorted presets and handles missing cur
 
     REQUIRE(pm.load_next());
     REQUIRE(pm.current_preset_name() == "Alpha");
+}
+
+TEST_CASE("PresetManager navigation on empty preset list returns false",
+          "[state][preset][coverage][issue-647]") {
+    pulp::test::PresetTestSandbox sandbox("pulp-preset-navigation-empty");
+    StateStore store;
+    setup_test_store(store);
+    PresetManager pm(store, "TestCo", "TestPlugin");
+
+    REQUIRE_FALSE(pm.load_next());
+    REQUIRE_FALSE(pm.load_previous());
+    REQUIRE(pm.current_preset_name().empty());
 }

--- a/test/test_properties_file.cpp
+++ b/test/test_properties_file.cpp
@@ -4,6 +4,7 @@
 #include <pulp/runtime/temporary_file.hpp>
 #include <filesystem>
 #include <fstream>
+#include <random>
 
 using namespace pulp::state;
 using namespace pulp::runtime;
@@ -35,6 +36,21 @@ TEST_CASE("PropertiesFile numeric getters reject invalid stored strings", "[stat
 
     REQUIRE_FALSE(props.get_int("count").has_value());
     REQUIRE_FALSE(props.get_double("gain").has_value());
+}
+
+TEST_CASE("PropertiesFile bool getter treats stored false-like values as false",
+          "[state][properties][issue-641]") {
+    PropertiesFile props;
+    props.set_string("word_false", "false");
+    props.set_string("zero", "0");
+    props.set_string("garbage", "not-a-bool");
+
+    REQUIRE(props.get_bool("word_false").has_value());
+    REQUIRE_FALSE(*props.get_bool("word_false"));
+    REQUIRE(props.get_bool("zero").has_value());
+    REQUIRE_FALSE(*props.get_bool("zero"));
+    REQUIRE(props.get_bool("garbage").has_value());
+    REQUIRE_FALSE(*props.get_bool("garbage"));
 }
 
 TEST_CASE("PropertiesFile set and get int", "[state][properties]") {
@@ -157,6 +173,21 @@ TEST_CASE("PropertiesFile load invalid JSON returns false", "[state][properties]
     REQUIRE_FALSE(props.load(tmp.path_string()));
 }
 
+TEST_CASE("PropertiesFile load non-object JSON leaves existing values intact",
+          "[state][properties][issue-641]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << "[\"not\", \"an\", \"object\"]";
+    }
+
+    PropertiesFile props;
+    props.set_string("stale", "value");
+    REQUIRE_FALSE(props.load(tmp.path_string()));
+    REQUIRE(props.get_string("stale").value_or("") == "value");
+    REQUIRE(props.path() == tmp.path_string());
+}
+
 TEST_CASE("PropertiesFile load empty file clears existing values", "[state][properties]") {
     TemporaryFile tmp(".json");
     {
@@ -171,11 +202,53 @@ TEST_CASE("PropertiesFile load empty file clears existing values", "[state][prop
     REQUIRE(props.size() == 0);
 }
 
+TEST_CASE("PropertiesFile load skips unsupported JSON member types",
+          "[state][properties][json][issue-641]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << R"JSON({
+            "name": "Pulp",
+            "enabled": true,
+            "count": 7,
+            "gain": 0.5,
+            "ignored_null": null,
+            "ignored_array": [1, 2],
+            "ignored_object": {"nested": true}
+        })JSON";
+    }
+
+    PropertiesFile props;
+    REQUIRE(props.load(tmp.path_string()));
+    REQUIRE(props.size() == 4);
+    REQUIRE(props.get_string("name").value_or("") == "Pulp");
+    REQUIRE(props.get_bool("enabled").value_or(false));
+    REQUIRE(props.get_int("count").value_or(0) == 7);
+    REQUIRE_THAT(props.get_double("gain").value_or(0.0), WithinAbs(0.5, 1e-9));
+    REQUIRE_FALSE(props.contains("ignored_null"));
+    REQUIRE_FALSE(props.contains("ignored_array"));
+    REQUIRE_FALSE(props.contains("ignored_object"));
+}
+
 TEST_CASE("PropertiesFile save without path returns false", "[state][properties]") {
     PropertiesFile props;
     props.set_string("key", "value");
 
     REQUIRE_FALSE(props.save());
+}
+
+TEST_CASE("PropertiesFile save fails when destination is a directory",
+          "[state][properties][issue-641]") {
+    auto dir = std::filesystem::temp_directory_path() /
+               ("pulp_props_dir_dest_" + std::to_string(std::random_device{}()));
+    std::filesystem::create_directories(dir);
+
+    PropertiesFile props;
+    props.set_string("key", "value");
+    REQUIRE_FALSE(props.save(dir.string()));
+    REQUIRE(props.path() == dir.string());
+
+    std::filesystem::remove_all(dir);
 }
 
 TEST_CASE("PropertiesFile save creates parent directories", "[state][properties]") {
@@ -207,6 +280,21 @@ TEST_CASE("PropertiesFile save and reload preserves path", "[state][properties]"
     PropertiesFile props2;
     REQUIRE(props2.load(tmp.path_string()));
     REQUIRE(props2.get_string("key2").value_or("") == "val2");
+}
+
+TEST_CASE("PropertiesFile remove missing key and clear empty file are no-ops",
+          "[state][properties][issue-641]") {
+    PropertiesFile props;
+    props.remove("missing");
+    REQUIRE(props.size() == 0);
+
+    props.clear();
+    REQUIRE(props.keys().empty());
+
+    props.set_string("present", "yes");
+    props.remove("missing");
+    REQUIRE(props.size() == 1);
+    REQUIRE(props.contains("present"));
 }
 
 // ── ApplicationProperties ───────────────────────────────────────────────

--- a/test/test_property_list.cpp
+++ b/test/test_property_list.cpp
@@ -124,3 +124,60 @@ TEST_CASE("PropertyList set_value only mutates existing keys", "[view][property_
     REQUIRE(gain != nullptr);
     REQUIRE(std::get<float>(gain->value) == 0.75f);
 }
+
+TEST_CASE("PropertyList category visibility and label fallback paint paths",
+          "[view][property_list][coverage][issue-653]") {
+    PropertyList list;
+    list.set_bounds({0, 0, 220, 100});
+    list.set_row_height(20.0f);
+    list.set_label_width_fraction(0.25f);
+    list.set_show_categories(false);
+    list.set_properties({
+        {"key_only", "", std::string("value"), false, "Hidden"},
+        {"readonly", "Read Only", true, true, "Hidden"},
+    });
+
+    RecordingCanvas canvas;
+    list.paint(canvas);
+
+    REQUIRE_FALSE(has_text(canvas, "Hidden"));
+    REQUIRE(has_text(canvas, "key_only"));
+    REQUIRE(has_text(canvas, "value"));
+    REQUIRE(has_text(canvas, "Read Only"));
+    REQUIRE(has_text(canvas, "true"));
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_line) == 2);
+    REQUIRE(list.intrinsic_height() == 40.0f);
+}
+
+TEST_CASE("PropertyList selection highlight covers non-bool rows and misses",
+          "[view][property_list][coverage][issue-653]") {
+    PropertyList list;
+    list.set_bounds({0, 0, 180, 100});
+    list.set_row_height(20.0f);
+    list.set_properties({
+        {"name", "Name", std::string("Main"), false, ""},
+        {"bypass", "Bypass", false, false, ""},
+    });
+
+    int changes = 0;
+    list.on_change = [&](const std::string&, PropertyList::PropertyValue) {
+        ++changes;
+    };
+
+    list.on_mouse_down({5.0f, 5.0f});
+    RecordingCanvas selected_text;
+    list.paint(selected_text);
+    REQUIRE(selected_text.count(DrawCommand::Type::fill_rect) == 2);
+    REQUIRE(changes == 0);
+
+    list.on_mouse_down({5.0f, 200.0f});
+    RecordingCanvas after_miss;
+    list.paint(after_miss);
+    REQUIRE(after_miss.count(DrawCommand::Type::fill_rect) == 1);
+
+    list.on_mouse_down({5.0f, 25.0f});
+    REQUIRE(changes == 1);
+    auto* bypass = list.find_property("bypass");
+    REQUIRE(bypass != nullptr);
+    REQUIRE(std::get<bool>(bypass->value));
+}

--- a/test/test_psdf_atlas.cpp
+++ b/test/test_psdf_atlas.cpp
@@ -18,6 +18,20 @@ TEST_CASE("PsdfAtlas builds with the requested glyphs", "[canvas][psdf]") {
     REQUIRE(atlas.pixels() != nullptr);
 }
 
+TEST_CASE("PsdfAtlas keeps the SdfAtlas lookup and move surface",
+          "[canvas][psdf][coverage][issue-650]") {
+    PsdfAtlas atlas;
+    REQUIRE(atlas.build("stub", {U'P', U'S'}, 24, 3, 256));
+    REQUIRE(atlas.base_size() == 24);
+    REQUIRE(atlas.glyph(U'P') != nullptr);
+    REQUIRE(atlas.glyph(U'X') == nullptr);
+
+    PsdfAtlas moved(std::move(atlas));
+    REQUIRE(moved.glyph_count() == 2);
+    REQUIRE(moved.pixels() != nullptr);
+    REQUIRE(moved.glyph(U'S') != nullptr);
+}
+
 TEST_CASE("vector_fallback threshold picks SDF vs path rendering",
           "[canvas][psdf][fallback]") {
     // base_size 48 → 1x at 48px, 4x at 192px, 10x at 480px.
@@ -34,4 +48,12 @@ TEST_CASE("vector_fallback threshold picks SDF vs path rendering",
     // Degenerate base_size is never a fallback trigger.
     REQUIRE_FALSE(should_use_vector_fallback(100.0f, 0.0f));
     REQUIRE_FALSE(should_use_vector_fallback(-100.0f, 48.0f));
+}
+
+TEST_CASE("vector_fallback equality and negative thresholds are strict",
+          "[canvas][psdf][fallback][coverage][issue-650]") {
+    REQUIRE_FALSE(should_use_vector_fallback(96.0f, 48.0f, 2.0f));
+    REQUIRE(should_use_vector_fallback(96.1f, 48.0f, 2.0f));
+    REQUIRE(should_use_vector_fallback(1.0f, 48.0f, -1.0f));
+    REQUIRE_FALSE(should_use_vector_fallback(1.0f, -48.0f, -1.0f));
 }

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -14,6 +14,7 @@ using namespace pulp::runtime;
 
 TEST_CASE("SpscQueue basic operations", "[runtime][spsc]") {
     SpscQueue<int, 16> q;
+    REQUIRE(SpscQueue<int, 16>::capacity() == 16);
 
     SECTION("Empty queue") {
         REQUIRE(q.empty());
@@ -80,6 +81,18 @@ TEST_CASE("SpscQueue cross-thread", "[runtime][spsc]") {
 
     int expected = (count - 1) * count / 2;
     REQUIRE(sum.load() == expected);
+}
+
+TEST_CASE("SpscQueue accepts rvalue pushes", "[runtime][spsc][coverage][phase3]") {
+    SpscQueue<std::string, 2> q;
+
+    REQUIRE(q.try_push(std::string("alpha")));
+    REQUIRE(q.size_approx() == 1);
+
+    auto value = q.try_pop();
+    REQUIRE(value.has_value());
+    REQUIRE(*value == "alpha");
+    REQUIRE(q.empty());
 }
 
 TEST_CASE("ScopeGuard executes on exit", "[runtime][scope_guard]") {

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -283,3 +283,29 @@ TEST_CASE("DynamicLibrary move keeps failed handles closed", "[runtime][dynamic_
     REQUIRE_FALSE(second.is_open());
     REQUIRE_FALSE(second.error().empty());
 }
+
+TEST_CASE("DynamicLibrary move transfers an open handle", "[runtime][dynamic_library][coverage][phase3]") {
+    DynamicLibrary original;
+#ifdef __APPLE__
+    REQUIRE(original.open("/usr/lib/libSystem.B.dylib"));
+    const char* symbol = "malloc";
+#elif defined(__linux__)
+    REQUIRE(original.open("libc.so.6"));
+    const char* symbol = "malloc";
+#else
+    const char* symbol = nullptr;
+    SUCCEED("No stable system library fixture on this platform.");
+    return;
+#endif
+
+    DynamicLibrary moved(std::move(original));
+    REQUIRE_FALSE(original.is_open());
+    REQUIRE(moved.is_open());
+    REQUIRE(moved.find_symbol(symbol) != nullptr);
+
+    DynamicLibrary assigned;
+    assigned = std::move(moved);
+    REQUIRE_FALSE(moved.is_open());
+    REQUIRE(assigned.is_open());
+    REQUIRE(assigned.find_symbol(symbol) != nullptr);
+}

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -49,6 +49,29 @@ TEST_CASE("SpscQueue basic operations", "[runtime][spsc]") {
     }
 }
 
+TEST_CASE("SpscQueue reuses slots after wrap-around",
+          "[runtime][spsc][coverage][issue-641]") {
+    SpscQueue<int, 4> q;
+    REQUIRE(q.capacity() == 4);
+
+    for (int cycle = 0; cycle < 3; ++cycle) {
+        REQUIRE(q.empty());
+        for (int i = 0; i < 4; ++i) {
+            REQUIRE(q.try_push(cycle * 10 + i));
+        }
+        REQUIRE_FALSE(q.try_push(999));
+        REQUIRE(q.size_approx() == 4);
+        for (int i = 0; i < 4; ++i) {
+            auto value = q.try_pop();
+            REQUIRE(value.has_value());
+            REQUIRE(*value == cycle * 10 + i);
+        }
+    }
+
+    REQUIRE(q.empty());
+    REQUIRE_FALSE(q.try_pop().has_value());
+}
+
 TEST_CASE("SpscQueue cross-thread", "[runtime][spsc]") {
     SpscQueue<int, 1024> q;
     constexpr int count = 10000;
@@ -106,6 +129,16 @@ TEST_CASE("ScopeGuard move transfers cleanup ownership", "[runtime][scope_guard]
         auto guard = make_scope_guard([&] { ++calls; });
         auto moved = std::move(guard);
         static_cast<void>(moved);
+    }
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("PULP_ON_SCOPE_EXIT runs at block exit",
+          "[runtime][scope_guard][coverage][issue-641]") {
+    int calls = 0;
+    {
+        PULP_ON_SCOPE_EXIT(++calls);
+        REQUIRE(calls == 0);
     }
     REQUIRE(calls == 1);
 }

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -152,6 +152,20 @@ TEST_CASE("Runtime GMT helper returns UTC tm", "[runtime][system]") {
     REQUIRE(tm.tm_sec == 0);
 }
 
+TEST_CASE("Runtime localtime helper returns a normalized tm", "[runtime][system][coverage][phase3]") {
+    auto tm = localtime_local(static_cast<std::time_t>(0));
+    REQUIRE(tm.tm_mon >= 0);
+    REQUIRE(tm.tm_mon <= 11);
+    REQUIRE(tm.tm_mday >= 1);
+    REQUIRE(tm.tm_mday <= 31);
+    REQUIRE(tm.tm_hour >= 0);
+    REQUIRE(tm.tm_hour <= 23);
+    REQUIRE(tm.tm_min >= 0);
+    REQUIRE(tm.tm_min <= 59);
+    REQUIRE(tm.tm_sec >= 0);
+    REQUIRE(tm.tm_sec <= 60);
+}
+
 TEST_CASE("Runtime C string copy truncates safely", "[runtime][system]") {
     char buffer[5]{};
     copy_c_string(buffer, "abcdef");
@@ -168,6 +182,16 @@ TEST_CASE("Runtime C string copy handles degenerate buffers", "[runtime][system]
     REQUIRE(untouched == 'x');
 
     REQUIRE_NOTHROW(copy_c_string(nullptr, 4, "abc"));
+}
+
+TEST_CASE("Runtime system info convenience helpers mirror cached info",
+          "[runtime][system][coverage][phase3]") {
+    const auto& info = get_system_info();
+    REQUIRE_FALSE(info.os_name.empty());
+    REQUIRE_FALSE(info.arch.empty());
+    REQUIRE(info.cpu_threads >= 0);
+    REQUIRE(cpu_thread_count() == info.cpu_threads);
+    REQUIRE(total_memory_mb() == info.total_memory_mb);
 }
 
 TEST_CASE("TemporaryFile creates extensions and release preserves path", "[runtime][temporary_file]") {

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -8,8 +8,10 @@
 #include <pulp/runtime/http.hpp>
 #include <pulp/runtime/range.hpp>
 #include <pulp/runtime/text_diff.hpp>
+#include <algorithm>
 #include <fstream>
 #include <filesystem>
+#include <iterator>
 
 using namespace pulp::runtime;
 
@@ -87,6 +89,52 @@ TEST_CASE("MemoryMappedFile move semantics", "[runtime][mmap]") {
     REQUIRE_FALSE(a.is_open());
 }
 
+TEST_CASE("MemoryMappedFile ReadWrite mode persists byte edits",
+          "[runtime][mmap][coverage][issue-641]") {
+    TemporaryFile tmp(".bin");
+    {
+        std::ofstream f(tmp.path(), std::ios::binary);
+        f << "abcde";
+    }
+
+    MemoryMappedFile mmap;
+    REQUIRE(mmap.open(tmp.path_string(), MapMode::ReadWrite));
+    REQUIRE(mmap.is_open());
+    REQUIRE(mmap.size() == 5);
+    REQUIRE(mmap.mutable_data() != nullptr);
+
+    mmap.mutable_data()[1] = static_cast<uint8_t>('A');
+    mmap.mutable_data()[3] = static_cast<uint8_t>('D');
+    mmap.close();
+    REQUIRE_FALSE(mmap.is_open());
+
+    std::ifstream f(tmp.path(), std::ios::binary);
+    std::string contents((std::istreambuf_iterator<char>(f)),
+                         std::istreambuf_iterator<char>());
+    REQUIRE(contents == "aAcDe");
+}
+
+TEST_CASE("MemoryMappedFile open failure clears an existing mapping",
+          "[runtime][mmap][coverage][issue-641]") {
+    TemporaryFile mapped(".bin");
+    {
+        std::ofstream f(mapped.path(), std::ios::binary);
+        f << "mapped";
+    }
+
+    TemporaryFile empty(".bin");
+
+    MemoryMappedFile mmap;
+    REQUIRE(mmap.open(mapped.path_string()));
+    REQUIRE(mmap.is_open());
+    REQUIRE(mmap.size() == 6);
+
+    REQUIRE_FALSE(mmap.open(empty.path_string()));
+    REQUIRE_FALSE(mmap.is_open());
+    REQUIRE(mmap.data() == nullptr);
+    REQUIRE(mmap.size() == 0);
+}
+
 // ── DynamicLibrary ──────────────────────────────────────────────────────
 
 TEST_CASE("DynamicLibrary loads system library", "[runtime][dynlib]") {
@@ -128,6 +176,25 @@ TEST_CASE("InterProcessLock double lock succeeds", "[runtime][ipc_lock]") {
     InterProcessLock lock("test_lock_double");
     REQUIRE(lock.try_lock());
     REQUIRE(lock.try_lock());  // Already locked, should still return true
+}
+
+TEST_CASE("InterProcessLock unlock is idempotent and permits reacquire",
+          "[runtime][ipc_lock][coverage][issue-641]") {
+    InterProcessLock lock("test_lock_reacquire");
+    REQUIRE_FALSE(lock.is_locked());
+
+    lock.unlock();
+    REQUIRE_FALSE(lock.is_locked());
+
+    REQUIRE(lock.try_lock());
+    REQUIRE(lock.is_locked());
+    lock.unlock();
+    REQUIRE_FALSE(lock.is_locked());
+    lock.unlock();
+    REQUIRE_FALSE(lock.is_locked());
+
+    REQUIRE(lock.try_lock());
+    REQUIRE(lock.is_locked());
 }
 
 // ── ChildProcess ────────────────────────────────────────────────────────
@@ -239,6 +306,24 @@ TEST_CASE("base64 binary round-trip", "[runtime][base64]") {
     REQUIRE(*decoded == data);
 }
 
+TEST_CASE("base64 handles explicit byte pointers and exact quartet decoding",
+          "[runtime][base64][coverage][issue-641]") {
+    REQUIRE(base64_encode(nullptr, 0) == "");
+
+    const uint8_t bytes[] = {0x00, 0x10, 0x20, 0x30, 0xff};
+    auto encoded = base64_encode(bytes, sizeof(bytes));
+    REQUIRE(encoded == "ABAgMP8=");
+
+    auto decoded = base64_decode("ABAgMP8=");
+    REQUIRE(decoded.has_value());
+    REQUIRE(decoded->size() == sizeof(bytes));
+    REQUIRE(std::equal(decoded->begin(), decoded->end(), std::begin(bytes)));
+
+    auto quartet = base64_decode("////");
+    REQUIRE(quartet.has_value());
+    REQUIRE(*quartet == std::vector<uint8_t>{0xff, 0xff, 0xff});
+}
+
 // ── HTTP URL parsing ───────────────────────────────────────────────────
 
 TEST_CASE("HTTP helpers reject malformed URLs without transport work",
@@ -317,6 +402,26 @@ TEST_CASE("text_diff preserves equal lines across replacements and appends",
             "+ delta\n"
             "  gamma\n"
             "+ omega\n");
+}
+
+TEST_CASE("text_diff keeps repeated-line matches stable",
+          "[runtime][text-diff][coverage][issue-641]") {
+    auto diff = text_diff("same\nkeep\nsame\nremove\nsame",
+                          "same\nkeep\nsame\ninsert\nsame");
+
+    REQUIRE(diff.size() == 6);
+    REQUIRE(diff[0].op == DiffOp::Equal);
+    REQUIRE(diff[0].text == "same");
+    REQUIRE(diff[1].op == DiffOp::Equal);
+    REQUIRE(diff[1].text == "keep");
+    REQUIRE(diff[2].op == DiffOp::Equal);
+    REQUIRE(diff[2].text == "same");
+    REQUIRE(diff[3].op == DiffOp::Delete);
+    REQUIRE(diff[3].text == "remove");
+    REQUIRE(diff[4].op == DiffOp::Insert);
+    REQUIRE(diff[4].text == "insert");
+    REQUIRE(diff[5].op == DiffOp::Equal);
+    REQUIRE(diff[5].text == "same");
 }
 
 // ── Range ───────────────────────────────────────────────────────────────
@@ -401,4 +506,15 @@ TEST_CASE("FloatRange", "[runtime][range]") {
     FloatRange r(0.0f, 1.0f);
     REQUIRE(r.contains(0.5f));
     REQUIRE_FALSE(r.contains(1.0f));
+}
+
+TEST_CASE("Range boundary touch points remain non-intersections",
+          "[runtime][range][coverage][issue-641]") {
+    REQUIRE_FALSE(IntRange(0, 10).intersects(IntRange(10, 20)));
+    REQUIRE(IntRange(0, 10).intersection(IntRange(10, 20)).empty());
+    REQUIRE(IntRange(10, 20).intersection(IntRange(0, 10)).empty());
+
+    REQUIRE(IntRange(5, 5).empty());
+    REQUIRE(IntRange(5, 4).empty());
+    REQUIRE(IntRange(5, 5).constrain(100) == 5);
 }

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -7,6 +7,7 @@
 #include <pulp/runtime/base64.hpp>
 #include <pulp/runtime/http.hpp>
 #include <pulp/runtime/range.hpp>
+#include <pulp/runtime/scope_guard.hpp>
 #include <pulp/runtime/text_diff.hpp>
 #include <fstream>
 #include <filesystem>
@@ -44,6 +45,83 @@ TEST_CASE("TemporaryFile move semantics", "[runtime][temp_file]") {
     TemporaryFile b = std::move(a);
     REQUIRE(b.path() == path);
     REQUIRE(std::filesystem::exists(path));
+}
+
+TEST_CASE("TemporaryFile normalizes bare extensions and exposes path string",
+          "[runtime][temp_file][coverage][phase3]") {
+    std::filesystem::path path;
+    std::string path_string;
+    {
+        TemporaryFile tmp("wav");
+        path = tmp.path();
+        path_string = tmp.path_string();
+        REQUIRE(path.extension() == ".wav");
+        REQUIRE(path_string == path.string());
+        REQUIRE(std::filesystem::exists(path));
+    }
+    REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
+TEST_CASE("TemporaryFile move assignment deletes previous active file",
+          "[runtime][temp_file][coverage][phase3]") {
+    std::filesystem::path old_path;
+    std::filesystem::path new_path;
+    {
+        TemporaryFile old_file(".old");
+        TemporaryFile new_file(".new");
+        old_path = old_file.path();
+        new_path = new_file.path();
+        REQUIRE(std::filesystem::exists(old_path));
+        REQUIRE(std::filesystem::exists(new_path));
+
+        old_file = std::move(new_file);
+
+        REQUIRE_FALSE(std::filesystem::exists(old_path));
+        REQUIRE(old_file.path() == new_path);
+        REQUIRE(std::filesystem::exists(new_path));
+    }
+    REQUIRE_FALSE(std::filesystem::exists(new_path));
+}
+
+// ── ScopeGuard ─────────────────────────────────────────────────────────
+
+TEST_CASE("ScopeGuard runs on scope exit unless dismissed",
+          "[runtime][scope_guard][coverage][phase3]") {
+    int counter = 0;
+    {
+        auto guard = make_scope_guard([&] { counter += 1; });
+        REQUIRE(counter == 0);
+    }
+    REQUIRE(counter == 1);
+
+    {
+        auto guard = make_scope_guard([&] { counter += 10; });
+        guard.dismiss();
+    }
+    REQUIRE(counter == 1);
+}
+
+TEST_CASE("ScopeGuard move transfers the active cleanup",
+          "[runtime][scope_guard][coverage][phase3]") {
+    int counter = 0;
+    {
+        auto first = make_scope_guard([&] { counter += 1; });
+        auto second = std::move(first);
+        REQUIRE(counter == 0);
+    }
+    REQUIRE(counter == 1);
+}
+
+TEST_CASE("PULP_ON_SCOPE_EXIT macro captures local scope",
+          "[runtime][scope_guard][coverage][phase3]") {
+    int counter = 0;
+    {
+        int delta = 4;
+        PULP_ON_SCOPE_EXIT(counter += delta;);
+        delta = 7;
+        REQUIRE(counter == 0);
+    }
+    REQUIRE(counter == 7);
 }
 
 // ── MemoryMappedFile ────────────────────────────────────────────────────

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -87,6 +87,55 @@ TEST_CASE("MemoryMappedFile move semantics", "[runtime][mmap]") {
     REQUIRE_FALSE(a.is_open());
 }
 
+TEST_CASE("MemoryMappedFile read-write maps persist and move assignment closes old map",
+          "[runtime][mmap][coverage][issue-656]") {
+    TemporaryFile first(".bin");
+    TemporaryFile second(".bin");
+    {
+        std::ofstream f(first.path(), std::ios::binary);
+        f << "abcd";
+    }
+    {
+        std::ofstream f(second.path(), std::ios::binary);
+        f << "wxyz";
+    }
+
+    MemoryMappedFile old_map;
+    REQUIRE(old_map.open(first.path_string(), MapMode::ReadOnly));
+    REQUIRE(old_map.is_open());
+
+    MemoryMappedFile writable;
+    REQUIRE(writable.open(second.path_string(), MapMode::ReadWrite));
+    REQUIRE(writable.is_open());
+    REQUIRE(writable.size() == 4);
+    writable.mutable_data()[1] = static_cast<uint8_t>('!');
+
+    old_map = std::move(writable);
+    REQUIRE(old_map.is_open());
+    REQUIRE_FALSE(writable.is_open());
+    REQUIRE(old_map.size() == 4);
+    REQUIRE(std::string(reinterpret_cast<const char*>(old_map.data()), old_map.size()) == "w!yz");
+
+    old_map.close();
+    std::ifstream f(second.path(), std::ios::binary);
+    std::string saved((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    REQUIRE(saved == "w!yz");
+}
+
+TEST_CASE("MemoryMappedFile rejects empty files and close is idempotent",
+          "[runtime][mmap][coverage][issue-656]") {
+    TemporaryFile tmp(".bin");
+
+    MemoryMappedFile mmap;
+    REQUIRE_FALSE(mmap.open(tmp.path_string()));
+    REQUIRE_FALSE(mmap.is_open());
+    REQUIRE(mmap.size() == 0);
+    REQUIRE(mmap.data() == nullptr);
+    mmap.close();
+    mmap.close();
+    REQUIRE_FALSE(mmap.is_open());
+}
+
 // ── DynamicLibrary ──────────────────────────────────────────────────────
 
 TEST_CASE("DynamicLibrary loads system library", "[runtime][dynlib]") {
@@ -267,6 +316,26 @@ TEST_CASE("HTTP helpers reject invalid numeric URL ports",
     const auto too_large_port = http_post("http://example.com:65536/path", "body", "text/plain", 1);
     REQUIRE(too_large_port.status_code == 0);
     REQUIRE(too_large_port.error == "Invalid URL");
+}
+
+TEST_CASE("HttpResponse ok covers status code boundaries", "[runtime][http][url][coverage][issue-656]") {
+    HttpResponse response;
+    response.status_code = 199;
+    REQUIRE_FALSE(response.ok());
+    response.status_code = 200;
+    REQUIRE(response.ok());
+    response.status_code = 299;
+    REQUIRE(response.ok());
+    response.status_code = 300;
+    REQUIRE_FALSE(response.ok());
+}
+
+TEST_CASE("HTTP helpers reject malformed URL hosts and schemes",
+          "[runtime][http][url][coverage][issue-656]") {
+    REQUIRE(http_get("https://:443/path", 1).error == "Invalid URL");
+    REQUIRE(http_get("http://example.com:not-a-port/path", 1).error == "Invalid URL");
+    REQUIRE(http_post("file://example.com/path", "body", "text/plain", 1).error == "Invalid URL");
+    REQUIRE_FALSE(http_download("http://", "/tmp/pulp-url-invalid-download-656", 1));
 }
 
 // ── Text Diff ────────────────────────────────────────────────────────────

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -268,6 +268,18 @@ TEST_CASE("run_process captures exit code", "[runtime][child_process]") {
     REQUIRE(result->exit_code == 42);
 }
 
+TEST_CASE("run_process captures stderr separately",
+          "[runtime][child_process][coverage][phase3]") {
+#ifdef _WIN32
+    auto result = run_process("powershell", {"-NoProfile", "-Command", "Write-Error 'bad news'; exit 7"});
+#else
+    auto result = run_process("/bin/sh", {"-c", "echo bad-news >&2; exit 7"});
+#endif
+    REQUIRE(result.has_value());
+    REQUIRE(result->exit_code == 7);
+    REQUIRE(result->stderr_output.find("bad-news") != std::string::npos);
+}
+
 TEST_CASE("run_process fails on nonexistent", "[runtime][child_process]") {
 #ifdef _WIN32
     auto result = run_process("C:\\nonexistent_binary_12345.exe");

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -165,6 +165,41 @@ TEST_CASE("MemoryMappedFile move semantics", "[runtime][mmap]") {
     REQUIRE_FALSE(a.is_open());
 }
 
+TEST_CASE("MemoryMappedFile read-write mapping and move assignment",
+          "[runtime][mmap][coverage][phase3]") {
+    TemporaryFile old_tmp(".bin");
+    TemporaryFile new_tmp(".bin");
+    {
+        std::ofstream f(old_tmp.path(), std::ios::binary);
+        f << "old";
+    }
+    {
+        std::ofstream f(new_tmp.path(), std::ios::binary);
+        f << "new";
+    }
+
+    MemoryMappedFile old_map;
+    REQUIRE(old_map.open(old_tmp.path_string()));
+    REQUIRE(old_map.is_open());
+
+    MemoryMappedFile new_map;
+    REQUIRE(new_map.open(new_tmp.path_string(), MapMode::ReadWrite));
+    REQUIRE(new_map.is_open());
+    REQUIRE(new_map.size() == 3);
+    new_map.mutable_data()[0] = 'N';
+
+    old_map = std::move(new_map);
+    REQUIRE(old_map.is_open());
+    REQUIRE_FALSE(new_map.is_open());
+    REQUIRE(std::string(reinterpret_cast<const char*>(old_map.data()), old_map.size()) == "New");
+
+    old_map.close();
+    std::ifstream f(new_tmp.path(), std::ios::binary);
+    std::string persisted;
+    f >> persisted;
+    REQUIRE(persisted == "New");
+}
+
 // ── DynamicLibrary ──────────────────────────────────────────────────────
 
 TEST_CASE("DynamicLibrary loads system library", "[runtime][dynlib]") {

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/runtime/memory_mapped_file.hpp>
 #include <pulp/runtime/temporary_file.hpp>
 #include <pulp/runtime/dynamic_library.hpp>
@@ -46,6 +47,47 @@ TEST_CASE("TemporaryFile move semantics", "[runtime][temp_file]") {
     REQUIRE(std::filesystem::exists(path));
 }
 
+TEST_CASE("TemporaryFile normalizes extensions without leading dots",
+          "[runtime][temp_file][issue-641]") {
+    TemporaryFile tmp("raw");
+    REQUIRE(tmp.path().extension() == ".raw");
+    REQUIRE(std::filesystem::exists(tmp.path()));
+}
+
+TEST_CASE("TemporaryFile move assignment removes the previous active file",
+          "[runtime][temp_file][issue-641]") {
+    std::filesystem::path old_path;
+    std::filesystem::path new_path;
+    {
+        TemporaryFile old_file(".old");
+        TemporaryFile new_file(".new");
+        old_path = old_file.path();
+        new_path = new_file.path();
+
+        old_file = std::move(new_file);
+        REQUIRE(old_file.path() == new_path);
+        REQUIRE_FALSE(std::filesystem::exists(old_path));
+        REQUIRE(std::filesystem::exists(new_path));
+    }
+
+    REQUIRE_FALSE(std::filesystem::exists(new_path));
+}
+
+TEST_CASE("TemporaryFile self move assignment preserves ownership",
+          "[runtime][temp_file][issue-641]") {
+    std::filesystem::path path;
+    {
+        TemporaryFile tmp(".self");
+        path = tmp.path();
+        auto& ref = tmp;
+        tmp = std::move(ref);
+        REQUIRE(tmp.path() == path);
+        REQUIRE(std::filesystem::exists(path));
+    }
+
+    REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
 // ── MemoryMappedFile ────────────────────────────────────────────────────
 
 TEST_CASE("MemoryMappedFile maps a file", "[runtime][mmap]") {
@@ -85,6 +127,28 @@ TEST_CASE("MemoryMappedFile move semantics", "[runtime][mmap]") {
     MemoryMappedFile b = std::move(a);
     REQUIRE(b.is_open());
     REQUIRE_FALSE(a.is_open());
+}
+
+TEST_CASE("MemoryMappedFile reopen closes the previous mapping",
+          "[runtime][mmap][issue-641]") {
+    TemporaryFile first(".bin");
+    TemporaryFile second(".bin");
+    {
+        std::ofstream f(first.path(), std::ios::binary);
+        f << "first";
+    }
+    {
+        std::ofstream f(second.path(), std::ios::binary);
+        f << "second-file";
+    }
+
+    MemoryMappedFile mmap;
+    REQUIRE(mmap.open(first.path_string()));
+    REQUIRE(mmap.size() == 5);
+    REQUIRE(mmap.open(second.path_string()));
+    REQUIRE(mmap.is_open());
+    REQUIRE(mmap.size() == 11);
+    REQUIRE(std::string(reinterpret_cast<const char*>(mmap.data()), mmap.size()) == "second-file");
 }
 
 // ── DynamicLibrary ──────────────────────────────────────────────────────
@@ -361,6 +425,13 @@ TEST_CASE("Range constrain", "[runtime][range]") {
     REQUIRE(r.constrain(200) == 99);
 }
 
+TEST_CASE("Range constrain handles empty and reversed integer ranges",
+          "[runtime][range][coverage][issue-641]") {
+    REQUIRE(IntRange(5, 5).constrain(100) == 5);
+    REQUIRE(IntRange(10, 5).constrain(-100) == 10);
+    REQUIRE(IntRange(-3, -1).constrain(9) == -2);
+}
+
 TEST_CASE("Range from_start_length", "[runtime][range]") {
     auto r = IntRange::from_start_length(5, 10);
     REQUIRE(r.start == 5);
@@ -401,4 +472,18 @@ TEST_CASE("FloatRange", "[runtime][range]") {
     FloatRange r(0.0f, 1.0f);
     REQUIRE(r.contains(0.5f));
     REQUIRE_FALSE(r.contains(1.0f));
+}
+
+TEST_CASE("DoubleRange intersections and unions preserve fractional bounds",
+          "[runtime][range][coverage][issue-641]") {
+    DoubleRange a(0.25, 2.75);
+    DoubleRange b(1.5, 4.0);
+
+    auto intersection = a.intersection(b);
+    REQUIRE_THAT(intersection.start, Catch::Matchers::WithinAbs(1.5, 1e-12));
+    REQUIRE_THAT(intersection.end, Catch::Matchers::WithinAbs(2.75, 1e-12));
+
+    auto combined = a.enclosing_union(b);
+    REQUIRE_THAT(combined.start, Catch::Matchers::WithinAbs(0.25, 1e-12));
+    REQUIRE_THAT(combined.end, Catch::Matchers::WithinAbs(4.0, 1e-12));
 }

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -271,7 +271,7 @@ TEST_CASE("run_process captures exit code", "[runtime][child_process]") {
 TEST_CASE("run_process captures stderr separately",
           "[runtime][child_process][coverage][phase3]") {
 #ifdef _WIN32
-    auto result = run_process("powershell", {"-NoProfile", "-Command", "Write-Error 'bad news'; exit 7"});
+    auto result = run_process("powershell", {"-NoProfile", "-Command", "[Console]::Error.WriteLine('bad-news'); exit 7"});
 #else
     auto result = run_process("/bin/sh", {"-c", "echo bad-news >&2; exit 7"});
 #endif

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -347,6 +347,26 @@ TEST_CASE("HTTP helpers reject invalid numeric URL ports",
     REQUIRE(too_large_port.error == "Invalid URL");
 }
 
+TEST_CASE("HttpResponse ok helper follows 2xx status range",
+          "[runtime][http][coverage][phase3]") {
+    HttpResponse response;
+
+    response.status_code = 199;
+    REQUIRE_FALSE(response.ok());
+
+    response.status_code = 200;
+    REQUIRE(response.ok());
+
+    response.status_code = 204;
+    REQUIRE(response.ok());
+
+    response.status_code = 299;
+    REQUIRE(response.ok());
+
+    response.status_code = 300;
+    REQUIRE_FALSE(response.ok());
+}
+
 // ── Text Diff ────────────────────────────────────────────────────────────
 
 TEST_CASE("text_diff handles empty inputs", "[runtime][text-diff][issue-641]") {

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -5,9 +5,12 @@
 #include <pulp/runtime/inter_process_lock.hpp>
 #include <pulp/runtime/child_process.hpp>
 #include <pulp/runtime/base64.hpp>
+#include <pulp/runtime/expression.hpp>
 #include <pulp/runtime/http.hpp>
 #include <pulp/runtime/range.hpp>
 #include <pulp/runtime/text_diff.hpp>
+#include <catch2/catch_approx.hpp>
+#include <cmath>
 #include <fstream>
 #include <filesystem>
 
@@ -237,6 +240,82 @@ TEST_CASE("base64 binary round-trip", "[runtime][base64]") {
     auto decoded = base64_decode(encoded);
     REQUIRE(decoded.has_value());
     REQUIRE(*decoded == data);
+}
+
+// ── Expression ─────────────────────────────────────────────────────────
+
+TEST_CASE("Expression evaluator handles precedence and exponent edge cases",
+          "[runtime][expression][coverage][issue-641]") {
+    auto value = evaluate("2 + 3 * 4 ^ 2");
+    REQUIRE(value.has_value());
+    REQUIRE(*value == Catch::Approx(50.0));
+
+    auto signed_power = evaluate("-2^2");
+    REQUIRE(signed_power.has_value());
+    REQUIRE(*signed_power == Catch::Approx(4.0));
+
+    auto grouped = evaluate("(-2)^2");
+    REQUIRE(grouped.has_value());
+    REQUIRE(*grouped == Catch::Approx(4.0));
+}
+
+TEST_CASE("Expression evaluator handles constants, functions, and scientific notation",
+          "[runtime][expression][coverage][issue-641]") {
+    auto trig = evaluate("sin(pi / 2) + cos(0)");
+    REQUIRE(trig.has_value());
+    REQUIRE(*trig == Catch::Approx(2.0));
+
+    auto clamped = evaluate("clamp(12, 10)");
+    REQUIRE(clamped.has_value());
+    REQUIRE(*clamped == Catch::Approx(10.0));
+
+    auto scientific = evaluate("1.5e2 + 2E-1");
+    REQUIRE(scientific.has_value());
+    REQUIRE(*scientific == Catch::Approx(150.2));
+}
+
+TEST_CASE("Expression evaluator resolves variables and rejects malformed inputs",
+          "[runtime][expression][coverage][issue-641]") {
+    auto variable = evaluate("gain * 2 + offset", {{"gain", 0.75}, {"offset", 0.25}});
+    REQUIRE(variable.has_value());
+    REQUIRE(*variable == Catch::Approx(1.75));
+
+    REQUIRE_FALSE(evaluate("missing + 1").has_value());
+    REQUIRE_FALSE(evaluate("min(1)").has_value());
+    REQUIRE_FALSE(evaluate("(1 + 2").has_value());
+    REQUIRE_FALSE(evaluate("").has_value());
+}
+
+TEST_CASE("ExpressionEvaluator stores variables and clears them",
+          "[runtime][expression][coverage][issue-641]") {
+    ExpressionEvaluator evaluator;
+    evaluator.set("x", 4.0);
+    evaluator.set("y", 2.5);
+
+    REQUIRE(evaluator.get("x").has_value());
+    REQUIRE(*evaluator.get("x") == Catch::Approx(4.0));
+
+    auto value = evaluator.evaluate("x * y");
+    REQUIRE(value.has_value());
+    REQUIRE(*value == Catch::Approx(10.0));
+
+    evaluator.clear_variables();
+    REQUIRE_FALSE(evaluator.get("x").has_value());
+    REQUIRE_FALSE(evaluator.evaluate("x").has_value());
+}
+
+TEST_CASE("ExpressionEvaluator dispatches registered unary functions",
+          "[runtime][expression][coverage][issue-641]") {
+    ExpressionEvaluator evaluator;
+    evaluator.register_function("db_to_gain", [](double db) {
+        return std::pow(10.0, db / 20.0);
+    });
+
+    auto unity = evaluator.evaluate("db_to_gain(0)");
+    REQUIRE(unity.has_value());
+    REQUIRE(*unity == Catch::Approx(1.0));
+
+    REQUIRE_FALSE(evaluator.evaluate("missing_fn(1)").has_value());
 }
 
 // ── HTTP URL parsing ───────────────────────────────────────────────────

--- a/test/test_scan_blacklist.cpp
+++ b/test/test_scan_blacklist.cpp
@@ -143,3 +143,41 @@ TEST_CASE("load_from and save_to report unavailable paths",
     fs::create_directories(f.path);
     REQUIRE_FALSE(bl.save_to(f.path.string()));
 }
+
+TEST_CASE("from_text accepts empty/comment-only files and clears previous entries",
+          "[host][blacklist][issue-493]") {
+    ScanBlacklist bl;
+    REQUIRE(bl.from_text("/old|1|2|stale\n"));
+    REQUIRE(bl.size() == 1);
+
+    REQUIRE(bl.from_text("# only comments\n\n   \n"));
+    REQUIRE(bl.size() == 0);
+    REQUIRE_FALSE(bl.is_blacklisted("/old"));
+}
+
+TEST_CASE("from_text preserves reasons containing delimiter-like escaped data",
+          "[host][blacklist][issue-493]") {
+    ScanBlacklist bl;
+    REQUIRE(bl.from_text("/plugin.vst3|10|20|first%7Csecond%25third\n"));
+
+    auto entry = bl.entries().find("/plugin.vst3");
+    REQUIRE(entry != bl.entries().end());
+    REQUIRE(entry->second.mtime == 10);
+    REQUIRE(entry->second.size == 20);
+    REQUIRE(entry->second.reason == "first|second%third");
+
+    const auto text = bl.to_text();
+    REQUIRE(text.find("first%7Csecond%25third") != std::string::npos);
+}
+
+TEST_CASE("from_text tolerates signed stamp values from old blacklist files",
+          "[host][blacklist][issue-493]") {
+    ScanBlacklist bl;
+    REQUIRE(bl.from_text("/plugin.vst3|-1|-2|old stamp\n"));
+
+    auto entry = bl.entries().find("/plugin.vst3");
+    REQUIRE(entry != bl.entries().end());
+    REQUIRE(entry->second.mtime == -1);
+    REQUIRE(entry->second.size == -2);
+    REQUIRE(entry->second.reason == "old stamp");
+}

--- a/test/test_sdf_atlas.cpp
+++ b/test/test_sdf_atlas.cpp
@@ -28,6 +28,28 @@ TEST_CASE("SdfAtlas default state is empty", "[canvas][sdf][issue-641]") {
     REQUIRE(atlas.glyph(U'A') == nullptr);
 }
 
+TEST_CASE("SdfAtlas move operations transfer atlas storage",
+          "[canvas][sdf][coverage][issue-650]") {
+    SdfAtlas original;
+    REQUIRE(original.build("stub", {U'A', U'B'}, 20, 2, 128));
+    const auto* before = original.glyph(U'B');
+    REQUIRE(before != nullptr);
+
+    SdfAtlas moved(std::move(original));
+    REQUIRE(moved.glyph_count() == 2);
+    REQUIRE(moved.base_size() == 20);
+    REQUIRE(moved.pixels() != nullptr);
+    REQUIRE(moved.glyph(U'B') != nullptr);
+    REQUIRE(moved.glyph(U'B')->atlas_x == before->atlas_x);
+
+    SdfAtlas assigned;
+    assigned = std::move(moved);
+    REQUIRE(assigned.glyph_count() == 2);
+    REQUIRE(assigned.pixels() != nullptr);
+    REQUIRE(assigned.glyph(U'A') != nullptr);
+    REQUIRE(assigned.glyph(U'Z') == nullptr);
+}
+
 TEST_CASE("SdfAtlas builds with the requested glyphs", "[canvas][sdf]") {
     SdfAtlas atlas;
     std::vector<char32_t> chars = {U'A', U'B', U'C', U'D'};
@@ -64,6 +86,24 @@ TEST_CASE("SdfAtlas rejects invalid build arguments without allocation",
     REQUIRE_FALSE(invalid_padding.build("stub", {U'A'}, 32, -1, 256));
     REQUIRE(invalid_padding.glyph_count() == 0);
     REQUIRE(invalid_padding.pixels() == nullptr);
+}
+
+TEST_CASE("SdfAtlas invalid rebuild preserves prior atlas but overflow clears it",
+          "[canvas][sdf][coverage][issue-650]") {
+    SdfAtlas atlas;
+    REQUIRE(atlas.build("stub", {U'A'}, 16, 2, 128));
+    REQUIRE(atlas.glyph_count() == 1);
+    REQUIRE(atlas.glyph(U'A') != nullptr);
+
+    REQUIRE_FALSE(atlas.build("stub", {}, 16, 2, 128));
+    REQUIRE(atlas.glyph_count() == 1);
+    REQUIRE(atlas.glyph(U'A') != nullptr);
+
+    std::vector<char32_t> many;
+    for (char32_t c = 0; c < 100; ++c) many.push_back(c);
+    REQUIRE_FALSE(atlas.build("stub", many, 128, 8, 256));
+    REQUIRE(atlas.glyph_count() == 0);
+    REQUIRE(atlas.pixels() == nullptr);
 }
 
 TEST_CASE("SdfAtlas packs glyphs into deterministic tile coordinates",

--- a/test/test_sdf_atlas_cache.cpp
+++ b/test/test_sdf_atlas_cache.cpp
@@ -12,6 +12,15 @@ TEST_CASE("SdfAtlasCache initializes with a seed glyph set", "[canvas][cache]") 
     REQUIRE(cache.touch(U'Z') == nullptr);
 }
 
+TEST_CASE("SdfAtlasCache can initialize an empty resident set",
+          "[canvas][cache][coverage][issue-650]") {
+    SdfAtlasCache cache;
+    REQUIRE_FALSE(cache.initialize("", {}, 24, 4, 512));
+    REQUIRE(cache.size() == 0);
+    REQUIRE(cache.touch(U'A') == nullptr);
+    REQUIRE(cache.atlas().pixels() == nullptr);
+}
+
 TEST_CASE("SdfAtlasCache failed initialize clears prior resident glyphs",
           "[canvas][cache][issue-641]") {
     SdfAtlasCache cache;
@@ -40,6 +49,24 @@ TEST_CASE("SdfAtlasCache reinitialize stamps new glyphs at current frame",
     const auto* z = cache.touch(U'Z');
     REQUIRE(z != nullptr);
     REQUIRE(z->frame_last_used == cache.current_frame());
+}
+
+TEST_CASE("SdfAtlasCache touching resident glyph updates recency without clearing dirty",
+          "[canvas][cache][coverage][issue-650]") {
+    SdfAtlasCache cache;
+    REQUIRE(cache.initialize("", {U'A', U'B'}, 24, 4, 512));
+
+    cache.next_frame();
+    cache.next_frame();
+    const auto* a = cache.touch(U'A');
+    REQUIRE(a != nullptr);
+    REQUIRE(a->frame_last_used == 2);
+    REQUIRE(a->dirty);
+
+    cache.next_frame();
+    REQUIRE(cache.evict_older_than(2) == 1);
+    REQUIRE(cache.touch(U'B') == nullptr);
+    REQUIRE(cache.touch(U'A') != nullptr);
 }
 
 TEST_CASE("SdfAtlasCache advances frame counter and records recency",

--- a/test/test_sdf_effects.cpp
+++ b/test/test_sdf_effects.cpp
@@ -6,6 +6,20 @@
 
 using namespace pulp::canvas;
 
+TEST_CASE("SdfEffectParams default to inactive shader-safe values",
+          "[canvas][sdf][effects][coverage][issue-650]") {
+    SdfEffectParams p;
+    REQUIRE(p.active == 0);
+    REQUIRE_FALSE(has_effect(p.active, SdfEffect::Outline));
+    REQUIRE_FALSE(has_effect(p.active, SdfEffect::Glow));
+    REQUIRE_FALSE(has_effect(p.active, SdfEffect::Shadow));
+    REQUIRE_FALSE(has_effect(p.active, SdfEffect::Bevel));
+    REQUIRE(p.outline_color[3] == 1.0f);
+    REQUIRE(p.glow_color[3] == 1.0f);
+    REQUIRE(p.shadow_color[3] == 0.5f);
+    REQUIRE(p.bevel_mix == 0.0f);
+}
+
 TEST_CASE("SdfEffect bitmask composes with |", "[canvas][sdf][effects]") {
     const std::uint8_t mask = SdfEffect::Outline | SdfEffect::Shadow;
     REQUIRE(has_effect(mask, SdfEffect::Outline));
@@ -13,6 +27,17 @@ TEST_CASE("SdfEffect bitmask composes with |", "[canvas][sdf][effects]") {
     REQUIRE_FALSE(has_effect(mask, SdfEffect::Glow));
     REQUIRE_FALSE(has_effect(mask, SdfEffect::Bevel));
     REQUIRE_FALSE(has_effect(mask, SdfEffect::None));
+}
+
+TEST_CASE("SdfEffect bitmask accepts manually combined active masks",
+          "[canvas][sdf][effects][coverage][issue-650]") {
+    const auto mask = static_cast<std::uint8_t>(SdfEffect::Outline)
+                    | static_cast<std::uint8_t>(SdfEffect::Glow)
+                    | static_cast<std::uint8_t>(SdfEffect::Bevel);
+    REQUIRE(has_effect(mask, SdfEffect::Outline));
+    REQUIRE(has_effect(mask, SdfEffect::Glow));
+    REQUIRE(has_effect(mask, SdfEffect::Bevel));
+    REQUIRE_FALSE(has_effect(mask, SdfEffect::Shadow));
 }
 
 TEST_CASE("preset_subtle_shadow has only Shadow active",
@@ -29,6 +54,19 @@ TEST_CASE("preset_outline width is respected",
     auto p = preset_outline(3.0f);
     REQUIRE(has_effect(p.active, SdfEffect::Outline));
     REQUIRE(p.outline_width == 3.0f);
+}
+
+TEST_CASE("SDF effect presets preserve explicit zero dimensions",
+          "[canvas][sdf][effects][presets][coverage][issue-650]") {
+    auto outline = preset_outline(0.0f);
+    REQUIRE(has_effect(outline.active, SdfEffect::Outline));
+    REQUIRE(outline.outline_width == 0.0f);
+
+    auto glow = preset_glow(0.0f, {0.2f, 0.3f, 0.4f, 0.5f});
+    REQUIRE(has_effect(glow.active, SdfEffect::Glow));
+    REQUIRE(glow.glow_radius == 0.0f);
+    REQUIRE(glow.glow_color[2] == 0.4f);
+    REQUIRE(glow.glow_color[3] == 0.5f);
 }
 
 TEST_CASE("preset_glow carries the given color",

--- a/test/test_sdf_software_renderer.cpp
+++ b/test/test_sdf_software_renderer.cpp
@@ -68,6 +68,22 @@ TEST_CASE("software SDF render handles empty quad list",
     for (auto v : out) REQUIRE(v == 0);
 }
 
+TEST_CASE("software SDF render leaves output untouched for invalid output bounds",
+          "[canvas][sdf][render][coverage][issue-650]") {
+    TinyAtlas atlas{1, 1, {255}};
+    SdfTextQuad q;
+    q.dst_w = 1.0f;
+    q.dst_h = 1.0f;
+    q.src_w = 1.0f;
+    q.src_h = 1.0f;
+
+    std::uint8_t out[1] = {11};
+    render_sdf_text_software(atlas, {q}, out, 0, 1);
+    REQUIRE(out[0] == 11);
+    render_sdf_text_software(atlas, {q}, out, 1, 0);
+    REQUIRE(out[0] == 11);
+}
+
 TEST_CASE("software SDF render leaves output untouched for empty atlas",
           "[canvas][sdf][render][issue-641]") {
     TinyAtlas atlas;
@@ -160,4 +176,23 @@ TEST_CASE("software SDF render keeps maximum alpha for overlapping quads",
     std::uint8_t out[1] = {0};
     render_sdf_text_software(atlas, {low, high}, out, 1, 1);
     REQUIRE(out[0] == 255);
+}
+
+TEST_CASE("software SDF render honors custom edge thresholds",
+          "[canvas][sdf][render][coverage][issue-650]") {
+    TinyAtlas atlas{2, 1, {64, 255}};
+    SdfTextQuad q;
+    q.dst_w = 2.0f;
+    q.dst_h = 1.0f;
+    q.src_w = 2.0f;
+    q.src_h = 1.0f;
+
+    std::uint8_t out[2] = {0, 0};
+    SdfTextOptions opts;
+    opts.edge = 1.0f;
+    render_sdf_text_software(atlas, {q}, out, 2, 1, opts);
+
+    REQUIRE(out[0] == 0);
+    REQUIRE(out[1] > 0);
+    REQUIRE(out[1] < 255);
 }

--- a/test/test_sdf_text.cpp
+++ b/test/test_sdf_text.cpp
@@ -41,6 +41,16 @@ struct FakeAtlas {
 };
 }  // namespace
 
+TEST_CASE("SdfTextOptions default to shader contract values",
+          "[canvas][sdf][layout][coverage][issue-650]") {
+    SdfTextOptions opts;
+    REQUIRE(opts.edge == Catch::Approx(0.5f));
+    REQUIRE(opts.softness == 0.0f);
+    REQUIRE(opts.mip_bias == 0.0f);
+    REQUIRE(opts.gamma == Catch::Approx(2.2f));
+    REQUIRE(opts.snap == SdfPenSnap::Free);
+}
+
 TEST_CASE("snap_pen_x honours the pen-snap policy", "[canvas][sdf][snap]") {
     REQUIRE(snap_pen_x(3.7f, SdfPenSnap::Free)    == 3.7f);
     REQUIRE(snap_pen_x(3.7f, SdfPenSnap::Nearest) == 4.0f);
@@ -96,6 +106,20 @@ TEST_CASE("build_text_quads skips missing glyphs", "[canvas][sdf][layout]") {
     REQUIRE(quads.size() == 2);  // X is skipped.
 }
 
+TEST_CASE("build_text_quads handles empty text and zero render size",
+          "[canvas][sdf][layout][coverage][issue-650]") {
+    FakeAtlas atlas;
+    REQUIRE(build_text_quads(atlas, std::u32string(), 10.0f, 20.0f, 12.0f).empty());
+
+    auto zero = build_text_quads(atlas, std::u32string(U"A"),
+                                 10.0f, 20.0f, 0.0f);
+    REQUIRE(zero.size() == 1);
+    REQUIRE(zero[0].dst_x == 10.0f);
+    REQUIRE(zero[0].dst_y == 20.0f);
+    REQUIRE(zero[0].dst_w == 0.0f);
+    REQUIRE(zero[0].dst_h == 0.0f);
+}
+
 TEST_CASE("build_text_quads returns empty when atlas base size is invalid",
           "[canvas][sdf][layout][issue-641]") {
     FakeAtlas atlas;
@@ -139,6 +163,27 @@ TEST_CASE("named SDF text wrappers forward to shared quad builder",
     REQUIRE(sdf[0].codepoint == U'A');
     REQUIRE(msdf[0].codepoint == U'A');
     REQUIRE(psdf[0].codepoint == U'A');
+}
+
+TEST_CASE("named SDF text wrappers forward options consistently",
+          "[canvas][sdf][layout][coverage][issue-650]") {
+    FakeAtlas atlas;
+    SdfTextOptions opts;
+    opts.snap = SdfPenSnap::Nearest;
+
+    const auto sdf = fill_text_sdf(atlas, std::u32string(U"A"),
+                                   1.6f, 2.4f, 10.0f, opts);
+    const auto msdf = fill_text_msdf(atlas, std::u32string(U"A"),
+                                     1.6f, 2.4f, 10.0f, opts);
+    const auto psdf = fill_text_psdf(atlas, std::u32string(U"A"),
+                                     1.6f, 2.4f, 10.0f, opts);
+
+    REQUIRE(sdf.size() == 1);
+    REQUIRE(msdf.size() == 1);
+    REQUIRE(psdf.size() == 1);
+    REQUIRE(sdf[0].dst_x == msdf[0].dst_x);
+    REQUIRE(msdf[0].dst_x == psdf[0].dst_x);
+    REQUIRE(sdf[0].dst_y == psdf[0].dst_y);
 }
 
 TEST_CASE("build_text_quads works against MsdfAtlas (shared surface)",

--- a/test/test_sdl3_surface.cpp
+++ b/test/test_sdl3_surface.cpp
@@ -1,0 +1,37 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/render/sdl3_surface.hpp>
+
+using namespace pulp;
+
+TEST_CASE("SDL3 surface info validity follows backend state - issue-646",
+          "[render][sdl3][issue-646]") {
+    render::Sdl3SurfaceInfo info;
+    REQUIRE_FALSE(info.is_valid());
+
+    info.x11_display = reinterpret_cast<void*>(0x1);
+    info.x11_window = 42;
+    REQUIRE_FALSE(info.is_valid());
+
+    info.backend = render::Sdl3SurfaceInfo::Backend::vulkan_x11;
+    REQUIRE(info.is_valid());
+
+    info = {};
+    info.hwnd = reinterpret_cast<void*>(0x2);
+    info.hinstance = reinterpret_cast<void*>(0x3);
+    info.backend = render::Sdl3SurfaceInfo::Backend::d3d12;
+    REQUIRE(info.is_valid());
+}
+
+TEST_CASE("SDL3 surface extraction rejects null windows - issue-646",
+          "[render][sdl3][issue-646]") {
+    auto info = render::extract_sdl3_surface(nullptr);
+    REQUIRE_FALSE(info.is_valid());
+    REQUIRE(info.backend == render::Sdl3SurfaceInfo::Backend::none);
+    REQUIRE(info.metal_layer == nullptr);
+    REQUIRE(info.hwnd == nullptr);
+    REQUIRE(info.hinstance == nullptr);
+    REQUIRE(info.x11_display == nullptr);
+    REQUIRE(info.x11_window == 0);
+    REQUIRE(info.wayland_display == nullptr);
+    REQUIRE(info.wayland_surface == nullptr);
+}

--- a/test/test_signal.cpp
+++ b/test/test_signal.cpp
@@ -342,6 +342,39 @@ TEST_CASE("ADSR release to zero", "[signal][adsr]") {
     REQUIRE_THAT(env.next(), WithinAbs(0.0, 0.001));
 }
 
+TEST_CASE("ADSR handles immediate stages, idle note_off, and reset",
+          "[signal][adsr][issue-645]") {
+    Adsr env;
+    env.set_sample_rate(1000.0f);
+    env.set_params({0.0f, -0.01f, 0.25f, 0.0f});
+
+    env.note_off();
+    REQUIRE_FALSE(env.is_active());
+    REQUIRE(env.stage() == Adsr::Stage::idle);
+    REQUIRE_THAT(env.next(), WithinAbs(0.0f, 1e-6f));
+
+    env.note_on();
+    REQUIRE(env.stage() == Adsr::Stage::attack);
+    REQUIRE_THAT(env.next(), WithinAbs(1.0f, 1e-6f));
+    REQUIRE(env.stage() == Adsr::Stage::decay);
+    REQUIRE_THAT(env.next(), WithinAbs(0.25f, 1e-6f));
+    REQUIRE(env.stage() == Adsr::Stage::sustain);
+    REQUIRE_THAT(env.next(), WithinAbs(0.25f, 1e-6f));
+
+    env.note_off();
+    REQUIRE(env.stage() == Adsr::Stage::release);
+    REQUIRE_THAT(env.next(), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_FALSE(env.is_active());
+    REQUIRE(env.stage() == Adsr::Stage::idle);
+
+    env.note_on();
+    REQUIRE_THAT(env.next(), WithinAbs(1.0f, 1e-6f));
+    env.reset();
+    REQUIRE_FALSE(env.is_active());
+    REQUIRE(env.stage() == Adsr::Stage::idle);
+    REQUIRE_THAT(env.next(), WithinAbs(0.0f, 1e-6f));
+}
+
 // ── Biquad ───────────────────────────────────────────────────────────────────
 
 TEST_CASE("Biquad lowpass attenuates high frequencies", "[signal][biquad]") {
@@ -558,6 +591,53 @@ TEST_CASE("Oscillator triangle output", "[signal][osc]") {
     REQUIRE(rms > 0.2f); // Triangle RMS ≈ 1/sqrt(3) ≈ 0.577
 }
 
+TEST_CASE("Oscillator reset, phase wrap, and PolyBLEP edges are deterministic",
+          "[signal][osc][issue-645]") {
+    Oscillator sine;
+    sine.set_sample_rate(8.0f);
+    sine.set_frequency(2.0f);
+    sine.set_waveform(Oscillator::Waveform::sine);
+
+    REQUIRE_THAT(sine.frequency(), WithinAbs(2.0f, 1e-6f));
+    REQUIRE_THAT(sine.phase(), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(sine.next(), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(sine.phase(), WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(sine.next(), WithinAbs(1.0f, 1e-6f));
+    sine.reset();
+    REQUIRE_THAT(sine.phase(), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(sine.next(), WithinAbs(0.0f, 1e-6f));
+
+    Oscillator saw;
+    saw.set_sample_rate(10.0f);
+    saw.set_frequency(3.0f);
+    saw.set_waveform(Oscillator::Waveform::saw);
+
+    for (int i = 0; i < 4; ++i) {
+        REQUIRE(std::isfinite(saw.next()));
+    }
+    REQUIRE_THAT(saw.phase(), WithinAbs(0.2f, 1e-6f));
+
+    Oscillator square;
+    square.set_sample_rate(10.0f);
+    square.set_frequency(3.0f);
+    square.set_waveform(Oscillator::Waveform::square);
+
+    for (int i = 0; i < 4; ++i) {
+        REQUIRE(std::isfinite(square.next()));
+    }
+    REQUIRE_THAT(square.phase(), WithinAbs(0.2f, 1e-6f));
+
+    Oscillator triangle;
+    triangle.set_sample_rate(10.0f);
+    triangle.set_frequency(3.0f);
+    triangle.set_waveform(Oscillator::Waveform::triangle);
+
+    for (int i = 0; i < 4; ++i) {
+        REQUIRE(std::isfinite(triangle.next()));
+    }
+    REQUIRE_THAT(triangle.phase(), WithinAbs(0.2f, 1e-6f));
+}
+
 // ── SVF ──────────────────────────────────────────────────────────────────────
 
 TEST_CASE("SVF lowpass attenuates high frequencies", "[signal][svf]") {
@@ -678,6 +758,35 @@ TEST_CASE("NoiseGate passes loud signals", "[signal][gate]") {
     REQUIRE_THAT(out, WithinAbs(loud, 0.01));
 }
 
+TEST_CASE("NoiseGate clamps range, instant timing, reset, and buffers",
+          "[signal][gate][issue-645]") {
+    NoiseGate instant;
+    instant.set_sample_rate(1000.0f);
+    instant.set_params({-20.0f, 20.0f, 0.0f, 0.0f, -12.0f});
+
+    REQUIRE(instant.process(0.0f) == 0.0f);
+
+    const float quiet = 0.001f;
+    const float expected_range_gain = std::pow(10.0f, -12.0f / 20.0f);
+    REQUIRE_THAT(instant.process(quiet),
+                 WithinAbs(quiet * expected_range_gain, 1e-7f));
+    REQUIRE_THAT(instant.process(1.0f), WithinAbs(1.0f, 1e-6f));
+
+    float buffer[] = {quiet, 1.0f, -quiet};
+    instant.process(buffer, 3);
+    REQUIRE_THAT(buffer[0], WithinAbs(quiet * expected_range_gain, 1e-7f));
+    REQUIRE_THAT(buffer[1], WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(buffer[2], WithinAbs(-quiet * expected_range_gain, 1e-7f));
+
+    NoiseGate held;
+    held.set_sample_rate(1000.0f);
+    held.set_params({-20.0f, 20.0f, 0.0f, 1000.0f, -12.0f});
+    REQUIRE(std::abs(held.process(quiet)) < quiet);
+    REQUIRE(held.process(1.0f) < 1.0f);
+    held.reset();
+    REQUIRE_THAT(held.process(1.0f), WithinAbs(1.0f, 1e-6f));
+}
+
 // ── Panner ───────────────────────────────────────────────────────────────────
 
 TEST_CASE("Panner center", "[signal][panner]") {
@@ -746,6 +855,46 @@ TEST_CASE("Chorus produces stereo output", "[signal][chorus]") {
     REQUIRE(sum_r > 0);
     // Left and right should differ (stereo widening)
     REQUIRE(std::abs(sum_l - sum_r) > 0.01f);
+}
+
+TEST_CASE("Chorus dry mix, phase wrap, and reset are deterministic",
+          "[signal][chorus][issue-645]") {
+    Chorus dry;
+    dry.prepare(32.0f);
+    dry.set_rate(32.0f);
+    dry.set_depth(1.0f);
+    dry.set_delay_ms(20.0f);
+    dry.set_mix(0.0f);
+
+    for (float input : {1.0f, -0.5f, 0.25f}) {
+        auto out = dry.process(input);
+        REQUIRE_THAT(out.left, WithinAbs(input, 1e-6f));
+        REQUIRE_THAT(out.right, WithinAbs(input, 1e-6f));
+    }
+
+    Chorus chorus;
+    chorus.prepare(1000.0f);
+    chorus.set_rate(1000.0f);
+    chorus.set_depth(1.0f);
+    chorus.set_delay_ms(1.0f);
+    chorus.set_mix(1.0f);
+
+    const std::array<float, 6> input{{1.0f, 0.5f, -0.25f, 0.0f, 0.125f, 0.0f}};
+    std::array<Chorus::StereoSample, input.size()> first{};
+    std::array<Chorus::StereoSample, input.size()> second{};
+
+    for (size_t i = 0; i < input.size(); ++i) {
+        first[i] = chorus.process(input[i]);
+        REQUIRE(std::isfinite(first[i].left));
+        REQUIRE(std::isfinite(first[i].right));
+    }
+
+    chorus.reset();
+    for (size_t i = 0; i < input.size(); ++i) {
+        second[i] = chorus.process(input[i]);
+        REQUIRE_THAT(second[i].left, WithinAbs(first[i].left, 1e-6f));
+        REQUIRE_THAT(second[i].right, WithinAbs(first[i].right, 1e-6f));
+    }
 }
 
 // ── Phaser ───────────────────────────────────────────────────────────────────
@@ -819,6 +968,55 @@ TEST_CASE("Reverb produces decay tail", "[signal][reverb]") {
     REQUIRE(energy > 0.001f); // Should have reverb tail
 }
 
+TEST_CASE("Reverb handles zero decay, damping clamp, dry mix, and reset",
+          "[signal][reverb][issue-645]") {
+    Reverb reverb;
+    reverb.prepare(441.0f);
+    reverb.set_decay(0.0f);
+    reverb.set_damping(-1.0f);
+    reverb.set_mix(1.0f);
+
+    (void)reverb.process(1.0f);
+
+    float early_energy = 0.0f;
+    float late_energy = 0.0f;
+    for (int i = 0; i < 40; ++i) {
+        auto out = reverb.process(0.0f);
+        REQUIRE(std::isfinite(out.left));
+        REQUIRE(std::isfinite(out.right));
+        float energy = out.left * out.left + out.right * out.right;
+        if (i < 20) {
+            early_energy += energy;
+        } else {
+            late_energy += energy;
+        }
+    }
+
+    REQUIRE(early_energy > 0.0f);
+    REQUIRE_THAT(late_energy, WithinAbs(0.0f, 1e-6f));
+
+    reverb.set_decay(0.5f);
+    reverb.set_damping(4.0f);
+    (void)reverb.process(1.0f);
+    reverb.reset();
+
+    for (int i = 0; i < 24; ++i) {
+        auto out = reverb.process(0.0f);
+        REQUIRE_THAT(out.left, WithinAbs(0.0f, 1e-6f));
+        REQUIRE_THAT(out.right, WithinAbs(0.0f, 1e-6f));
+    }
+
+    Reverb dry;
+    dry.prepare(441.0f);
+    dry.set_decay(2.0f);
+    dry.set_damping(2.0f);
+    dry.set_mix(0.0f);
+
+    auto out = dry.process(0.25f);
+    REQUIRE_THAT(out.left, WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(out.right, WithinAbs(0.25f, 1e-6f));
+}
+
 // ── LadderFilter ─────────────────────────────────────────────────────────────
 
 TEST_CASE("LadderFilter lowpass behavior", "[signal][ladder]") {
@@ -836,6 +1034,35 @@ TEST_CASE("LadderFilter lowpass behavior", "[signal][ladder]") {
     }
     float rms = std::sqrt(sum_sq / 4210.0f);
     REQUIRE(rms < 0.05f); // 24dB/oct should heavily attenuate
+}
+
+TEST_CASE("LadderFilter resets buffer state and clamps resonance inputs",
+          "[signal][ladder][issue-645]") {
+    LadderFilter ladder;
+    ladder.set_sample_rate(48000.0f);
+    ladder.set_frequency(1200.0f);
+    ladder.set_resonance(-2.0f);
+
+    float impulse[] = {1.0f, 0.0f, 0.0f, 0.0f};
+    ladder.process(impulse, 4);
+    for (float sample : impulse) {
+        REQUIRE(std::isfinite(sample));
+    }
+
+    ladder.reset();
+    REQUIRE_THAT(ladder.process(0.0f), WithinAbs(0.0f, 1e-6f));
+
+    ladder.set_resonance(3.0f);
+    ladder.set_frequency(8000.0f);
+    for (int i = 0; i < 32; ++i) {
+        const float sample = (i == 0) ? 0.75f : 0.0f;
+        REQUIRE(std::isfinite(ladder.process(sample)));
+    }
+
+    float unchanged[] = {0.25f, -0.25f};
+    ladder.process(unchanged, 0);
+    REQUIRE_THAT(unchanged[0], WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(unchanged[1], WithinAbs(-0.25f, 1e-6f));
 }
 
 // ── LinkwitzRiley ────────────────────────────────────────────────────────────
@@ -868,6 +1095,55 @@ TEST_CASE("LinkwitzRiley splits into low and high bands", "[signal][lr]") {
         }
     }
     REQUIRE(high_energy > low_energy * 10.0f); // High band should dominate
+}
+
+TEST_CASE("LinkwitzRiley reset clears history while preserving coefficients",
+          "[signal][lr][issue-645]") {
+    auto impulse_response = [](LinkwitzRiley& lr) {
+        std::vector<LinkwitzRiley::BandSplit> response;
+        response.reserve(24);
+        for (int i = 0; i < 24; ++i) {
+            response.push_back(lr.process(i == 0 ? 1.0f : 0.0f));
+        }
+        return response;
+    };
+
+    LinkwitzRiley fresh;
+    fresh.set_frequency(1200.0f, 48000.0f);
+    auto expected = impulse_response(fresh);
+
+    LinkwitzRiley reused;
+    reused.set_frequency(1200.0f, 48000.0f);
+    for (int i = 0; i < 128; ++i) {
+        auto split = reused.process((i % 3 == 0) ? 0.75f : -0.25f);
+        REQUIRE(std::isfinite(split.low));
+        REQUIRE(std::isfinite(split.high));
+    }
+
+    reused.reset();
+    auto actual = impulse_response(reused);
+
+    REQUIRE(actual.size() == expected.size());
+    for (std::size_t i = 0; i < actual.size(); ++i) {
+        REQUIRE_THAT(actual[i].low, WithinAbs(expected[i].low, 1e-6f));
+        REQUIRE_THAT(actual[i].high, WithinAbs(expected[i].high, 1e-6f));
+    }
+}
+
+TEST_CASE("LinkwitzRiley cutoff boundary processing stays finite",
+          "[signal][lr][issue-645]") {
+    for (float cutoff : {0.0f, 20.0f, 20000.0f, 24000.0f}) {
+        LinkwitzRiley lr;
+        lr.set_frequency(cutoff, 48000.0f);
+
+        for (int i = 0; i < 64; ++i) {
+            float input = (i == 0) ? 1.0f : ((i % 2 == 0) ? 0.125f : -0.125f);
+            auto split = lr.process(input);
+            INFO("cutoff=" << cutoff << " sample=" << i);
+            REQUIRE(std::isfinite(split.low));
+            REQUIRE(std::isfinite(split.high));
+        }
+    }
 }
 
 // ── WindowFunction ───────────────────────────────────────────────────────────

--- a/test/test_standalone_editor_chrome.cpp
+++ b/test/test_standalone_editor_chrome.cpp
@@ -40,6 +40,7 @@ public:
     void hide() override {}
     bool is_visible() const override { return false; }
     void repaint() override {}
+    std::vector<uint8_t> capture_png() override { return {0x89, 'P', 'N', 'G'}; }
     void set_close_callback(std::function<void()>) override {}
     void run_event_loop() override {}
 };
@@ -487,6 +488,8 @@ TEST_CASE("WindowHost default content-size and resize callback are no-ops",
         resize_fired = true;
     });
     REQUIRE_FALSE(resize_fired);
+
+    REQUIRE(window.capture_back_buffer_png() == std::vector<uint8_t>{0x89, 'P', 'N', 'G'});
 }
 
 TEST_CASE("Standalone host sync installs a resize callback and applies initial size",

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/state/state.hpp>
+#include <cstring>
 #include <vector>
 
 using namespace pulp::state;
@@ -13,6 +14,33 @@ static ParamInfo make_param_info(ParamID id, const char* name, const char* unit,
     info.unit = unit;
     info.range = range;
     return info;
+}
+
+static uint32_t read_u32_le(const std::vector<uint8_t>& data, std::size_t offset) {
+    return static_cast<uint32_t>(data[offset])
+        | (static_cast<uint32_t>(data[offset + 1]) << 8)
+        | (static_cast<uint32_t>(data[offset + 2]) << 16)
+        | (static_cast<uint32_t>(data[offset + 3]) << 24);
+}
+
+static void write_u32_le(std::vector<uint8_t>& data, std::size_t offset, uint32_t value) {
+    data[offset] = static_cast<uint8_t>(value & 0xffu);
+    data[offset + 1] = static_cast<uint8_t>((value >> 8) & 0xffu);
+    data[offset + 2] = static_cast<uint8_t>((value >> 16) & 0xffu);
+    data[offset + 3] = static_cast<uint8_t>((value >> 24) & 0xffu);
+}
+
+static uint32_t crc32_simple_for_test(const std::vector<uint8_t>& data,
+                                      std::size_t len) {
+    uint32_t crc = 0xFFFFFFFFu;
+    for (std::size_t i = 0; i < len; ++i) {
+        crc ^= data[i];
+        for (int j = 0; j < 8; ++j) {
+            const uint32_t mask = (crc & 1u) ? 0xFFFFFFFFu : 0u;
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+    return ~crc;
 }
 
 TEST_CASE("ParamRange normalization", "[state][range]") {
@@ -32,6 +60,26 @@ TEST_CASE("ParamRange with step", "[state][range]") {
 
     REQUIRE_THAT(range.denormalize(0.33f), WithinAbs(3.0, 0.5));
     REQUIRE_THAT(range.denormalize(0.77f), WithinAbs(8.0, 0.5));
+}
+
+TEST_CASE("ParamRange clamps normalized conversions at range boundaries",
+          "[state][range][coverage][issue-646]") {
+    ParamRange range{-10.0f, 30.0f, 5.0f, 0.0f};
+
+    REQUIRE_THAT(range.normalize(-100.0f), WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(range.normalize(100.0f), WithinAbs(1.0, 0.001));
+    REQUIRE_THAT(range.denormalize(-0.5f), WithinAbs(-10.0, 0.001));
+    REQUIRE_THAT(range.denormalize(1.5f), WithinAbs(30.0, 0.001));
+}
+
+TEST_CASE("ParamRange zero-width ranges normalize safely",
+          "[state][range][coverage][issue-646]") {
+    ParamRange range{7.0f, 7.0f, 7.0f, 0.0f};
+
+    REQUIRE_THAT(range.normalize(7.0f), WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(range.normalize(100.0f), WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(range.denormalize(0.25f), WithinAbs(7.0, 0.001));
+    REQUIRE_THAT(range.denormalize(2.0f), WithinAbs(7.0, 0.001));
 }
 
 TEST_CASE("StateStore basic operations", "[state][store]") {
@@ -158,6 +206,53 @@ TEST_CASE("StateStore serialization", "[state][serialize]") {
     SECTION("Too-short data rejected") {
         REQUIRE_FALSE(store.deserialize(std::span<const uint8_t>{}));
     }
+}
+
+TEST_CASE("StateStore serialization records header fields and rejects future versions",
+          "[state][serialize][coverage][issue-646]") {
+    StateStore store;
+    auto p1 = make_param_info(10, "Drive", "", {0.0f, 1.0f, 0.25f});
+    auto p2 = make_param_info(20, "Tone", "", {-1.0f, 1.0f, 0.0f});
+    store.add_parameter(p1);
+    store.add_parameter(p2);
+    store.set_value(10, 0.75f);
+
+    auto data = store.serialize();
+    REQUIRE(data.size() == 32);
+    REQUIRE(std::memcmp(data.data(), "PULP", 4) == 0);
+    REQUIRE(read_u32_le(data, 4) == 1);
+    REQUIRE(read_u32_le(data, 8) == 2);
+    REQUIRE(read_u32_le(data, 12) == 10);
+    REQUIRE(read_u32_le(data, 20) == 20);
+
+    auto future = data;
+    write_u32_le(future, 4, 999u);
+    const auto payload_size = future.size() - 4;
+    write_u32_le(future, payload_size, crc32_simple_for_test(future, payload_size));
+
+    StateStore target;
+    target.add_parameter(p1);
+    target.set_value(10, 0.1f);
+    REQUIRE_FALSE(target.deserialize(future));
+    REQUIRE_THAT(target.get_value(10), WithinAbs(0.1, 0.001));
+}
+
+TEST_CASE("StateStore set_normalized clamps and quantizes via ParamRange",
+          "[state][store][coverage][issue-646]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "Steps", "", {0.0f, 10.0f, 5.0f, 2.0f}));
+
+    store.set_normalized(1, -1.0f);
+    REQUIRE_THAT(store.get_value(1), WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(store.get_normalized(1), WithinAbs(0.0, 0.001));
+
+    store.set_normalized(1, 0.34f);
+    REQUIRE_THAT(store.get_value(1), WithinAbs(4.0, 0.001));
+    REQUIRE_THAT(store.get_normalized(1), WithinAbs(0.4, 0.001));
+
+    store.set_normalized(1, 4.0f);
+    REQUIRE_THAT(store.get_value(1), WithinAbs(10.0, 0.001));
+    REQUIRE_THAT(store.get_normalized(1), WithinAbs(1.0, 0.001));
 }
 
 TEST_CASE("StateStore change listener", "[state][listener]") {

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -37,6 +37,23 @@ TEST_CASE("StateTree get with defaults", "[state][tree]") {
     REQUIRE(tree->get_bool("missing", true) == true);
 }
 
+TEST_CASE("StateTree typed getters keep defaults for mismatched property types",
+          "[state][tree][issue-641]") {
+    auto tree = StateTree::create("test");
+    tree->set("as_string", std::string("123"));
+    tree->set("as_bool", true);
+    tree->set("as_int", int64_t(9));
+    tree->set("as_double", 1.25);
+
+    REQUIRE(tree->get_int("as_string", 77) == 77);
+    REQUIRE(tree->get_bool("as_string", true));
+    REQUIRE(tree->get_string("as_int", "fallback") == "fallback");
+    REQUIRE_THAT(tree->get_double("as_int", 0.0), WithinAbs(9.0, 1e-9));
+    REQUIRE(tree->get_int("as_double", 44) == 44);
+    REQUIRE(tree->get_bool("as_int", false) == false);
+    REQUIRE(tree->get_bool("as_bool", false) == true);
+}
+
 TEST_CASE("StateTree has and remove", "[state][tree]") {
     auto tree = StateTree::create("test");
     tree->set("key", std::string("value"));
@@ -104,6 +121,23 @@ TEST_CASE("StateTree remove child by index", "[state][tree]") {
     REQUIRE(root->child(1)->type_name() == "c");
 }
 
+TEST_CASE("StateTree child access and removal ignore invalid indexes",
+          "[state][tree][issue-641]") {
+    auto root = StateTree::create("root");
+    root->add_child(StateTree::create("a"));
+
+    int removed_count = 0;
+    root->add_child_removed_listener(
+        [&](StateTree&, StateTree&, int) { removed_count++; });
+
+    REQUIRE(root->child(-1) == nullptr);
+    REQUIRE(root->child(1) == nullptr);
+    root->remove_child(-1);
+    root->remove_child(99);
+    REQUIRE(root->child_count() == 1);
+    REQUIRE(removed_count == 0);
+}
+
 TEST_CASE("StateTree insert child at index", "[state][tree]") {
     auto root = StateTree::create("root");
     root->add_child(StateTree::create("a"));
@@ -112,6 +146,21 @@ TEST_CASE("StateTree insert child at index", "[state][tree]") {
     root->insert_child(1, StateTree::create("b"));
     REQUIRE(root->child_count() == 3);
     REQUIRE(root->child(1)->type_name() == "b");
+}
+
+TEST_CASE("StateTree insert at end and missing child pointer removal are stable",
+          "[state][tree][issue-641]") {
+    auto root = StateTree::create("root");
+    auto missing = StateTree::create("missing");
+
+    root->add_child(StateTree::create("a"));
+    root->insert_child(root->child_count(), StateTree::create("b"));
+    root->remove_child(missing.get());
+
+    REQUIRE(root->child_count() == 2);
+    REQUIRE(root->child(0)->type_name() == "a");
+    REQUIRE(root->child(1)->type_name() == "b");
+    REQUIRE(missing->parent() == nullptr);
 }
 
 // ── Listeners ───────────────────────────────────────────────────────────
@@ -126,6 +175,44 @@ TEST_CASE("StateTree property change listener", "[state][tree]") {
 
     tree->set("volume", 0.5);
     REQUIRE(changed_prop == "volume");
+}
+
+TEST_CASE("StateTree property listener receives old and new values",
+          "[state][tree][issue-641]") {
+    auto tree = StateTree::create("test");
+    std::vector<PropertyValue> old_values;
+    std::vector<PropertyValue> new_values;
+
+    tree->add_listener(
+        [&](StateTree&, std::string_view, const PropertyValue& old_val,
+            const PropertyValue& new_val) {
+            old_values.push_back(old_val);
+            new_values.push_back(new_val);
+        });
+
+    tree->set("gain", 0.25);
+    tree->set("gain", 0.5);
+
+    REQUIRE(old_values.size() == 2);
+    REQUIRE(std::holds_alternative<std::monostate>(old_values[0]));
+    REQUIRE_THAT(std::get<double>(new_values[0]), WithinAbs(0.25, 1e-9));
+    REQUIRE_THAT(std::get<double>(old_values[1]), WithinAbs(0.25, 1e-9));
+    REQUIRE_THAT(std::get<double>(new_values[1]), WithinAbs(0.5, 1e-9));
+}
+
+TEST_CASE("StateTree remove does not emit property callbacks",
+          "[state][tree][issue-641]") {
+    auto tree = StateTree::create("test");
+    tree->set("name", std::string("before"));
+
+    int count = 0;
+    tree->add_listener([&](StateTree&, std::string_view, const PropertyValue&,
+                           const PropertyValue&) { count++; });
+
+    tree->remove("name");
+    tree->remove("missing");
+    REQUIRE(count == 0);
+    REQUIRE_FALSE(tree->has("name"));
 }
 
 TEST_CASE("StateTree child added listener", "[state][tree]") {
@@ -258,6 +345,42 @@ TEST_CASE("StateTree from_json with empty object", "[state][tree][json]") {
     REQUIRE(result->type_name() == "node");  // Default type
 }
 
+TEST_CASE("StateTree from_json skips unsupported properties and child values",
+          "[state][tree][json][issue-641]") {
+    auto result = StateTree::from_json(R"JSON({
+        "type": 123,
+        "properties": {
+            "name": "Patch",
+            "enabled": false,
+            "voice_count": 8,
+            "gain": 0.25,
+            "ignored_null": null,
+            "ignored_array": [1, 2],
+            "ignored_object": {"nested": true}
+        },
+        "children": [
+            {"type": "osc", "properties": {"wave": "sine"}},
+            null,
+            42,
+            {"properties": {"default_type": true}}
+        ]
+    })JSON");
+
+    REQUIRE(result != nullptr);
+    REQUIRE(result->type_name() == "node");
+    REQUIRE(result->get_string("name") == "Patch");
+    REQUIRE_FALSE(result->get_bool("enabled", true));
+    REQUIRE(result->get_int("voice_count") == 8);
+    REQUIRE_THAT(result->get_double("gain"), WithinAbs(0.25, 1e-9));
+    REQUIRE_FALSE(result->has("ignored_null"));
+    REQUIRE_FALSE(result->has("ignored_array"));
+    REQUIRE_FALSE(result->has("ignored_object"));
+    REQUIRE(result->child_count() == 2);
+    REQUIRE(result->child(0)->type_name() == "osc");
+    REQUIRE(result->child(1)->type_name() == "node");
+    REQUIRE(result->child(1)->get_bool("default_type"));
+}
+
 // ── Deep copy ───────────────────────────────────────────────────────────
 
 TEST_CASE("StateTree deep copy", "[state][tree]") {
@@ -273,6 +396,19 @@ TEST_CASE("StateTree deep copy", "[state][tree]") {
     // Modifying copy doesn't affect original
     copy->set("name", std::string("modified"));
     REQUIRE(root->get_string("name") == "original");
+}
+
+TEST_CASE("StateTree deep copy rewires child parent pointers",
+          "[state][tree][issue-641]") {
+    auto root = StateTree::create("root");
+    auto child = StateTree::create("child");
+    root->add_child(child);
+
+    auto copy = root->deep_copy();
+    REQUIRE(copy->child_count() == 1);
+    REQUIRE(copy->child(0).get() != child.get());
+    REQUIRE(copy->child(0)->parent() == copy.get());
+    REQUIRE(child->parent() == root.get());
 }
 
 // ── ObservableValue ─────────────────────────────────────────────────────
@@ -322,6 +458,27 @@ TEST_CASE("ObservableValue remove listener", "[state][observable]") {
     val.remove_listener(id);
     val.set(2);
     REQUIRE(count == 1);  // Listener removed
+}
+
+TEST_CASE("ObservableValue assignment operator emits one change",
+          "[state][observable][issue-641]") {
+    ObservableValue<int> val(1);
+    int old_value = 0;
+    int new_value = 0;
+    int count = 0;
+    val.add_listener([&](const int& old_val, const int& next_val) {
+        old_value = old_val;
+        new_value = next_val;
+        count++;
+    });
+
+    val = 5;
+    val = 5;
+
+    REQUIRE(val.get() == 5);
+    REQUIRE(old_value == 1);
+    REQUIRE(new_value == 5);
+    REQUIRE(count == 1);
 }
 
 // ── CachedProperty ──────────────────────────────────────────────────────
@@ -380,6 +537,19 @@ TEST_CASE("CachedProperty unbound set only updates local cache", "[state][cached
     REQUIRE(size.get() == 512);
 }
 
+TEST_CASE("CachedProperty ignores mismatched external updates",
+          "[state][cached][issue-641]") {
+    auto tree = StateTree::create("params");
+    tree->set("name", std::string("Initial"));
+    CachedProperty<std::string> name(tree, "name", "Default");
+
+    tree->set("name", int64_t(123));
+    REQUIRE(name.get() == "Initial");
+
+    name.set("Restored");
+    REQUIRE(tree->get_string("name") == "Restored");
+}
+
 // ── StateTreeSynchroniser ───────────────────────────────────────────────
 
 TEST_CASE("StateTreeSynchroniser records property and child deltas", "[state][sync]") {
@@ -409,6 +579,25 @@ TEST_CASE("StateTreeSynchroniser records property and child deltas", "[state][sy
     REQUIRE(deltas[2].child_index == 0);
 
     REQUIRE(sync.take_deltas().empty());
+}
+
+TEST_CASE("StateTreeSynchroniser attach replaces the previous tree",
+          "[state][sync][issue-641]") {
+    auto first = StateTree::create("first");
+    auto second = StateTree::create("second");
+    StateTreeSynchroniser sync;
+
+    sync.attach(first);
+    first->set("name", std::string("before"));
+    sync.attach(second);
+    first->set("name", std::string("ignored"));
+    second->set("name", std::string("recorded"));
+
+    auto deltas = sync.take_deltas();
+    REQUIRE(deltas.size() == 1);
+    REQUIRE(deltas[0].path == "second");
+    REQUIRE(deltas[0].key == "name");
+    REQUIRE(std::get<std::string>(deltas[0].value) == "recorded");
 }
 
 TEST_CASE("StateTreeSynchroniser detach clears pending and stops recording", "[state][sync]") {
@@ -465,6 +654,32 @@ TEST_CASE("StateTreeSynchroniser decode rejects undersized buffers", "[state][sy
 
     decoded = StateTreeSynchroniser::decode(nullptr, 0);
     REQUIRE(decoded.empty());
+}
+
+TEST_CASE("StateTreeSynchroniser encodes and decodes empty delta batches",
+          "[state][sync][issue-641]") {
+    auto encoded = StateTreeSynchroniser::encode({});
+    REQUIRE(encoded.size() == 2);
+
+    auto decoded = StateTreeSynchroniser::decode(encoded.data(), encoded.size());
+    REQUIRE(decoded.empty());
+}
+
+TEST_CASE("StateTreeSynchroniser decode keeps complete prefix on truncated batches",
+          "[state][sync][issue-641]") {
+    std::vector<SyncDelta> deltas = {
+        {SyncDeltaType::PropertySet, "root", "name", std::string("Lead"), 0},
+        {SyncDeltaType::PropertySet, "root", "count", int64_t(3), 0},
+    };
+    auto encoded = StateTreeSynchroniser::encode(deltas);
+    auto first_only = StateTreeSynchroniser::encode({deltas[0]});
+    encoded.resize(first_only.size() + 1);
+
+    auto decoded = StateTreeSynchroniser::decode(encoded.data(), encoded.size());
+    REQUIRE(decoded.size() == 1);
+    REQUIRE(decoded[0].type == SyncDeltaType::PropertySet);
+    REQUIRE(decoded[0].key == "name");
+    REQUIRE(std::get<std::string>(decoded[0].value) == "Lead");
 }
 
 TEST_CASE("StateTreeSynchroniser apply mutates properties and children", "[state][sync]") {

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -27,6 +27,25 @@ std::filesystem::path make_temp_path(const char* stem) {
 
 }  // namespace
 
+TEST_CASE("StreamResult helper predicates classify errors",
+          "[stream][coverage][phase3]") {
+    auto ok = StreamResult::make(3);
+    REQUIRE(ok.ok());
+    REQUIRE_FALSE(ok.would_block());
+    REQUIRE_FALSE(ok.closed());
+    REQUIRE(ok.bytes == 3);
+
+    auto would_block = StreamResult::fail(StreamError::WouldBlock);
+    REQUIRE_FALSE(would_block.ok());
+    REQUIRE(would_block.would_block());
+    REQUIRE_FALSE(would_block.closed());
+
+    auto invalid = StreamResult::fail(StreamError::Invalid);
+    REQUIRE_FALSE(invalid.ok());
+    REQUIRE_FALSE(invalid.would_block());
+    REQUIRE_FALSE(invalid.closed());
+}
+
 TEST_CASE("MemoryStream round-trip", "[stream]") {
     MemoryStream s;
     const std::uint8_t msg[] = {1, 2, 3, 4, 5};
@@ -181,6 +200,44 @@ TEST_CASE("FileStream append and move keep handle ownership correct", "[stream]"
         REQUIRE(std::memcmp(out, "abcde", sizeof(out)) == 0);
     }
 
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("FileStream read-write mode tracks position and zero-byte I/O",
+          "[stream][coverage][phase3]") {
+    auto path = make_temp_path("pulp_stream_readwrite");
+    const std::uint8_t payload[] = {'r', 'w', '0'};
+
+    FileStream stream(path.string(), FileStream::Mode::ReadWrite);
+    REQUIRE(stream.is_open());
+    REQUIRE(stream.position() == 0);
+
+    REQUIRE(stream.write(payload, 0).ok());
+    REQUIRE(stream.position() == 0);
+
+    auto wrote = stream.write(payload, sizeof(payload));
+    REQUIRE(wrote.ok());
+    REQUIRE(wrote.bytes == sizeof(payload));
+    REQUIRE(stream.position() == sizeof(payload));
+    REQUIRE(stream.flush());
+
+    stream.close();
+    REQUIRE_FALSE(stream.is_open());
+    REQUIRE_FALSE(stream.flush());
+    REQUIRE(stream.position() == static_cast<std::size_t>(-1));
+
+    FileStream reader(path.string(), FileStream::Mode::Read);
+    REQUIRE(reader.is_open());
+    std::uint8_t out[sizeof(payload)]{};
+    REQUIRE(reader.read(out, 0).ok());
+    REQUIRE(reader.position() == 0);
+
+    auto got = reader.read(out, sizeof(out));
+    REQUIRE(got.ok());
+    REQUIRE(got.bytes == sizeof(out));
+    REQUIRE(std::memcmp(out, payload, sizeof(payload)) == 0);
+
+    reader.close();
     std::filesystem::remove(path);
 }
 

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <pulp/runtime/named_pipe.hpp>
+#include <pulp/runtime/network_stream.hpp>
 #include <pulp/runtime/stream.hpp>
 
 #include <array>
@@ -11,11 +12,13 @@
 #include <string>
 
 using pulp::runtime::FileStream;
+using pulp::runtime::HttpStream;
 using pulp::runtime::MemoryStream;
 using pulp::runtime::NamedPipe;
 using pulp::runtime::Stream;
 using pulp::runtime::StreamError;
 using pulp::runtime::StreamResult;
+using pulp::runtime::TcpStream;
 
 namespace {
 
@@ -209,6 +212,92 @@ TEST_CASE("Stream polymorphic usage", "[stream]") {
     REQUIRE(r.ok());
     REQUIRE(r.bytes == std::strlen(msg));
     REQUIRE(std::memcmp(buf.data(), msg, std::strlen(msg)) == 0);
+}
+
+TEST_CASE("FileStream ReadWrite mode tracks position and truncates on open",
+          "[stream][file][coverage][issue-641]") {
+    auto path = make_temp_path("pulp_stream_readwrite");
+    const std::uint8_t first[] = {'o', 'l', 'd'};
+    const std::uint8_t second[] = {'n', 'e', 'w', '!'};
+
+    {
+        FileStream seed(path.string(), FileStream::Mode::Write);
+        REQUIRE(seed.write(first, sizeof(first)).bytes == sizeof(first));
+        REQUIRE(seed.flush());
+    }
+
+    {
+        FileStream stream(path.string(), FileStream::Mode::ReadWrite);
+        REQUIRE(stream.is_open());
+        REQUIRE(stream.position() == 0);
+        REQUIRE(stream.write(second, sizeof(second)).bytes == sizeof(second));
+        REQUIRE(stream.position() == sizeof(second));
+        REQUIRE(stream.flush());
+    }
+
+    {
+        FileStream readback(path.string(), FileStream::Mode::Read);
+        std::array<std::uint8_t, sizeof(second)> out{};
+        auto got = readback.read(out.data(), out.size());
+        REQUIRE(got.ok());
+        REQUIRE(got.bytes == out.size());
+        REQUIRE(std::memcmp(out.data(), second, sizeof(second)) == 0);
+        REQUIRE(readback.read(out.data(), out.size()).closed());
+    }
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("MemoryStream clear keeps closed streams closed",
+          "[stream][memory][coverage][issue-641]") {
+    MemoryStream stream(std::vector<std::uint8_t>{1, 2, 3});
+    stream.close();
+    stream.clear();
+
+    REQUIRE_FALSE(stream.is_open());
+    REQUIRE(stream.size() == 0);
+    REQUIRE(stream.read_position() == 0);
+
+    std::uint8_t byte = 0;
+    REQUIRE(stream.read(&byte, 1).closed());
+    REQUIRE(stream.write(&byte, 1).closed());
+}
+
+TEST_CASE("TcpStream closed state rejects I/O and survives move assignment",
+          "[stream][tcp][coverage][issue-641]") {
+    TcpStream first;
+    TcpStream second;
+    std::uint8_t byte = 0;
+
+    REQUIRE_FALSE(first.is_open());
+    REQUIRE(first.read(&byte, 1).closed());
+    REQUIRE(first.write(&byte, 1).closed());
+
+    second = std::move(first);
+    REQUIRE_FALSE(second.is_open());
+    REQUIRE(second.read(&byte, 1).closed());
+    REQUIRE(second.write(&byte, 1).closed());
+}
+
+TEST_CASE("HttpStream invalid URLs fail without external transport",
+          "[stream][http][coverage][issue-641]") {
+    HttpStream stream;
+    HttpStream::Request request;
+    request.url = "not-a-url";
+    request.timeout_seconds = 1;
+
+    REQUIRE_FALSE(stream.fetch(request));
+    REQUIRE_FALSE(stream.is_open());
+    REQUIRE(stream.status_code() == 0);
+    REQUIRE(stream.transport_error() == "Invalid URL");
+
+    std::array<std::uint8_t, 8> out{};
+    REQUIRE(stream.read(out.data(), out.size()).error == StreamError::IoError);
+    REQUIRE(stream.write(out.data(), out.size()).error == StreamError::Invalid);
+    REQUIRE(stream.eof());
+
+    stream.close();
+    REQUIRE(stream.read(out.data(), out.size()).closed());
 }
 
 TEST_CASE("NamedPipe closed and missing endpoints fail closed", "[stream][named_pipe][issue-641]") {

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -117,6 +117,23 @@ TEST_CASE("MemoryStream zero-size, rewind, and clear edge paths", "[stream]") {
     REQUIRE(eof.closed());
 }
 
+TEST_CASE("StreamResult helpers classify non-ok states", "[stream][coverage][issue-656]") {
+    auto ok = StreamResult::make(3);
+    REQUIRE(ok.ok());
+    REQUIRE(ok.bytes == 3);
+    REQUIRE_FALSE(ok.closed());
+    REQUIRE_FALSE(ok.would_block());
+
+    auto blocked = StreamResult::fail(StreamError::WouldBlock);
+    REQUIRE_FALSE(blocked.ok());
+    REQUIRE(blocked.would_block());
+    REQUIRE_FALSE(blocked.closed());
+
+    auto invalid = StreamResult::fail(StreamError::Invalid);
+    REQUIRE_FALSE(invalid.ok());
+    REQUIRE_FALSE(invalid.closed());
+}
+
 TEST_CASE("FileStream round-trip via filesystem", "[stream]") {
     auto path = make_temp_path("pulp_stream");
     const std::uint8_t payload[] = {'p', 'u', 'l', 'p', 0, 1, 2, 3};
@@ -193,6 +210,45 @@ TEST_CASE("FileStream open failure leaves stream closed", "[stream]") {
     auto r = s.read(buf, sizeof(buf));
     REQUIRE_FALSE(r.ok());
     REQUIRE(r.closed());
+}
+
+TEST_CASE("FileStream zero-size operations and positions are stable", "[stream][coverage][issue-656]") {
+    auto path = make_temp_path("pulp_stream_position");
+    const std::uint8_t payload[] = {'x', 'y', 'z'};
+
+    {
+        FileStream stream(path.string(), FileStream::Mode::ReadWrite);
+        REQUIRE(stream.is_open());
+        REQUIRE(stream.position() == 0);
+
+        auto zero_write = stream.write(payload, 0);
+        REQUIRE(zero_write.ok());
+        REQUIRE(zero_write.bytes == 0);
+        REQUIRE(stream.position() == 0);
+
+        auto wrote = stream.write(payload, sizeof(payload));
+        REQUIRE(wrote.ok());
+        REQUIRE(wrote.bytes == sizeof(payload));
+        REQUIRE(stream.position() == sizeof(payload));
+        REQUIRE(stream.flush());
+    }
+
+    {
+        FileStream stream(path.string(), FileStream::Mode::Read);
+        std::uint8_t out[3]{};
+        auto zero_read = stream.read(out, 0);
+        REQUIRE(zero_read.ok());
+        REQUIRE(zero_read.bytes == 0);
+        REQUIRE(stream.position() == 0);
+    }
+
+    FileStream closed;
+    REQUIRE(closed.position() == static_cast<std::size_t>(-1));
+    REQUIRE_FALSE(closed.flush());
+    closed.close();
+    REQUIRE_FALSE(closed.is_open());
+
+    std::filesystem::remove(path);
 }
 
 TEST_CASE("Stream polymorphic usage", "[stream]") {

--- a/test/test_table_list_box.cpp
+++ b/test/test_table_list_box.cpp
@@ -173,3 +173,51 @@ TEST_CASE("SimpleTableModel handles negative sort columns and sparse rows",
     REQUIRE(model.cell_text(0, 1).empty());
     REQUIRE(model.cell_text(1, 1) == "two");
 }
+
+TEST_CASE("TableListBox clear columns and model-less clicks are stable",
+          "[gui][table][coverage][issue-653]") {
+    TableListBox table;
+    table.set_bounds({0, 0, 160, 80});
+    table.set_header_height(20.0f);
+    table.add_column({"Name", 80.0f});
+    table.add_column({"Value", 80.0f});
+    REQUIRE(table.column_count() == 2);
+
+    table.on_mouse_down({10.0f, 5.0f});
+    table.on_mouse_down({10.0f, 35.0f});
+    REQUIRE(table.selected_row() == -1);
+
+    table.clear_columns();
+    REQUIRE(table.column_count() == 0);
+
+    RecordingCanvas canvas;
+    table.paint(canvas);
+    REQUIRE(canvas.command_count() == 0);
+}
+
+TEST_CASE("TableListBox paints selected row and ignores negative body clicks",
+          "[gui][table][coverage][issue-653]") {
+    RecordingTableModel model({
+        {"First", "A"},
+        {"Second", "B"},
+    });
+
+    TableListBox table;
+    table.set_bounds({0, 0, 180, 80});
+    table.set_header_height(20.0f);
+    table.set_row_height(20.0f);
+    table.set_model(&model);
+    table.add_column({"Name", 90.0f});
+    table.add_column({"Value", 90.0f});
+    table.set_selected_row(1);
+
+    table.on_mouse_down({10.0f, -5.0f});
+    REQUIRE(model.sort_calls.empty());
+    REQUIRE(table.selected_row() == 1);
+
+    RecordingCanvas canvas;
+    table.paint(canvas);
+    REQUIRE(has_text(canvas, "First"));
+    REQUIRE(has_text(canvas, "Second"));
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rect) >= 3);
+}

--- a/test/test_table_list_box.cpp
+++ b/test/test_table_list_box.cpp
@@ -221,3 +221,26 @@ TEST_CASE("TableListBox paints selected row and ignores negative body clicks",
     REQUIRE(has_text(canvas, "Second"));
     REQUIRE(canvas.count(DrawCommand::Type::fill_rect) >= 3);
 }
+
+TEST_CASE("TableListBox ignores clicks outside right and bottom bounds",
+          "[gui][table][coverage][issue-653]") {
+    RecordingTableModel model({
+        {"First", "A"},
+        {"Second", "B"},
+    });
+
+    TableListBox table;
+    table.set_bounds({0, 0, 180, 80});
+    table.set_header_height(20.0f);
+    table.set_row_height(20.0f);
+    table.set_model(&model);
+    table.add_column({"Name", 90.0f, true});
+    table.add_column({"Value", 90.0f, true});
+
+    table.on_mouse_down({180.0f, 5.0f});
+    table.on_mouse_down({10.0f, 80.0f});
+
+    REQUIRE(model.sort_calls.empty());
+    REQUIRE(model.selected_rows.empty());
+    REQUIRE(table.selected_row() == -1);
+}

--- a/test/test_theme.cpp
+++ b/test/test_theme.cpp
@@ -232,6 +232,32 @@ TEST_CASE("Theme from_json maps malformed color strings to default color",
     REQUIRE(theme.color("bad.short").value() == Color{});
 }
 
+TEST_CASE("Theme JSON parser covers optional sections and alpha colors",
+          "[view][theme][coverage][issue-651]") {
+    auto theme = Theme::from_json(R"({
+        "colors": {
+            "overlay.tint": "#10203040",
+            "missing.hash": "102030"
+        },
+        "strings": {
+            "font.family": "Mono"
+        }
+    })");
+
+    auto tint = theme.color("overlay.tint").value();
+    REQUIRE(tint.r8() == 0x10);
+    REQUIRE(tint.g8() == 0x20);
+    REQUIRE(tint.b8() == 0x30);
+    REQUIRE(tint.a8() == 0x40);
+
+    REQUIRE(theme.color("missing.hash").value() == Color{});
+    REQUIRE_FALSE(theme.dimension("spacing.md").has_value());
+    REQUIRE(theme.string_token("font.family").value() == "Mono");
+
+    auto json = theme.to_json();
+    REQUIRE(json.find("#10203040") != std::string::npos);
+}
+
 TEST_CASE("Theme load and save handle file edge cases",
           "[view][theme][issue-493]") {
     const auto path = std::filesystem::temp_directory_path() /
@@ -261,6 +287,26 @@ TEST_CASE("Theme load and save handle file edge cases",
         loaded.dimension("spacing.md").value(),
         WithinAbs(theme.dimension("spacing.md").value(), 0.001));
     REQUIRE(loaded.string_token("font.family") == theme.string_token("font.family"));
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("Theme file IO rejects invalid JSON and unwritable targets",
+          "[view][theme][coverage][issue-651]") {
+    const auto path = std::filesystem::temp_directory_path() /
+        "pulp-theme-invalid-json-test.json";
+
+    {
+        std::ofstream invalid(path);
+        invalid << "{ invalid json";
+    }
+
+    auto invalid = Theme::load_from_file(path.string());
+    REQUIRE(invalid.colors.empty());
+    REQUIRE(invalid.dimensions.empty());
+    REQUIRE(invalid.strings.empty());
+
+    REQUIRE_FALSE(Theme::dark().save_to_file(std::filesystem::temp_directory_path().string()));
 
     std::filesystem::remove(path);
 }

--- a/test/test_theme_contrast.cpp
+++ b/test/test_theme_contrast.cpp
@@ -61,6 +61,16 @@ TEST_CASE("Min contrast thresholds are correct", "[view][contrast]") {
     REQUIRE_THAT(min_contrast_for_level(ContrastLevel::aaa_large), WithinAbs(4.5, 0.01));
 }
 
+TEST_CASE("Contrast helpers clamp channel inputs",
+          "[view][contrast][coverage][issue-651]") {
+    auto below_black = Color::rgba(-1.0f, -0.5f, -0.25f);
+    auto above_white = Color::rgba(2.0f, 1.5f, 1.25f);
+
+    REQUIRE_THAT(relative_luminance(below_black), WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(relative_luminance(above_white), WithinAbs(1.0, 0.001));
+    REQUIRE_THAT(contrast_ratio(below_black, above_white), WithinAbs(21.0, 0.1));
+}
+
 // ── Auto Contrast ───────────────────────────────────────────────────────────
 
 TEST_CASE("Auto contrast picks white on dark background", "[view][contrast]") {
@@ -114,6 +124,16 @@ TEST_CASE("Shift hue wraps around", "[view][contrast][hsl]") {
     auto shifted = shift_hue(red, 120.0f); // Should be green-ish
     auto hsl = rgb_to_hsl(shifted);
     REQUIRE_THAT(hsl.h, WithinAbs(120.0, 2.0));
+}
+
+TEST_CASE("Shift hue wraps negative and alpha is preserved",
+          "[view][contrast][hsl][coverage][issue-651]") {
+    auto color = Color::rgba8(0, 255, 0, 96);
+    auto shifted = shift_hue(color, -240.0f);
+    auto hsl = rgb_to_hsl(shifted);
+
+    REQUIRE_THAT(hsl.h, WithinAbs(240.0, 2.0));
+    REQUIRE_THAT(shifted.a, WithinAbs(color.a, 0.001));
 }
 
 TEST_CASE("Adjust lightness clamps at range bounds", "[view][contrast][hsl]") {
@@ -202,4 +222,23 @@ TEST_CASE("Auto-fix contrast produces valid theme", "[view][contrast][theme]") {
     if (tp && bp) {
         REQUIRE(contrast_ratio(*tp, *bp) >= 4.5f);
     }
+}
+
+TEST_CASE("Theme contrast validation skips missing pairs and reports failures",
+          "[view][contrast][theme][coverage][issue-651]") {
+    Theme partial;
+    partial.colors["bg.primary"] = Color::rgba8(255, 255, 255);
+    partial.colors["text.primary"] = Color::rgba8(200, 200, 200);
+
+    auto issues = validate_theme_contrast(partial, ContrastLevel::aa_normal);
+    REQUIRE(issues.size() == 1);
+    REQUIRE(issues.front().foreground_token == "text.primary");
+    REQUIRE(issues.front().background_token == "bg.primary");
+    REQUIRE(issues.front().ratio < min_contrast_for_level(ContrastLevel::aa_normal));
+    REQUIRE(issues.front().required_level == ContrastLevel::aa_normal);
+
+    auto fixed = auto_fix_contrast(partial, ContrastLevel::aa_normal);
+    REQUIRE(meets_contrast(*fixed.color("text.primary"),
+                           *fixed.color("bg.primary"),
+                           ContrastLevel::aa_normal));
 }

--- a/test/test_theme_presets.cpp
+++ b/test/test_theme_presets.cpp
@@ -37,6 +37,17 @@ TEST_CASE("find_preset returns nullptr for unknown", "[view][presets]") {
     REQUIRE(find_preset("nonexistent") == nullptr);
 }
 
+TEST_CASE("preset_ids preserves library order and exact size",
+          "[view][presets][coverage][issue-651]") {
+    const auto& presets = all_presets();
+    auto ids = preset_ids();
+
+    REQUIRE(ids.size() == presets.size());
+    REQUIRE_FALSE(ids.empty());
+    REQUIRE(ids.front() == presets.front().id);
+    REQUIRE(ids.back() == presets.back().id);
+}
+
 // ── Derivation Layer ────────────────────────────────────────────────────────
 
 TEST_CASE("Derived theme has all required tokens", "[view][presets][derive]") {
@@ -106,6 +117,36 @@ TEST_CASE("Derived theme JSON round-trip", "[view][presets][derive]") {
     auto orig_knob = original.color("knob.arc").value();
     auto rest_knob = restored.color("knob.arc").value();
     REQUIRE(orig_knob == rest_knob);
+}
+
+TEST_CASE("theme_from_preset applies variant-specific overrides",
+          "[view][presets][derive][coverage][issue-651]") {
+    ThemePreset preset;
+    preset.id = "custom";
+    preset.name = "Custom";
+    preset.light = all_presets().front().light;
+    preset.dark = all_presets().front().dark;
+    preset.light_overrides.colors["accent.primary"] = color_from_hex(0x010203);
+    preset.light_overrides.dimensions["spacing.md"] = 11.0f;
+    preset.light_overrides.strings["font.family"] = "LightFace";
+    preset.dark_overrides.colors["accent.primary"] = color_from_hex(0xA0B0C0);
+    preset.dark_overrides.dimensions["spacing.md"] = 7.0f;
+    preset.dark_overrides.strings["font.family"] = "DarkFace";
+
+    auto light = theme_from_preset(preset, false);
+    auto dark = theme_from_preset(preset, true);
+
+    REQUIRE(light.color("accent.primary")->r8() == 0x01);
+    REQUIRE(light.color("accent.primary")->g8() == 0x02);
+    REQUIRE(light.color("accent.primary")->b8() == 0x03);
+    REQUIRE_THAT(light.dimension("spacing.md").value(), Catch::Matchers::WithinAbs(11.0, 0.001));
+    REQUIRE(light.string_token("font.family").value() == "LightFace");
+
+    REQUIRE(dark.color("accent.primary")->r8() == 0xA0);
+    REQUIRE(dark.color("accent.primary")->g8() == 0xB0);
+    REQUIRE(dark.color("accent.primary")->b8() == 0xC0);
+    REQUIRE_THAT(dark.dimension("spacing.md").value(), Catch::Matchers::WithinAbs(7.0, 0.001));
+    REQUIRE(dark.string_token("font.family").value() == "DarkFace");
 }
 
 // ── Specific Presets ────────────────────────────────────────────────────────

--- a/test/test_tree_view.cpp
+++ b/test/test_tree_view.cpp
@@ -22,6 +22,14 @@ KeyEvent key_down(KeyCode key) {
     return e;
 }
 
+bool has_fill_text(const RecordingCanvas& canvas, const std::string& text) {
+    for (const auto& command : canvas.commands()) {
+        if (command.type == DrawCommand::Type::fill_text && command.text == text)
+            return true;
+    }
+    return false;
+}
+
 } // namespace
 
 TEST_CASE("TreeNode add children", "[view][tree]") {
@@ -113,6 +121,14 @@ TEST_CASE("TreeView triangle click toggles without selecting", "[view][tree]") {
     REQUIRE(toggled_state);
     REQUIRE(select_count == 0);
     REQUIRE(tree.selected_node() == nullptr);
+
+    tree.on_mouse_event(mouse_down(4, 5));
+
+    REQUIRE_FALSE(synths.expanded);
+    REQUIRE(toggled_label == "Synths");
+    REQUIRE_FALSE(toggled_state);
+    REQUIRE(select_count == 0);
+    REQUIRE(tree.selected_node() == nullptr);
 }
 
 TEST_CASE("TreeView double click activates without selecting", "[view][tree]") {
@@ -165,6 +181,21 @@ TEST_CASE("TreeView key left collapses expanded selection", "[view][tree]") {
     REQUIRE(collapsed);
 }
 
+TEST_CASE("TreeView key left consumes collapsed selected nodes without toggling",
+          "[view][tree]") {
+    TreeView tree;
+    auto& synths = tree.root().add_child("Synths");
+    synths.add_child("Bass");
+    tree.set_selected_node(&synths);
+
+    int toggle_count = 0;
+    tree.on_toggle = [&](TreeNode&, bool) { ++toggle_count; };
+
+    REQUIRE(tree.on_key_event(key_down(KeyCode::left)));
+    REQUIRE_FALSE(synths.expanded);
+    REQUIRE(toggle_count == 0);
+}
+
 TEST_CASE("TreeView ignores unhandled key edges", "[view][tree]") {
     TreeView tree;
     auto& leaf = tree.root().add_child("Leaf");
@@ -195,6 +226,29 @@ TEST_CASE("TreeView user data lookup finds nested nodes only for non-null data",
     REQUIRE(tree.find_node_by_user_data(&nested_payload) == &nested);
     REQUIRE(tree.find_node_by_user_data(nullptr) == nullptr);
     REQUIRE(tree.find_node_by_user_data(&root_payload) == &tree.root());
+}
+
+TEST_CASE("TreeView paint covers selection highlight and disclosure states",
+          "[view][tree]") {
+    TreeView tree;
+    auto& group = tree.root().add_child("Group");
+    group.add_child("Nested");
+    tree.set_selected_node(&group);
+    tree.set_bounds({0, 0, 200, 100});
+
+    RecordingCanvas collapsed;
+    tree.paint(collapsed);
+    REQUIRE(collapsed.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(has_fill_text(collapsed, "\xe2\x96\xb6"));
+    REQUIRE(has_fill_text(collapsed, "Group"));
+    REQUIRE_FALSE(has_fill_text(collapsed, "Nested"));
+
+    group.expanded = true;
+    RecordingCanvas expanded;
+    tree.paint(expanded);
+    REQUIRE(expanded.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(has_fill_text(expanded, "\xe2\x96\xbc"));
+    REQUIRE(has_fill_text(expanded, "Nested"));
 }
 
 TEST_CASE("TreeView paint produces draw commands", "[view][tree]") {

--- a/test/test_tree_view.cpp
+++ b/test/test_tree_view.cpp
@@ -2,6 +2,9 @@
 #include <pulp/view/tree_view.hpp>
 #include <pulp/canvas/canvas.hpp>
 
+#include <algorithm>
+#include <string>
+
 using namespace pulp::view;
 using namespace pulp::canvas;
 
@@ -22,12 +25,27 @@ KeyEvent key_down(KeyCode key) {
     return e;
 }
 
+bool has_text(const RecordingCanvas& canvas, const std::string& text) {
+    return std::any_of(canvas.commands().begin(),
+                       canvas.commands().end(),
+                       [&](const DrawCommand& cmd) {
+                           return cmd.type == DrawCommand::Type::fill_text &&
+                                  cmd.text == text;
+                       });
+}
+
 bool has_fill_text(const RecordingCanvas& canvas, const std::string& text) {
-    for (const auto& command : canvas.commands()) {
-        if (command.type == DrawCommand::Type::fill_text && command.text == text)
-            return true;
-    }
-    return false;
+    return has_text(canvas, text);
+}
+
+int text_count(const RecordingCanvas& canvas, const std::string& text) {
+    return static_cast<int>(std::count_if(
+        canvas.commands().begin(),
+        canvas.commands().end(),
+        [&](const DrawCommand& cmd) {
+            return cmd.type == DrawCommand::Type::fill_text &&
+                   cmd.text == text;
+        }));
 }
 
 } // namespace
@@ -269,4 +287,65 @@ TEST_CASE("TreeView row_height and indent configurable", "[view][tree]") {
 
     REQUIRE(tree.row_height() == 30.0f);
     REQUIRE(tree.indent() == 24.0f);
+}
+
+TEST_CASE("TreeView collapsed children are hidden from paint and hit testing",
+          "[view][tree][coverage][issue-654]") {
+    TreeView tree;
+    auto& group = tree.root().add_child("Group");
+    group.add_child("Hidden child");
+    auto& visible = tree.root().add_child("Visible");
+    tree.set_bounds({0, 0, 240, 120});
+
+    std::string selected;
+    tree.on_select = [&](TreeNode& node) { selected = node.label; };
+
+    RecordingCanvas collapsed;
+    tree.paint(collapsed);
+    REQUIRE(has_text(collapsed, "Group"));
+    REQUIRE_FALSE(has_text(collapsed, "Hidden child"));
+    REQUIRE(has_text(collapsed, "Visible"));
+
+    tree.on_mouse_event(mouse_down(40, 28));
+    REQUIRE(selected == "Visible");
+    REQUIRE(tree.selected_node() == &visible);
+}
+
+TEST_CASE("TreeView expanded child activation and selected paint paths",
+          "[view][tree][coverage][issue-654]") {
+    TreeView tree;
+    tree.set_bounds({0, 0, 240, 160});
+    tree.set_row_height(20.0f);
+    tree.set_indent(24.0f);
+    auto& group = tree.root().add_child("Group");
+    auto& child = group.add_child("Child");
+    group.expanded = true;
+
+    std::string activated;
+    tree.on_activate = [&](TreeNode& node) { activated = node.label; };
+
+    tree.on_mouse_event(mouse_down(54, 25, 2));
+    REQUIRE(activated == "Child");
+
+    tree.set_selected_node(&child);
+    RecordingCanvas selected;
+    tree.paint(selected);
+    REQUIRE(selected.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(text_count(selected, "\xe2\x96\xbc") == 1);
+    REQUIRE(has_text(selected, "Child"));
+}
+
+TEST_CASE("TreeView left key on collapsed parent is handled without toggling",
+          "[view][tree][coverage][issue-654]") {
+    TreeView tree;
+    auto& group = tree.root().add_child("Group");
+    group.add_child("Child");
+    tree.set_selected_node(&group);
+
+    int toggles = 0;
+    tree.on_toggle = [&](TreeNode&, bool) { ++toggles; };
+
+    REQUIRE(tree.on_key_event(key_down(KeyCode::left)));
+    REQUIRE_FALSE(group.expanded);
+    REQUIRE(toggles == 0);
 }

--- a/test/test_ui_components.cpp
+++ b/test/test_ui_components.cpp
@@ -206,6 +206,40 @@ TEST_CASE("ComboBox global click closes only outside active popup",
     REQUIRE(ComboBox::active_popup_ == nullptr);
 }
 
+TEST_CASE("ComboBox opening another popup closes the previous one",
+          "[view][combo][issue-493]") {
+    ComboBox::close_active_popup();
+
+    ComboBox first;
+    first.set_items({"One", "Two"});
+    ComboBox second;
+    second.set_items({"Alpha", "Beta"});
+
+    KeyEvent space;
+    space.key = KeyCode::space;
+    space.is_down = true;
+
+    REQUIRE(first.on_key_event(space));
+    REQUIRE(first.is_open());
+    REQUIRE(ComboBox::active_popup_ == &first);
+
+    REQUIRE(second.on_key_event(space));
+    REQUIRE_FALSE(first.is_open());
+    REQUIRE(second.is_open());
+    REQUIRE(ComboBox::active_popup_ == &second);
+
+    int changes = 0;
+    second.on_change = [&](int) { ++changes; };
+    TextInputEvent no_match;
+    no_match.text = "z";
+    second.on_text_input(no_match);
+    REQUIRE(second.selected() == 0);
+    REQUIRE(changes == 0);
+    REQUIRE(second.is_open());
+
+    ComboBox::close_active_popup();
+}
+
 // ── Tooltip ──────────────────────────────────────────────────────────────
 
 TEST_CASE("Tooltip show and hide", "[view][tooltip]") {
@@ -556,6 +590,57 @@ TEST_CASE("ScrollView vertical wheel leave and horizontal track click edges",
     REQUIRE(horizontal_track.scroll_x() > 0.0f);
 }
 
+TEST_CASE("ScrollView hit testing honors pointer modes with scrolled children",
+          "[view][scroll][issue-493]") {
+    ScrollView sv;
+    sv.set_bounds({0, 0, 100, 100});
+    sv.set_content_size({100, 300});
+
+    auto child = std::make_unique<View>();
+    child->set_bounds({10, 150, 20, 20});
+    auto* child_ptr = child.get();
+    sv.add_child(std::move(child));
+    sv.set_scroll(0, 100);
+
+    REQUIRE(sv.hit_test({20, 60}) == child_ptr);
+
+    sv.set_pointer_events(View::PointerEvents::box_only);
+    REQUIRE(sv.hit_test({20, 60}) == &sv);
+
+    sv.set_pointer_events(View::PointerEvents::box_none);
+    REQUIRE(sv.hit_test({20, 60}) == child_ptr);
+    REQUIRE(sv.hit_test({2, 2}) == nullptr);
+
+    sv.set_pointer_events(View::PointerEvents::none);
+    REQUIRE(sv.hit_test({20, 60}) == nullptr);
+}
+
+TEST_CASE("ScrollView paint_all clips translated content and skips invisible views",
+          "[view][scroll][issue-493]") {
+    ScrollView hidden;
+    hidden.set_visible(false);
+    RecordingCanvas hidden_canvas;
+    hidden.paint_all(hidden_canvas);
+    REQUIRE(hidden_canvas.command_count() == 0);
+
+    ScrollView sv;
+    sv.set_direction(ScrollView::Direction::both);
+    sv.set_bounds({5, 7, 100, 50});
+    sv.set_content_size({200, 150});
+    sv.set_scroll(10, 20);
+
+    auto child = std::make_unique<View>();
+    child->set_bounds({0, 0, 20, 20});
+    sv.add_child(std::move(child));
+
+    RecordingCanvas canvas;
+    sv.paint_all(canvas);
+    REQUIRE(canvas.count(DrawCommand::Type::save) >= 2);
+    REQUIRE(canvas.count(DrawCommand::Type::clip_rect) >= 2);
+    REQUIRE(canvas.count(DrawCommand::Type::translate) >= 2);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rounded_rect) >= 2);
+}
+
 // ── ListBox ──────────────────────────────────────────────────────────────
 
 TEST_CASE("ListBox set items and select", "[view][listbox]") {
@@ -658,4 +743,38 @@ TEST_CASE("ListBox wheel scrolling double-click and enter activation",
     RecordingCanvas canvas;
     list.paint(canvas);
     REQUIRE(canvas.count(DrawCommand::Type::fill_rounded_rect) == 1);
+}
+
+TEST_CASE("ListBox ignores boundary keys and out-of-range mouse presses",
+          "[view][listbox][issue-493]") {
+    ListBox list;
+    list.set_bounds({0, 0, 120, 48});
+    list.set_items({"Alpha", "Beta"});
+    list.set_selected(1);
+
+    int selects = 0;
+    list.on_select = [&](int) { ++selects; };
+
+    KeyEvent down;
+    down.key = KeyCode::down;
+    down.is_down = true;
+    REQUIRE_FALSE(list.on_key_event(down));
+    REQUIRE(list.selected() == 1);
+
+    KeyEvent enter;
+    enter.key = KeyCode::enter;
+    enter.is_down = true;
+    REQUIRE_FALSE(list.on_key_event(enter));
+
+    KeyEvent up_released;
+    up_released.key = KeyCode::up;
+    up_released.is_down = false;
+    REQUIRE_FALSE(list.on_key_event(up_released));
+
+    MouseEvent far_click;
+    far_click.position = {10.0f, 500.0f};
+    far_click.is_down = true;
+    list.on_mouse_event(far_click);
+    REQUIRE(list.selected() == 1);
+    REQUIRE(selects == 0);
 }

--- a/test/test_validation_harness.cpp
+++ b/test/test_validation_harness.cpp
@@ -99,6 +99,12 @@ std::filesystem::path make_temp_path(const char* stem) {
     return std::filesystem::temp_directory_path() / (std::string(stem) + "-" + unique + ".json");
 }
 
+std::filesystem::path make_temp_dir(const char* stem) {
+    auto unique = std::to_string(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+    return std::filesystem::temp_directory_path() / (std::string(stem) + "-" + unique);
+}
+
 } // anonymous namespace
 
 using Catch::Matchers::WithinAbs;
@@ -122,6 +128,20 @@ TEST_CASE("ValidationHarness set/get param", "[harness][phase2]") {
     REQUIRE_THAT(harness.get_param(2), WithinAbs(0.5, 0.01));
 }
 
+TEST_CASE("ValidationHarness configure creates artifact directory",
+          "[harness][phase2][coverage][issue-646]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    auto out_dir = make_temp_dir("pulp-harness-output-dir");
+    REQUIRE_FALSE(std::filesystem::exists(out_dir));
+
+    harness.configure({.output_dir = out_dir});
+
+    REQUIRE(std::filesystem::is_directory(out_dir));
+    std::error_code ec;
+    std::filesystem::remove_all(out_dir, ec);
+    REQUIRE_FALSE(ec);
+}
+
 TEST_CASE("ValidationHarness processes silence blocks", "[harness][phase2]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({.buffer_size = 64});
@@ -132,6 +152,18 @@ TEST_CASE("ValidationHarness processes silence blocks", "[harness][phase2]") {
     REQUIRE(output.size() == 128);
 
     // All zeros (silence in, unity gain)
+    for (float s : output) {
+        REQUIRE_THAT(static_cast<double>(s), WithinAbs(0.0, 0.0001));
+    }
+}
+
+TEST_CASE("ValidationHarness process_blocks zero blocks returns one silent buffer",
+          "[harness][phase2][coverage][issue-646]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    harness.configure({.buffer_size = 8, .output_channels = 2});
+
+    auto output = harness.process_blocks(0);
+    REQUIRE(output.size() == 16);
     for (float s : output) {
         REQUIRE_THAT(static_cast<double>(s), WithinAbs(0.0, 0.0001));
     }
@@ -253,6 +285,29 @@ TEST_CASE("ValidationHarness generates valid report JSON", "[harness][phase2]") 
     REQUIRE_THAT(report, ContainsSubstring("\"total\": 50"));
 }
 
+TEST_CASE("ValidationHarness report escapes JSON metadata and entry strings",
+          "[harness][phase2][coverage][issue-646]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    harness.configure({
+        .git_ref = "branch/quote\"slash\\",
+        .run_id = "run\nwith\ttabs",
+    });
+
+    pulp::format::ReportEntry entry;
+    entry.type = "validator";
+    entry.status = pulp::format::ValidationStatus::error;
+    entry.target = "Plugin \"A\"";
+    entry.error_message = "line1\nline2\\done";
+    entry.payload_json = "{\"tool\":\"fake\"}";
+    harness.add_entry(entry);
+
+    auto report = harness.generate_report();
+    REQUIRE_THAT(report, ContainsSubstring("branch/quote\\\"slash\\\\"));
+    REQUIRE_THAT(report, ContainsSubstring("run\\nwith\\ttabs"));
+    REQUIRE_THAT(report, ContainsSubstring("Plugin \\\"A\\\""));
+    REQUIRE_THAT(report, ContainsSubstring("line1\\nline2\\\\done"));
+}
+
 TEST_CASE("ValidationHarness empty report is valid", "[harness][phase2]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
@@ -291,6 +346,21 @@ TEST_CASE("ValidationHarness write_report creates file", "[harness][phase2]") {
     REQUIRE_FALSE(ec);
 }
 
+TEST_CASE("ValidationHarness write_report creates nested directories",
+          "[harness][phase2][coverage][issue-646]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    harness.configure({});
+
+    auto dir = make_temp_dir("pulp-harness-nested-report");
+    auto report_path = dir / "a" / "b" / "report.json";
+    REQUIRE(harness.write_report(report_path));
+    REQUIRE(std::filesystem::is_regular_file(report_path));
+
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+    REQUIRE_FALSE(ec);
+}
+
 // ── Validator graceful degradation ──────────────────────────────────────────
 
 TEST_CASE("ValidationHarness run_validator skips missing tool", "[harness][phase2]") {
@@ -319,6 +389,23 @@ TEST_CASE("ValidationHarness run_validator errors on missing plugin", "[harness]
 
     REQUIRE(entry.status == pulp::format::ValidationStatus::error);
     REQUIRE_THAT(entry.error_message, ContainsSubstring("not found"));
+}
+
+TEST_CASE("ValidationHarness run_validator errors on unknown installed tool",
+          "[harness][phase2][coverage][issue-646]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    harness.configure({});
+
+    auto tmp_plugin = make_temp_path("fake-plugin-for-unknown-validator");
+    { std::ofstream f(tmp_plugin); f << "dummy"; }
+
+    auto entry = harness.run_validator("sh", tmp_plugin);
+    REQUIRE(entry.status == pulp::format::ValidationStatus::error);
+    REQUIRE_THAT(entry.error_message, ContainsSubstring("Unknown validator tool: sh"));
+
+    std::error_code ec;
+    std::filesystem::remove(tmp_plugin, ec);
+    REQUIRE_FALSE(ec);
 }
 
 // ── Screenshot / inspector providers (#298) ─────────────────────────────────

--- a/test/test_visualization.cpp
+++ b/test/test_visualization.cpp
@@ -123,6 +123,79 @@ TEST_CASE("VisualizationBridge publishes waveform", "[view][vizbridge]") {
     REQUIRE(wf.samples[wf.num_samples - 1] > 0.9f);
 }
 
+TEST_CASE("VisualizationBridge skips waveform when capture is disabled", "[view][vizbridge]") {
+    VisualizationBridge bridge;
+
+    VisualizationConfig cfg;
+    cfg.fft_size = 256;
+    cfg.hop_size = 128;
+    cfg.num_channels = 1;
+    cfg.sample_rate = 44100.0f;
+    cfg.capture_waveform = false;
+    cfg.waveform_length = 64;
+
+    bridge.configure(cfg);
+
+    std::vector<float> buf(128, 0.25f);
+    const float* channels[] = {buf.data()};
+    bridge.process(channels, 1, 128);
+
+    const auto& wf = bridge.read_waveform();
+    REQUIRE(wf.num_samples == 0);
+    REQUIRE(wf.num_channels == 0);
+}
+
+TEST_CASE("VisualizationBridge zero-channel block only publishes empty meter", "[view][vizbridge]") {
+    VisualizationBridge bridge;
+
+    VisualizationConfig cfg;
+    cfg.fft_size = 256;
+    cfg.hop_size = 128;
+    cfg.num_channels = 2;
+    cfg.sample_rate = 1000.0f;
+    cfg.capture_waveform = true;
+    cfg.waveform_length = 32;
+
+    bridge.configure(cfg);
+
+    bridge.process(nullptr, 0, 16);
+
+    const auto& meter = bridge.read_meter();
+    const auto& spec = bridge.read_spectrum();
+    const auto& wf = bridge.read_waveform();
+
+    REQUIRE(meter.num_channels == 0);
+    REQUIRE(spec.num_bins == 0);
+    REQUIRE(wf.num_samples == 0);
+    REQUIRE(wf.num_channels == 0);
+}
+
+TEST_CASE("VisualizationBridge clamps waveform capture length to storage", "[view][vizbridge]") {
+    VisualizationBridge bridge;
+
+    VisualizationConfig cfg;
+    cfg.fft_size = 256;
+    cfg.hop_size = 128;
+    cfg.num_channels = 1;
+    cfg.sample_rate = 44100.0f;
+    cfg.capture_waveform = true;
+    cfg.waveform_length = WaveformData::kMaxSamples + 256;
+
+    bridge.configure(cfg);
+
+    std::vector<float> ramp(16);
+    for (int i = 0; i < static_cast<int>(ramp.size()); ++i)
+        ramp[i] = static_cast<float>(i) / static_cast<float>(ramp.size());
+
+    const float* channels[] = {ramp.data()};
+    bridge.process(channels, 1, static_cast<int>(ramp.size()));
+
+    const auto& wf = bridge.read_waveform();
+    REQUIRE(wf.num_samples == WaveformData::kMaxSamples);
+    REQUIRE(wf.num_channels == 1);
+    REQUIRE_THAT(wf.samples[wf.num_samples - 1], WithinAbs(15.0f / 16.0f, 1e-6f));
+}
+
 TEST_CASE("VisualizationBridge reset clears state", "[view][vizbridge]") {
     VisualizationBridge bridge;
 

--- a/test/test_waveform_editor.cpp
+++ b/test/test_waveform_editor.cpp
@@ -63,6 +63,22 @@ TEST_CASE("WaveformEditor selection callback", "[view][waveform_editor]") {
     REQUIRE(cb_end == 1500);
 }
 
+TEST_CASE("WaveformEditor clamps selection bounds and reversed ranges", "[view][waveform_editor]") {
+    WaveformEditor editor;
+    auto data = make_sine(1000);
+    editor.set_audio_data(data.data(), 1000, 44100.0f);
+
+    editor.set_selection(-100, 1200);
+    REQUIRE(editor.selection_start() == 0);
+    REQUIRE(editor.selection_end() == 1000);
+    REQUIRE(editor.selection_length() == 1000);
+
+    editor.set_selection(900, 100);
+    REQUIRE(editor.selection_start() == 100);
+    REQUIRE(editor.selection_end() == 900);
+    REQUIRE(editor.selection_length() == 800);
+}
+
 TEST_CASE("WaveformEditor zoom in/out", "[view][waveform_editor]") {
     WaveformEditor editor;
     auto data = make_sine(44100);
@@ -103,6 +119,18 @@ TEST_CASE("WaveformEditor zoom to selection", "[view][waveform_editor]") {
     REQUIRE(editor.visible_length() == 10000);
 }
 
+TEST_CASE("WaveformEditor zoom to selection is a no-op without selection", "[view][waveform_editor]") {
+    WaveformEditor editor;
+    auto data = make_sine(1000);
+    editor.set_audio_data(data.data(), 1000, 44100.0f);
+    editor.set_visible_range(200, 250);
+
+    editor.zoom_to_selection();
+
+    REQUIRE(editor.visible_start() == 200);
+    REQUIRE(editor.visible_length() == 250);
+}
+
 TEST_CASE("WaveformEditor scroll", "[view][waveform_editor]") {
     WaveformEditor editor;
     auto data = make_sine(44100);
@@ -127,6 +155,20 @@ TEST_CASE("WaveformEditor scroll clamped at boundaries", "[view][waveform_editor
     REQUIRE(editor.visible_start() + editor.visible_length() <= 44100);
 }
 
+TEST_CASE("WaveformEditor visible range clamps minimum length near end", "[view][waveform_editor]") {
+    WaveformEditor editor;
+    auto data = make_sine(1000);
+    editor.set_audio_data(data.data(), 1000, 44100.0f);
+
+    editor.set_visible_range(995, 1);
+    REQUIRE(editor.visible_length() == 16);
+    REQUIRE(editor.visible_start() == 984);
+
+    editor.set_visible_range(-50, 100);
+    REQUIRE(editor.visible_start() == 0);
+    REQUIRE(editor.visible_length() == 100);
+}
+
 TEST_CASE("WaveformEditor playhead", "[view][waveform_editor]") {
     WaveformEditor editor;
     auto data = make_sine(44100);
@@ -134,6 +176,18 @@ TEST_CASE("WaveformEditor playhead", "[view][waveform_editor]") {
 
     editor.set_playhead(22050);
     REQUIRE(editor.playhead() == 22050);
+}
+
+TEST_CASE("WaveformEditor playhead clamps to audio bounds", "[view][waveform_editor]") {
+    WaveformEditor editor;
+    auto data = make_sine(1000);
+    editor.set_audio_data(data.data(), 1000, 44100.0f);
+
+    editor.set_playhead(-50);
+    REQUIRE(editor.playhead() == 0);
+
+    editor.set_playhead(5000);
+    REQUIRE(editor.playhead() == 1000);
 }
 
 TEST_CASE("WaveformEditor regions", "[view][waveform_editor]") {
@@ -164,6 +218,22 @@ TEST_CASE("WaveformEditor paint produces draw commands", "[view][waveform_editor
     REQUIRE(canvas.count(DrawCommand::Type::stroke_line) > 0);
 }
 
+TEST_CASE("WaveformEditor paint records regions selection and playhead", "[view][waveform_editor]") {
+    WaveformEditor editor;
+    auto data = make_sine(400);
+    editor.set_audio_data(data.data(), 400, 44100.0f);
+    editor.set_bounds({0, 0, 80, 40});
+    editor.set_selection(40, 120);
+    editor.add_region({160, 240, "Loop"});
+    editor.set_playhead(200);
+
+    RecordingCanvas canvas;
+    editor.paint(canvas);
+
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rect) >= 3);
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_line) >= 82);
+}
+
 TEST_CASE("WaveformEditor key Cmd+A selects all", "[view][waveform_editor]") {
     WaveformEditor editor;
     auto data = make_sine(44100);
@@ -180,4 +250,61 @@ TEST_CASE("WaveformEditor key Cmd+A selects all", "[view][waveform_editor]") {
     REQUIRE(editor.on_key_event(e));
     REQUIRE(editor.selection_start() == 0);
     REQUIRE(editor.selection_end() == 44100);
+}
+
+TEST_CASE("WaveformEditor key scrolls and release events are ignored", "[view][waveform_editor]") {
+    WaveformEditor editor;
+    auto data = make_sine(1000);
+    editor.set_audio_data(data.data(), 1000, 44100.0f);
+    editor.set_visible_range(200, 200);
+
+    KeyEvent release;
+    release.key = KeyCode::right;
+    release.is_down = false;
+    REQUIRE_FALSE(editor.on_key_event(release));
+    REQUIRE(editor.visible_start() == 200);
+
+    KeyEvent right;
+    right.key = KeyCode::right;
+    REQUIRE(editor.on_key_event(right));
+    REQUIRE(editor.visible_start() == 220);
+
+    KeyEvent left;
+    left.key = KeyCode::left;
+    REQUIRE(editor.on_key_event(left));
+    REQUIRE(editor.visible_start() == 200);
+}
+
+TEST_CASE("WaveformEditor mouse click and shift extend selection", "[view][waveform_editor]") {
+    WaveformEditor editor;
+    auto data = make_sine(1000);
+    editor.set_audio_data(data.data(), 1000, 44100.0f);
+    editor.set_bounds({0, 0, 100, 40});
+
+    MouseEvent down;
+    down.is_down = true;
+    down.position = {25, 10};
+    editor.on_mouse_event(down);
+    REQUIRE(editor.selection_start() == 250);
+    REQUIRE(editor.selection_end() == 250);
+    REQUIRE_FALSE(editor.has_selection());
+
+    editor.set_selection(100, 200);
+    int cb_start = -1;
+    int cb_end = -1;
+    editor.on_selection_changed = [&](int start, int end) {
+        cb_start = start;
+        cb_end = end;
+    };
+
+    MouseEvent shift_down;
+    shift_down.is_down = true;
+    shift_down.modifiers = kModShift;
+    shift_down.position = {50, 10};
+    editor.on_mouse_event(shift_down);
+
+    REQUIRE(editor.selection_start() == 100);
+    REQUIRE(editor.selection_end() == 500);
+    REQUIRE(cb_start == 100);
+    REQUIRE(cb_end == 500);
 }

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -2011,6 +2011,28 @@ TEST_CASE("Widget setters skip repaint when value is unchanged [issue-73]",
         knob.set_label("Cutoff");
         REQUIRE(host.repaint_count == after);
     }
+
+    SECTION("Fader::set_label idempotent") {
+        Fader fader;
+        CountingHost host;
+        fader.set_window_host(&host);
+        fader.set_label("Volume");
+        int after = host.repaint_count;
+
+        fader.set_label("Volume");
+        REQUIRE(host.repaint_count == after);
+    }
+
+    SECTION("ToggleButton::set_label idempotent") {
+        ToggleButton tb;
+        CountingHost host;
+        tb.set_window_host(&host);
+        tb.set_label("Bypass");
+        int after = host.repaint_count;
+
+        tb.set_label("Bypass");
+        REQUIRE(host.repaint_count == after);
+    }
 }
 
 TEST_CASE("Widget set_label programmatic mutation requests repaint [issue-73]",
@@ -2044,4 +2066,20 @@ TEST_CASE("Widget set_label programmatic mutation requests repaint [issue-73]",
         tb.set_label("Mute");
         REQUIRE(host.repaint_count > before);
     }
+}
+
+TEST_CASE("Knob format setter requests repaint without changing value [issue-73]",
+          "[view][widget][issue-73]") {
+    Knob knob;
+    knob.set_value(0.25f);
+    CountingHost host;
+    knob.set_window_host(&host);
+    int before = host.repaint_count;
+
+    knob.set_format([](float value) {
+        return std::to_string(static_cast<int>(value * 100.0f)) + "%";
+    });
+
+    REQUIRE(knob.value() == 0.25f);
+    REQUIRE(host.repaint_count > before);
 }

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -1027,6 +1027,158 @@ TEST_CASE("Audio widgets render declarative schemas and invalid schema fallback"
     REQUIRE(invalid_canvas.count(DrawCommand::Type::fill_rect) == 1);
 }
 
+TEST_CASE("Audio widgets custom shader paths fall back on recording canvas",
+          "[view][widget][shader][issue-493]") {
+    Knob knob;
+    knob.set_bounds({0, 0, 80, 80});
+    knob.set_value(0.5f);
+    knob.set_label("Drive");
+    knob.set_format([](float) { return "50%"; });
+    knob.set_custom_shader("uniform float time; half4 main(float2 p) { return half4(time); }");
+    REQUIRE(knob.has_custom_shader());
+    REQUIRE(knob.shader_uses_time());
+
+    RecordingCanvas knob_canvas;
+    knob.paint(knob_canvas);
+    REQUIRE(knob_canvas.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(knob_canvas.count(DrawCommand::Type::fill_text) >= 2);
+
+    Fader fader;
+    fader.set_bounds({0, 0, 24, 120});
+    fader.set_label("Level");
+    fader.set_custom_shader("half4 main(float2 p) { return half4(1); }");
+    REQUIRE(fader.has_custom_shader());
+    REQUIRE_FALSE(fader.shader_uses_time());
+
+    RecordingCanvas fader_canvas;
+    fader.paint(fader_canvas);
+    REQUIRE(fader_canvas.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(fader_canvas.count(DrawCommand::Type::fill_text) == 1);
+
+    Toggle toggle;
+    toggle.set_bounds({0, 0, 64, 32});
+    toggle.set_on(true);
+    toggle.set_label("On");
+    toggle.set_custom_shader("uniform float time; half4 main(float2 p) { return half4(time); }");
+    REQUIRE(toggle.has_custom_shader());
+    REQUIRE(toggle.shader_uses_time());
+
+    RecordingCanvas toggle_canvas;
+    toggle.paint(toggle_canvas);
+    REQUIRE(toggle_canvas.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(toggle_canvas.count(DrawCommand::Type::fill_text) == 1);
+}
+
+TEST_CASE("Audio widgets minimal render style paints simplified branches",
+          "[view][widget][style][issue-493]") {
+    Knob knob;
+    knob.set_bounds({0, 0, 64, 64});
+    knob.set_render_style(WidgetRenderStyle::minimal);
+
+    RecordingCanvas knob_canvas;
+    knob.paint(knob_canvas);
+    REQUIRE(knob_canvas.count(DrawCommand::Type::fill_circle) == 1);
+    REQUIRE(knob_canvas.count(DrawCommand::Type::stroke_circle) == 1);
+    REQUIRE(knob_canvas.count(DrawCommand::Type::stroke_arc) == 0);
+
+    Fader fader;
+    fader.set_bounds({0, 0, 28, 120});
+    fader.set_render_style(WidgetRenderStyle::minimal);
+
+    RecordingCanvas fader_canvas;
+    fader.paint(fader_canvas);
+    REQUIRE(fader_canvas.count(DrawCommand::Type::fill_rounded_rect) == 1);
+    REQUIRE(fader_canvas.count(DrawCommand::Type::fill_circle) == 0);
+
+    Meter meter;
+    meter.set_bounds({0, 0, 8, 6});
+    meter.set_render_style(WidgetRenderStyle::minimal);
+
+    RecordingCanvas meter_canvas;
+    meter.paint(meter_canvas);
+    REQUIRE(meter_canvas.count(DrawCommand::Type::fill_rect) == 6);
+    REQUIRE(meter_canvas.count(DrawCommand::Type::fill_rounded_rect) == 0);
+}
+
+TEST_CASE("Knob mouse paths update value, hover animation, and default reset",
+          "[view][widget][interaction][issue-493]") {
+    Knob knob;
+    knob.set_value(0.25f);
+    knob.set_default_value(0.75f);
+
+    std::vector<float> changes;
+    knob.on_change = [&](float v) { changes.push_back(v); };
+
+    knob.on_mouse_enter();
+    knob.advance_animations(1.0f);
+    REQUIRE(knob.hover_glow() > 0.9f);
+
+    knob.on_mouse_leave();
+    knob.advance_animations(1.0f);
+    REQUIRE(knob.hover_glow() < 0.1f);
+
+    knob.on_mouse_down({0, 100});
+    knob.on_mouse_drag({0, 55});
+    REQUIRE(knob.value() > 0.25f);
+    REQUIRE_FALSE(changes.empty());
+
+    MouseEvent reset;
+    reset.is_down = true;
+    reset.click_count = 2;
+    knob.on_mouse_event(reset);
+    REQUIRE_THAT(knob.value(), WithinAbs(0.75, 0.001));
+    REQUIRE_THAT(changes.back(), WithinAbs(0.75, 0.001));
+}
+
+TEST_CASE("Fader and toggle mouse paths dispatch clamped interactive values",
+          "[view][widget][interaction][issue-493]") {
+    Fader vertical;
+    vertical.set_bounds({0, 0, 24, 100});
+    std::vector<float> fader_changes;
+    vertical.on_change = [&](float v) { fader_changes.push_back(v); };
+
+    MouseEvent down;
+    down.is_down = true;
+    down.position = {12, 75};
+    vertical.on_mouse_event(down);
+    REQUIRE_THAT(vertical.value(), WithinAbs(0.25, 0.001));
+
+    vertical.on_mouse_drag({12, 20});
+    REQUIRE_THAT(vertical.value(), WithinAbs(0.80, 0.001));
+
+    MouseEvent up = down;
+    up.is_down = false;
+    vertical.on_mouse_event(up);
+    vertical.on_mouse_drag({12, 100});
+    REQUIRE_THAT(vertical.value(), WithinAbs(0.80, 0.001));
+    REQUIRE(fader_changes.size() >= 2);
+
+    Fader horizontal;
+    horizontal.set_bounds({0, 0, 200, 24});
+    horizontal.set_orientation(Fader::Orientation::horizontal);
+    MouseEvent horizontal_down;
+    horizontal_down.is_down = true;
+    horizontal_down.position = {50, 12};
+    horizontal.on_mouse_event(horizontal_down);
+    REQUIRE_THAT(horizontal.value(), WithinAbs(0.25, 0.001));
+
+    Toggle toggle;
+    std::vector<bool> toggle_changes;
+    toggle.on_toggle = [&](bool v) { toggle_changes.push_back(v); };
+
+    toggle.on_mouse_enter();
+    toggle.advance_animations(1.0f);
+    REQUIRE(toggle.hover_opacity() > 0.9f);
+
+    toggle.on_mouse_down({4, 4});
+    REQUIRE(toggle.is_on());
+    REQUIRE(toggle_changes == std::vector<bool>{true});
+
+    toggle.on_mouse_leave();
+    toggle.advance_animations(1.0f);
+    REQUIRE(toggle.hover_opacity() < 0.1f);
+}
+
 TEST_CASE("Checkbox, toggle button, icons, and image placeholders cover widget paint edges",
           "[view][widget][controls]") {
     Checkbox checkbox;

--- a/test/test_window_manager.cpp
+++ b/test/test_window_manager.cpp
@@ -53,6 +53,26 @@ TEST_CASE("WindowManager unregister", "[view][multiwindow]") {
     REQUIRE(mgr.window(id) == nullptr);
 }
 
+TEST_CASE("WindowManager unregister invokes close callback and ignores missing ids",
+          "[view][multiwindow]") {
+    WindowManager mgr;
+    View root;
+    StubWindowHost host;
+    auto id = mgr.register_window(&host, &root, WindowType::main);
+
+    std::vector<WindowId> closed;
+    mgr.set_on_window_closed([&](WindowId closed_id) {
+        closed.push_back(closed_id);
+    });
+
+    mgr.unregister_window(id);
+    mgr.unregister_window(id);
+    mgr.unregister_window(999);
+
+    REQUIRE(closed == std::vector<WindowId>{id});
+    REQUIRE(mgr.window_count() == 0);
+}
+
 TEST_CASE("WindowManager unique IDs", "[view][multiwindow]") {
     WindowManager mgr;
     View r1, r2, r3;
@@ -154,6 +174,29 @@ TEST_CASE("WindowManager close leaf only", "[view][multiwindow]") {
     REQUIRE(mgr.window(main_id) != nullptr);
     REQUIRE(h2.close_requested_);
     REQUIRE_FALSE(h1.close_requested_);
+}
+
+TEST_CASE("WindowManager closes windows without host or root view",
+          "[view][multiwindow]") {
+    WindowManager mgr;
+    mgr.set_shared_theme(Theme::dark());
+
+    auto id = mgr.register_window(nullptr, nullptr, WindowType::popup);
+    auto* rec = mgr.window(id);
+    REQUIRE(rec != nullptr);
+    REQUIRE(rec->host == nullptr);
+    REQUIRE(rec->root_view == nullptr);
+
+    std::vector<WindowId> closed;
+    mgr.set_on_window_closed([&](WindowId closed_id) {
+        closed.push_back(closed_id);
+    });
+
+    mgr.close_window(id);
+
+    REQUIRE(closed == std::vector<WindowId>{id});
+    REQUIRE(mgr.window_count() == 0);
+    REQUIRE(mgr.window(id) == nullptr);
 }
 
 // ── Theme propagation ───────────────────────────────────────────────────────
@@ -268,6 +311,30 @@ TEST_CASE("WindowManager message handler removed on unregister", "[view][multiwi
     msg.type = "test";
     mgr.send_message(id, msg);
     REQUIRE_FALSE(called);
+}
+
+TEST_CASE("WindowManager send and broadcast skip missing handlers",
+          "[view][multiwindow]") {
+    WindowManager mgr;
+    View r1, r2;
+    StubWindowHost h1, h2;
+
+    auto id1 = mgr.register_window(&h1, &r1, WindowType::main);
+    auto id2 = mgr.register_window(&h2, &r2, WindowType::palette);
+
+    int count = 0;
+    mgr.set_message_handler(id1, [&](const WindowMessage& msg) {
+        REQUIRE(msg.type == "ping");
+        ++count;
+    });
+
+    WindowMessage msg;
+    msg.type = "ping";
+    mgr.send_message(id2, msg);
+    REQUIRE(count == 0);
+
+    mgr.broadcast_message(msg);
+    REQUIRE(count == 1);
 }
 
 // ── Window state save / restore ─────────────────────────────────────────────

--- a/test/test_xml_zip.cpp
+++ b/test/test_xml_zip.cpp
@@ -111,6 +111,46 @@ TEST_CASE("XmlDocument invalid XML", "[runtime][xml]") {
     REQUIRE_FALSE(doc.error().empty());
 }
 
+TEST_CASE("XmlDocument empty document queries are inert",
+          "[runtime][xml][coverage][issue-641]") {
+    XmlDocument doc;
+
+    REQUIRE_FALSE(doc.is_valid());
+    REQUIRE(doc.root_name().empty());
+    REQUIRE_FALSE(doc.root_attribute("missing").has_value());
+    REQUIRE_FALSE(doc.xpath_string("//missing").has_value());
+    REQUIRE(doc.xpath_strings("//missing").empty());
+
+    int walk_count = 0;
+    doc.walk([&](std::string_view, std::string_view) {
+        ++walk_count;
+    });
+    REQUIRE(walk_count == 0);
+}
+
+TEST_CASE("XmlDocument move construction and assignment preserve parsed state",
+          "[runtime][xml][coverage][issue-641]") {
+    XmlDocument original;
+    REQUIRE(original.parse(R"(<root name="first"><child>value</child></root>)"));
+
+    XmlDocument moved(std::move(original));
+    REQUIRE(moved.is_valid());
+    REQUIRE(moved.root_name() == "root");
+    REQUIRE(moved.root_attribute("name") == std::optional<std::string>{"first"});
+    REQUIRE_FALSE(original.is_valid());
+    REQUIRE(original.root_name().empty());
+
+    XmlDocument replacement;
+    REQUIRE(replacement.parse(R"(<replacement><leaf>next</leaf></replacement>)"));
+
+    moved = std::move(replacement);
+    REQUIRE(moved.is_valid());
+    REQUIRE(moved.root_name() == "replacement");
+    REQUIRE(moved.xpath_string("//leaf") == std::optional<std::string>{"next"});
+    REQUIRE_FALSE(replacement.is_valid());
+    REQUIRE(replacement.root_name().empty());
+}
+
 TEST_CASE("xml_generate creates document", "[runtime][xml]") {
     auto xml = xml_generate("preset", {
         {"name", "Default"},
@@ -124,6 +164,28 @@ TEST_CASE("xml_generate creates document", "[runtime][xml]") {
     auto name = doc.xpath_string("//name");
     REQUIRE(name.has_value());
     REQUIRE(*name == "Default");
+}
+
+TEST_CASE("xml_generate handles empty and repeated elements",
+          "[runtime][xml][coverage][issue-641]") {
+    auto xml = xml_generate("metadata", {
+        {"tag", "alpha"},
+        {"tag", "beta"},
+        {"empty", ""}
+    });
+
+    XmlDocument doc;
+    REQUIRE(doc.parse(xml));
+    REQUIRE(doc.root_name() == "metadata");
+
+    auto tags = doc.xpath_strings("//tag");
+    REQUIRE(tags.size() == 2);
+    REQUIRE(tags[0] == "alpha");
+    REQUIRE(tags[1] == "beta");
+
+    auto empty = doc.xpath_string("//empty");
+    REQUIRE(empty.has_value());
+    REQUIRE(empty->empty());
 }
 
 TEST_CASE("xml_generate escapes text content", "[runtime][xml]") {

--- a/tools/local-ci/test_local_ci_extra.py
+++ b/tools/local-ci/test_local_ci_extra.py
@@ -36,6 +36,14 @@ class LocalCiPureHelperTests(unittest.TestCase):
 
     def test_state_dir_uses_xdg_and_home_fallbacks_on_non_macos(self) -> None:
         with mock.patch.object(self.mod.Path, "home", return_value=self.root / "home"):
+            with mock.patch.object(self.mod.sys, "platform", "darwin"):
+                with mock.patch.dict(os.environ, {}, clear=True):
+                    self.assertEqual(
+                        self.mod.state_dir(),
+                        self.root / "home" / "Library" / "Application Support" / "Pulp" / "local-ci",
+                    )
+
+        with mock.patch.object(self.mod.Path, "home", return_value=self.root / "home"):
             with mock.patch.object(self.mod.sys, "platform", "linux"):
                 with mock.patch.dict(os.environ, {"XDG_STATE_HOME": str(self.root / "xdg")}, clear=True):
                     self.assertEqual(
@@ -48,10 +56,35 @@ class LocalCiPureHelperTests(unittest.TestCase):
                         self.root / "home" / ".local" / "state" / "pulp" / "local-ci",
                     )
 
+    def test_state_path_helpers_create_expected_directories_and_logs(self) -> None:
+        with mock.patch.dict(os.environ, {"PULP_LOCAL_CI_HOME": str(self.root / "state")}, clear=True):
+            self.mod.ensure_state_dirs()
+            for path in (
+                self.mod.results_dir(),
+                self.mod.cloud_runs_dir(),
+                self.mod.logs_dir(),
+                self.mod.bundles_dir(),
+                self.mod.desktop_state_dir(),
+                self.mod.desktop_receipts_dir(),
+            ):
+                self.assertTrue(path.is_dir(), f"{path} should exist")
+
+            log_path = self.mod.prepare_target_log("job-1", "mac")
+            self.assertEqual(log_path, self.mod.target_log_path("job-1", "mac"))
+            self.assertTrue(log_path.is_file())
+            self.assertEqual(log_path.read_text(), "")
+
     def test_default_desktop_artifact_root_platform_branches(self) -> None:
         with mock.patch.object(self.mod.Path, "home", return_value=self.root / "home"):
             with mock.patch.dict(os.environ, {"PULP_DESKTOP_ARTIFACT_ROOT": str(self.root / "override")}, clear=True):
                 self.assertEqual(self.mod.default_desktop_artifact_root(), self.root / "override")
+
+            with mock.patch.object(self.mod.sys, "platform", "darwin"):
+                with mock.patch.dict(os.environ, {}, clear=True):
+                    self.assertEqual(
+                        self.mod.default_desktop_artifact_root(),
+                        self.root / "home" / "Library" / "Application Support" / "Pulp" / "desktop-automation" / "runs",
+                    )
 
             with mock.patch.object(self.mod.sys, "platform", "win32"):
                 with mock.patch.dict(os.environ, {"LOCALAPPDATA": str(self.root / "localapp")}, clear=True):
@@ -65,6 +98,11 @@ class LocalCiPureHelperTests(unittest.TestCase):
                     self.assertEqual(
                         self.mod.default_desktop_artifact_root(),
                         self.root / "xdg" / "pulp" / "desktop-automation" / "runs",
+                    )
+                with mock.patch.dict(os.environ, {}, clear=True):
+                    self.assertEqual(
+                        self.mod.default_desktop_artifact_root(),
+                        self.root / "home" / ".local" / "state" / "pulp" / "desktop-automation" / "runs",
                     )
 
     def test_normalizers_reject_invalid_modes_and_parse_booleans(self) -> None:

--- a/tools/packages/test_freshness_check_extra.py
+++ b/tools/packages/test_freshness_check_extra.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Additional unit tests for package freshness checking edge paths.
+
+Run:
+    python3 tools/packages/test_freshness_check_extra.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).parent
+
+
+def load_module(name: str, path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+fc = load_module("freshness_check_extra_target", ROOT / "freshness_check.py")
+
+
+@contextlib.contextmanager
+def argv(args: list[str]):
+    old = sys.argv[:]
+    sys.argv = args[:]
+    try:
+        yield
+    finally:
+        sys.argv = old
+
+
+@contextlib.contextmanager
+def module_attr(module, name: str, value):
+    old = getattr(module, name)
+    setattr(module, name, value)
+    try:
+        yield
+    finally:
+        setattr(module, name, old)
+
+
+class FreshnessCheckExtraTests(unittest.TestCase):
+    def test_result_preserves_explicit_issue_list(self) -> None:
+        issues = ["already known"]
+
+        result = fc.CheckResult(
+            package="audio-lib",
+            pinned_version="1.0.0",
+            issues=issues,
+        )
+
+        self.assertIs(result.issues, issues)
+
+    def test_extract_owner_repo_rejects_incomplete_github_url(self) -> None:
+        self.assertIsNone(fc.extract_owner_repo("https://github.com/acme"))
+
+    def test_check_package_falls_back_to_tags_without_release(self) -> None:
+        responses = {
+            "repos/acme/audio-lib": {"archived": False, "pushed_at": ""},
+            "repos/acme/audio-lib/releases?per_page=1": [],
+            "repos/acme/audio-lib/tags?per_page=1": [{"name": "v1.2.3"}],
+            "repos/acme/audio-lib/license": {"license": {"spdx_id": "NOASSERTION"}},
+        }
+
+        with mock.patch.object(fc, "run_gh", side_effect=lambda args: responses[args[0]]):
+            result = fc.check_package(
+                "audio-lib",
+                {
+                    "version": "v1.2.3",
+                    "license": "MIT",
+                    "fetch": {"git_repository": "https://github.com/acme/audio-lib"},
+                },
+            )
+
+        self.assertEqual(result.latest_version, "v1.2.3")
+        self.assertIsNone(result.last_commit_date)
+        self.assertFalse(result.archived)
+        self.assertFalse(result.license_changed)
+        self.assertEqual(result.issues, [])
+
+    def test_check_package_tolerates_missing_tags_and_license(self) -> None:
+        responses = {
+            "repos/acme/audio-lib": {"archived": False},
+            "repos/acme/audio-lib/releases?per_page=1": None,
+            "repos/acme/audio-lib/tags?per_page=1": [],
+            "repos/acme/audio-lib/license": None,
+        }
+
+        with mock.patch.object(fc, "run_gh", side_effect=lambda args: responses[args[0]]):
+            result = fc.check_package(
+                "audio-lib",
+                {
+                    "version": "v1.2.3",
+                    "license": "MIT",
+                    "fetch": {"git_repository": "https://github.com/acme/audio-lib"},
+                },
+            )
+
+        self.assertIsNone(result.latest_version)
+        self.assertIsNone(result.last_commit_date)
+        self.assertEqual(result.issues, [])
+
+    def test_main_emits_markdown_for_all_packages(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            registry_path = pathlib.Path(td) / "registry.json"
+            registry_path.write_text(
+                json.dumps(
+                    {
+                        "packages": {
+                            "ok": {"version": "1.0.0"},
+                            "stale": {"version": "1.0.0"},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            def fake_check(slug: str, pkg: dict):
+                if slug == "stale":
+                    return fc.CheckResult(
+                        package=slug,
+                        pinned_version=pkg["version"],
+                        latest_version="2.0.0",
+                        issues=["Newer version available"],
+                    )
+                return fc.CheckResult(
+                    package=slug,
+                    pinned_version=pkg["version"],
+                    latest_version=pkg["version"],
+                    last_commit_date="2026-04-01",
+                )
+
+            out = io.StringIO()
+            err = io.StringIO()
+            with module_attr(fc, "REGISTRY", registry_path), mock.patch.object(fc, "check_package", fake_check):
+                with argv(["freshness_check.py", "--format", "markdown"]):
+                    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                        rc = fc.main()
+
+        self.assertEqual(rc, 1)
+        text = out.getvalue()
+        self.assertIn("| Package | Pinned | Latest | Last Commit | Issues |", text)
+        self.assertIn("| ok | 1.0.0 | 1.0.0 | 2026-04-01 | OK |", text)
+        self.assertIn("| stale | 1.0.0 | 2.0.0 | ? | Newer version available |", text)
+        self.assertIn("2 packages checked, 1 issues", err.getvalue())
+
+    def test_main_emits_text_for_ok_and_issue_results(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            registry_path = pathlib.Path(td) / "registry.json"
+            registry_path.write_text(
+                json.dumps(
+                    {
+                        "packages": {
+                            "ok": {"version": "1.0.0"},
+                            "stale": {"version": "1.0.0"},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            def fake_check(slug: str, pkg: dict):
+                if slug == "stale":
+                    return fc.CheckResult(
+                        package=slug,
+                        pinned_version=pkg["version"],
+                        issues=["Cannot reach GitHub API"],
+                    )
+                return fc.CheckResult(package=slug, pinned_version=pkg["version"])
+
+            out = io.StringIO()
+            err = io.StringIO()
+            with module_attr(fc, "REGISTRY", registry_path), mock.patch.object(fc, "check_package", fake_check):
+                with argv(["freshness_check.py"]):
+                    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                        rc = fc.main()
+
+        self.assertEqual(rc, 1)
+        text = out.getvalue()
+        self.assertRegex(text, r"ok\s+\.+\s+OK")
+        self.assertRegex(text, r"stale\s+\.+\s+ISSUES")
+        self.assertIn("    - Cannot reach GitHub API", text)
+        self.assertIn("2 packages checked, 1 issues", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/scripts/local_diff_cover.sh
+++ b/tools/scripts/local_diff_cover.sh
@@ -221,19 +221,21 @@ find "${PROFRAW_DIR}" -name '*.profraw' -print0 \
 # the diff-cover gate. See issue #919 (Codex review on PR #919).
 BINARIES=()
 
-# 1. Test executables — primary coverage drivers.
-while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
-    find "${BUILD_DIR}/test" -maxdepth 2 -type f -perm -u+x \
-        ! -name '*.cmake' ! -name '*.txt' 2>/dev/null || true
-)
-
-# 2. First-party static archives — expose every instrumented TU even
+# 1. First-party static archives — expose every instrumented TU even
 #    when no test transitively links it. `pulp-*.lib` covers Windows
-#    where clang-cl emits MSVC-style archives.
+#    where clang-cl emits MSVC-style archives. Keep these before test
+#    executables so duplicate source coverage maps from actually-run
+#    tests win over archive-only zero-hit records.
 while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
     find "${BUILD_DIR}" -type f \
         \( -name 'libpulp-*.a' -o -name 'pulp-*.lib' \) \
         2>/dev/null || true
+)
+
+# 2. Test executables — primary coverage drivers.
+while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
+    find "${BUILD_DIR}/test" -maxdepth 2 -type f -perm -u+x \
+        ! -name '*.cmake' ! -name '*.txt' 2>/dev/null || true
 )
 
 # 3. First-party non-test executables — CLI, standalone host, inspector.

--- a/tools/scripts/test_android_target.py
+++ b/tools/scripts/test_android_target.py
@@ -56,6 +56,17 @@ class AndroidSdkDiscoveryTests(unittest.TestCase):
                  mock.patch.object(android_target.os, "getlogin", return_value="tester"):
                 self.assertEqual(android_target.find_android_sdk(), str(sdk))
 
+    def test_find_android_sdk_checks_linux_default_location(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            home = pathlib.Path(td)
+            sdk = home / "Android" / "Sdk"
+            sdk.mkdir(parents=True)
+
+            with mock.patch.dict(os.environ, {}, clear=True), \
+                 mock.patch.object(android_target.Path, "home", return_value=home), \
+                 mock.patch.object(android_target.os, "getlogin", return_value="tester"):
+                self.assertEqual(android_target.find_android_sdk(), str(sdk))
+
     def test_find_android_sdk_returns_empty_string_when_missing(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             home = pathlib.Path(td)
@@ -211,6 +222,24 @@ class BuildAndroidTests(unittest.TestCase):
         self.assertEqual(run.call_args.args[0], [str(gradlew), "assembleDebug"])
         self.assertIn("Android APK built", out.getvalue())
         self.assertIn("2.0 MB", out.getvalue())
+
+    def test_build_android_reports_success_when_expected_apk_is_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            android_dir = root / "android"
+            android_dir.mkdir()
+            gradlew = android_dir / "gradlew"
+            gradlew.write_text("#!/bin/sh\n", encoding="utf-8")
+            completed = subprocess.CompletedProcess([str(gradlew), "assembleDebug"], 0)
+
+            out = io.StringIO()
+            with mock.patch.object(android_target, "find_android_sdk", return_value="/sdk"), \
+                 mock.patch.object(android_target.subprocess, "run", return_value=completed), \
+                 contextlib.redirect_stdout(out):
+                rc = android_target.build_android(root, verbose=True)
+
+        self.assertEqual(rc, 0)
+        self.assertIn("Build succeeded but APK path not found", out.getvalue())
 
     def test_build_android_returns_gradle_failure_status(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/scripts/test_android_target.py
+++ b/tools/scripts/test_android_target.py
@@ -76,6 +76,24 @@ class AndroidSdkDiscoveryTests(unittest.TestCase):
                  mock.patch.object(android_target.os, "getlogin", return_value="tester"):
                 self.assertEqual(android_target.find_android_sdk(), "")
 
+    def test_find_android_sdk_ignores_missing_env_paths_and_falls_back(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            home = pathlib.Path(td)
+            sdk = home / "Android" / "Sdk"
+            sdk.mkdir(parents=True)
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "ANDROID_HOME": str(home / "missing-home"),
+                    "ANDROID_SDK_ROOT": str(home / "missing-root"),
+                },
+                clear=True,
+            ), \
+                 mock.patch.object(android_target.Path, "home", return_value=home), \
+                 mock.patch.object(android_target.os, "getlogin", return_value="tester"):
+                self.assertEqual(android_target.find_android_sdk(), str(sdk))
+
 
 class NdkDiscoveryTests(unittest.TestCase):
     def test_find_ndk_returns_latest_installation_with_toolchain_file(self) -> None:
@@ -152,6 +170,21 @@ class PrerequisiteTests(unittest.TestCase):
                  side_effect=FileNotFoundError,
              ):
             self.assertEqual(android_target.check_prerequisites(), ["Java not found in PATH"])
+
+    def test_check_prerequisites_reports_empty_java_version_output(self) -> None:
+        completed = subprocess.CompletedProcess(
+            ["java", "-version"],
+            0,
+            stderr="",
+        )
+
+        with mock.patch.object(android_target, "find_android_sdk", return_value="/sdk"), \
+             mock.patch.object(android_target, "find_ndk", return_value="/sdk/ndk/30"), \
+             mock.patch.object(android_target.subprocess, "run", return_value=completed):
+            self.assertEqual(
+                android_target.check_prerequisites(),
+                ["Java 17+ required. Found: "],
+            )
 
 
 class BuildAndroidTests(unittest.TestCase):

--- a/tools/scripts/test_auto_release_decision.py
+++ b/tools/scripts/test_auto_release_decision.py
@@ -36,6 +36,17 @@ spec.loader.exec_module(ard)
 
 
 class SemverCmpTests(unittest.TestCase):
+    def test_parse_version_accepts_numeric_triplets(self):
+        self.assertEqual(ard.parse_version("1.2.3"), (1, 2, 3))
+        self.assertEqual(ard.parse_version("01.002.0003"), (1, 2, 3))
+
+    def test_parse_version_rejects_missing_or_malformed_values(self):
+        self.assertIsNone(ard.parse_version(""))
+        self.assertIsNone(ard.parse_version(None))
+        self.assertIsNone(ard.parse_version("1.2"))
+        self.assertIsNone(ard.parse_version("1.2.3.4"))
+        self.assertIsNone(ard.parse_version("1.two.3"))
+
     def test_strict_greater(self):
         self.assertEqual(ard.semver_cmp("0.23.1", "0.23.0"), "gt")
         self.assertEqual(ard.semver_cmp("1.0.0", "0.99.99"), "gt")
@@ -58,6 +69,8 @@ class SemverCmpTests(unittest.TestCase):
         # Not strictly required, but document behavior
         self.assertEqual(ard.semver_cmp("not.a.version", "0.1.0"), "lt")
         self.assertEqual(ard.semver_cmp("0.1", "0.1.0"), "lt")
+        self.assertEqual(ard.semver_cmp("1.0.0", "latest"), "gt")
+        self.assertEqual(ard.semver_cmp("broken", "also-broken"), "eq")
 
 
 class DecideTests(unittest.TestCase):
@@ -282,6 +295,16 @@ class CliContractTests(unittest.TestCase):
 
         self.assertEqual(cm.exception.code, 2)
         self.assertIn("invalid choice", stderr.getvalue())
+
+    def test_cli_help_exits_zero(self):
+        stdout = io.StringIO()
+        with mock.patch.object(sys, "argv", ["auto_release_decision.py", "--help"]), \
+             contextlib.redirect_stdout(stdout):
+            with self.assertRaises(SystemExit) as cm:
+                ard.main()
+
+        self.assertEqual(cm.exception.code, 0)
+        self.assertIn("Decide whether auto-release.yml", stdout.getvalue())
 
     def test_script_entrypoint_prints_json_and_exits_zero(self):
         stdout = io.StringIO()

--- a/tools/scripts/test_auto_release_decision_extra.py
+++ b/tools/scripts/test_auto_release_decision_extra.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Additional edge coverage for auto_release_decision.py."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import pathlib
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+
+HERE = pathlib.Path(__file__).resolve().parent
+SCRIPT = HERE / "auto_release_decision.py"
+
+spec = importlib.util.spec_from_file_location("auto_release_decision", SCRIPT)
+ard = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(ard)
+
+
+class ParseVersionEdgeTests(unittest.TestCase):
+    def test_parse_version_returns_tuple_for_exact_semver(self) -> None:
+        self.assertEqual(ard.parse_version("10.2.300"), (10, 2, 300))
+
+    def test_parse_version_rejects_wrong_part_counts(self) -> None:
+        self.assertIsNone(ard.parse_version("1.2"))
+        self.assertIsNone(ard.parse_version("1.2.3.4"))
+
+    def test_parse_version_rejects_non_numeric_parts(self) -> None:
+        self.assertIsNone(ard.parse_version("1.two.3"))
+
+
+class MainCliEdgeTests(unittest.TestCase):
+    def test_main_prints_json_decision_for_plugin_surface(self) -> None:
+        argv = [
+            str(SCRIPT),
+            "--head-version",
+            "2.0.0",
+            "--tag-version",
+            "1.9.9",
+            "--bump-commit-has-skip",
+            "0",
+            "--surface",
+            "plugin",
+        ]
+        output = io.StringIO()
+        with mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(output):
+            self.assertEqual(ard.main(), 0)
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(payload["should_tag"], 1)
+        self.assertEqual(payload["surface"], "plugin")
+        self.assertIn("tagging", payload["reason"])
+
+    def test_script_entrypoint_handles_empty_head_version(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT), "--surface", "sdk"],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["should_tag"], 0)
+        self.assertIn("no sdk version", payload["reason"])
+
+    def test_script_entrypoint_rejects_invalid_skip_flag(self) -> None:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--head-version",
+                "1.0.0",
+                "--bump-commit-has-skip",
+                "2",
+            ],
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("invalid choice", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/scripts/test_build_migration_index_extra.py
+++ b/tools/scripts/test_build_migration_index_extra.py
@@ -144,6 +144,24 @@ class CodegenAndMainExtra(unittest.TestCase):
         self.assertIn("const MigrationEntry* const kMigrationIndex = nullptr;", generated)
         self.assertIn("const std::size_t kMigrationIndexSize = 0;", generated)
 
+    def test_emit_cpp_nonbreaking_default_and_source_comments(self):
+        entry = _bmi.Entry(
+            version="0.40.0",
+            breaking=False,
+            applies_if="",
+            summary="plain",
+            body="body",
+            source_path=pathlib.Path("docs/migrations/v0.40.0.md"),
+        )
+
+        generated = _bmi.emit_cpp([entry])
+
+        self.assertIn("// source: docs/migrations/v0.40.0.md", generated)
+        self.assertIn('"0.40.0"', generated)
+        self.assertIn("false", generated)
+        self.assertIn("const MigrationEntry* const kMigrationIndex = kTable;", generated)
+        self.assertIn("sizeof(kTable) / sizeof(kTable[0])", generated)
+
     def test_main_success_sorts_skips_readme_escapes_and_is_idempotent(self):
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)
@@ -200,6 +218,19 @@ class CodegenAndMainExtra(unittest.TestCase):
 
         self.assertEqual(result, 2)
         self.assertIn("docs dir not found", stderr)
+
+    def test_main_empty_docs_dir_writes_null_index(self):
+        with tempfile.TemporaryDirectory() as td:
+            docs = pathlib.Path(td) / "docs"
+            docs.mkdir()
+            out = pathlib.Path(td) / "generated" / "migration_index.cpp"
+
+            result = _bmi.main(["--docs-dir", str(docs), "--out", str(out)])
+
+            self.assertEqual(result, 0)
+            text = out.read_text(encoding="utf-8")
+            self.assertIn("No migration docs found", text)
+            self.assertIn("kMigrationIndex = nullptr", text)
 
     def test_main_duplicate_versions_fail_before_writing(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tools/scripts/test_check_format_validation.py
+++ b/tools/scripts/test_check_format_validation.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/check_format_validation.py."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "tools" / "check_format_validation.py"
+
+spec = importlib.util.spec_from_file_location("check_format_validation", SCRIPT)
+assert spec and spec.loader
+cfv = importlib.util.module_from_spec(spec)
+sys.modules["check_format_validation"] = cfv
+spec.loader.exec_module(cfv)
+
+
+class ExtractFormatsTests(unittest.TestCase):
+    def test_extract_formats_reads_nested_platform_statuses(self) -> None:
+        text = """\
+formats:
+  vst3:
+    macos: stable
+    windows: usable
+  clap:
+    linux: experimental
+production_validated:
+  vst3:
+    macos: [Reaper]
+"""
+
+        self.assertEqual(
+            cfv.extract_formats(text),
+            {
+                "vst3": {"macos": "stable", "windows": "usable"},
+                "clap": {"linux": "experimental"},
+            },
+        )
+
+    def test_extract_formats_returns_empty_when_block_absent(self) -> None:
+        self.assertEqual(cfv.extract_formats("production_validated:\n"), {})
+
+
+class ExtractProductionTests(unittest.TestCase):
+    def test_extract_production_reads_empty_and_populated_inline_lists(self) -> None:
+        text = """\
+production_validated:
+  vst3:
+    macos: [Reaper, "Logic Pro", 'Cubase']
+    windows: []
+  clap:
+    linux: [Bitwig]
+formats:
+  vst3:
+    macos: stable
+"""
+
+        self.assertEqual(
+            cfv.extract_production(text),
+            {
+                "vst3": {
+                    "macos": ["Reaper", "Logic Pro", "Cubase"],
+                    "windows": [],
+                },
+                "clap": {"linux": ["Bitwig"]},
+            },
+        )
+
+    def test_extract_production_ignores_comments_and_blank_lines(self) -> None:
+        text = """\
+production_validated:
+  # Populated during host smoke validation.
+
+  auv2:
+    macos: []
+"""
+
+        self.assertEqual(cfv.extract_production(text), {"auv2": {"macos": []}})
+
+    def test_extract_production_returns_empty_when_block_absent(self) -> None:
+        self.assertEqual(cfv.extract_production("formats:\n"), {})
+
+
+class MainTests(unittest.TestCase):
+    def _run_main(self, matrix_text: str, *args: str) -> tuple[int, str, str]:
+        with tempfile.TemporaryDirectory() as td:
+            matrix = pathlib.Path(td) / "support-matrix.yaml"
+            matrix.write_text(matrix_text, encoding="utf-8")
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with mock.patch.object(cfv, "MATRIX_PATH", matrix), \
+                 mock.patch.object(sys, "argv", ["check_format_validation.py", *args]), \
+                 contextlib.redirect_stdout(stdout), \
+                 contextlib.redirect_stderr(stderr):
+                rc = cfv.main()
+            return rc, stdout.getvalue(), stderr.getvalue()
+
+    def test_warn_mode_reports_gaps_but_exits_zero(self) -> None:
+        rc, out, err = self._run_main(
+            """\
+formats:
+  vst3:
+    macos: stable
+    windows: usable
+    linux: experimental
+  clap:
+    linux: stable
+production_validated:
+  vst3:
+    macos: [Reaper]
+    windows: []
+""",
+        )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(err, "")
+        self.assertIn("1 format/platform pairs host-validated", out)
+        self.assertIn("1 acknowledged but empty", out)
+        self.assertIn("1 missing from production_validated", out)
+        self.assertIn("EMPTY:   vst3.windows is 'usable'", out)
+        self.assertIn("MISSING: production_validated.clap.linux absent", out)
+        self.assertNotIn("vst3.linux", out)
+
+    def test_report_mode_returns_one_when_required_validation_is_missing(self) -> None:
+        rc, out, _ = self._run_main(
+            """\
+formats:
+  vst3:
+    macos: stable
+production_validated:
+  vst3:
+    macos: []
+""",
+            "--mode=report",
+        )
+
+        self.assertEqual(rc, 1)
+        self.assertIn("mode=report", out)
+        self.assertIn("EMPTY:   vst3.macos is 'stable'", out)
+
+    def test_report_mode_returns_zero_when_all_required_pairs_have_hosts(self) -> None:
+        rc, out, err = self._run_main(
+            """\
+formats:
+  vst3:
+    macos: stable
+  clap:
+    linux: usable
+production_validated:
+  vst3:
+    macos: [Reaper]
+  clap:
+    linux: [Bitwig]
+""",
+            "--mode=report",
+        )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(err, "")
+        self.assertIn("2 format/platform pairs host-validated", out)
+        self.assertIn("0 acknowledged but empty", out)
+        self.assertIn("0 missing from production_validated", out)
+
+    def test_read_error_returns_two_and_writes_stderr(self) -> None:
+        missing = pathlib.Path(tempfile.gettempdir()) / "pulp-missing-support-matrix.yaml"
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with mock.patch.object(cfv, "MATRIX_PATH", missing), \
+             mock.patch.object(sys, "argv", ["check_format_validation.py"]), \
+             contextlib.redirect_stdout(stdout), \
+             contextlib.redirect_stderr(stderr):
+            rc = cfv.main()
+
+        self.assertEqual(rc, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("Failed to read", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/test_coverage_diff_comment_extra.py
+++ b/tools/scripts/test_coverage_diff_comment_extra.py
@@ -36,11 +36,64 @@ class RenderPlainReportTests(unittest.TestCase):
         self.assertIn("core/runtime/src/base64.cpp", body)
         self.assertIn("<details>", body)
 
+    def test_top_level_heading_only_report_still_renders_details(self) -> None:
+        body = cdc.render(
+            "# Diff Coverage\n",
+            flip_date="2026-05-05",
+            threshold=80,
+        )
+
+        self.assertIn("<details>", body)
+        self.assertIn("</details>", body)
+        self.assertNotIn("# Diff Coverage", body)
+
+    def test_required_empty_report_uses_required_banner_without_details(self) -> None:
+        body = cdc.render(
+            "",
+            flip_date="2026-05-05",
+            threshold=80,
+            advisory=False,
+        )
+
+        self.assertIn("## Diff coverage (required)", body)
+        self.assertIn("Diff coverage threshold: **80%**", body)
+        self.assertIn("did not touch any instrumented source", body)
+        self.assertNotIn("informational only", body)
+        self.assertNotIn("<details>", body)
+
 
 class ReadReportEdgeTests(unittest.TestCase):
     def test_directory_report_returns_none(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             self.assertIsNone(cdc._read_report(pathlib.Path(tmpdir)))
+
+
+class MainExtraTests(unittest.TestCase):
+    def test_main_no_advisory_flag_writes_required_comment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = pathlib.Path(tmpdir)
+            report = tmp / "coverage-diff.md"
+            out = tmp / "coverage-diff-comment.md"
+            report.write_text(PLAIN_REPORT, encoding="utf-8")
+
+            rc = cdc.main(
+                [
+                    "--report",
+                    str(report),
+                    "--flip-date",
+                    "2026-05-05",
+                    "--threshold",
+                    "80",
+                    "--no-advisory",
+                    "--out",
+                    str(out),
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            body = out.read_text(encoding="utf-8")
+            self.assertIn("## Diff coverage (required)", body)
+            self.assertIn("core/runtime/src/base64.cpp", body)
 
 
 class ScriptEntrypointTests(unittest.TestCase):

--- a/tools/scripts/test_coverage_tier_check_extra.py
+++ b/tools/scripts/test_coverage_tier_check_extra.py
@@ -334,6 +334,25 @@ class RenderExtraTests(unittest.TestCase):
 
         self.assertEqual(result.percent, 100.0)
 
+    def test_render_failure_lists_only_failed_tiers(self) -> None:
+        body = ctc.render(
+            [
+                ctc.TierResult(
+                    tier=ctc.Tier("audio-critical", 80, ("core/audio/**",)),
+                    touched_lines=4,
+                    covered_lines=4,
+                ),
+                ctc.TierResult(
+                    tier=ctc.Tier("user-facing", 70, ("core/view/**",)),
+                    touched_lines=4,
+                    covered_lines=2,
+                ),
+            ]
+        )
+
+        self.assertIn("**Per-tier gate failed:** user-facing", body)
+        self.assertNotIn("audio-critical below", body)
+
 
 class AggregateExtraTests(unittest.TestCase):
 
@@ -356,11 +375,65 @@ class AggregateExtraTests(unittest.TestCase):
         self.assertEqual(results[0].touched_lines, 0)
         self.assertEqual(results[0].files, [])
 
+    def test_missing_instrumented_file_records_uncovered_diff_lines(self) -> None:
+        tier = ctc.Tier("audio-critical", 80, ("core/audio/**",))
+
+        results = ctc.aggregate(
+            [tier],
+            ["core/audio/src/new_voice.cpp"],
+            {},
+            lines_getter=lambda _p: {3, 4, 5},
+        )
+
+        self.assertEqual(results[0].touched_lines, 3)
+        self.assertEqual(results[0].covered_lines, 0)
+        self.assertEqual(results[0].files, ["core/audio/src/new_voice.cpp"])
+        self.assertFalse(results[0].passed)
+
+    def test_unclassified_instrumented_file_is_ignored_by_per_tier_gate(self) -> None:
+        tier = ctc.Tier("audio-critical", 80, ("core/audio/**",))
+        getter = mock.Mock(return_value={1, 2, 3})
+
+        results = ctc.aggregate(
+            [tier],
+            ["third_party/lib.cpp"],
+            {},
+            lines_getter=getter,
+        )
+
+        self.assertEqual(results[0].touched_lines, 0)
+        getter.assert_not_called()
+
+    def test_non_instrumented_tier_file_does_not_query_diff_lines(self) -> None:
+        tier = ctc.Tier("infra", 50, ("tools/**",))
+        getter = mock.Mock(return_value={1, 2, 3})
+
+        results = ctc.aggregate(
+            [tier],
+            ["tools/scripts/release_notes.py"],
+            {},
+            lines_getter=getter,
+        )
+
+        self.assertEqual(results[0].touched_lines, 0)
+        getter.assert_not_called()
+
 
 class InstrumentedSourceExtraTests(unittest.TestCase):
 
     def test_extensionless_path_is_not_instrumented(self) -> None:
         self.assertFalse(ctc.is_instrumented_source("tools/scripts/pulp-helper"))
+
+    def test_extension_match_is_case_insensitive(self) -> None:
+        self.assertTrue(ctc.is_instrumented_source("core/audio/src/Plugin.CPP"))
+
+    def test_react_surface_matches_only_exact_prefix(self) -> None:
+        self.assertTrue(
+            ctc.is_instrumented_source("packages/pulp-react/src/widget.tsx")
+        )
+        self.assertFalse(
+            ctc.is_instrumented_source("packages/pulp-reactive/src/widget.tsx")
+        )
 
 
 if __name__ == "__main__":

--- a/tools/scripts/test_fetch_skia_for_release.py
+++ b/tools/scripts/test_fetch_skia_for_release.py
@@ -168,6 +168,31 @@ class ManifestValidation(unittest.TestCase):
 
         self.assertEqual(rc, 0)
 
+    def test_known_platform_without_asset_reports_matrix_and_manifest_key(self):
+        with _in_tempdir() as td:
+            (td / "tools" / "deps").mkdir(parents=True)
+            manifest = {
+                "dependencies": [
+                    {
+                        "name": "Skia",
+                        "determinism": {"release_assets": {}},
+                    }
+                ]
+            }
+            (td / "tools" / "deps" / "manifest.json").write_text(
+                json.dumps(manifest), encoding="utf-8"
+            )
+
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                rc = fetch_skia.main(
+                    ["fetch_skia_for_release.py", "windows-arm64"]
+                )
+
+        self.assertEqual(rc, 0)
+        self.assertIn("matrix=windows-arm64", out.getvalue())
+        self.assertIn("manifest key 'win-arm64'", out.getvalue())
+
 
 class FlatLayoutSucceeds(unittest.TestCase):
     """Pre-m144 layout: libs flat under Release/ (no arch subdir)."""
@@ -193,6 +218,7 @@ class FlatLayoutSucceeds(unittest.TestCase):
             )
             self.assertTrue(expected.is_file())
             self.assertEqual(expected.read_bytes(), b"skia-flat")
+            self.assertFalse((td / "skia-release-asset.zip").exists())
 
 
 class ArchSubdirLayoutFlattens(unittest.TestCase):
@@ -340,6 +366,27 @@ class MissingLibFails(unittest.TestCase):
                 ["fetch_skia_for_release.py", "darwin-arm64"]
             )
             self.assertEqual(rc, 1, "missing libskia.a must exit non-zero")
+
+    def test_no_lib_prints_directory_listing(self):
+        with _in_tempdir() as td:
+            zip_path = td / "skia-empty.zip"
+            payload = {
+                "build/mac-gpu/lib/Release/README.txt": b"no libs here",
+            }
+            sha = _make_zip(zip_path, payload)
+            _write_manifest(
+                td, f"file://{zip_path.as_posix()}", sha, "mac-arm64"
+            )
+
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                rc = fetch_skia.main(
+                    ["fetch_skia_for_release.py", "darwin-arm64"]
+                )
+
+        self.assertEqual(rc, 1)
+        self.assertIn("expected library not found", err.getvalue())
+        self.assertIn("README.txt", err.getvalue())
 
 
 class Sha256MismatchFails(unittest.TestCase):

--- a/tools/scripts/test_fetch_skia_for_release.py
+++ b/tools/scripts/test_fetch_skia_for_release.py
@@ -104,12 +104,25 @@ class ExpectedLibraryPath(unittest.TestCase):
 
 
 class UnknownMatrixPlatform(unittest.TestCase):
+    def test_missing_platform_argument_returns_usage_error(self):
+        with _in_tempdir():
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                rc = fetch_skia.main(["fetch_skia_for_release.py"])
+
+        self.assertEqual(rc, 2)
+        self.assertIn("usage:", err.getvalue())
+
     def test_returns_zero_with_warning(self):
         with _in_tempdir():
-            rc = fetch_skia.main(
-                ["fetch_skia_for_release.py", "amiga-68k"]
-            )
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                rc = fetch_skia.main(
+                    ["fetch_skia_for_release.py", "amiga-68k"]
+                )
+
         self.assertEqual(rc, 0)
+        self.assertIn("unknown matrix platform", err.getvalue())
 
 
 class ManifestValidation(unittest.TestCase):
@@ -258,6 +271,56 @@ class ArchSubdirLayoutFlattens(unittest.TestCase):
             )
             self.assertTrue(expected.is_file())
             self.assertEqual(expected.read_bytes(), b"linux-skia")
+
+    def test_windows_x64_arch_subdir(self):
+        with _in_tempdir() as td:
+            zip_path = td / "skia-win.zip"
+            payload = {
+                "build/win-gpu/lib/Release/x64/skia.lib": b"windows-skia",
+                "build/win-gpu/lib/Release/x64/skparagraph.lib": b"windows-para",
+            }
+            sha = _make_zip(zip_path, payload)
+            _write_manifest(
+                td, f"file://{zip_path.as_posix()}", sha, "win-x64"
+            )
+
+            rc = fetch_skia.main(["fetch_skia_for_release.py", "windows-x64"])
+
+            self.assertEqual(rc, 0)
+            release_dir = (
+                td / "external/skia-build/build/win-gpu/lib/Release"
+            )
+            self.assertEqual((release_dir / "skia.lib").read_bytes(), b"windows-skia")
+            self.assertEqual(
+                (release_dir / "skparagraph.lib").read_bytes(), b"windows-para"
+            )
+
+    def test_arch_subdir_does_not_clobber_existing_flat_file(self):
+        with _in_tempdir() as td:
+            zip_path = td / "skia-mac.zip"
+            payload = {
+                "build/mac-gpu/lib/Release/arm64/libskia.a": b"arch-copy",
+                "build/mac-gpu/lib/Release/libdawn_combined.a": b"already-flat",
+                "build/mac-gpu/lib/Release/arm64/libdawn_combined.a": b"dawn",
+            }
+            sha = _make_zip(zip_path, payload)
+            _write_manifest(
+                td, f"file://{zip_path.as_posix()}", sha, "mac-arm64"
+            )
+
+            rc = fetch_skia.main(
+                ["fetch_skia_for_release.py", "darwin-arm64"]
+            )
+
+            self.assertEqual(rc, 0)
+            release_dir = (
+                td / "external/skia-build/build/mac-gpu/lib/Release"
+            )
+            self.assertEqual((release_dir / "libskia.a").read_bytes(), b"arch-copy")
+            self.assertEqual(
+                (release_dir / "libdawn_combined.a").read_bytes(), b"already-flat"
+            )
+            self.assertTrue((release_dir / "arm64" / "libdawn_combined.a").is_file())
 
 
 class MissingLibFails(unittest.TestCase):

--- a/tools/scripts/test_fetch_skia_for_release.py
+++ b/tools/scripts/test_fetch_skia_for_release.py
@@ -112,6 +112,50 @@ class UnknownMatrixPlatform(unittest.TestCase):
         self.assertEqual(rc, 0)
 
 
+class ManifestValidation(unittest.TestCase):
+    def test_missing_manifest_fails_for_known_platform(self):
+        with _in_tempdir():
+            rc = fetch_skia.main(
+                ["fetch_skia_for_release.py", "darwin-arm64"]
+            )
+        self.assertEqual(rc, 1)
+
+    def test_manifest_without_skia_dependency_fails(self):
+        with _in_tempdir() as td:
+            (td / "tools" / "deps").mkdir(parents=True)
+            (td / "tools" / "deps" / "manifest.json").write_text(
+                json.dumps({"dependencies": [{"name": "Other"}]}),
+                encoding="utf-8",
+            )
+
+            rc = fetch_skia.main(
+                ["fetch_skia_for_release.py", "darwin-arm64"]
+            )
+
+        self.assertEqual(rc, 1)
+
+    def test_known_platform_without_asset_skips(self):
+        with _in_tempdir() as td:
+            (td / "tools" / "deps").mkdir(parents=True)
+            manifest = {
+                "dependencies": [
+                    {
+                        "name": "Skia",
+                        "determinism": {"release_assets": {}},
+                    }
+                ]
+            }
+            (td / "tools" / "deps" / "manifest.json").write_text(
+                json.dumps(manifest), encoding="utf-8"
+            )
+
+            rc = fetch_skia.main(
+                ["fetch_skia_for_release.py", "windows-arm64"]
+            )
+
+        self.assertEqual(rc, 0)
+
+
 class FlatLayoutSucceeds(unittest.TestCase):
     """Pre-m144 layout: libs flat under Release/ (no arch subdir)."""
 
@@ -172,6 +216,28 @@ class ArchSubdirLayoutFlattens(unittest.TestCase):
                 (release_dir / "arm64").exists(),
                 "arm64/ subdir should be removed after flatten",
             )
+
+    def test_arch_subdir_with_nested_dir_keeps_nonempty_dir(self):
+        with _in_tempdir() as td:
+            zip_path = td / "skia-mac.zip"
+            payload = {
+                "build/mac-gpu/lib/Release/arm64/libskia.a": b"skia-arch",
+                "build/mac-gpu/lib/Release/arm64/obj/keep.txt": b"keep",
+            }
+            sha = _make_zip(zip_path, payload)
+            _write_manifest(
+                td, f"file://{zip_path.as_posix()}", sha, "mac-arm64"
+            )
+            rc = fetch_skia.main(
+                ["fetch_skia_for_release.py", "darwin-arm64"]
+            )
+
+            self.assertEqual(rc, 0)
+            release_dir = (
+                td / "external/skia-build/build/mac-gpu/lib/Release"
+            )
+            self.assertTrue((release_dir / "libskia.a").is_file())
+            self.assertTrue((release_dir / "arm64" / "obj" / "keep.txt").is_file())
 
     def test_linux_x64_arch_subdir(self):
         with _in_tempdir() as td:

--- a/tools/scripts/test_fetch_skia_for_release_extra.py
+++ b/tools/scripts/test_fetch_skia_for_release_extra.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Additional unit tests for tools/scripts/fetch_skia_for_release.py."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import importlib.util
+import io
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+import zipfile
+from unittest import mock
+
+
+SCRIPT = pathlib.Path(__file__).parent / "fetch_skia_for_release.py"
+
+spec = importlib.util.spec_from_file_location("fetch_skia_for_release_extra_target", SCRIPT)
+assert spec and spec.loader
+skia = importlib.util.module_from_spec(spec)
+sys.modules["fetch_skia_for_release_extra_target"] = skia
+spec.loader.exec_module(skia)
+
+
+class _FakeResponse:
+    def __init__(self, data: bytes):
+        self._data = data
+        self._offset = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self, size: int = -1) -> bytes:
+        if self._offset >= len(self._data):
+            return b""
+        if size < 0:
+            size = len(self._data) - self._offset
+        chunk = self._data[self._offset:self._offset + size]
+        self._offset += len(chunk)
+        return chunk
+
+
+def make_zip_bytes(rel_path: pathlib.Path, payload: bytes = b"skia") -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(rel_path.as_posix(), payload)
+    return buf.getvalue()
+
+
+@contextlib.contextmanager
+def cwd(path: pathlib.Path):
+    old = pathlib.Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old)
+
+
+class FetchSkiaForReleaseExtraTests(unittest.TestCase):
+    def test_main_usage_unknown_platform_and_missing_manifest_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(skia.main(["fetch"]), 2)
+            self.assertIn("usage:", err.getvalue())
+
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(skia.main(["fetch", "weird-platform"]), 0)
+            self.assertIn("unknown matrix platform", err.getvalue())
+
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 1)
+            self.assertIn("manifest.json not found", err.getvalue())
+
+    def test_main_skips_platform_without_release_asset(self) -> None:
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            manifest = pathlib.Path("tools/deps/manifest.json")
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(
+                json.dumps({"dependencies": [{"name": "Skia", "determinism": {"release_assets": {}}}]}),
+                encoding="utf-8",
+            )
+
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                self.assertEqual(skia.main(["fetch", "linux-arm64"]), 0)
+            self.assertIn("no Skia release asset", out.getvalue())
+
+    def test_main_reports_missing_skia_entry_and_checksum_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            manifest = pathlib.Path("tools/deps/manifest.json")
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(json.dumps({"dependencies": []}), encoding="utf-8")
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 1)
+            self.assertIn("no 'Skia' dependency", err.getvalue())
+
+            manifest.write_text(
+                json.dumps({
+                    "dependencies": [{
+                        "name": "Skia",
+                        "determinism": {
+                            "release_assets": {
+                                "mac-arm64": {"url": "https://example.invalid/skia.zip", "sha256": "0" * 64}
+                            }
+                        },
+                    }]
+                }),
+                encoding="utf-8",
+            )
+            with mock.patch.object(skia.urllib.request, "urlopen", return_value=_FakeResponse(b"not a zip")), \
+                 contextlib.redirect_stderr(err := io.StringIO()), \
+                 contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 1)
+            self.assertIn("sha256 mismatch", err.getvalue())
+
+    def test_main_unpacks_valid_asset_and_reports_zip_layout_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            data = make_zip_bytes(pathlib.Path("build/mac-gpu/lib/Release/libskia.a"), b"abc")
+            digest = hashlib.sha256(data).hexdigest()
+            manifest = pathlib.Path("tools/deps/manifest.json")
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(
+                json.dumps({
+                    "dependencies": [{
+                        "name": "skia",
+                        "determinism": {
+                            "release_assets": {
+                                "mac-arm64": {"url": "https://example.invalid/skia.zip", "sha256": digest}
+                            }
+                        },
+                    }]
+                }),
+                encoding="utf-8",
+            )
+
+            out = io.StringIO()
+            with mock.patch.object(skia.urllib.request, "urlopen", return_value=_FakeResponse(data)), \
+                 contextlib.redirect_stdout(out):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 0)
+
+            self.assertTrue(skia.expected_library_path("darwin-arm64").is_file())
+            self.assertFalse(pathlib.Path("skia-release-asset.zip").exists())
+            self.assertIn("OK:", out.getvalue())
+
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            data = make_zip_bytes(pathlib.Path("wrong/place/libskia.a"), b"abc")
+            digest = hashlib.sha256(data).hexdigest()
+            manifest = pathlib.Path("tools/deps/manifest.json")
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(
+                json.dumps({
+                    "dependencies": [{
+                        "name": "Skia",
+                        "determinism": {
+                            "release_assets": {
+                                "mac-arm64": {"url": "https://example.invalid/skia.zip", "sha256": digest}
+                            }
+                        },
+                    }]
+                }),
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(skia.urllib.request, "urlopen", return_value=_FakeResponse(data)), \
+                 contextlib.redirect_stdout(io.StringIO()), \
+                 contextlib.redirect_stderr(err := io.StringIO()):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 1)
+            self.assertIn("expected library not found", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/test_host_pump_lint.py
+++ b/tools/scripts/test_host_pump_lint.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/scripts/host_pump_lint.py."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPT = pathlib.Path(__file__).parent / "host_pump_lint.py"
+
+spec = importlib.util.spec_from_file_location("host_pump_lint", SCRIPT)
+assert spec and spec.loader
+hpl = importlib.util.module_from_spec(spec)
+sys.modules["host_pump_lint"] = hpl
+spec.loader.exec_module(hpl)
+
+
+class HostPumpLintTests(unittest.TestCase):
+    def test_scan_file_ignores_missing_files(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            missing = pathlib.Path(td) / "missing.cpp"
+            self.assertEqual(hpl.scan_file(missing), [])
+
+    def test_scan_file_accepts_paired_calls_in_same_block(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            source = pathlib.Path(td) / "main.cpp"
+            source.write_text(
+                """
+void tick() {
+    bridge->poll_async_results();
+    bridge->service_frame_callbacks();
+}
+""",
+                encoding="utf-8",
+            )
+            self.assertEqual(hpl.scan_file(source), [])
+
+    def test_scan_file_flags_unpaired_poll_before_block_close(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            source = root / "examples" / "design-tool" / "main.cpp"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                """
+void tick() {
+    bridge->poll_async_results();
+}
+void later() {
+    bridge->service_frame_callbacks();
+}
+""",
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(hpl, "REPO_ROOT", root):
+                violations = hpl.scan_file(source)
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("examples/design-tool/main.cpp:3", violations[0])
+            self.assertIn("not paired", violations[0])
+
+    def test_scan_file_accepts_inline_skip_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            source = pathlib.Path(td) / "main.cpp"
+            source.write_text(
+                f"bridge->poll_async_results(); // {hpl.SKIP_MARKER} - one-shot\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(hpl.scan_file(source), [])
+
+    def test_scan_file_respects_window_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            source = pathlib.Path(td) / "main.cpp"
+            gap = "\n".join("    do_work();" for _ in range(hpl.WINDOW_LINES + 1))
+            source.write_text(
+                f"""
+void tick() {{
+    bridge->poll_async_results();
+{gap}
+    bridge->service_frame_callbacks();
+}}
+""",
+                encoding="utf-8",
+            )
+            self.assertEqual(len(hpl.scan_file(source)), 1)
+
+    def test_main_reports_violations_and_read_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            host = root / "host.cpp"
+            host.write_text("bridge->poll_async_results();\n", encoding="utf-8")
+
+            err = io.StringIO()
+            with mock.patch.object(hpl, "REPO_ROOT", root), \
+                 mock.patch.object(hpl, "HOST_FILES", ["host.cpp"]), \
+                 contextlib.redirect_stderr(err):
+                self.assertEqual(hpl.main(), 1)
+            self.assertIn("idle-pump pairing violations", err.getvalue())
+
+            with mock.patch.object(hpl, "HOST_FILES", ["host.cpp"]), \
+                 mock.patch.object(hpl, "scan_file", side_effect=OSError("denied")), \
+                 contextlib.redirect_stderr(err := io.StringIO()):
+                self.assertEqual(hpl.main(), 2)
+            self.assertIn("failed to read", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/test_local_diff_cover.py
+++ b/tools/scripts/test_local_diff_cover.py
@@ -388,6 +388,25 @@ class ObjectDiscoveryParityTests(unittest.TestCase):
                 f"surface set, so dropping it here desyncs both lanes.",
             )
 
+    def test_static_archives_are_discovered_before_test_binaries(self) -> None:
+        """Duplicate maps must let executed test binaries win.
+
+        Production files linked into both libpulp-*.a and a test executable
+        can otherwise report the archive's zero-hit map even when CTest
+        exercised the code. The CI and local scripts should keep archives
+        first, then test binaries.
+        """
+
+        for path in (SCRIPT, CI_SCRIPT):
+            text = path.read_text()
+            archive_idx = text.index("libpulp-*.a")
+            tests_idx = text.index('"${BUILD_DIR}/test"')
+            self.assertLess(
+                archive_idx,
+                tests_idx,
+                f"{path} must discover static archives before test binaries",
+            )
+
 
 class TargetedCtestTests(unittest.TestCase):
     """Targeted local diff-cover runs must also limit the ctest pass."""

--- a/tools/scripts/test_macos_reroute_watcher.py
+++ b/tools/scripts/test_macos_reroute_watcher.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/scripts/macos_reroute_watcher.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+
+SCRIPT = pathlib.Path(__file__).parent / "macos_reroute_watcher.py"
+
+spec = importlib.util.spec_from_file_location("macos_reroute_watcher", SCRIPT)
+assert spec and spec.loader
+watcher = importlib.util.module_from_spec(spec)
+sys.modules["macos_reroute_watcher"] = watcher
+spec.loader.exec_module(watcher)
+
+
+class MacosRerouteWatcherTests(unittest.TestCase):
+    def test_gh_returns_stripped_stdout(self) -> None:
+        completed = subprocess.CompletedProcess(["gh"], 0, stdout="  ok\n")
+        with mock.patch.object(watcher.subprocess, "run", return_value=completed) as run:
+            self.assertEqual(watcher._gh(["repos/acme/project"]), "ok")
+        run.assert_called_once()
+        self.assertEqual(run.call_args.args[0], ["gh", "api", "repos/acme/project"])
+        self.assertEqual(run.call_args.kwargs["timeout"], 20)
+
+    def test_local_is_busy_detects_runner_processes_and_failures(self) -> None:
+        busy_output = (
+            "/Users/runner/actions-runner/_work/pulp/pulp/_temp cmake --build build\n"
+            "/usr/bin/other\n"
+        )
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["ps"], 0, stdout=busy_output),
+        ):
+            self.assertTrue(watcher.local_is_busy())
+
+        worker_output = "/Users/runner/actions-runner/_work/pulp/pulp Runner.Worker spawnclient\n"
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["ps"], 0, stdout=worker_output),
+        ):
+            self.assertTrue(watcher.local_is_busy())
+
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["ps"], 0, stdout="/usr/bin/idle\n"),
+        ):
+            self.assertFalse(watcher.local_is_busy())
+
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["ps"], timeout=10),
+        ):
+            self.assertIsNone(watcher.local_is_busy())
+
+    def test_macos_job_target_detection(self) -> None:
+        with mock.patch.object(watcher, "_gh", return_value="self-hosted,macOS"):
+            self.assertFalse(watcher._macos_job_targets_cloud(10))
+
+        for labels in ("macos-15,ARM64", "nscloud-macos,macOS", "namespace-profile-macos"):
+            with self.subTest(labels=labels), mock.patch.object(watcher, "_gh", return_value=labels):
+                self.assertTrue(watcher._macos_job_targets_cloud(10))
+
+        with mock.patch.object(watcher, "_gh", return_value=""):
+            self.assertFalse(watcher._macos_job_targets_cloud(10))
+
+        with mock.patch.object(watcher, "_gh", side_effect=subprocess.CalledProcessError(1, ["gh"])):
+            self.assertFalse(watcher._macos_job_targets_cloud(10))
+
+    def test_list_queued_cloud_bat_runs_filters_invalid_and_local_rows(self) -> None:
+        raw = "\n".join([
+            json.dumps({"id": 101, "pr": 11}),
+            "{not json",
+            json.dumps({"id": None, "pr": 12}),
+            json.dumps({"id": 102, "pr": None}),
+            json.dumps({"id": 103, "pr": 13}),
+        ])
+
+        def fake_cloud(run_id: int) -> bool:
+            return run_id == 101
+
+        with mock.patch.object(watcher, "_gh", return_value=raw), \
+             mock.patch.object(watcher, "_macos_job_targets_cloud", side_effect=fake_cloud):
+            self.assertEqual(watcher.list_queued_cloud_bat_runs(), [(11, 101)])
+
+        with mock.patch.object(watcher, "_gh", side_effect=subprocess.CalledProcessError(1, ["gh"])):
+            self.assertEqual(watcher.list_queued_cloud_bat_runs(), [])
+
+    def test_reroute_to_local_reports_success_and_failure(self) -> None:
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["pulp"], 0, stdout="done\n", stderr=""),
+        ) as run:
+            self.assertTrue(watcher.reroute_to_local(42))
+        self.assertEqual(
+            run.call_args.args[0],
+            ["pulp", "macos", "retarget", "--pr", "42", "--to", "local"],
+        )
+
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["pulp"], 2, stdout="", stderr="nope"),
+        ):
+            self.assertFalse(watcher.reroute_to_local(42))
+
+        with mock.patch.object(
+            watcher.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["pulp"], timeout=60),
+        ):
+            self.assertFalse(watcher.reroute_to_local(42))
+
+    def test_flap_guard_window_and_trim(self) -> None:
+        guard = watcher.FlapGuard(window_seconds=10)
+        with mock.patch.object(watcher.time, "time", return_value=100.0):
+            self.assertTrue(guard.can_reroute(1))
+            guard.record(1)
+            self.assertFalse(guard.can_reroute(1))
+        with mock.patch.object(watcher.time, "time", return_value=111.0):
+            self.assertTrue(guard.can_reroute(1))
+
+        guard = watcher.FlapGuard(window_seconds=10)
+        guard._last[2] = 80.0
+        guard._last[3] = 95.0
+        with mock.patch.object(watcher.time, "time", return_value=111.0):
+            guard.record(4)
+        self.assertNotIn(2, guard._last)
+        self.assertIn(3, guard._last)
+        self.assertIn(4, guard._last)
+
+    def test_tick_respects_busy_probe_candidates_flap_guard_and_one_reroute(self) -> None:
+        guard = watcher.FlapGuard(window_seconds=300)
+
+        with mock.patch.object(watcher, "local_is_busy", return_value=None), \
+             mock.patch.object(watcher, "list_queued_cloud_bat_runs") as queued:
+            watcher.tick(guard)
+            queued.assert_not_called()
+
+        with mock.patch.object(watcher, "local_is_busy", return_value=True), \
+             mock.patch.object(watcher, "list_queued_cloud_bat_runs") as queued:
+            watcher.tick(guard)
+            queued.assert_not_called()
+
+        with mock.patch.object(watcher, "local_is_busy", return_value=False), \
+             mock.patch.object(watcher, "list_queued_cloud_bat_runs", return_value=[]), \
+             mock.patch.object(watcher, "reroute_to_local") as reroute:
+            watcher.tick(guard)
+            reroute.assert_not_called()
+
+        with mock.patch.object(watcher, "local_is_busy", return_value=False), \
+             mock.patch.object(watcher, "list_queued_cloud_bat_runs", return_value=[(10, 100), (11, 101)]), \
+             mock.patch.object(watcher, "reroute_to_local", return_value=True) as reroute, \
+             mock.patch.object(watcher.time, "time", return_value=1000.0):
+            watcher.tick(guard)
+            reroute.assert_called_once_with(10)
+
+        with mock.patch.object(watcher, "local_is_busy", return_value=False), \
+             mock.patch.object(watcher, "list_queued_cloud_bat_runs", return_value=[(10, 102), (11, 103)]), \
+             mock.patch.object(watcher, "reroute_to_local", return_value=True) as reroute, \
+             mock.patch.object(watcher.time, "time", return_value=1001.0):
+            watcher.tick(guard)
+            reroute.assert_called_once_with(11)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/test_merge_cobertura_extra.py
+++ b/tools/scripts/test_merge_cobertura_extra.py
@@ -62,6 +62,32 @@ class ParseXmlEdgeTests(unittest.TestCase):
             },
         )
 
+    def test_parse_normalizes_windows_paths_and_filters_ignored_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            coverage = ET.Element("coverage")
+            classes = ET.SubElement(
+                ET.SubElement(ET.SubElement(coverage, "packages"), "package"),
+                "classes",
+            )
+            for filename in (
+                r"core\format\src\clap_adapter.cpp",
+                r"test\test_host.cpp",
+                r"build\generated.cpp",
+                r"external\dep.cpp",
+            ):
+                cls = ET.SubElement(
+                    classes,
+                    "class",
+                    attrib={"name": filename, "filename": filename},
+                )
+                lines = ET.SubElement(cls, "lines")
+                ET.SubElement(lines, "line", attrib={"number": "1", "hits": "1"})
+
+            parsed = mc.parse_xml(_write_tree(tmp / "windows.xml", coverage))
+
+        self.assertEqual(parsed, {"core/format/src/clap_adapter.cpp": {1: 1}})
+
 
 class RenderEdgeTests(unittest.TestCase):
     def test_render_handles_empty_totals_and_empty_file_line_sets(self) -> None:
@@ -109,6 +135,28 @@ class CliEntrypointTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertIn("merged 1 XML(s)", proc.stderr)
         self.assertEqual(reparsed, {"core/cli.cpp": {9: 2}})
+
+    def test_main_returns_distinct_code_when_all_inputs_are_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            out = tmp / "merged.xml"
+
+            rc = mc.main([str(tmp / "missing.xml"), "--out", str(out)])
+
+        self.assertEqual(rc, mc.EXIT_ALL_INPUTS_MISSING)
+        self.assertFalse(out.exists())
+
+    def test_main_rejects_corrupt_xml_without_empty_input_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            corrupt = tmp / "corrupt.xml"
+            corrupt.write_text("<coverage>", encoding="utf-8")
+            out = tmp / "merged.xml"
+
+            rc = mc.main(["--out", str(out), str(corrupt)])
+
+        self.assertEqual(rc, 1)
+        self.assertFalse(out.exists())
 
 
 if __name__ == "__main__":

--- a/tools/scripts/test_package_cli_extra.py
+++ b/tools/scripts/test_package_cli_extra.py
@@ -82,6 +82,50 @@ class FindWgpuLibExtraTests(unittest.TestCase):
 
 
 class RpathExtraTests(unittest.TestCase):
+    def test_fix_rpath_macos_deletes_multiple_absolute_rpaths(self) -> None:
+        otool_output = """
+Load command 1
+          cmd LC_RPATH
+      cmdsize 48
+         path /Users/runner/Library/Caches/Pulp/wgpu (offset 12)
+Load command 2
+          cmd LC_RPATH
+      cmdsize 48
+         path /opt/pulp/cache/wgpu (offset 12)
+Load command 3
+          cmd LC_RPATH
+      cmdsize 40
+         path @loader_path (offset 12)
+        """
+        binary = pathlib.Path("/tmp/pulp")
+
+        with mock.patch.object(pc.subprocess, "check_output", return_value=otool_output):
+            with mock.patch.object(pc.subprocess, "check_call") as check_call:
+                with mock.patch.object(pc.subprocess, "run") as run:
+                    pc.fix_rpath_macos(binary)
+
+        self.assertEqual(check_call.call_count, 2)
+        check_call.assert_any_call(
+            [
+                "install_name_tool",
+                "-delete_rpath",
+                "/Users/runner/Library/Caches/Pulp/wgpu",
+                str(binary),
+            ]
+        )
+        check_call.assert_any_call(
+            [
+                "install_name_tool",
+                "-delete_rpath",
+                "/opt/pulp/cache/wgpu",
+                str(binary),
+            ]
+        )
+        run.assert_called_once_with(
+            ["install_name_tool", "-add_rpath", "@loader_path", str(binary)],
+            check=False,
+        )
+
     def test_fix_rpath_macos_ignores_relative_rpath(self) -> None:
         otool_output = """
 Load command 1
@@ -111,6 +155,35 @@ Load command 1
 
         check_call.assert_not_called()
         run.assert_called_once()
+
+
+class StageBinaryExtraTests(unittest.TestCase):
+    def test_stage_binary_sets_unix_executable_bit(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            src = root / "built-pulp"
+            src.write_text("binary", encoding="utf-8")
+            stage = root / "stage"
+            stage.mkdir()
+
+            staged = pc.stage_binary(src, stage, "pulp", is_windows=False)
+
+            self.assertEqual(staged, stage / "pulp")
+            self.assertEqual(staged.read_text(encoding="utf-8"), "binary")
+            self.assertTrue(pc.os.access(staged, pc.os.X_OK))
+
+    def test_stage_binary_keeps_windows_copy_non_executable(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            src = root / "built-pulp.exe"
+            src.write_text("binary", encoding="utf-8")
+            stage = root / "stage"
+            stage.mkdir()
+
+            staged = pc.stage_binary(src, stage, "pulp.exe", is_windows=True)
+
+            self.assertEqual(staged, stage / "pulp.exe")
+            self.assertEqual(staged.read_text(encoding="utf-8"), "binary")
 
 
 class MainExtraTests(unittest.TestCase):
@@ -144,6 +217,39 @@ class MainExtraTests(unittest.TestCase):
             fix_rpath.assert_called_once()
             with tarfile.open(out, "r:gz") as tar:
                 self.assertEqual(sorted(tar.getnames()), ["libwgpu_native.dylib", "pulp"])
+
+    def test_main_packages_unknown_platform_as_tarball_without_rpath(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp-built"
+            binary.write_text("binary", encoding="utf-8")
+            wgpu = root / "libwgpu_native.custom"
+            wgpu.write_text("wgpu", encoding="utf-8")
+            out = root / "pulp-custom.tar.gz"
+
+            with mock.patch.object(pc, "find_wgpu_lib", return_value=wgpu):
+                with mock.patch.object(pc, "fix_rpath_macos") as mac_rpath:
+                    with mock.patch.object(pc, "fix_rpath_linux") as linux_rpath:
+                        with argv(
+                            [
+                                "package_cli.py",
+                                "--binary",
+                                str(binary),
+                                "--build-dir",
+                                str(root / "build"),
+                                "--platform",
+                                "haiku-x64",
+                                "--out",
+                                str(out),
+                            ]
+                        ):
+                            rc = pc.main()
+
+            self.assertEqual(rc, 0)
+            mac_rpath.assert_not_called()
+            linux_rpath.assert_not_called()
+            with tarfile.open(out, "r:gz") as tar:
+                self.assertEqual(sorted(tar.getnames()), ["libwgpu_native.custom", "pulp"])
 
     def test_script_entrypoint_reports_missing_binary(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/scripts/test_package_cli_extra.py
+++ b/tools/scripts/test_package_cli_extra.py
@@ -35,6 +35,20 @@ def argv(args: list[str]):
 
 
 class FindWgpuLibExtraTests(unittest.TestCase):
+    def test_find_wgpu_lib_prefers_build_dir_before_cache_roots(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_lib = root / "build" / "_deps" / "wgpu" / "libwgpu_native.so"
+            cache_lib = root / "home" / ".cache" / "pulp" / "libwgpu_native.so"
+            build_lib.parent.mkdir(parents=True)
+            cache_lib.parent.mkdir(parents=True)
+            build_lib.write_text("build", encoding="utf-8")
+            cache_lib.write_text("cache", encoding="utf-8")
+
+            with mock.patch.object(pc.Path, "home", return_value=root / "home"):
+                with mock.patch.dict(pc.os.environ, {}, clear=True):
+                    self.assertEqual(pc.find_wgpu_lib(root / "build", "linux-x64"), build_lib)
+
     def test_find_wgpu_lib_dedupes_roots_and_ignores_non_file_matches(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)
@@ -281,6 +295,48 @@ class MainExtraTests(unittest.TestCase):
                 self.assertEqual(
                     sorted(z.namelist()),
                     ["pulp-cpp.exe", "pulp.exe", "wgpu_native.dll"],
+                )
+
+    def test_main_rewrites_macos_rpath_for_primary_and_delegate(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp-built"
+            cpp_binary = root / "pulp-cpp-built"
+            wgpu = root / "libwgpu_native.dylib"
+            binary.write_text("binary", encoding="utf-8")
+            cpp_binary.write_text("cpp", encoding="utf-8")
+            wgpu.write_text("wgpu", encoding="utf-8")
+            out = root / "pulp-darwin-x64.tar.gz"
+
+            with mock.patch.object(pc, "find_wgpu_lib", return_value=wgpu):
+                with mock.patch.object(pc, "fix_rpath_macos") as fix_rpath:
+                    with argv(
+                        [
+                            "package_cli.py",
+                            "--binary",
+                            str(binary),
+                            "--cpp-binary",
+                            str(cpp_binary),
+                            "--build-dir",
+                            str(root / "build"),
+                            "--platform",
+                            "darwin-x64",
+                            "--out",
+                            str(out),
+                        ]
+                    ):
+                        rc = pc.main()
+
+            self.assertEqual(rc, 0)
+            self.assertEqual(fix_rpath.call_count, 2)
+            self.assertEqual(
+                [call.args[0].name for call in fix_rpath.call_args_list],
+                ["pulp", "pulp-cpp"],
+            )
+            with tarfile.open(out, "r:gz") as tar:
+                self.assertEqual(
+                    sorted(tar.getnames()),
+                    ["libwgpu_native.dylib", "pulp", "pulp-cpp"],
                 )
 
     def test_main_rewrites_linux_rpath_for_primary_and_delegate(self) -> None:

--- a/tools/scripts/test_package_cli_extra.py
+++ b/tools/scripts/test_package_cli_extra.py
@@ -12,6 +12,7 @@ import sys
 import tarfile
 import tempfile
 import unittest
+import zipfile
 from unittest import mock
 
 
@@ -187,6 +188,143 @@ class StageBinaryExtraTests(unittest.TestCase):
 
 
 class MainExtraTests(unittest.TestCase):
+    def test_main_rejects_missing_cpp_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp-built"
+            binary.write_text("binary", encoding="utf-8")
+
+            with argv(
+                [
+                    "package_cli.py",
+                    "--binary",
+                    str(binary),
+                    "--cpp-binary",
+                    str(root / "missing-pulp-cpp"),
+                    "--build-dir",
+                    str(root / "build"),
+                    "--platform",
+                    "linux-x64",
+                    "--out",
+                    str(root / "pulp-linux-x64.tar.gz"),
+                ]
+            ):
+                with contextlib.redirect_stderr(io.StringIO()) as stderr:
+                    rc = pc.main()
+
+            self.assertEqual(rc, 2)
+            self.assertIn("FAIL: --cpp-binary not at", stderr.getvalue())
+
+    def test_main_rejects_missing_wgpu_library(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp-built"
+            binary.write_text("binary", encoding="utf-8")
+            out = root / "pulp-linux-x64.tar.gz"
+
+            with mock.patch.object(pc, "find_wgpu_lib", return_value=None):
+                with argv(
+                    [
+                        "package_cli.py",
+                        "--binary",
+                        str(binary),
+                        "--build-dir",
+                        str(root / "build"),
+                        "--platform",
+                        "linux-x64",
+                        "--out",
+                        str(out),
+                    ]
+                ):
+                    with contextlib.redirect_stderr(io.StringIO()) as stderr:
+                        rc = pc.main()
+
+            self.assertEqual(rc, 1)
+            self.assertFalse(out.exists())
+            self.assertIn("wgpu native library not found", stderr.getvalue())
+
+    def test_main_packages_windows_zip_with_delegate_and_dll(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp-built.exe"
+            cpp_binary = root / "pulp-cpp-built.exe"
+            wgpu = root / "wgpu_native.dll"
+            binary.write_text("binary", encoding="utf-8")
+            cpp_binary.write_text("cpp", encoding="utf-8")
+            wgpu.write_text("wgpu", encoding="utf-8")
+            out = root / "pulp-windows-x64.zip"
+
+            with mock.patch.object(pc, "find_wgpu_lib", return_value=wgpu):
+                with mock.patch.object(pc, "fix_rpath_macos") as mac_rpath:
+                    with mock.patch.object(pc, "fix_rpath_linux") as linux_rpath:
+                        with argv(
+                            [
+                                "package_cli.py",
+                                "--binary",
+                                str(binary),
+                                "--cpp-binary",
+                                str(cpp_binary),
+                                "--build-dir",
+                                str(root / "build"),
+                                "--platform",
+                                "windows-x64",
+                                "--out",
+                                str(out),
+                            ]
+                        ):
+                            rc = pc.main()
+
+            self.assertEqual(rc, 0)
+            mac_rpath.assert_not_called()
+            linux_rpath.assert_not_called()
+            with zipfile.ZipFile(out) as z:
+                self.assertEqual(
+                    sorted(z.namelist()),
+                    ["pulp-cpp.exe", "pulp.exe", "wgpu_native.dll"],
+                )
+
+    def test_main_rewrites_linux_rpath_for_primary_and_delegate(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp-built"
+            cpp_binary = root / "pulp-cpp-built"
+            wgpu = root / "libwgpu_native.so"
+            binary.write_text("binary", encoding="utf-8")
+            cpp_binary.write_text("cpp", encoding="utf-8")
+            wgpu.write_text("wgpu", encoding="utf-8")
+            out = root / "pulp-linux-x64.tar.gz"
+
+            with mock.patch.object(pc, "find_wgpu_lib", return_value=wgpu):
+                with mock.patch.object(pc, "fix_rpath_linux") as fix_rpath:
+                    with argv(
+                        [
+                            "package_cli.py",
+                            "--binary",
+                            str(binary),
+                            "--cpp-binary",
+                            str(cpp_binary),
+                            "--build-dir",
+                            str(root / "build"),
+                            "--platform",
+                            "linux-x64",
+                            "--out",
+                            str(out),
+                        ]
+                    ):
+                        rc = pc.main()
+
+            self.assertEqual(rc, 0)
+            self.assertEqual(fix_rpath.call_count, 2)
+            self.assertEqual(
+                [call.args[0].name for call in fix_rpath.call_args_list],
+                ["pulp", "pulp-cpp"],
+            )
+            with tarfile.open(out, "r:gz") as tar:
+                self.assertEqual(
+                    sorted(tar.getnames()),
+                    ["libwgpu_native.so", "pulp", "pulp-cpp"],
+                )
+
     def test_main_packages_macos_tarball_and_rewrites_rpath(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)

--- a/tools/scripts/test_package_cli_extra.py
+++ b/tools/scripts/test_package_cli_extra.py
@@ -381,6 +381,52 @@ class MainExtraTests(unittest.TestCase):
                     ["libwgpu_native.so", "pulp", "pulp-cpp"],
                 )
 
+    def test_main_rewrites_linux_rpath_for_mcp_binary_too(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp-built"
+            cpp_binary = root / "pulp-cpp-built"
+            mcp_binary = root / "pulp-mcp-built"
+            wgpu = root / "libwgpu_native.so"
+            binary.write_text("binary", encoding="utf-8")
+            cpp_binary.write_text("cpp", encoding="utf-8")
+            mcp_binary.write_text("mcp", encoding="utf-8")
+            wgpu.write_text("wgpu", encoding="utf-8")
+            out = root / "pulp-linux-x64.tar.gz"
+
+            with mock.patch.object(pc, "find_wgpu_lib", return_value=wgpu):
+                with mock.patch.object(pc, "fix_rpath_linux") as fix_rpath:
+                    with argv(
+                        [
+                            "package_cli.py",
+                            "--binary",
+                            str(binary),
+                            "--cpp-binary",
+                            str(cpp_binary),
+                            "--mcp-binary",
+                            str(mcp_binary),
+                            "--build-dir",
+                            str(root / "build"),
+                            "--platform",
+                            "linux-x64",
+                            "--out",
+                            str(out),
+                        ]
+                    ):
+                        rc = pc.main()
+
+            self.assertEqual(rc, 0)
+            self.assertEqual(fix_rpath.call_count, 3)
+            self.assertEqual(
+                [call.args[0].name for call in fix_rpath.call_args_list],
+                ["pulp", "pulp-cpp", "pulp-mcp"],
+            )
+            with tarfile.open(out, "r:gz") as tar:
+                self.assertEqual(
+                    sorted(tar.getnames()),
+                    ["libwgpu_native.so", "pulp", "pulp-cpp", "pulp-mcp"],
+                )
+
     def test_main_packages_macos_tarball_and_rewrites_rpath(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)

--- a/tools/scripts/test_release_workflow_test_step.py
+++ b/tools/scripts/test_release_workflow_test_step.py
@@ -183,6 +183,58 @@ class ReleaseCliLinuxNoWebView(unittest.TestCase):
         )
 
 
+class ReleaseCliDualBinaryPackaging(unittest.TestCase):
+    """release-cli.yml must keep `pulp` and `pulp-cpp` bundled and smoked.
+
+    The Rust CLI delegates several C++-owned subcommands to `pulp-cpp`.
+    A release archive that contains only `pulp` can pass a basic CLI smoke
+    test but fail later when a user runs a delegated command.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = RELEASE_CLI.read_text(encoding="utf-8")
+
+    def _find_step_run(self, step_name: str) -> str:
+        pattern = re.compile(
+            rf"-\s*name:\s*{re.escape(step_name)}\s*\n"
+            r"(?:(?!\n\s*-\s*name:).)*?"
+            r"\s*run:\s*(.+?)(?=\n\s*-\s*name:|\Z)",
+            re.DOTALL,
+        )
+        match = pattern.search(self.text)
+        self.assertIsNotNone(match, f"could not locate `{step_name}` step")
+        return match.group(1)
+
+    def test_unix_package_step_bundles_cpp_delegate(self) -> None:
+        run_block = self._find_step_run("Package CLI (Unix)")
+        self.assertIn("tools/scripts/package_cli.py", run_block)
+        self.assertRegex(run_block, r"--binary\s+build/pulp")
+        self.assertRegex(run_block, r"--cpp-binary\s+build/tools/cli/pulp-cpp")
+        self.assertRegex(run_block, r"--out\s+pulp-\$\{\{\s*matrix\.platform\s*\}\}\.tar\.gz")
+
+    def test_windows_package_step_bundles_cpp_delegate(self) -> None:
+        run_block = self._find_step_run("Package CLI (Windows)")
+        self.assertIn("tools/scripts/package_cli.py", run_block)
+        self.assertRegex(run_block, r"--binary\s+build/pulp\.exe")
+        self.assertRegex(run_block, r"--cpp-binary\s+build/tools/cli/Release/pulp-cpp\.exe")
+        self.assertRegex(run_block, r"--out\s+pulp-\$\{\{\s*matrix\.platform\s*\}\}\.zip")
+
+    def test_unix_smoke_step_exercises_both_cli_binaries(self) -> None:
+        run_block = self._find_step_run("Smoke `pulp help` + `pulp-cpp help` (Unix)")
+        self.assertRegex(run_block, r"for\s+ART\s+in\s+pulp\s+pulp-cpp")
+        self.assertIn('"$BIN" help', run_block)
+        self.assertIn("Library not loaded", run_block)
+        self.assertIn("cannot open shared object", run_block)
+
+    def test_windows_smoke_step_exercises_both_cli_binaries(self) -> None:
+        run_block = self._find_step_run("Smoke `pulp help` + `pulp-cpp help` (Windows)")
+        self.assertIn('@("pulp.exe", "pulp-cpp.exe")', run_block)
+        self.assertIn('-ArgumentList "help"', run_block)
+        self.assertIn("DLL was not found", run_block)
+        self.assertIn("missing.*\\.dll", run_block)
+
+
 class SignAndReleaseContentsWriteTest(unittest.TestCase):
     """#724: sign-and-release.yml must declare `contents: write` on its
     macOS job so the final `Create GitHub Release` step can call the

--- a/tools/scripts/test_release_workflow_test_step.py
+++ b/tools/scripts/test_release_workflow_test_step.py
@@ -211,6 +211,7 @@ class ReleaseCliDualBinaryPackaging(unittest.TestCase):
         self.assertIn("tools/scripts/package_cli.py", run_block)
         self.assertRegex(run_block, r"--binary\s+build/pulp")
         self.assertRegex(run_block, r"--cpp-binary\s+build/tools/cli/pulp-cpp")
+        self.assertRegex(run_block, r"--mcp-binary\s+build/tools/mcp/pulp-mcp")
         self.assertRegex(run_block, r"--out\s+pulp-\$\{\{\s*matrix\.platform\s*\}\}\.tar\.gz")
 
     def test_windows_package_step_bundles_cpp_delegate(self) -> None:
@@ -218,19 +219,27 @@ class ReleaseCliDualBinaryPackaging(unittest.TestCase):
         self.assertIn("tools/scripts/package_cli.py", run_block)
         self.assertRegex(run_block, r"--binary\s+build/pulp\.exe")
         self.assertRegex(run_block, r"--cpp-binary\s+build/tools/cli/Release/pulp-cpp\.exe")
+        self.assertRegex(run_block, r"--mcp-binary\s+build/tools/mcp/Release/pulp-mcp\.exe")
         self.assertRegex(run_block, r"--out\s+pulp-\$\{\{\s*matrix\.platform\s*\}\}\.zip")
 
-    def test_unix_smoke_step_exercises_both_cli_binaries(self) -> None:
-        run_block = self._find_step_run("Smoke `pulp help` + `pulp-cpp help` (Unix)")
-        self.assertRegex(run_block, r"for\s+ART\s+in\s+pulp\s+pulp-cpp")
-        self.assertIn('"$BIN" help', run_block)
+    def test_unix_smoke_step_exercises_all_cli_binaries(self) -> None:
+        run_block = self._find_step_run(
+            "Smoke `pulp help` + `pulp-cpp help` + `pulp-mcp --version` (Unix)"
+        )
+        self.assertRegex(run_block, r"for\s+ART\s+in\s+pulp\s+pulp-cpp\s+pulp-mcp")
+        self.assertIn('pulp-mcp) echo "--version"', run_block)
+        self.assertIn('"$BIN" $CMD', run_block)
         self.assertIn("Library not loaded", run_block)
         self.assertIn("cannot open shared object", run_block)
 
-    def test_windows_smoke_step_exercises_both_cli_binaries(self) -> None:
-        run_block = self._find_step_run("Smoke `pulp help` + `pulp-cpp help` (Windows)")
-        self.assertIn('@("pulp.exe", "pulp-cpp.exe")', run_block)
-        self.assertIn('-ArgumentList "help"', run_block)
+    def test_windows_smoke_step_exercises_all_cli_binaries(self) -> None:
+        run_block = self._find_step_run(
+            "Smoke `pulp help` + `pulp-cpp help` + `pulp-mcp --version` (Windows)"
+        )
+        self.assertIn('"pulp.exe"      = "help"', run_block)
+        self.assertIn('"pulp-cpp.exe"  = "help"', run_block)
+        self.assertIn('"pulp-mcp.exe"  = "--version"', run_block)
+        self.assertIn("-ArgumentList $cmd", run_block)
         self.assertIn("DLL was not found", run_block)
         self.assertIn("missing.*\\.dll", run_block)
 

--- a/tools/scripts/test_resolve_runs_on_extra.py
+++ b/tools/scripts/test_resolve_runs_on_extra.py
@@ -23,6 +23,32 @@ spec.loader.exec_module(resolver)
 
 
 class ResolverEdgeTests(unittest.TestCase):
+    def test_load_selector_accepts_string_and_array_json(self) -> None:
+        self.assertEqual(
+            resolver._load_selector('"ubuntu-latest"', "Linux"),
+            '"ubuntu-latest"',
+        )
+        self.assertEqual(
+            resolver._load_selector('["self-hosted","macos"]', "macOS"),
+            '["self-hosted", "macos"]',
+        )
+
+    def test_load_selector_rejects_invalid_json_with_target_name(self) -> None:
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as ctx:
+                resolver._load_selector("{bad", "Windows")
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("Windows runner selector JSON is not valid", stderr.getvalue())
+
+    def test_env_nonempty_handles_missing_none_and_whitespace(self) -> None:
+        with mock.patch.dict(os.environ, {"EMPTY": "   ", "VALUE": " label "}, clear=True):
+            self.assertEqual(resolver._env_nonempty(None), "")
+            self.assertEqual(resolver._env_nonempty("MISSING"), "")
+            self.assertEqual(resolver._env_nonempty("EMPTY"), "")
+            self.assertEqual(resolver._env_nonempty("VALUE"), "label")
+
     def test_optional_namespace_returns_empty_when_namespace_has_no_selector(self) -> None:
         with mock.patch.dict(
             os.environ,
@@ -77,6 +103,55 @@ class ResolverEdgeTests(unittest.TestCase):
 
         self.assertEqual(ctx.exception.code, 1)
         self.assertIn("Unsupported runner_provider: self-hosted", stderr.getvalue())
+
+    def test_provider_mode_can_read_custom_requested_provider_env(self) -> None:
+        stdout = io.StringIO()
+        with mock.patch.dict(
+            os.environ,
+            {
+                "PULP_RUNNER_PROVIDER": "local",
+                "LOCAL_LINUX_RUNS_ON_JSON": '["self-hosted","linux"]',
+            },
+            clear=True,
+        ):
+            with contextlib.redirect_stdout(stdout):
+                rc = resolver.main(
+                    [
+                        "--target-name",
+                        "Linux (x64)",
+                        "--mode",
+                        "provider",
+                        "--requested-provider-env",
+                        "PULP_RUNNER_PROVIDER",
+                        "--github-hosted-label",
+                        "ubuntu-latest",
+                        "--local-env",
+                        "LOCAL_LINUX_RUNS_ON_JSON",
+                    ]
+                )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout.getvalue(), '["self-hosted", "linux"]')
+
+    def test_optional_namespace_main_prints_empty_for_github_hosted(self) -> None:
+        stdout = io.StringIO()
+        with mock.patch.dict(os.environ, {"REQUESTED_PROVIDER": "github-hosted"}, clear=True):
+            with contextlib.redirect_stdout(stdout):
+                rc = resolver.main(
+                    [
+                        "--target-name",
+                        "macOS (ARM64)",
+                        "--mode",
+                        "optional-namespace",
+                        "--explicit-env",
+                        "EXPLICIT_MACOS_RUNNER_SELECTOR_JSON",
+                        "--namespace-env",
+                        "NAMESPACE_MACOS_RUNS_ON_JSON",
+                    ]
+                )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout.getvalue(), "")
 
 
 if __name__ == "__main__":

--- a/tools/scripts/test_ruleset_drift_config.py
+++ b/tools/scripts/test_ruleset_drift_config.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Structural tests for the ruleset drift workflow.
+
+These tests keep the checked-in branch protection intent aligned with the
+workflow that compares it to GitHub's live ruleset. They are intentionally
+offline: no GitHub API calls, no workflow dispatch, and no runner access.
+
+Run:
+    python3 tools/scripts/test_ruleset_drift_config.py
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import unittest
+
+import yaml
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ruleset-drift-check.yml"
+RULESET = REPO_ROOT / ".github" / "rulesets" / "main-protection.json"
+
+EXPECTED_REQUIRED_CONTEXTS = {
+    "macos",
+    "linux",
+    "windows",
+    "Enforce version & skill sync",
+}
+
+EXPECTED_ADVISORY_CONTEXTS = {
+    "AddressSanitizer (macOS ARM64)",
+    "ThreadSanitizer (macOS ARM64)",
+    "UndefinedBehaviorSanitizer (macOS ARM64)",
+    "RealtimeSanitizer (Linux x86_64, Clang 18)",
+}
+
+
+def workflow_on(doc: dict) -> dict:
+    """Return the GitHub Actions `on:` block from a PyYAML-loaded document."""
+    # PyYAML's YAML 1.1 resolver treats the bare word "on" as boolean True.
+    # GitHub Actions treats it as a literal key.
+    return doc.get("on") or doc.get(True) or {}
+
+
+def required_contexts(ruleset: dict) -> set[str]:
+    contexts: set[str] = set()
+    for rule in ruleset.get("rules", []):
+        if rule.get("type") != "required_status_checks":
+            continue
+        params = rule.get("parameters", {})
+        for check in params.get("required_status_checks", []):
+            context = check.get("context")
+            if context:
+                contexts.add(context)
+    return contexts
+
+
+def advisory_contexts(ruleset: dict) -> set[str]:
+    advisory = ruleset.get("advisory_status_checks", {})
+    return {
+        check["context"]
+        for check in advisory.get("checks", [])
+        if check.get("context")
+    }
+
+
+class RulesetDriftConfig(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow_text = WORKFLOW.read_text(encoding="utf-8")
+        cls.workflow = yaml.safe_load(cls.workflow_text)
+        cls.ruleset = json.loads(RULESET.read_text(encoding="utf-8"))
+
+    def test_pull_request_trigger_is_scoped_to_ruleset_files(self) -> None:
+        trigger = workflow_on(self.workflow)
+        pull_request = trigger.get("pull_request", {})
+
+        self.assertEqual(pull_request.get("branches"), ["main"])
+        self.assertEqual(
+            set(pull_request.get("paths", [])),
+            {
+                ".github/rulesets/**",
+                ".github/workflows/ruleset-drift-check.yml",
+            },
+        )
+
+    def test_manual_trigger_can_override_drift_failure(self) -> None:
+        trigger = workflow_on(self.workflow)
+        dispatch = trigger.get("workflow_dispatch", {})
+        fail_on_drift = dispatch.get("inputs", {}).get("fail_on_drift", {})
+
+        self.assertEqual(
+            fail_on_drift.get("default"),
+            "",
+            "manual runs should default to the workflow's event-sensitive "
+            "failure policy instead of forcing failures on every dispatch",
+        )
+        self.assertFalse(fail_on_drift.get("required", True))
+
+    def test_workflow_points_at_checked_in_ruleset_name(self) -> None:
+        diff_job = self.workflow["jobs"]["diff"]
+        env = diff_job["env"]
+
+        self.assertEqual(
+            env["CHECKED_IN_PATH"],
+            ".github/rulesets/main-protection.json",
+        )
+        self.assertEqual(env["RULESET_NAME"], self.ruleset["name"])
+        self.assertEqual(self.ruleset["target"], "branch")
+        self.assertEqual(self.ruleset["source_type"], "Repository")
+        self.assertEqual(self.ruleset["enforcement"], "active")
+
+    def test_required_and_advisory_contexts_stay_separate(self) -> None:
+        required = required_contexts(self.ruleset)
+        advisory = advisory_contexts(self.ruleset)
+
+        self.assertEqual(required, EXPECTED_REQUIRED_CONTEXTS)
+        self.assertEqual(advisory, EXPECTED_ADVISORY_CONTEXTS)
+        self.assertTrue(
+            required.isdisjoint(advisory),
+            "slow sanitizer contexts must remain advisory-only unless branch "
+            "protection policy changes explicitly",
+        )
+
+    def test_fetch_filters_out_inherited_org_rulesets(self) -> None:
+        self.assertIn(
+            "includes_parents=false",
+            self.workflow_text,
+            "ruleset drift fetch must ignore inherited org rulesets so a "
+            "same-named org ruleset cannot mask repo-local drift",
+        )
+        self.assertIn(
+            "source_type')=='Repository'",
+            self.workflow_text,
+            "ruleset id selection must require Repository source_type",
+        )
+
+    def test_pr_comment_is_fork_safe_and_scheduled_drift_fails(self) -> None:
+        self.assertIn(
+            "github.event.pull_request.head.repo.full_name == github.repository",
+            self.workflow_text,
+            "PR drift comments must be skipped for fork heads because their "
+            "GITHUB_TOKEN cannot write issue comments",
+        )
+        self.assertIn(
+            "steps.diff.outputs.drift == 'true' && github.event_name != 'pull_request'",
+            self.workflow_text,
+            "scheduled/manual drift must surface as a failing check while PR "
+            "drift remains advisory",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/scripts/test_run_python_coverage_extra.py
+++ b/tools/scripts/test_run_python_coverage_extra.py
@@ -115,6 +115,60 @@ class SurfaceExtraTests(unittest.TestCase):
     def test_matches_any_glob_returns_false_for_empty_pattern_set(self) -> None:
         self.assertFalse(rpc._matches_any_glob("tools/scripts/run.py", []))
 
+    def test_selected_surfaces_appends_always_include_surface(self) -> None:
+        selected = rpc._selected_surfaces(
+            [rpc.REPO_ROOT / "tools/scripts/test_alpha.py"]
+        )
+
+        self.assertGreaterEqual(len(selected), 2)
+        self.assertEqual(selected[0].source_roots, ("tools/scripts",))
+        self.assertTrue(selected[-1].always_include)
+
+    def test_normalized_source_roots_drops_children_when_parent_selected(self) -> None:
+        surfaces = [
+            rpc.CoverageSurface(("tools",), ("tools/test_*.py",)),
+            rpc.CoverageSurface(("tools/scripts",), ("tools/scripts/test_*.py",)),
+            rpc.CoverageSurface(("core/view/js",), ("tools/test_*.py",)),
+        ]
+
+        self.assertEqual(rpc._normalized_source_roots(surfaces), ["tools", "core/view/js"])
+
+    def test_report_source_files_respects_omit_globs_and_private_modules(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            script_dir = root / "tools" / "scripts"
+            script_dir.mkdir(parents=True)
+            keep = script_dir / "run_me.py"
+            keep.write_text("print('keep')\n", encoding="utf-8")
+            (script_dir / "test_run_me.py").write_text("print('test')\n", encoding="utf-8")
+            (script_dir / "_private.py").write_text("print('private')\n", encoding="utf-8")
+
+            with mock.patch.object(rpc, "REPO_ROOT", root):
+                files = rpc._report_source_files(
+                    ["tools/scripts"],
+                    ["tools/scripts/test_*.py", "tools/scripts/_*.py"],
+                )
+
+        self.assertEqual(files, [keep])
+
+    def test_write_coveragerc_requires_selected_sources_and_writes_omit(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            out = pathlib.Path(td)
+            with mock.patch.object(rpc, "OUTPUT_DIR", out), \
+                 mock.patch.object(rpc, "HTML_DIR", out / "html"), \
+                 mock.patch.object(rpc, "XML_FILE", out / "coverage.xml"), \
+                 mock.patch.object(rpc, "RCFILE", out / ".coveragerc"):
+                with self.assertRaises(ValueError):
+                    rpc._write_coveragerc([])
+
+                rpc._write_coveragerc(
+                    [rpc.CoverageSurface(("tools/scripts",), ("tools/scripts/test_*.py",))]
+                )
+                text = (out / ".coveragerc").read_text(encoding="utf-8")
+
+        self.assertIn("source =\n    tools/scripts", text)
+        self.assertIn("omit =\n    tools/scripts/test_*.py", text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/scripts/test_validate_hosts.py
+++ b/tools/scripts/test_validate_hosts.py
@@ -118,6 +118,12 @@ class RemoteCommandTests(unittest.TestCase):
         self.assertIn("$branch='feature/one''two'", command)
         self.assertIn("-NoTests:$false", command)
 
+    def test_windows_remote_command_can_skip_tests(self) -> None:
+        command = vh.windows_remote_command("C:\\repo", "main", True)
+
+        self.assertIn("-NoTests:$true", command)
+        self.assertIn("validate-build.ps1", command)
+
 
 class MainTests(unittest.TestCase):
     def test_main_builds_local_unix_and_windows_commands_from_config(self) -> None:
@@ -200,6 +206,31 @@ class MainTests(unittest.TestCase):
                     rc = vh.main()
 
         self.assertEqual(rc, 1)
+
+    def test_main_uses_current_branch_when_branch_argument_is_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            config = pathlib.Path(td) / "missing-hosts.json"
+            observed: list[tuple[str, list[str]]] = []
+
+            def fake_run(label: str, cmd: list[str]) -> bool:
+                observed.append((label, cmd))
+                return True
+
+            with mock.patch.object(vh, "current_branch", return_value="feature/current"), \
+                 mock.patch.object(vh, "run", side_effect=fake_run):
+                with argv(["validate_hosts.py", "--config", str(config)]):
+                    rc = vh.main()
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(observed), 1)
+        self.assertEqual(observed[0][0], "local")
+        self.assertEqual(observed[0][1], [
+            "bash",
+            "./validate-build.sh",
+            "--quiet",
+            "--ref",
+            "feature/current",
+        ])
 
     def test_script_entrypoint_exits_with_main_status(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/scripts/test_validate_hosts.py
+++ b/tools/scripts/test_validate_hosts.py
@@ -60,6 +60,22 @@ class ConfigTests(unittest.TestCase):
             self.assertEqual(vh.load_config(config)["unix_targets"][0]["host"], "linux")
             self.assertEqual(vh.load_config(config)["windows_targets"][0]["host"], "win")
 
+    def test_load_config_preserves_extra_keys_for_future_callers(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            config = pathlib.Path(td) / "hosts.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "unix_targets": [],
+                        "windows_targets": [],
+                        "notes": {"owner": "release"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(vh.load_config(config)["notes"], {"owner": "release"})
+
 
 class SubprocessTests(unittest.TestCase):
     def test_current_branch_returns_stripped_git_output(self) -> None:
@@ -98,6 +114,16 @@ class SubprocessTests(unittest.TestCase):
         text = out.getvalue()
         self.assertIn("success: OK", text)
         self.assertIn("failure: FAILED (7)", text)
+
+    def test_run_uses_repo_root_for_subprocess(self) -> None:
+        with mock.patch.object(
+            vh.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["true"], 0),
+        ) as run:
+            self.assertTrue(vh.run("rooted", ["true"]))
+
+        run.assert_called_once_with(["true"], cwd=vh.ROOT)
 
 
 class RemoteCommandTests(unittest.TestCase):
@@ -206,6 +232,33 @@ class MainTests(unittest.TestCase):
                     rc = vh.main()
 
         self.assertEqual(rc, 1)
+
+    def test_main_continues_after_local_failure_to_collect_remote_results(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            config = pathlib.Path(td) / "hosts.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "unix_targets": [{"host": "linux-host", "path": "/srv/pulp"}],
+                        "windows_targets": [{"host": "win-host", "path": "C:\\pulp"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            labels: list[str] = []
+
+            def fake_run(label: str, cmd: list[str]) -> bool:
+                labels.append(label)
+                return label != "local"
+
+            with mock.patch.object(vh, "run", side_effect=fake_run):
+                with argv(
+                    ["validate_hosts.py", "--config", str(config), "--branch", "local/test"]
+                ):
+                    rc = vh.main()
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(labels, ["local", "ssh linux-host", "ssh win-host"])
 
     def test_main_uses_current_branch_when_branch_argument_is_absent(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/scripts/test_validate_registry_extra.py
+++ b/tools/scripts/test_validate_registry_extra.py
@@ -317,6 +317,84 @@ class MainTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("1 packages validated, 0 errors, 2 warnings", out.getvalue())
 
+    def test_main_non_strict_allows_warnings_and_skips_license_check(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            registry = root / "registry.json"
+            schema = root / "schema.json"
+            write_json(
+                registry,
+                {
+                    "registry_version": 2,
+                    "packages": {
+                        "desktop-only": {
+                            "version": "1.0.0",
+                            "license": "Commercial",
+                            "verification": {
+                                "verified_version": "0.9.0",
+                                "build_status": {"Linux-x64": "pass"},
+                            },
+                            "platforms": {"Linux": {}},
+                        },
+                    },
+                },
+            )
+            write_json(schema, {})
+
+            out = io.StringIO()
+            with mock.patch.object(vr, "REGISTRY", registry), \
+                 mock.patch.object(vr, "SCHEMA", schema), \
+                 mock.patch.object(vr, "validate_schema", return_value=[]), \
+                 argv(["validate_registry.py"]), \
+                 contextlib.redirect_stdout(out):
+                rc = vr.main()
+
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        self.assertIn("desktop-only", text)
+        self.assertIn("Warnings:", text)
+        self.assertNotIn("License warnings:", text)
+        self.assertIn("1 packages validated, 0 errors, 2 warnings", text)
+
+    def test_main_marks_package_status_fail_when_errors_reference_slug(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            registry = root / "registry.json"
+            schema = root / "schema.json"
+            write_json(
+                registry,
+                {
+                    "registry_version": 2,
+                    "packages": {
+                        "bad-license": {
+                            "version": "1.0.0",
+                            "license": "AGPL-3.0-only",
+                            "verification": {
+                                "verified_version": "1.0.0",
+                                "build_status": {"Android-arm64": "pass"},
+                            },
+                            "platforms": {"Android": {}},
+                        },
+                    },
+                },
+            )
+            write_json(schema, {})
+
+            out = io.StringIO()
+            with mock.patch.object(vr, "REGISTRY", registry), \
+                 mock.patch.object(vr, "SCHEMA", schema), \
+                 mock.patch.object(vr, "validate_schema", return_value=[]), \
+                 argv(["validate_registry.py", "--check-licenses"]), \
+                 contextlib.redirect_stdout(out):
+                rc = vr.main()
+
+        self.assertEqual(rc, 1)
+        text = out.getvalue()
+        self.assertIn("bad-license", text)
+        self.assertIn("FAIL", text)
+        self.assertIn("License errors:", text)
+        self.assertIn("1 packages validated, 1 errors, 0 warnings", text)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tools/scripts/test_validate_registry_extra.py
+++ b/tools/scripts/test_validate_registry_extra.py
@@ -165,6 +165,37 @@ class ValidationHelperTests(unittest.TestCase):
         self.assertIn("custom", warnings[0])
         self.assertIn("not in known-allowed list", warnings[0])
 
+    def test_structural_validation_accepts_matching_mobile_package(self) -> None:
+        errors, warnings = vr.validate_structural(
+            {
+                "registry_version": 2,
+                "packages": {
+                    "good-mobile": {
+                        "version": "1.2.3",
+                        "verification": {
+                            "verified_version": "1.2.3",
+                            "build_status": {"Android-arm64": "pass"},
+                        },
+                        "platforms": {"Android": {}, "iOS": {}},
+                    },
+                },
+            }
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(warnings, [])
+
+    def test_license_validation_warns_for_missing_license(self) -> None:
+        errors, warnings = vr.validate_licenses(
+            {"packages": {"missing-license": {"version": "1.0.0"}}}
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            warnings,
+            ["  missing-license: license '' not in known-allowed list — review required"],
+        )
+
 
 class MainTests(unittest.TestCase):
     def test_script_entrypoint_invokes_main_for_help(self) -> None:

--- a/tools/scripts/test_version_bump_check_extra.py
+++ b/tools/scripts/test_version_bump_check_extra.py
@@ -128,6 +128,58 @@ class VersionFileIoTests(unittest.TestCase):
             self.assertIsNone(vbc.read_version(repo, vbc.VersionFile("plain.txt", "unknown")))
             self.assertFalse(vbc.write_version(repo, vbc.VersionFile("plain.txt", "unknown"), "1.0.0"))
 
+    def test_json_path_rejects_bad_array_segments_and_scalar_walks(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo = pathlib.Path(td)
+            (repo / "marketplace.json").write_text(
+                '{"plugins": [{"version": "1.0.0"}], "scalar": "value"}\n',
+                encoding="utf-8",
+            )
+
+            bad_index = vbc.VersionFile("marketplace.json", "json_path", "plugins.first.version")
+            scalar = vbc.VersionFile("marketplace.json", "json_path", "scalar.version")
+
+            self.assertIsNone(vbc.read_version(repo, bad_index))
+            self.assertFalse(vbc.write_version(repo, bad_index, "2.0.0"))
+            self.assertIsNone(vbc.read_version(repo, scalar))
+            self.assertFalse(vbc.write_version(repo, scalar, "2.0.0"))
+
+    def test_load_config_strips_metadata_and_defaults_trailer_key(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            cfg_path = pathlib.Path(td) / "versioning.json"
+            cfg_path.write_text(
+                json.dumps(
+                    {
+                        "$schema": "https://example.invalid/schema.json",
+                        "_comment": "ignored",
+                        "generated_globs": ["build/**"],
+                        "surfaces": {
+                            "sdk": {
+                                "_comment": "ignored",
+                                "label": "SDK",
+                                "version_files": [
+                                    {
+                                        "_comment": "ignored",
+                                        "path": "sdk.json",
+                                        "kind": "json_field",
+                                        "field": "version",
+                                    }
+                                ],
+                                "trigger_paths": ["src/**"],
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            cfg = vbc.load_config(cfg_path)
+
+        self.assertEqual(cfg.generated_globs, ["build/**"])
+        self.assertEqual(cfg.trailer_version_bump, "Version-Bump")
+        self.assertEqual(cfg.surfaces[0].name, "sdk")
+        self.assertEqual(cfg.surfaces[0].version_files[0].field, "version")
+
     def test_script_entrypoint_help_exits_zero(self) -> None:
         script = pathlib.Path(vbc.__file__).resolve()
         with mock.patch.object(sys, "argv", [str(script), "--help"]), \
@@ -688,6 +740,18 @@ class AssessmentReportApplyTests(unittest.TestCase):
             vbc,
             "git_log_subjects_and_bodies",
             return_value=[("sha", "chore(versions): bump SDK", "")],
+        ):
+            self.assertTrue(vbc._range_has_bump_commit("base", "head"))
+        with mock.patch.object(
+            vbc,
+            "git_log_subjects_and_bodies",
+            return_value=[("sha", "chore: bump SDK to v1.2.3", "")],
+        ):
+            self.assertFalse(vbc._range_has_bump_commit("base", "head"))
+        with mock.patch.object(
+            vbc,
+            "git_log_subjects_and_bodies",
+            return_value=[("sha", "chore: bump versions for release", "")],
         ):
             self.assertTrue(vbc._range_has_bump_commit("base", "head"))
 


### PR DESCRIPTION
Consolidates superseded Codecov/test PRs #2048, #2049, #2050, #2051, #2097, #2098, #2099, and #2100 into one GitHub-hosted CI run to reduce macOS runner pressure.

Local validation:
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build -j8`
- `ctest --test-dir build --output-on-failure -R "BigInteger copy move|TemporaryFile normalizes|TemporaryFile move assignment|TemporaryFile self move|MemoryMappedFile|HttpResponse ok|HTTP helpers reject malformed|excerpt bundle reader fills defaults|excerpt bundle reader reports empty|EventLoop|Timer|ActionBroadcaster|MountedVolumeListChangeDetector|IPC|NetworkServiceDiscovery|GraphSerializer|StateTree remove notifies|StateTreeSynchroniser records property removals|StateTreeSynchroniser apply"`

Note: pre-push diff coverage was demoted locally because the coverage configure hit the known FetchContent checkout issue for `mbedtls v3.6.2`; the branch should rely on the GitHub-hosted CI run for full coverage validation.

Supersedes: #2048 #2049 #2050 #2051 #2097 #2098 #2099 #2100