### PR TITLE
feat(view): focus-guard for bare-key global shortcuts

### DIFF
--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -511,6 +511,26 @@ mouse / pointer / wheel on macOS. Every dispatcher MUST:
 - Leave `on_mouse_down` / `on_mouse_drag` / `on_mouse_up` deepest-wins
   (those are the JUCE-style click channel, not the W3C bubbling channel).
 
+### registerShortcut focus-guard
+
+`WidgetBridge::forward_key_event` checks `registerShortcut` entries
+before falling through to the W3C `__global__` keydown dispatch. To
+prevent global bare-key shortcuts (`?` for cheatsheet, etc.) from
+firing while the user types into a text input, the loop reads
+`View::focused_input_` and suppresses any registered shortcut whose
+modifier mask has no `kModCtrl|kModAlt|kModMeta|kModCmd` bit set.
+Shift alone counts as bare (Shift only picks the upper-case glyph).
+Modifier chords (`Cmd+S`, `Cmd+,`) always fire — they are always-global
+by design and must work even when an editor has focus.
+
+The focused-input slot is the same one used by the macOS PulpView for
+text-input dispatch (#1708); TextEditor-like widgets claim it via
+`View::claim_input_focus()` and release on focus-out / destruction.
+
+Prereq for the default-shortcuts pass (`planning/2026-05-16-default-
+keyboard-shortcuts.md`), which adds a bare-`?` cheatsheet binding to
+imported designs.
+
 ### Tests that pin the contract
 
 `test/test_widget_bridge.cpp` — `[contract]` tag:
@@ -518,6 +538,7 @@ mouse / pointer / wheel on macOS. Every dispatcher MUST:
 - "Event contract: W3C MouseEvent.button maps left=0, middle=1, right=2"
 - "Event contract: forward_key_event emits W3C UIEvent.key strings + modifier booleans"
 - "Event contract: window.addEventListener('keydown', fn) receives __global__ keydown"
+- "WidgetBridge focus-guard: bare-key shortcuts suppressed while text input focused"
 - "Event contract: __dispatch__ try/catch keeps listeners alive after a handler throws"
 - "Event contract: wheel dispatch is an object {deltaX,deltaY,clientX,clientY}"
 - "Event contract: registerPointer/registerWheel are idempotent (no lambda-stack growth)"

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -516,16 +516,23 @@ mouse / pointer / wheel on macOS. Every dispatcher MUST:
 `WidgetBridge::forward_key_event` checks `registerShortcut` entries
 before falling through to the W3C `__global__` keydown dispatch. To
 prevent global bare-key shortcuts (`?` for cheatsheet, etc.) from
-firing while the user types into a text input, the loop reads
-`View::focused_input_` and suppresses any registered shortcut whose
-modifier mask has no `kModCtrl|kModAlt|kModMeta|kModCmd` bit set.
-Shift alone counts as bare (Shift only picks the upper-case glyph).
-Modifier chords (`Cmd+S`, `Cmd+,`) always fire — they are always-global
-by design and must work even when an editor has focus.
+firing while the user types into a text input, the loop suppresses any
+registered shortcut whose modifier mask has no
+`kModCtrl|kModAlt|kModMeta|kModCmd` bit set, IF a text-accepting
+widget currently has focus. Shift alone counts as bare (Shift only
+picks the upper-case glyph). Modifier chords (`Cmd+S`, `Cmd+,`) always
+fire — they are always-global by design and must work even when an
+editor has focus.
 
-The focused-input slot is the same one used by the macOS PulpView for
-text-input dispatch (#1708); TextEditor-like widgets claim it via
-`View::claim_input_focus()` and release on focus-out / destruction.
+The focus signal is `View::focused_input_` (the same static slot the
+macOS PulpView already maintains for text-input dispatch, #1708)
+**narrowed** by `View::accepts_text_input()`. The slot is populated
+for ANY focusable widget — Knob, Button, ListBox, TextEditor — via the
+window-host focus path, so checking just `focused_input_ != nullptr`
+would wrongly kill bare-key shortcuts after clicking a knob (Codex P1
+finding on #2120). The virtual `accepts_text_input()` returns false by
+default; only `TextEditor` (and any future text-input widget) overrides
+to true.
 
 Prereq for the default-shortcuts pass (`planning/2026-05-16-default-
 keyboard-shortcuts.md`), which adds a bare-`?` cheatsheet binding to

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.39.1",
+      "version": "0.40.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.39.1"
+  "version": "0.40.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v01040"></a>
+## [0.40.0]
+
+## [0.105.0]
+
 ## [0.104.0] - 2026-05-16
 
 - feat(design-import): extract keyboard shortcuts from React source (V1) ([#2116](https://github.com/danielraffel/pulp/pull/2116))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.104.0
+    VERSION 0.105.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/text_editor.hpp
+++ b/core/view/include/pulp/view/text_editor.hpp
@@ -38,6 +38,8 @@ class TextEditor : public View {
 public:
     TextEditor() { set_focusable(true); set_cursor(CursorStyle::text); }
 
+    bool accepts_text_input() const override { return true; }
+
     static constexpr int kMaxUndoHistory = 1000;
 
     // ── Configuration ────────────────────────────────────────────────────

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -231,6 +231,15 @@ public:
     bool focusable() const { return focusable_; }
     void set_focusable(bool f) { focusable_ = f; }
 
+    /// Does this widget consume printable character keys for text entry?
+    /// Default false. Override to true on TextEditor and any future
+    /// text-accepting widget. Used by `WidgetBridge::forward_key_event`
+    /// to suppress bare-key global shortcuts (e.g. bare `?` for cheatsheet)
+    /// while the user is typing — non-text focusables like Knob, Button,
+    /// ListBox return false so single-key shortcuts still fire after they
+    /// take focus.
+    virtual bool accepts_text_input() const { return false; }
+
     /// CSS :disabled equivalent — blocks input, reduces opacity
     bool enabled() const { return enabled_; }
     void set_enabled(bool e) { enabled_ = e; }

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -9438,10 +9438,24 @@ static std::string keycode_to_w3c_key(int key_code, bool shift_held) {
 void WidgetBridge::forward_key_event(int key_code, uint16_t modifiers, bool is_down) {
     if (!is_down) return;
 
-    // Check registered shortcuts first
+    // Check registered shortcuts first. Bare-key shortcuts (no Ctrl/Alt/
+    // Meta/Cmd — Shift alone counts as bare since it just selects the
+    // upper-case glyph) are suppressed while a text input has keyboard
+    // focus, so a user typing `?` into a search box doesn't trigger a
+    // global "open cheatsheet" handler. Modifier chords always fire —
+    // Cmd+S, Cmd+,, etc. are always-global by design.
+    constexpr uint16_t kGlobalModifierMask =
+        kModCtrl | kModAlt | kModMeta | kModCmd;
+    const bool has_global_modifier = (modifiers & kGlobalModifierMask) != 0;
+    const bool text_input_focused  = (View::focused_input_ != nullptr);
+
     auto kc = static_cast<KeyCode>(key_code);
     for (auto& s : shortcuts_) {
         if (s.key == kc && s.modifiers == modifiers) {
+            if (!has_global_modifier && text_input_focused) {
+                // Let the key fall through to the focused text input.
+                break;
+            }
             engine_.evaluate(s.callback + "()");
             return;
         }

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -9440,14 +9440,24 @@ void WidgetBridge::forward_key_event(int key_code, uint16_t modifiers, bool is_d
 
     // Check registered shortcuts first. Bare-key shortcuts (no Ctrl/Alt/
     // Meta/Cmd — Shift alone counts as bare since it just selects the
-    // upper-case glyph) are suppressed while a text input has keyboard
-    // focus, so a user typing `?` into a search box doesn't trigger a
-    // global "open cheatsheet" handler. Modifier chords always fire —
-    // Cmd+S, Cmd+,, etc. are always-global by design.
+    // upper-case glyph) are suppressed while a text-accepting widget has
+    // keyboard focus, so a user typing `?` into a search box doesn't
+    // trigger a global "open cheatsheet" handler. Modifier chords always
+    // fire — Cmd+S, Cmd+,, etc. are always-global by design.
+    //
+    // The focus slot `View::focused_input_` is claimed by ANY focusable
+    // widget (Knob, Button, ListBox, TextEditor, ...) via the macOS host
+    // focus path. We narrow that to text-accepting widgets via the virtual
+    // `View::accepts_text_input()` — defaults false; only TextEditor (and
+    // any future text-input widget) returns true. Otherwise focusing a
+    // knob would silently kill every single-key shortcut until focus
+    // moved off it.
     constexpr uint16_t kGlobalModifierMask =
         kModCtrl | kModAlt | kModMeta | kModCmd;
     const bool has_global_modifier = (modifiers & kGlobalModifierMask) != 0;
-    const bool text_input_focused  = (View::focused_input_ != nullptr);
+    const bool text_input_focused  =
+        (View::focused_input_ != nullptr &&
+         View::focused_input_->accepts_text_input());
 
     auto kc = static_cast<KeyCode>(key_code);
     for (auto& s : shortcuts_) {

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -14004,11 +14004,11 @@ TEST_CASE("WidgetBridge focus-guard: bare-key shortcuts suppressed while text in
         REQUIRE(engine.evaluate("bare_count").getWithDefault<int>(0) == 1);
     }
 
-    SECTION("input focused: bare-key suppressed") {
-        View input;
-        input.set_focusable(true);
+    SECTION("text input focused: bare-key suppressed") {
+        TextEditor input;
         input.claim_input_focus();
         REQUIRE(View::focused_input_ == &input);
+        REQUIRE(input.accepts_text_input());
 
         bridge.forward_key_event(63, 0, true);
         REQUIRE(engine.evaluate("bare_count").getWithDefault<int>(0) == 0);
@@ -14026,9 +14026,28 @@ TEST_CASE("WidgetBridge focus-guard: bare-key shortcuts suppressed while text in
         REQUIRE(View::focused_input_ == nullptr);
     }
 
+    SECTION("non-text focusable (knob/button) focused: bare-key still fires") {
+        // Codex review pin (#2120): `focused_input_` is claimed by any
+        // focusable widget, not just text inputs. The guard MUST check
+        // `accepts_text_input()` — otherwise clicking a knob would kill
+        // every global single-key shortcut until focus moved away.
+        View knob_like;
+        knob_like.set_focusable(true);
+        knob_like.claim_input_focus();
+        REQUIRE(View::focused_input_ == &knob_like);
+        REQUIRE_FALSE(knob_like.accepts_text_input());
+
+        bridge.forward_key_event(63, 0, true);
+        REQUIRE(engine.evaluate("bare_count").getWithDefault<int>(0) == 1);
+
+        bridge.forward_key_event(63, 1, true);
+        REQUIRE(engine.evaluate("shift_count").getWithDefault<int>(0) == 1);
+
+        knob_like.release_input_focus();
+    }
+
     SECTION("focus released: bare-key fires again") {
-        View input;
-        input.set_focusable(true);
+        TextEditor input;
         input.claim_input_focus();
         bridge.forward_key_event(63, 0, true);
         REQUIRE(engine.evaluate("bare_count").getWithDefault<int>(0) == 0);

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -13957,3 +13957,84 @@ TEST_CASE("minWidth / minHeight / maxWidth / maxHeight route % and calc-family t
     REQUIRE(xh_calc_px->flex().dim_max_height.unit == DimensionUnit::px);
     REQUIRE_THAT(xh_calc_px->flex().dim_max_height.value, WithinAbs(150.0f, 0.001f));
 }
+
+// Focus-guard for global key shortcuts. Bare-key shortcuts (no Ctrl/Alt/
+// Meta/Cmd; Shift alone counts as bare since it just picks the upper-case
+// glyph) must NOT fire while a text input has focus — otherwise typing a
+// `?` into a search box would open the global cheatsheet. Modifier chords
+// (Cmd+S, Cmd+,) are always-global by design and must still fire when an
+// input is focused.
+//
+// Prereq for the default-shortcuts pass (planning/2026-05-16-default-
+// keyboard-shortcuts.md), which adds a bare-`?` cheatsheet binding.
+TEST_CASE("WidgetBridge focus-guard: bare-key shortcuts suppressed while text input focused",
+          "[view][bridge][shortcuts][focus-guard]") {
+    using namespace pulp::view;
+
+    // Always start the test with a clean focus slot so prior cases don't
+    // bleed in (the slot is a static and tests share the same process).
+    View::focused_input_ = nullptr;
+
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var bare_count = 0;
+        var shift_count = 0;
+        var cmd_count = 0;
+        function bareHit()  { bare_count++; }
+        function shiftHit() { shift_count++; }
+        function cmdHit()   { cmd_count++; }
+
+        // Bare-`?` (no modifiers): cheatsheet pattern.
+        registerShortcut(63, 0, 'bareHit');
+        // Shift+`?` (kModShift = 1): also bare for guard purposes — Shift
+        // alone is just the glyph selector when typing.
+        registerShortcut(63, 1, 'shiftHit');
+        // Cmd+`,` (kModCmd = 16): always-global modifier chord.
+        registerShortcut(44, 16, 'cmdHit');
+    )");
+
+    SECTION("no input focused: bare-key fires") {
+        REQUIRE(View::focused_input_ == nullptr);
+        bridge.forward_key_event(63, 0, true);
+        REQUIRE(engine.evaluate("bare_count").getWithDefault<int>(0) == 1);
+    }
+
+    SECTION("input focused: bare-key suppressed") {
+        View input;
+        input.set_focusable(true);
+        input.claim_input_focus();
+        REQUIRE(View::focused_input_ == &input);
+
+        bridge.forward_key_event(63, 0, true);
+        REQUIRE(engine.evaluate("bare_count").getWithDefault<int>(0) == 0);
+
+        // Shift alone is also guarded.
+        bridge.forward_key_event(63, 1, true);
+        REQUIRE(engine.evaluate("shift_count").getWithDefault<int>(0) == 0);
+
+        // Modifier chord still fires — Cmd+, opens Settings even from an
+        // input.
+        bridge.forward_key_event(44, 16, true);
+        REQUIRE(engine.evaluate("cmd_count").getWithDefault<int>(0) == 1);
+
+        input.release_input_focus();
+        REQUIRE(View::focused_input_ == nullptr);
+    }
+
+    SECTION("focus released: bare-key fires again") {
+        View input;
+        input.set_focusable(true);
+        input.claim_input_focus();
+        bridge.forward_key_event(63, 0, true);
+        REQUIRE(engine.evaluate("bare_count").getWithDefault<int>(0) == 0);
+
+        input.release_input_focus();
+        bridge.forward_key_event(63, 0, true);
+        REQUIRE(engine.evaluate("bare_count").getWithDefault<int>(0) == 1);
+    }
+}


### PR DESCRIPTION
## Summary

Prereq for the default-shortcuts pass spec'd in `planning/2026-05-16-default-keyboard-shortcuts.md`. Suppresses bare-key `registerShortcut` entries (no Ctrl/Alt/Meta/Cmd; Shift alone counts as bare since it only picks the upper-case glyph) while a text input has keyboard focus. Modifier chords (`Cmd+S`, `Cmd+,`) remain always-global and still fire from inside an input.

Without this guard, the upcoming default that binds bare `?` to "open keyboard cheatsheet" would steal every `?` the user types into a search box. Every web app that uses bare `?` (GitHub, Gmail, Linear, Notion, Slack, Discord) does the same focus check.

### How
The focus signal is `View::focused_input_`, the same static slot the macOS PulpView already maintains for text-input dispatch (#1708). TextEditor-like widgets claim it via `View::claim_input_focus()` on focus-in and release on focus-out / destruction.

Guard lives in `forward_key_event`'s shortcut-match loop. On suppression it `break`s (not `return`s) so the W3C `__dispatch__('__global__', 'keydown', ...)` fan-out still runs and React's `onKeyDown` / `addEventListener` handlers receive the event normally.

### Files
- `core/view/src/widget_bridge.cpp` — guard inside shortcut-match loop in `forward_key_event` (+15 / -1)
- `test/test_widget_bridge.cpp` — new `[focus-guard]` case (+80)
- `.agents/skills/view-bridge/SKILL.md` — focus-guard subsection + contract-test row (+21)

### Test plan
- [x] New `[focus-guard]` case: no input focused → bare-key fires; input focused → bare-key suppressed + Shift+key suppressed + Cmd+chord still fires; focus released → bare-key fires again
- [x] Full widget-bridge suite — 396 cases / 2288 assertions pass locally
- [ ] CI matrix green

### Followup
- #2119 V2 wire-up (already open) — emits the `registerShortcut` lines this guard now governs.
- Default-shortcuts pass (next PR per planning spec) — relies on this guard to land bare-`?` cheatsheet binding safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)