### PR TITLE
fix(view): SvgPathWidget exposes viewBox as intrinsic size (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v01021"></a>
+## [0.103.0]
+
 ## [0.102.1] - 2026-05-15
 
 - fix(view/mac): re-sync _focusedView at every deref site (closes #2088) ([#2093](https://github.com/danielraffel/pulp/pull/2093))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.102.1
+    VERSION 0.103.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/svg_path_widget.hpp
+++ b/core/view/include/pulp/view/svg_path_widget.hpp
@@ -97,6 +97,17 @@ public:
 
     void paint(canvas::Canvas& canvas) override;
 
+    /// pulp #72 — expose the viewBox as the natural / intrinsic size so
+    /// Yoga can use it as flex-basis when the host doesn't set explicit
+    /// dimensions. Without these, an `<svg viewBox="0 0 24 24"><path/></svg>`
+    /// dropped into a flex container collapses to 0×0 and `paint()` early-
+    /// exits at the `local_bounds().width <= 0` guard — the symptom that
+    /// blanked Spectr's preset-manager band-shape thumbnails. Returns 0
+    /// when no viewBox is set (caller must provide explicit size, same
+    /// pre-fix behavior).
+    float intrinsic_width() const override  { return viewbox_w_ > 0 ? viewbox_w_ : 0; }
+    float intrinsic_height() const override { return viewbox_h_ > 0 ? viewbox_h_ : 0; }
+
 private:
     void reparse();
 

--- a/test/test_svg_path_widget.cpp
+++ b/test/test_svg_path_widget.cpp
@@ -33,6 +33,27 @@ TEST_CASE("SvgPathWidget defaults match HTML <path> semantics", "[svg_path][issu
     REQUIRE(w.segments().empty());
 }
 
+TEST_CASE("SvgPathWidget intrinsic size reflects viewBox", "[svg_path][issue-72]") {
+    // Spectr preset-manager thumbnails mount <svg viewBox="0 0 W H"><path/></svg>
+    // into a flex container without explicit width/height. Pre-fix, Yoga had
+    // nothing to size the widget with (intrinsic_*() returned 0 from the base),
+    // so paint() saw a 0x0 local_bounds and early-exited. Exposing the
+    // viewBox as the intrinsic size lets Yoga pick it up as flex-basis.
+    SvgPathWidget w;
+    REQUIRE(w.intrinsic_width() == 0.0f);   // no viewBox set
+    REQUIRE(w.intrinsic_height() == 0.0f);
+
+    w.set_viewbox(24.0f, 16.0f);
+    REQUIRE(w.intrinsic_width() == 24.0f);
+    REQUIRE(w.intrinsic_height() == 16.0f);
+
+    // Zero / negative viewBox stays at 0 (caller must provide explicit size,
+    // matching pre-fix behavior for the no-viewBox case).
+    w.set_viewbox(0.0f, 0.0f);
+    REQUIRE(w.intrinsic_width() == 0.0f);
+    REQUIRE(w.intrinsic_height() == 0.0f);
+}
+
 TEST_CASE("SvgPathWidget parses absolute M/L/Z", "[svg_path][issue-965]") {
     SvgPathWidget w;
     w.set_path("M 1 2 L 3 4 Z");


### PR DESCRIPTION
## Summary

Pulp framework fix for issue #72 (preset-manager band-shape preview blank in Spectr).

`SvgPathWidget` inherited `View`'s default `intrinsic_width()` / `intrinsic_height()` which return 0. When the widget was mounted inside a flex container with no explicit width/height (Spectr's preset thumbnails do exactly this), Yoga resolved dimensions to 0×0, and `paint()` early-exited at the `local_bounds().width <= 0` guard.

Fix: override `intrinsic_width()/intrinsic_height()` to return `viewbox_w_/viewbox_h_` when set, 0 when unset.

## Test plan
- [x] Catch2 test exercises default-zero / set-viewBox / clear-viewBox transitions
- [ ] CI build + tests across all platforms
- [ ] Manual Spectr re-import after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)