### PR TITLE
test(runtime): batch helper and host coverage edges

### DIFF
--- a/core/runtime/src/expression.cpp
+++ b/core/runtime/src/expression.cpp
@@ -91,7 +91,9 @@ private:
             if (pos_ < input_.size() && (input_[pos_] == 'e' || input_[pos_] == 'E')) {
                 pos_++;
                 if (pos_ < input_.size() && (input_[pos_] == '+' || input_[pos_] == '-')) pos_++;
+                size_t exponent_start = pos_;
                 while (pos_ < input_.size() && std::isdigit(input_[pos_])) pos_++;
+                if (pos_ == exponent_start) throw std::runtime_error("Malformed exponent");
             }
             return std::stod(std::string(input_.substr(start, pos_ - start)));
         }

--- a/test/test_background_scanner.cpp
+++ b/test/test_background_scanner.cpp
@@ -63,6 +63,39 @@ TEST_CASE("BackgroundScanner: completes a quick scan", "[host][bg-scan]") {
     REQUIRE(final_results[0].name == "A");
 }
 
+TEST_CASE("BackgroundScanner: empty worker still completes",
+          "[host][bg-scan][coverage]") {
+    BackgroundScanner bs;
+    bool completion_called = false;
+    bool final_cancelled = true;
+    std::vector<PluginInfo> final_results{fake_info("stale", PluginFormat::VST3)};
+
+    REQUIRE(bs.start(
+        nullptr,
+        [](const std::string&, int, int) {
+            FAIL("progress should not fire without a worker");
+        },
+        [&](std::vector<PluginInfo> results, bool cancelled) {
+            final_results = std::move(results);
+            final_cancelled = cancelled;
+            completion_called = true;
+        }));
+
+    bs.join();
+    REQUIRE(completion_called);
+    REQUIRE_FALSE(final_cancelled);
+    REQUIRE(final_results.empty());
+}
+
+TEST_CASE("BackgroundScanner: idle cancel and join are no-ops",
+          "[host][bg-scan][coverage]") {
+    BackgroundScanner bs;
+    REQUIRE_FALSE(bs.is_running());
+    bs.cancel();
+    bs.join();
+    REQUIRE_FALSE(bs.is_running());
+}
+
 TEST_CASE("BackgroundScanner: second start while running returns false",
           "[host][bg-scan]") {
     BackgroundScanner bs;
@@ -224,6 +257,16 @@ TEST_CASE("BackgroundScanner: progress callback fires from worker thread",
     bs.join();
     REQUIRE(done.load());
     REQUIRE(progress_calls.load() == 2);
+}
+
+TEST_CASE("CancelToken reset clears a prior cancellation request",
+          "[host][bg-scan][coverage]") {
+    CancelToken token;
+    REQUIRE_FALSE(token.requested());
+    token.request();
+    REQUIRE(token.requested());
+    token.reset();
+    REQUIRE_FALSE(token.requested());
 }
 
 TEST_CASE("BackgroundScanner: destructor cancels + joins any running worker",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -494,6 +494,9 @@ TEST_CASE("Expression evaluator resolves variables and rejects malformed inputs"
 
     REQUIRE_FALSE(evaluate("missing + 1").has_value());
     REQUIRE_FALSE(evaluate("min(1)").has_value());
+    REQUIRE_FALSE(evaluate("1e").has_value());
+    REQUIRE_FALSE(evaluate("1e+").has_value());
+    REQUIRE_FALSE(evaluate("1e-").has_value());
     REQUIRE_FALSE(evaluate("(1 + 2").has_value());
     REQUIRE_FALSE(evaluate("").has_value());
 }

--- a/test/test_v3_gaps.cpp
+++ b/test/test_v3_gaps.cpp
@@ -417,6 +417,8 @@ TEST_CASE("Expression rejects malformed numeric and grouping syntax",
     REQUIRE_FALSE(pulp::runtime::evaluate("").has_value());
     REQUIRE_FALSE(pulp::runtime::evaluate(".").has_value());
     REQUIRE_FALSE(pulp::runtime::evaluate("1e").has_value());
+    REQUIRE_FALSE(pulp::runtime::evaluate("1e+").has_value());
+    REQUIRE_FALSE(pulp::runtime::evaluate("1e-").has_value());
     REQUIRE_FALSE(pulp::runtime::evaluate("(1 + 2").has_value());
     REQUIRE_FALSE(pulp::runtime::evaluate("1 + )").has_value());
     REQUIRE_FALSE(pulp::runtime::evaluate("pow(2, 3").has_value());

--- a/test/test_v3_gaps.cpp
+++ b/test/test_v3_gaps.cpp
@@ -412,6 +412,24 @@ TEST_CASE("Expression rejects malformed calls and trailing tokens", "[runtime][e
     REQUIRE_FALSE(pulp::runtime::evaluate("1 2").has_value());
 }
 
+TEST_CASE("Expression rejects malformed numeric and grouping syntax",
+          "[runtime][expression][coverage]") {
+    REQUIRE_FALSE(pulp::runtime::evaluate("").has_value());
+    REQUIRE_FALSE(pulp::runtime::evaluate(".").has_value());
+    REQUIRE_FALSE(pulp::runtime::evaluate("1e").has_value());
+    REQUIRE_FALSE(pulp::runtime::evaluate("(1 + 2").has_value());
+    REQUIRE_FALSE(pulp::runtime::evaluate("1 + )").has_value());
+    REQUIRE_FALSE(pulp::runtime::evaluate("pow(2, 3").has_value());
+}
+
+TEST_CASE("Expression covers unary and nested function combinations",
+          "[runtime][expression][coverage]") {
+    REQUIRE_THAT(*pulp::runtime::evaluate("-(-4)"), WithinAbs(4.0, 1e-10));
+    REQUIRE_THAT(*pulp::runtime::evaluate("max(min(9, 4), abs(-3))"),
+                 WithinAbs(4.0, 1e-10));
+    REQUIRE_THAT(*pulp::runtime::evaluate("2 ^ -2"), WithinAbs(0.25, 1e-10));
+}
+
 TEST_CASE("ExpressionEvaluator custom functions and clearing", "[runtime][expression][issue-641]") {
     pulp::runtime::ExpressionEvaluator eval;
     eval.set("x", 4.0);


### PR DESCRIPTION
## Summary
- add runtime helper coverage for base64 zero-length input, IPv4 helpers, text diff LCS tie behavior, range singleton/empty constraints, and scope guards
- add host background scanner lifecycle coverage and scan blacklist parsing/save edge coverage
- tighten expression parser exponent validation and cover malformed/nested expression edges

## Local validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF
- cmake --build build --target pulp-test-runtime-utils pulp-test-background-scanner pulp-test-scan-blacklist pulp-test-v3-gaps -j8
- ./build/test/pulp-test-runtime-utils
- ./build/test/pulp-test-background-scanner
- ./build/test/pulp-test-scan-blacklist
- ./build/test/pulp-test-v3-gaps
- git diff --check

Note: direct push pre-push diff-cover hit the known FetchContent mbedtls v3.6.2 invalid-reference setup failure; focused tests above are green and GitHub-hosted CI is the merge gate.