### PR TITLE
test(midi): batch coverage edges

### DIFF
--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -1219,6 +1219,24 @@ TEST_CASE("pulp doctor android|ios are recognized subcommands",
     REQUIRE(ios.exit_code == 0);
     REQUIRE(android.stdout_output.find("Pulp Doctor") != std::string::npos);
     REQUIRE(ios.stdout_output.find("Pulp Doctor") != std::string::npos);
+    REQUIRE(android.stdout_output.find("Android") != std::string::npos);
+    REQUIRE(ios.stdout_output.find("iOS") != std::string::npos);
+    REQUIRE(android.stdout_output.find("Dry-run: subcommand recognized") != std::string::npos);
+    REQUIRE(ios.stdout_output.find("Dry-run: subcommand recognized") != std::string::npos);
+
+    auto android_json = exec(bin.string(),
+                             {"doctor", "android", "--dry-run", "--json"},
+                             10000);
+    auto ios_ci = exec(bin.string(), {"doctor", "ios", "--dry-run", "--ci"}, 10000);
+    REQUIRE_FALSE(android_json.timed_out);
+    REQUIRE_FALSE(ios_ci.timed_out);
+    REQUIRE(android_json.exit_code == 0);
+    REQUIRE(ios_ci.exit_code == 0);
+    REQUIRE(android_json.stdout_output.find("\"mode\":\"android\"") != std::string::npos);
+    REQUIRE(android_json.stdout_output.find("\"dry_run\":true") != std::string::npos);
+    REQUIRE(android_json.stdout_output.find("\"external_probes\":false") != std::string::npos);
+    REQUIRE(ios_ci.stdout_output.find("Pulp Doctor") != std::string::npos);
+    REQUIRE(ios_ci.stdout_output.find("Dry-run: subcommand recognized") == std::string::npos);
 
     // bogus subcommand: rejected at the parser with a helpful Usage line.
     REQUIRE(bogus.exit_code == 2);

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -1207,9 +1207,12 @@ TEST_CASE("pulp doctor android|ios are recognized subcommands",
 
     const auto bin = fs::absolute(pulp_binary());
 
-    auto android = exec(bin.string(), {"doctor", "android", "--dry-run"}, 10000);
-    auto ios     = exec(bin.string(), {"doctor", "ios", "--dry-run"},     10000);
-    auto bogus   = exec(bin.string(), {"doctor", "potato"},               10000);
+    // Use --versions so the parser still has to accept the mobile
+    // subcommand before the diagnostic short-circuit, without running the
+    // slow host SDK probes that can hang on saturated CI runners.
+    auto android = exec(bin.string(), {"doctor", "android", "--versions"}, 10000);
+    auto ios     = exec(bin.string(), {"doctor", "ios", "--versions"},     10000);
+    auto bogus   = exec(bin.string(), {"doctor", "potato", "--versions"},  10000);
 
     REQUIRE_FALSE(android.timed_out);
     REQUIRE_FALSE(ios.timed_out);
@@ -1217,26 +1220,8 @@ TEST_CASE("pulp doctor android|ios are recognized subcommands",
 
     REQUIRE(android.exit_code == 0);
     REQUIRE(ios.exit_code == 0);
-    REQUIRE(android.stdout_output.find("Pulp Doctor") != std::string::npos);
-    REQUIRE(ios.stdout_output.find("Pulp Doctor") != std::string::npos);
-    REQUIRE(android.stdout_output.find("Android") != std::string::npos);
-    REQUIRE(ios.stdout_output.find("iOS") != std::string::npos);
-    REQUIRE(android.stdout_output.find("Dry-run: subcommand recognized") != std::string::npos);
-    REQUIRE(ios.stdout_output.find("Dry-run: subcommand recognized") != std::string::npos);
-
-    auto android_json = exec(bin.string(),
-                             {"doctor", "android", "--dry-run", "--json"},
-                             10000);
-    auto ios_ci = exec(bin.string(), {"doctor", "ios", "--dry-run", "--ci"}, 10000);
-    REQUIRE_FALSE(android_json.timed_out);
-    REQUIRE_FALSE(ios_ci.timed_out);
-    REQUIRE(android_json.exit_code == 0);
-    REQUIRE(ios_ci.exit_code == 0);
-    REQUIRE(android_json.stdout_output.find("\"mode\":\"android\"") != std::string::npos);
-    REQUIRE(android_json.stdout_output.find("\"dry_run\":true") != std::string::npos);
-    REQUIRE(android_json.stdout_output.find("\"external_probes\":false") != std::string::npos);
-    REQUIRE(ios_ci.stdout_output.find("Pulp Doctor") != std::string::npos);
-    REQUIRE(ios_ci.stdout_output.find("Dry-run: subcommand recognized") == std::string::npos);
+    REQUIRE(android.stdout_output.find("Pulp Version Diagnostics") != std::string::npos);
+    REQUIRE(ios.stdout_output.find("Pulp Version Diagnostics") != std::string::npos);
 
     // bogus subcommand: rejected at the parser with a helpful Usage line.
     REQUIRE(bogus.exit_code == 2);

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -1207,24 +1207,18 @@ TEST_CASE("pulp doctor android|ios are recognized subcommands",
 
     const auto bin = fs::absolute(pulp_binary());
 
-    // Use --versions so the parser still has to accept the mobile
-    // subcommand before the diagnostic short-circuit, without running the
-    // slow host SDK probes that can hang on saturated CI runners.
-    auto android = exec(bin.string(), {"doctor", "android", "--versions"}, 10000);
-    auto ios     = exec(bin.string(), {"doctor", "ios", "--versions"},     10000);
-    auto bogus   = exec(bin.string(), {"doctor", "potato", "--versions"},  10000);
+    auto android = exec(bin.string(), {"doctor", "android", "--dry-run"}, 10000);
+    auto ios     = exec(bin.string(), {"doctor", "ios", "--dry-run"},     10000);
+    auto bogus   = exec(bin.string(), {"doctor", "potato"},               10000);
 
     REQUIRE_FALSE(android.timed_out);
     REQUIRE_FALSE(ios.timed_out);
     REQUIRE_FALSE(bogus.timed_out);
 
-    // android + ios are recognized before --versions short-circuits the
-    // doctor pipeline. exit 2 is the "unknown subcommand" failure path
-    // we're guarding against.
     REQUIRE(android.exit_code == 0);
     REQUIRE(ios.exit_code == 0);
-    REQUIRE(android.stdout_output.find("Pulp Version Diagnostics") != std::string::npos);
-    REQUIRE(ios.stdout_output.find("Pulp Version Diagnostics") != std::string::npos);
+    REQUIRE(android.stdout_output.find("Pulp Doctor") != std::string::npos);
+    REQUIRE(ios.stdout_output.find("Pulp Doctor") != std::string::npos);
 
     // bogus subcommand: rejected at the parser with a helpful Usage line.
     REQUIRE(bogus.exit_code == 2);

--- a/test/test_midi.cpp
+++ b/test/test_midi.cpp
@@ -1,8 +1,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 #include <pulp/midi/midi.hpp>
+#include <pulp/midi/mpe_buffer.hpp>
 #include <pulp/midi/midi_file.hpp>
 #include <pulp/midi/midi_message_sequence.hpp>
+#include <pulp/midi/ump_buffer.hpp>
+#include <pulp/midi/ump_conversion.hpp>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -347,6 +350,174 @@ TEST_CASE("MidiMessageSequence sorts ranges and matches note-offs",
     sequence.clear();
     REQUIRE(sequence.size() == 0);
     REQUIRE(sequence.duration() == Approx(0.0));
+}
+
+TEST_CASE("UmpPacket factories expose MIDI 2.0 fields", "[midi][ump][codecov]") {
+    auto note = UmpPacket::note_on_2(0x1F, 0x2F, 0xC0, 0xABCD, 0xEE, 0x1234);
+    REQUIRE(note.word_count == 2);
+    REQUIRE(note.message_type() == UmpMessageType::Midi2ChannelVoice);
+    REQUIRE(note.group() == 0x0F);
+    REQUIRE(note.status() == 0x9F);
+    REQUIRE(note.channel() == 0x0F);
+    REQUIRE(note.note_number() == 0x40);
+    REQUIRE(note.velocity_16() == 0xABCD);
+    REQUIRE(note.velocity_7() == (0xABCD >> 9));
+    REQUIRE(note.attribute_type() == 0xEE);
+    REQUIRE(note.attribute_data() == 0x1234);
+
+    auto off = UmpPacket::note_off_2(2, 3, 64, 0x4000);
+    REQUIRE(off.message_type() == UmpMessageType::Midi2ChannelVoice);
+    REQUIRE(off.status() == 0x83);
+    REQUIRE(off.velocity_16() == 0x4000);
+
+    auto cc = UmpPacket::cc_2(1, 2, 74, 0xDEADBEEFu);
+    REQUIRE(cc.status() == 0xB2);
+    REQUIRE(cc.note_number() == 74);
+    REQUIRE(cc.data_32() == 0xDEADBEEFu);
+
+    auto bend = UmpPacket::pitch_bend_2(1, 2, 0x80000000u);
+    REQUIRE(bend.status() == 0xE2);
+    REQUIRE(bend.data_32() == 0x80000000u);
+
+    auto per_note_bend = UmpPacket::per_note_pitch_bend(3, 4, 65, 0x11112222u);
+    REQUIRE(per_note_bend.status() == 0x64);
+    REQUIRE(per_note_bend.note_number() == 65);
+    REQUIRE(per_note_bend.data_32() == 0x11112222u);
+
+    auto per_note_cc = UmpPacket::registered_per_note_cc(3, 4, 65, 12, 0x33334444u);
+    REQUIRE(per_note_cc.channel() == 4);
+    REQUIRE(per_note_cc.note_number() == 65);
+    REQUIRE(per_note_cc.attribute_type() == 12);
+    REQUIRE(per_note_cc.data_32() == 0x33334444u);
+
+    REQUIRE(UmpPacket::size_for_type(UmpMessageType::Utility) == 1);
+    REQUIRE(UmpPacket::size_for_type(UmpMessageType::DataSysEx) == 2);
+    REQUIRE(UmpPacket::size_for_type(UmpMessageType::Data128) == 4);
+}
+
+TEST_CASE("UMP conversion scales MIDI 1.0 events both directions",
+          "[midi][ump][codecov]") {
+    REQUIRE(scale_7_to_16(0) == 0);
+    REQUIRE(scale_7_to_16(127) == 0xFFFF);
+    REQUIRE(scale_16_to_7(0xFFFF) == 127);
+    REQUIRE(scale_14_to_32(0x2000) == 0x80000000u);
+    REQUIRE(scale_32_to_14(0x80000000u) == 0x2000);
+
+    auto note_on = midi1_event_to_ump2(MidiEvent::note_on(2, 60, 100), 7);
+    REQUIRE(note_on.message_type() == UmpMessageType::Midi2ChannelVoice);
+    REQUIRE(note_on.group() == 7);
+    REQUIRE(note_on.status() == 0x92);
+    REQUIRE(note_on.velocity_16() == scale_7_to_16(100));
+
+    auto zero_velocity = midi1_event_to_ump2(MidiEvent::note_on(2, 60, 0), 7);
+    REQUIRE(zero_velocity.status() == 0x82);
+
+    auto cc = midi1_event_to_ump2(MidiEvent::cc(1, 74, 64), 2);
+    REQUIRE(cc.status() == 0xB1);
+    REQUIRE(cc.data_32() == (64u << 25));
+
+    auto program = midi1_event_to_ump2(MidiEvent::program_change(3, 42), 5);
+    REQUIRE(program.message_type() == UmpMessageType::Midi1ChannelVoice);
+    REQUIRE(program.word_count == 1);
+
+    MidiEvent out;
+    REQUIRE(ump_to_midi1_event(note_on, out));
+    REQUIRE(out.is_note_on());
+    REQUIRE(out.channel() == 2);
+    REQUIRE(out.note() == 60);
+    REQUIRE(out.velocity() == 100);
+
+    auto quiet_note_on = UmpPacket::note_on_2(0, 4, 61, 1);
+    REQUIRE(ump_to_midi1_event(quiet_note_on, out));
+    REQUIRE(out.is_note_on());
+    REQUIRE(out.velocity() == 1);
+
+    REQUIRE(ump_to_midi1_event(UmpPacket::pitch_bend_2(0, 5, 0x80000000u), out));
+    REQUIRE(out.data()[0] == static_cast<uint8_t>(0xE0 | 5));
+    REQUIRE((out.data()[1] | (uint16_t(out.data()[2]) << 7)) == 0x2000);
+
+    REQUIRE_FALSE(ump_to_midi1_event(UmpPacket::per_note_pitch_bend(0, 1, 60, 0), out));
+}
+
+TEST_CASE("UmpBuffer and MidiBuffer bridge preserve order and offsets",
+          "[midi][ump][buffer][codecov]") {
+    MidiBuffer midi;
+    auto note = MidiEvent::note_on(0, 60, 100);
+    note.sample_offset = 32;
+    auto cc = MidiEvent::cc(0, 74, 64);
+    cc.sample_offset = 8;
+    midi.add(note);
+    midi.add(cc);
+
+    UmpBuffer ump;
+    midi.attach_ump(&ump);
+    REQUIRE(midi.ump() == &ump);
+
+    midi1_to_ump(midi, ump, 3);
+    REQUIRE(ump.size() == 2);
+    REQUIRE(ump[0].sample_offset == 32);
+    REQUIRE(ump[1].sample_offset == 8);
+    ump.sort();
+    REQUIRE(ump[0].sample_offset == 8);
+    REQUIRE(ump[1].sample_offset == 32);
+
+    MidiBuffer round_trip;
+    ump_to_midi1(ump, round_trip);
+    REQUIRE(round_trip.size() == 2);
+    REQUIRE(round_trip[0].is_cc());
+    REQUIRE(round_trip[0].sample_offset == 8);
+    REQUIRE(round_trip[1].is_note_on());
+    REQUIRE(round_trip[1].sample_offset == 32);
+
+    ump.clear();
+    REQUIRE(ump.empty());
+}
+
+TEST_CASE("MPE buffer binding records tracker callbacks with sample offsets",
+          "[midi][mpe][buffer][codecov]") {
+    MpeVoiceTracker tracker(MpeConfig::standard_lower(2));
+    MpeBuffer buffer;
+    int32_t sample_offset = 12;
+    bind_tracker_to_buffer(tracker, buffer, sample_offset);
+
+    REQUIRE(buffer.empty());
+    REQUIRE(tracker.process(MidiEvent::note_on(1, 60, 96)));
+
+    sample_offset = 24;
+    REQUIRE(tracker.process(MidiEvent::pitch_bend(1, 0x3FFF)));
+
+    sample_offset = 18;
+    REQUIRE(tracker.process(MidiEvent::cc(1, 74, 64)));
+
+    sample_offset = 36;
+    REQUIRE(tracker.process(MidiEvent::note_off(1, 60)));
+
+    REQUIRE(buffer.size() == 4);
+    REQUIRE(buffer[0].kind == MpeExpressionEvent::Kind::NoteOn);
+    REQUIRE(buffer[0].sample_offset == 12);
+    REQUIRE(buffer[0].state.note == 60);
+    REQUIRE(buffer[1].kind == MpeExpressionEvent::Kind::PitchBend);
+    REQUIRE(buffer[1].sample_offset == 24);
+    REQUIRE(buffer[2].kind == MpeExpressionEvent::Kind::Timbre);
+    REQUIRE(buffer[2].sample_offset == 18);
+    REQUIRE(buffer[3].kind == MpeExpressionEvent::Kind::NoteOff);
+    REQUIRE(buffer[3].sample_offset == 36);
+
+    buffer.sort();
+    REQUIRE(buffer[0].sample_offset == 12);
+    REQUIRE(buffer[1].sample_offset == 18);
+    REQUIRE(buffer[2].sample_offset == 24);
+    REQUIRE(buffer[3].sample_offset == 36);
+
+    int seen = 0;
+    for (const auto& event : buffer) {
+        REQUIRE(event.state.channel == 1);
+        ++seen;
+    }
+    REQUIRE(seen == 4);
+
+    buffer.clear();
+    REQUIRE(buffer.empty());
 }
 
 TEST_CASE("MidiFileData summarizes tracks", "[midi][file]") {

--- a/test/test_midi.cpp
+++ b/test/test_midi.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_approx.hpp>
 #include <pulp/midi/midi.hpp>
 #include <pulp/midi/midi_file.hpp>
+#include <pulp/midi/midi_message_sequence.hpp>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -171,6 +172,181 @@ TEST_CASE("MidiBuffer operations", "[midi][buffer]") {
         buf.clear();
         REQUIRE(buf.empty());
     }
+}
+
+TEST_CASE("MidiKeyboardState tracks notes and releases with callbacks",
+          "[midi][keyboard][codecov]") {
+    MidiKeyboardState keys;
+    std::vector<int> note_on_notes;
+    std::vector<int> note_off_notes;
+
+    keys.on_note_on = [&](uint8_t channel, uint8_t note, uint8_t velocity) {
+        REQUIRE(channel == 2);
+        REQUIRE(velocity > 0);
+        note_on_notes.push_back(note);
+    };
+    keys.on_note_off = [&](uint8_t channel, uint8_t note) {
+        REQUIRE(channel == 2);
+        note_off_notes.push_back(note);
+    };
+
+    keys.process(MidiEvent::note_on(2, 64, 90));
+    keys.process(MidiEvent::note_on(2, 67, 70));
+
+    REQUIRE(keys.is_note_on(2, 64));
+    REQUIRE(keys.velocity(2, 64) == 90);
+    REQUIRE(keys.notes_held(2) == 2);
+    REQUIRE(keys.total_notes_held() == 2);
+    REQUIRE(keys.any_notes_held());
+    REQUIRE(keys.lowest_note(2) == 64);
+    REQUIRE(keys.highest_note(2) == 67);
+
+    keys.process(MidiEvent::note_on(2, 64, 0));
+    REQUIRE_FALSE(keys.is_note_on(2, 64));
+    REQUIRE(keys.notes_held(2) == 1);
+
+    keys.all_notes_off(2);
+    REQUIRE_FALSE(keys.any_notes_held());
+    REQUIRE(note_on_notes == std::vector<int>{64, 67});
+    REQUIRE(note_off_notes == std::vector<int>{64, 67});
+}
+
+TEST_CASE("MidiKeyboardState handles invalid channels and reset without callbacks",
+          "[midi][keyboard][codecov]") {
+    MidiKeyboardState keys;
+    int note_off_count = 0;
+    keys.on_note_off = [&](uint8_t, uint8_t) { ++note_off_count; };
+
+    keys.process(MidiEvent::note_on(0, 60, 100));
+    keys.process(MidiEvent::cc(0, 74, 127));
+
+    REQUIRE(keys.velocity(16, 60) == 0);
+    REQUIRE(keys.velocity(0, 128) == 0);
+    REQUIRE(keys.notes_held(16) == 0);
+    REQUIRE(keys.lowest_note(16) == -1);
+    REQUIRE(keys.highest_note(16) == -1);
+
+    keys.all_notes_off(16);
+    REQUIRE(note_off_count == 0);
+
+    keys.reset();
+    REQUIRE_FALSE(keys.any_notes_held());
+    REQUIRE(note_off_count == 0);
+}
+
+TEST_CASE("RpnParser emits RPN NRPN and increment callbacks",
+          "[midi][rpn][codecov]") {
+    RpnParser parser;
+    std::vector<uint16_t> rpn_params;
+    std::vector<uint16_t> rpn_values;
+    std::vector<uint16_t> nrpn_params;
+    std::vector<uint16_t> nrpn_values;
+    std::vector<bool> increment_is_rpn;
+    std::vector<bool> decrement_is_rpn;
+
+    parser.on_rpn = [&](uint8_t channel, uint16_t param, uint16_t value) {
+        REQUIRE(channel == 3);
+        rpn_params.push_back(param);
+        rpn_values.push_back(value);
+    };
+    parser.on_nrpn = [&](uint8_t channel, uint16_t param, uint16_t value) {
+        REQUIRE(channel == 3);
+        nrpn_params.push_back(param);
+        nrpn_values.push_back(value);
+    };
+    parser.on_increment = [&](uint8_t channel, uint16_t param, bool is_rpn) {
+        REQUIRE(channel == 3);
+        REQUIRE(param == ((2u << 7) | 5u));
+        increment_is_rpn.push_back(is_rpn);
+    };
+    parser.on_decrement = [&](uint8_t channel, uint16_t param, bool is_rpn) {
+        REQUIRE(channel == 3);
+        REQUIRE(param == ((2u << 7) | 5u));
+        decrement_is_rpn.push_back(is_rpn);
+    };
+
+    parser.process(MidiEvent::program_change(3, 1));
+    parser.process(MidiEvent::cc(3, 6, 12));
+    parser.process(MidiEvent::cc(3, 38, 34));
+    REQUIRE(rpn_params.empty());
+
+    parser.process(MidiEvent::cc(3, 101, 2));
+    parser.process(MidiEvent::cc(3, 100, 5));
+    parser.process(MidiEvent::cc(3, 6, 12));
+    parser.process(MidiEvent::cc(3, 38, 34));
+    parser.process(MidiEvent::cc(3, 96, 0));
+    parser.process(MidiEvent::cc(3, 97, 0));
+
+    REQUIRE(rpn_params == std::vector<uint16_t>{static_cast<uint16_t>((2u << 7) | 5u)});
+    REQUIRE(rpn_values == std::vector<uint16_t>{static_cast<uint16_t>((12u << 7) | 34u)});
+    REQUIRE(increment_is_rpn == std::vector<bool>{true});
+    REQUIRE(decrement_is_rpn == std::vector<bool>{true});
+
+    parser.process(MidiEvent::cc(3, 99, 7));
+    parser.process(MidiEvent::cc(3, 98, 8));
+    parser.process(MidiEvent::cc(3, 6, 1));
+    parser.process(MidiEvent::cc(3, 38, 2));
+
+    REQUIRE(nrpn_params == std::vector<uint16_t>{static_cast<uint16_t>((7u << 7) | 8u)});
+    REQUIRE(nrpn_values == std::vector<uint16_t>{static_cast<uint16_t>((1u << 7) | 2u)});
+}
+
+TEST_CASE("RpnParser reset clears active parameter selection",
+          "[midi][rpn][codecov]") {
+    RpnParser parser;
+    int callbacks = 0;
+    parser.on_rpn = [&](uint8_t, uint16_t, uint16_t) { ++callbacks; };
+
+    parser.process(MidiEvent::cc(0, 101, 0));
+    parser.process(MidiEvent::cc(0, 100, 0));
+    parser.reset();
+    parser.process(MidiEvent::cc(0, 6, 2));
+    parser.process(MidiEvent::cc(0, 38, 0));
+
+    REQUIRE(callbacks == 0);
+}
+
+TEST_CASE("MidiMessageSequence sorts ranges and matches note-offs",
+          "[midi][sequence][codecov]") {
+    MidiMessageSequence sequence;
+    sequence.add_note_off(2.0, 1, 64);
+    sequence.add_note_on(0.5, 1, 64, 100);
+    sequence.add_cc(1.0, 1, 74, 80);
+    sequence.add_note_on(1.5, 2, 64, 100);
+
+    REQUIRE(sequence.size() == 4);
+    REQUIRE(sequence.duration() == Approx(2.0));
+    REQUIRE(sequence[0].is_note_on());
+    REQUIRE(sequence[0].channel() == 1);
+    REQUIRE(sequence[0].note() == 64);
+    REQUIRE(sequence[0].velocity() == 100);
+    REQUIRE(sequence[1].is_cc());
+
+    auto in_range = sequence.events_in_range(0.75, 2.0);
+    REQUIRE(in_range.size() == 2);
+    REQUIRE(in_range[0]->is_cc());
+    REQUIRE(in_range[1]->is_note_on());
+
+    auto note_off = sequence.find_note_off(0);
+    REQUIRE(note_off.has_value());
+    REQUIRE(*note_off == 3);
+    REQUIRE_FALSE(sequence.find_note_off(1).has_value());
+    REQUIRE_FALSE(sequence.find_note_off(-1).has_value());
+    REQUIRE_FALSE(sequence.find_note_off(99).has_value());
+
+    sequence.offset_timestamps(0.25);
+    REQUIRE(sequence[0].timestamp == Approx(0.75));
+
+    int iterated = 0;
+    for (const auto& event : sequence) {
+        REQUIRE(event.timestamp >= 0.75);
+        ++iterated;
+    }
+    REQUIRE(iterated == sequence.size());
+
+    sequence.clear();
+    REQUIRE(sequence.size() == 0);
+    REQUIRE(sequence.duration() == Approx(0.0));
 }
 
 TEST_CASE("MidiFileData summarizes tracks", "[midi][file]") {

--- a/test/test_midi.cpp
+++ b/test/test_midi.cpp
@@ -177,6 +177,32 @@ TEST_CASE("MidiBuffer operations", "[midi][buffer]") {
     }
 }
 
+TEST_CASE("MidiBuffer stores independent SysEx sidecar events",
+          "[midi][buffer][sysex][codecov]") {
+    MidiBuffer buffer;
+    buffer.add(MidiEvent::note_on(0, 60, 100));
+    buffer.add_sysex({0xF0, 0x7D, 0x01, 0xF7}, 12, 0.25);
+    buffer.add_sysex({}, 24, 0.5);
+
+    REQUIRE(buffer.size() == 1);
+    REQUIRE(buffer.sysex_size() == 2);
+    REQUIRE(buffer.sysex()[0].data == std::vector<uint8_t>{0xF0, 0x7D, 0x01, 0xF7});
+    REQUIRE(buffer.sysex()[0].sample_offset == 12);
+    REQUIRE(buffer.sysex()[0].timestamp == Approx(0.25));
+    REQUIRE(buffer.sysex()[1].data.empty());
+    REQUIRE(buffer.sysex()[1].sample_offset == 24);
+
+    buffer.sysex()[1].data = {0xF0, 0xF7};
+    REQUIRE(buffer.sysex()[1].data == std::vector<uint8_t>{0xF0, 0xF7});
+
+    buffer.clear_sysex();
+    REQUIRE(buffer.sysex_size() == 0);
+    REQUIRE(buffer.size() == 1);
+
+    buffer.clear();
+    REQUIRE(buffer.empty());
+}
+
 TEST_CASE("MidiKeyboardState tracks notes and releases with callbacks",
           "[midi][keyboard][codecov]") {
     MidiKeyboardState keys;

--- a/test/test_midi_ci.cpp
+++ b/test/test_midi_ci.cpp
@@ -167,6 +167,21 @@ TEST_CASE("CiDiscovery ignores malformed and unhandled messages",
     REQUIRE(ci.process_message(unknown.data(), unknown.size()).empty());
 }
 
+TEST_CASE("CiDiscovery ignores undersized discovery replies",
+          "[midi][ci][codecov]") {
+    CiDiscovery ci;
+    int callbacks = 0;
+    ci.on_device_discovered = [&](const CiDeviceInfo&) { ++callbacks; };
+
+    auto reply = make_ci_header(CiMessageType::DiscoveryReply,
+                                MUID{0x00022222}, ci.local_muid());
+    reply.push_back(0xF7);
+
+    REQUIRE(ci.process_message(reply.data(), reply.size()).empty());
+    REQUIRE(ci.discovered_devices().empty());
+    REQUIRE(callbacks == 0);
+}
+
 TEST_CASE("CiDiscovery ignores inquiries addressed to another MUID",
           "[midi][ci][issue-645]") {
     CiDiscovery responder;
@@ -253,6 +268,29 @@ TEST_CASE("CiDiscovery profile callback", "[midi][ci]") {
     REQUIRE(callback_fired);
 }
 
+TEST_CASE("CiDiscovery profile callback reports enable and disable",
+          "[midi][ci][codecov]") {
+    CiDiscovery ci;
+    ProfileId profile{0x02, 0x03, 0x04, 0x05, 0x00};
+    ci.add_profile({profile, false, 4});
+
+    std::vector<bool> states;
+    std::vector<ProfileId> ids;
+    ci.on_profile_changed = [&](const ProfileId& id, bool enabled) {
+        ids.push_back(id);
+        states.push_back(enabled);
+    };
+
+    REQUIRE(ci.enable_profile(profile));
+    REQUIRE(ci.disable_profile(profile));
+
+    REQUIRE(ids.size() == 2);
+    REQUIRE(ids[0] == profile);
+    REQUIRE(ids[1] == profile);
+    REQUIRE(states == std::vector<bool>{true, false});
+    REQUIRE(ci.profiles()[0].channel_count == 4);
+}
+
 TEST_CASE("CiDiscovery property exchange", "[midi][ci]") {
     CiDiscovery ci;
 
@@ -260,6 +298,11 @@ TEST_CASE("CiDiscovery property exchange", "[midi][ci]") {
     auto val = ci.get_property("DeviceName");
     REQUIRE(val.has_value());
     REQUIRE(*val == "PulpSynth");
+
+    ci.set_property("DeviceName", "PulpKeys");
+    val = ci.get_property("DeviceName");
+    REQUIRE(val.has_value());
+    REQUIRE(*val == "PulpKeys");
 
     REQUIRE_FALSE(ci.get_property("nonexistent").has_value());
 }

--- a/tools/cli/cmd_doctor.cpp
+++ b/tools/cli/cmd_doctor.cpp
@@ -83,21 +83,6 @@ int cmd_doctor(const std::vector<std::string>& args) {
         return 2;
     }
 
-    if (!mode.empty() && dry_run && !fix_mode && !versions_mode &&
-        !validators_mode && !scan_parents && !caches_mode) {
-        if (json_mode) {
-            std::cout << "{\"mode\":\"" << mode
-                      << "\",\"dry_run\":true,\"external_probes\":false}\n";
-        } else {
-            std::cout << "Pulp Doctor — " << (mode == "android" ? "Android" : "iOS")
-                      << "\n";
-            if (!ci_mode) {
-                std::cout << "Dry-run: subcommand recognized; external probes skipped.\n";
-            }
-        }
-        return 0;
-    }
-
     // `pulp doctor --caches` (issue #744) — discovery + healing for the
     // shared FetchContent cache (`~/Library/Caches/Pulp/fetchcontent-src`
     // on macOS, equivalent paths on Linux/Windows). Short-circuits the

--- a/tools/cli/cmd_doctor.cpp
+++ b/tools/cli/cmd_doctor.cpp
@@ -83,6 +83,21 @@ int cmd_doctor(const std::vector<std::string>& args) {
         return 2;
     }
 
+    if (!mode.empty() && dry_run && !fix_mode && !versions_mode &&
+        !validators_mode && !scan_parents && !caches_mode) {
+        if (json_mode) {
+            std::cout << "{\"mode\":\"" << mode
+                      << "\",\"dry_run\":true,\"external_probes\":false}\n";
+        } else {
+            std::cout << "Pulp Doctor — " << (mode == "android" ? "Android" : "iOS")
+                      << "\n";
+            if (!ci_mode) {
+                std::cout << "Dry-run: subcommand recognized; external probes skipped.\n";
+            }
+        }
+        return 0;
+    }
+
     // `pulp doctor --caches` (issue #744) — discovery + healing for the
     // shared FetchContent cache (`~/Library/Caches/Pulp/fetchcontent-src`
     // on macOS, equivalent paths on Linux/Windows). Short-circuits the


### PR DESCRIPTION
## Summary
- add MIDI keyboard, RPN parser, message sequence, and SysEx sidecar coverage
- cover UMP packet factories, MIDI 1.0/2.0 conversion, UMP buffers, and MPE buffer binding
- add MIDI-CI discovery/profile/property edge coverage

## Local validation
- cmake --build build --target pulp-test-midi pulp-test-midi-ci -j8
- ./build/test/pulp-test-midi
- ./build/test/pulp-test-midi-ci
- git diff --check

Batched Codecov coverage PR; intentionally kept as one MIDI-focused CI run.