### PR TITLE
docs(ci): codify REST fallback when GraphQL is exhausted

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1316,6 +1316,44 @@ command to record the push as supervised AND suppress the warning.
 
 After the obstacle clears, resume `shipyard pr` on the next PR.
 
+### GraphQL exhaustion fallback
+
+GitHub's GraphQL quota is independent from the REST `core` quota and is easier
+to burn during broad PR sweeps because `gh pr list/view/merge --json ...`
+queries large nested PR/check payloads. When GraphQL is exhausted, do not idle
+and do not keep retrying GraphQL-backed commands in a loop.
+
+Check quota explicitly:
+
+```bash
+gh api rate_limit --jq '.resources | {core, graphql}'
+```
+
+Fallback rules while `graphql.remaining == 0`:
+
+- Use REST for status polling:
+  `gh api repos/OWNER/REPO/pulls/PR`,
+  `gh api repos/OWNER/REPO/commits/SHA/check-runs?per_page=100`, and
+  `gh api repos/OWNER/REPO/actions/jobs/JOB_ID/logs`.
+- Treat `gh pr view --json`, `gh pr list --json`, and `gh pr merge` as
+  unavailable unless proven otherwise; those paths commonly fail before REST
+  quota is close to exhausted.
+- If a PR is verified green via REST (required checks green, no actionable
+  failures in the checks being honored for that lane), merge via REST:
+
+```bash
+gh api repos/OWNER/REPO/pulls/PR/merge \
+  -X PUT \
+  -f merge_method=squash \
+  -f commit_title='subject (#PR)'
+```
+
+If REST merge returns `405 Base branch was modified`, refresh the PR's REST
+state and retry once after the base settles. If checks have re-queued or the
+head SHA changed, re-evaluate before merging. This fallback is for GitHub API
+transport exhaustion only; it does not relax the requirement to fix real CI,
+coverage, sanitizer, or review failures.
+
 ## Self-hosted runner ops
 
 Pulp's required `macos` branch-protection check on `main` routes

--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1342,17 +1342,21 @@ Fallback rules while `graphql.remaining == 0`:
   failures in the checks being honored for that lane), merge via REST:
 
 ```bash
+head_sha=$(gh api repos/OWNER/REPO/pulls/PR --jq '.head.sha')
 gh api repos/OWNER/REPO/pulls/PR/merge \
   -X PUT \
+  -f sha="$head_sha" \
   -f merge_method=squash \
   -f commit_title='subject (#PR)'
 ```
 
 If REST merge returns `405 Base branch was modified`, refresh the PR's REST
-state and retry once after the base settles. If checks have re-queued or the
-head SHA changed, re-evaluate before merging. This fallback is for GitHub API
-transport exhaustion only; it does not relax the requirement to fix real CI,
-coverage, sanitizer, or review failures.
+state and check runs, recompute `head_sha`, and retry once after the base
+settles only if the refreshed head SHA and green status are still the values
+you intend to merge. If checks have re-queued or the head SHA changed,
+re-evaluate before merging. This fallback is for GitHub API transport
+exhaustion only; it does not relax the requirement to fix real CI, coverage,
+sanitizer, or review failures.
 
 ## Self-hosted runner ops
 

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -322,6 +322,36 @@ shipyard update --dry-run                 # plan only
 shipyard wait pr <PR> --state green       # REST fallback as of v0.56.2
 ```
 
+### GraphQL quota fallback for PR sweeps
+
+The `gh pr ... --json` and `gh pr merge` paths can consume or require GitHub's
+GraphQL quota. That quota is separate from the REST `core` quota and can hit
+zero while REST still has thousands of calls available.
+
+When a broad PR sweep hits GraphQL exhaustion, switch the sweep to REST instead
+of waiting:
+
+```bash
+gh api rate_limit --jq '.resources | {core, graphql}'
+gh api repos/OWNER/REPO/pulls/PR
+gh api repos/OWNER/REPO/commits/SHA/check-runs?per_page=100
+gh api repos/OWNER/REPO/actions/jobs/JOB_ID/logs
+```
+
+For a PR already verified green through REST, merge through the REST endpoint:
+
+```bash
+gh api repos/OWNER/REPO/pulls/PR/merge \
+  -X PUT \
+  -f merge_method=squash \
+  -f commit_title='subject (#PR)'
+```
+
+If the merge endpoint returns `405 Base branch was modified`, refresh the PR
+state and check runs through REST, then retry once only if the head SHA and
+green status still match. This is a transport fallback, not a validation
+bypass: do not merge around real CI, coverage, sanitizer, or review failures.
+
 Use `shipyard rescue` when a PR is otherwise ready but blocked by queued,
 cancelled, or failed runner contexts caused by a self-hosted-runner wedge. It is
 the PR-side recovery path and avoids the old failure mode where cancelling

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -341,16 +341,19 @@ gh api repos/OWNER/REPO/actions/jobs/JOB_ID/logs
 For a PR already verified green through REST, merge through the REST endpoint:
 
 ```bash
+head_sha=$(gh api repos/OWNER/REPO/pulls/PR --jq '.head.sha')
 gh api repos/OWNER/REPO/pulls/PR/merge \
   -X PUT \
+  -f sha="$head_sha" \
   -f merge_method=squash \
   -f commit_title='subject (#PR)'
 ```
 
 If the merge endpoint returns `405 Base branch was modified`, refresh the PR
-state and check runs through REST, then retry once only if the head SHA and
-green status still match. This is a transport fallback, not a validation
-bypass: do not merge around real CI, coverage, sanitizer, or review failures.
+state and check runs through REST, recompute `head_sha`, then retry once only
+if the refreshed head SHA and green status are still the values you intend to
+merge. This is a transport fallback, not a validation bypass: do not merge
+around real CI, coverage, sanitizer, or review failures.
 
 Use `shipyard rescue` when a PR is otherwise ready but blocked by queued,
 cancelled, or failed runner contexts caused by a self-hosted-runner wedge. It is


### PR DESCRIPTION
Codifies the operational fallback we used today: when GitHub GraphQL quota is exhausted, use REST for PR polling, check-run inspection, job logs, and REST merge for PRs already verified green. This is explicitly a transport fallback, not a validation bypass.