### PR TITLE
test: batch runtime and host coverage edges

### DIFF
--- a/test/test_async_stream.cpp
+++ b/test/test_async_stream.cpp
@@ -25,6 +25,11 @@ public:
     StreamResult read(std::uint8_t* buf, std::size_t size) override {
         std::unique_lock<std::mutex> lock(mutex_);
         if (!open_) return StreamResult::fail(StreamError::Closed);
+        if (read_io_error_) return StreamResult::fail(StreamError::IoError);
+        if (read_zero_ok_count_ > 0) {
+            --read_zero_ok_count_;
+            return StreamResult::make(0);
+        }
         if (read_queue_.empty()) return StreamResult::fail(StreamError::WouldBlock);
         auto& chunk = read_queue_.front();
         auto n = std::min(size, chunk.size());
@@ -40,8 +45,27 @@ public:
     StreamResult write(const std::uint8_t* buf, std::size_t size) override {
         std::lock_guard<std::mutex> lock(mutex_);
         if (!open_) return StreamResult::fail(StreamError::Closed);
-        written_.insert(written_.end(), buf, buf + size);
-        return StreamResult::make(size);
+        if (write_would_block_count_ > 0) {
+            --write_would_block_count_;
+            return StreamResult::fail(StreamError::WouldBlock);
+        }
+        if (write_io_error_) return StreamResult::fail(StreamError::IoError);
+        if (write_io_error_after_bytes_ >= 0 &&
+            static_cast<int>(written_.size()) >= write_io_error_after_bytes_) {
+            return StreamResult::fail(StreamError::IoError);
+        }
+
+        auto n = size;
+        if (write_chunk_limit_ > 0) n = std::min(n, write_chunk_limit_);
+        if (write_io_error_after_bytes_ >= 0) {
+            auto remaining = static_cast<std::size_t>(
+                write_io_error_after_bytes_ - static_cast<int>(written_.size()));
+            n = std::min(n, remaining);
+        }
+        if (n == 0) return StreamResult::fail(StreamError::IoError);
+
+        written_.insert(written_.end(), buf, buf + n);
+        return StreamResult::make(n);
     }
 
     void close() override {
@@ -59,6 +83,36 @@ public:
         read_queue_.push_back(std::move(data));
     }
 
+    void set_read_zero_ok_count(int count) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        read_zero_ok_count_ = count;
+    }
+
+    void set_read_io_error(bool enabled) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        read_io_error_ = enabled;
+    }
+
+    void set_write_chunk_limit(std::size_t limit) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        write_chunk_limit_ = limit;
+    }
+
+    void set_write_would_block_count(int count) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        write_would_block_count_ = count;
+    }
+
+    void set_write_io_error(bool enabled) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        write_io_error_ = enabled;
+    }
+
+    void set_write_io_error_after_bytes(int bytes) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        write_io_error_after_bytes_ = bytes;
+    }
+
     std::vector<std::uint8_t> captured_writes() const {
         std::lock_guard<std::mutex> lock(mutex_);
         return written_;
@@ -68,6 +122,12 @@ private:
     mutable std::mutex mutex_;
     std::vector<std::vector<std::uint8_t>> read_queue_;
     std::vector<std::uint8_t> written_;
+    std::size_t write_chunk_limit_ = 0;
+    int write_would_block_count_ = 0;
+    int write_io_error_after_bytes_ = -1;
+    int read_zero_ok_count_ = 0;
+    bool read_io_error_ = false;
+    bool write_io_error_ = false;
     bool open_ = true;
 };
 
@@ -289,4 +349,147 @@ TEST_CASE("AsyncStream executor routes callbacks off worker", "[async_stream]") 
     for (auto& fn : to_run) fn();
 
     REQUIRE(received.load() == 3);
+}
+
+TEST_CASE("AsyncStream retries WouldBlock and partial writes before draining",
+          "[async_stream][coverage][phase3]") {
+    auto backing = std::make_unique<TestStream>();
+    auto* raw = backing.get();
+    raw->set_write_chunk_limit(2);
+    raw->set_write_would_block_count(1);
+
+    AsyncStream::Options opts;
+    opts.auto_read = false;
+    AsyncStream stream(std::move(backing), opts);
+
+    std::atomic<int> completions{0};
+    std::atomic<int> drains{0};
+    std::atomic<std::size_t> total_bytes{0};
+    std::atomic<StreamError> last_error{StreamError::Closed};
+    const std::uint8_t second[] = {'e', 'f'};
+
+    stream.on_drain([&] {
+        auto previous = drains.fetch_add(1);
+        if (previous == 0) {
+            REQUIRE(stream.write_async(second, sizeof(second),
+                                       [&](std::size_t n, StreamError err) {
+                                           total_bytes.fetch_add(n);
+                                           last_error.store(err);
+                                           completions.fetch_add(1);
+                                       }));
+        }
+    });
+
+    stream.start();
+    const std::uint8_t first[] = {'a', 'b', 'c', 'd'};
+    REQUIRE(stream.write_async(first, sizeof(first),
+                               [&](std::size_t n, StreamError err) {
+                                   total_bytes.fetch_add(n);
+                                   last_error.store(err);
+                                   completions.fetch_add(1);
+                               }));
+
+    REQUIRE(wait_until([&] { return completions.load() == 2 && drains.load() == 2; }));
+    REQUIRE(total_bytes.load() == 6);
+    REQUIRE(last_error.load() == StreamError::Ok);
+    REQUIRE(stream.pending_write_bytes() == 0);
+
+    auto captured = raw->captured_writes();
+    REQUIRE(captured == std::vector<std::uint8_t>{'a', 'b', 'c', 'd', 'e', 'f'});
+}
+
+TEST_CASE("AsyncStream reports partial write errors and stops writer",
+          "[async_stream][coverage][phase3]") {
+    auto backing = std::make_unique<TestStream>();
+    auto* raw = backing.get();
+    raw->set_write_chunk_limit(2);
+    raw->set_write_io_error_after_bytes(2);
+
+    AsyncStream::Options opts;
+    opts.auto_read = false;
+    AsyncStream stream(std::move(backing), opts);
+
+    std::atomic<bool> write_done{false};
+    std::atomic<bool> error_seen{false};
+    std::atomic<std::size_t> callback_bytes{99};
+    std::atomic<StreamError> callback_error{StreamError::Ok};
+    std::atomic<StreamError> stream_error{StreamError::Ok};
+
+    stream.on_error([&](StreamError err) {
+        stream_error.store(err);
+        error_seen.store(true);
+    });
+
+    stream.start();
+    const std::uint8_t payload[] = {'f', 'a', 'i', 'l'};
+    REQUIRE(stream.write_async(payload, sizeof(payload),
+                               [&](std::size_t n, StreamError err) {
+                                   callback_bytes.store(n);
+                                   callback_error.store(err);
+                                   write_done.store(true);
+                               }));
+
+    REQUIRE(wait_until([&] { return write_done.load() && error_seen.load(); }));
+    REQUIRE(callback_bytes.load() == 2);
+    REQUIRE(callback_error.load() == StreamError::IoError);
+    REQUIRE(stream_error.load() == StreamError::IoError);
+    REQUIRE(stream.pending_write_bytes() == 0);
+
+    auto captured = raw->captured_writes();
+    REQUIRE(captured == std::vector<std::uint8_t>{'f', 'a'});
+}
+
+TEST_CASE("AsyncStream read loop backs off on zero-byte reads before data",
+          "[async_stream][coverage][phase3]") {
+    auto backing = std::make_unique<TestStream>();
+    auto* raw = backing.get();
+    raw->set_read_zero_ok_count(3);
+
+    AsyncStream::Options opts;
+    opts.read_chunk = 2;
+    AsyncStream stream(std::move(backing), opts);
+
+    std::mutex m;
+    std::vector<std::uint8_t> received;
+    stream.on_data([&](const std::uint8_t* data, std::size_t n) {
+        std::lock_guard<std::mutex> lock(m);
+        received.insert(received.end(), data, data + n);
+    });
+
+    raw->push_read({1, 2, 3});
+    stream.start();
+
+    REQUIRE(wait_until([&] {
+        std::lock_guard<std::mutex> lock(m);
+        return received.size() == 3;
+    }));
+
+    std::lock_guard<std::mutex> lock(m);
+    REQUIRE(received == std::vector<std::uint8_t>{1, 2, 3});
+}
+
+TEST_CASE("AsyncStream read errors fire on_error and close fires once on stop",
+          "[async_stream][coverage][phase3]") {
+    auto backing = std::make_unique<TestStream>();
+    auto* raw = backing.get();
+    raw->set_read_io_error(true);
+
+    AsyncStream stream(std::move(backing));
+
+    std::atomic<int> errors{0};
+    std::atomic<int> closes{0};
+    std::atomic<StreamError> last_error{StreamError::Ok};
+    stream.on_error([&](StreamError err) {
+        last_error.store(err);
+        errors.fetch_add(1);
+    });
+    stream.on_close([&] { closes.fetch_add(1); });
+
+    stream.start();
+    REQUIRE(wait_until([&] { return errors.load() == 1; }));
+    REQUIRE(last_error.load() == StreamError::IoError);
+
+    stream.stop();
+    stream.stop();
+    REQUIRE(closes.load() == 1);
 }

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -1,9 +1,57 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/runtime/i18n.hpp>
 #include <pulp/runtime/temporary_file.hpp>
+#include <cstdlib>
 #include <fstream>
+#include <optional>
+#include <string>
 
 using namespace pulp::runtime;
+
+namespace {
+
+class ScopedLang {
+public:
+    explicit ScopedLang(const char* value) {
+        if (const char* existing = std::getenv("LANG"))
+            previous_ = std::string(existing);
+        if (value)
+            set(value);
+        else
+            unset();
+    }
+
+    ~ScopedLang() {
+        if (previous_)
+            set(previous_->c_str());
+        else
+            unset();
+    }
+
+    ScopedLang(const ScopedLang&) = delete;
+    ScopedLang& operator=(const ScopedLang&) = delete;
+
+private:
+    static void set(const char* value) {
+#if defined(_WIN32)
+        _putenv_s("LANG", value);
+#else
+        setenv("LANG", value, 1);
+#endif
+    }
+
+    static void unset() {
+#if defined(_WIN32)
+        _putenv_s("LANG", "");
+#else
+        unsetenv("LANG");
+#endif
+    }
+
+    std::optional<std::string> previous_;
+};
+
+} // namespace
 
 // ── In-memory operations ────────────────────────────────────────────────
 
@@ -327,4 +375,21 @@ TEST_CASE("i18n global tr supports argument substitution", "[runtime][i18n][issu
 TEST_CASE("i18n system_locale returns non-empty", "[runtime][i18n]") {
     auto locale = LocalisedStrings::system_locale();
     REQUIRE_FALSE(locale.empty());
+}
+
+TEST_CASE("i18n system_locale normalizes LANG where supported",
+          "[runtime][i18n][coverage]") {
+    ScopedLang lang("fr_CA.UTF-8");
+
+#if defined(_WIN32)
+    REQUIRE(LocalisedStrings::system_locale() == "fr_CA.UTF-8");
+#else
+    REQUIRE(LocalisedStrings::system_locale() == "fr");
+#endif
+}
+
+TEST_CASE("i18n system_locale falls back when LANG is absent",
+          "[runtime][i18n][coverage]") {
+    ScopedLang lang(nullptr);
+    REQUIRE(LocalisedStrings::system_locale() == "en");
 }

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -1,8 +1,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/runtime/dynamic_library.hpp>
+#include <pulp/runtime/high_resolution_timer.hpp>
 #include <pulp/runtime/runtime.hpp>
 #include <pulp/runtime/temporary_file.hpp>
 #include <array>
+#include <atomic>
+#include <chrono>
 #include <cstdlib>
 #include <ctime>
 #include <filesystem>
@@ -14,6 +17,7 @@
 #include <utility>
 
 using namespace pulp::runtime;
+using namespace std::chrono_literals;
 
 namespace {
 
@@ -460,4 +464,58 @@ TEST_CASE("DynamicLibrary move transfers an open handle", "[runtime][dynamic_lib
     REQUIRE_FALSE(moved.is_open());
     REQUIRE(assigned.is_open());
     REQUIRE(assigned.find_symbol(symbol) != nullptr);
+}
+
+TEST_CASE("HighResolutionTimer starts stops and reports running state",
+          "[runtime][timer][coverage][phase3]") {
+    HighResolutionTimer timer;
+    std::atomic<int> calls{0};
+
+    REQUIRE_FALSE(timer.is_running());
+    timer.start(5ms, [&] { calls.fetch_add(1, std::memory_order_relaxed); });
+    REQUIRE(timer.is_running());
+
+    const auto deadline = std::chrono::steady_clock::now() + 250ms;
+    while (calls.load(std::memory_order_relaxed) < 2 &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(2ms);
+    }
+
+    REQUIRE(calls.load(std::memory_order_relaxed) >= 2);
+    timer.stop();
+    REQUIRE_FALSE(timer.is_running());
+
+    const auto stopped_count = calls.load(std::memory_order_relaxed);
+    std::this_thread::sleep_for(20ms);
+    REQUIRE(calls.load(std::memory_order_relaxed) == stopped_count);
+
+    timer.stop();
+    REQUIRE_FALSE(timer.is_running());
+}
+
+TEST_CASE("HighResolutionTimer restart replaces callback",
+          "[runtime][timer][coverage][phase3]") {
+    HighResolutionTimer timer;
+    std::atomic<int> first{0};
+    std::atomic<int> second{0};
+
+    timer.start(20ms, [&] { first.fetch_add(1, std::memory_order_relaxed); });
+    std::this_thread::sleep_for(30ms);
+    timer.start(5ms, [&] { second.fetch_add(1, std::memory_order_relaxed); });
+
+    const auto first_after_restart = first.load(std::memory_order_relaxed);
+    const auto deadline = std::chrono::steady_clock::now() + 250ms;
+    while (second.load(std::memory_order_relaxed) < 2 &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(2ms);
+    }
+
+    timer.stop();
+    REQUIRE(second.load(std::memory_order_relaxed) >= 2);
+    REQUIRE(first.load(std::memory_order_relaxed) == first_after_restart);
+
+    timer.start(5ms, {});
+    REQUIRE(timer.is_running());
+    timer.stop();
+    REQUIRE_FALSE(timer.is_running());
 }

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -2,15 +2,66 @@
 #include <pulp/runtime/dynamic_library.hpp>
 #include <pulp/runtime/runtime.hpp>
 #include <pulp/runtime/temporary_file.hpp>
+#include <array>
 #include <cstdlib>
 #include <ctime>
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <utility>
 
 using namespace pulp::runtime;
+
+namespace {
+
+class ScopedEnvVar {
+public:
+    explicit ScopedEnvVar(const char* name)
+        : name_(name)
+        , previous_(get_env(name)) {}
+
+    ~ScopedEnvVar() {
+        if (previous_) {
+#ifdef _WIN32
+            static_cast<void>(_putenv_s(name_, previous_->c_str()));
+#else
+            static_cast<void>(setenv(name_, previous_->c_str(), 1));
+#endif
+        } else {
+#ifdef _WIN32
+            static_cast<void>(_putenv_s(name_, ""));
+#else
+            static_cast<void>(unsetenv(name_));
+#endif
+        }
+    }
+
+    void set(std::string_view value) const {
+        std::string owned(value);
+#ifdef _WIN32
+        REQUIRE(_putenv_s(name_, owned.c_str()) == 0);
+#else
+        REQUIRE(setenv(name_, owned.c_str(), 1) == 0);
+#endif
+    }
+
+    void unset() const {
+#ifdef _WIN32
+        REQUIRE(_putenv_s(name_, "") == 0);
+#else
+        REQUIRE(unsetenv(name_) == 0);
+#endif
+    }
+
+private:
+    const char* name_;
+    std::optional<std::string> previous_;
+};
+
+} // namespace
 
 TEST_CASE("SpscQueue basic operations", "[runtime][spsc]") {
     SpscQueue<int, 16> q;
@@ -175,6 +226,30 @@ TEST_CASE("Runtime environment helpers", "[runtime][system]") {
     REQUIRE_FALSE(get_env("PULP_RUNTIME_TEST_ENV_DOES_NOT_EXIST"));
 }
 
+TEST_CASE("Runtime environment helpers treat unset and empty as missing",
+          "[runtime][system][codecov]") {
+    ScopedEnvVar env("PULP_RUNTIME_TEST_EMPTY_ENV");
+
+    env.unset();
+    REQUIRE_FALSE(get_env("PULP_RUNTIME_TEST_EMPTY_ENV").has_value());
+
+    env.set("");
+    REQUIRE_FALSE(get_env("PULP_RUNTIME_TEST_EMPTY_ENV").has_value());
+}
+
+TEST_CASE("Runtime environment helpers preserve non-empty values verbatim",
+          "[runtime][system][codecov]") {
+    ScopedEnvVar env("PULP_RUNTIME_TEST_VERBATIM_ENV");
+
+    env.set(" value with spaces = yes ");
+    auto value = get_env("PULP_RUNTIME_TEST_VERBATIM_ENV");
+    REQUIRE(value.has_value());
+    REQUIRE(*value == " value with spaces = yes ");
+
+    env.set("0");
+    REQUIRE(get_env("PULP_RUNTIME_TEST_VERBATIM_ENV") == std::optional<std::string>{"0"});
+}
+
 TEST_CASE("Runtime GMT helper returns UTC tm", "[runtime][system]") {
     auto tm = gmtime_utc(static_cast<std::time_t>(0));
     REQUIRE(tm.tm_year == 70);
@@ -183,6 +258,17 @@ TEST_CASE("Runtime GMT helper returns UTC tm", "[runtime][system]") {
     REQUIRE(tm.tm_hour == 0);
     REQUIRE(tm.tm_min == 0);
     REQUIRE(tm.tm_sec == 0);
+}
+
+TEST_CASE("Runtime GMT helper handles leap-day timestamps",
+          "[runtime][system][codecov]") {
+    auto tm = gmtime_utc(static_cast<std::time_t>(951827696)); // 2000-02-29 12:34:56 UTC
+    REQUIRE(tm.tm_year == 100);
+    REQUIRE(tm.tm_mon == 1);
+    REQUIRE(tm.tm_mday == 29);
+    REQUIRE(tm.tm_hour == 12);
+    REQUIRE(tm.tm_min == 34);
+    REQUIRE(tm.tm_sec == 56);
 }
 
 TEST_CASE("Runtime localtime helper returns a normalized tm", "[runtime][system][coverage][phase3]") {
@@ -203,6 +289,39 @@ TEST_CASE("Runtime C string copy truncates safely", "[runtime][system]") {
     char buffer[5]{};
     copy_c_string(buffer, "abcdef");
     REQUIRE(std::string(buffer) == "abcd");
+}
+
+TEST_CASE("Runtime C string copy handles exact fits and leaves tail bytes alone",
+          "[runtime][system][codecov]") {
+    char exact[4]{};
+    copy_c_string(exact, "abc");
+    REQUIRE(exact[0] == 'a');
+    REQUIRE(exact[1] == 'b');
+    REQUIRE(exact[2] == 'c');
+    REQUIRE(exact[3] == '\0');
+
+    std::array<char, 6> padded{'?', '?', '?', '?', '?', '?'};
+    copy_c_string(padded.data(), padded.size(), "xy");
+    REQUIRE(padded[0] == 'x');
+    REQUIRE(padded[1] == 'y');
+    REQUIRE(padded[2] == '\0');
+    REQUIRE(padded[3] == '?');
+    REQUIRE(padded[4] == '?');
+    REQUIRE(padded[5] == '?');
+}
+
+TEST_CASE("Runtime C string copy respects string_view length with embedded nulls",
+          "[runtime][system][codecov]") {
+    std::array<char, 5> buffer{'?', '?', '?', '?', '?'};
+    constexpr char source[] = {'a', '\0', 'b'};
+
+    copy_c_string(buffer.data(), buffer.size(), std::string_view(source, sizeof(source)));
+
+    REQUIRE(buffer[0] == 'a');
+    REQUIRE(buffer[1] == '\0');
+    REQUIRE(buffer[2] == 'b');
+    REQUIRE(buffer[3] == '\0');
+    REQUIRE(buffer[4] == '?');
 }
 
 TEST_CASE("Runtime C string copy handles degenerate buffers", "[runtime][system]") {

--- a/test/test_scan_blacklist.cpp
+++ b/test/test_scan_blacklist.cpp
@@ -181,3 +181,72 @@ TEST_CASE("from_text tolerates signed stamp values from old blacklist files",
     REQUIRE(entry->second.size == -2);
     REQUIRE(entry->second.reason == "old stamp");
 }
+
+TEST_CASE("blacklisting a missing plugin records a durable manual block",
+          "[host][blacklist][codecov]") {
+    TempFile f;
+    ScanBlacklist bl;
+
+    REQUIRE_FALSE(fs::exists(f.path));
+    bl.blacklist(f.path.string(), "manual quarantine");
+
+    auto entry = bl.get(f.path.string());
+    REQUIRE(entry.has_value());
+    REQUIRE(entry->mtime == 0);
+    REQUIRE(entry->size == 0);
+    REQUIRE(entry->reason == "manual quarantine");
+    REQUIRE(bl.is_blacklisted(f.path.string()));
+
+    f.write("new plugin build");
+    REQUIRE_FALSE(bl.is_blacklisted(f.path.string()));
+}
+
+TEST_CASE("from_text duplicate blacklist records keep the last valid entry",
+          "[host][blacklist][codecov]") {
+    ScanBlacklist bl;
+    REQUIRE(bl.from_text(
+        "/plugin.vst3|1|2|first reason\n"
+        "/other.vst3|3|4|other reason\n"
+        "/plugin.vst3|5|6|second reason\n"));
+
+    REQUIRE(bl.size() == 2);
+    auto entry = bl.entries().find("/plugin.vst3");
+    REQUIRE(entry != bl.entries().end());
+    REQUIRE(entry->second.mtime == 5);
+    REQUIRE(entry->second.size == 6);
+    REQUIRE(entry->second.reason == "second reason");
+}
+
+TEST_CASE("from_text keeps unknown percent escapes literal",
+          "[host][blacklist][codecov]") {
+    ScanBlacklist bl;
+    REQUIRE(bl.from_text("/plugin%2Fname.vst3|7|8|bad%2Greason%7Cok\n"));
+
+    auto entry = bl.entries().find("/plugin%2Fname.vst3");
+    REQUIRE(entry != bl.entries().end());
+    REQUIRE(entry->second.reason == "bad%2Greason|ok");
+
+    const auto text = bl.to_text();
+    REQUIRE(text.find("/plugin%252Fname.vst3") != std::string::npos);
+    REQUIRE(text.find("bad%252Greason%7Cok") != std::string::npos);
+}
+
+TEST_CASE("save_to creates nested blacklist parent directories",
+          "[host][blacklist][codecov]") {
+    TempFile f;
+    const auto root = f.path.parent_path() / (f.path.filename().string() + "-dir");
+    const auto out_path = root / "nested" / "blacklist.txt";
+
+    ScanBlacklist a;
+    a.blacklist("/tmp/missing-plugin.clap", "timeout");
+    REQUIRE(a.save_to(out_path.string()));
+    REQUIRE(fs::exists(out_path));
+
+    ScanBlacklist b;
+    REQUIRE(b.load_from(out_path.string()));
+    REQUIRE(b.size() == 1);
+    REQUIRE(b.entries().at("/tmp/missing-plugin.clap").reason == "timeout");
+
+    std::error_code ec;
+    fs::remove_all(root, ec);
+}

--- a/test/test_scan_cache.cpp
+++ b/test/test_scan_cache.cpp
@@ -319,3 +319,135 @@ TEST_CASE("ScanCache load_from empty or malformed file keeps existing cache",
     REQUIRE(cache.size() == 1);
     REQUIRE(cache.entries().count("/tmp/existing.vst3") == 1);
 }
+
+TEST_CASE("ScanCache put on a missing path records metadata but never hits",
+          "[scan_cache][codecov]") {
+    TempFile f;
+    HostScanCache cache;
+    auto info = sample_info();
+    info.path = f.path.string();
+
+    REQUIRE_FALSE(fs::exists(f.path));
+    cache.put(f.path.string(), info);
+
+    REQUIRE(cache.size() == 1);
+    REQUIRE_FALSE(cache.get(f.path.string()).has_value());
+    const auto& entry = cache.entries().at(f.path.string());
+    REQUIRE(entry.mtime == 0);
+    REQUIRE(entry.size == 0);
+    REQUIRE(entry.info.path == f.path.string());
+
+    f.write("plugin appears later");
+    REQUIRE_FALSE(cache.get(f.path.string()).has_value());
+}
+
+TEST_CASE("ScanCache erase and clear leave cache reusable",
+          "[scan_cache][codecov]") {
+    HostScanCache cache;
+    cache.put("/tmp/one.vst3", sample_info());
+
+    auto second = sample_info();
+    second.name = "Second";
+    second.unique_id = "com.pulp.second";
+    cache.put("/tmp/two.vst3", second);
+    REQUIRE(cache.size() == 2);
+
+    cache.erase("/tmp/one.vst3");
+    REQUIRE(cache.size() == 1);
+    REQUIRE(cache.entries().count("/tmp/one.vst3") == 0);
+    REQUIRE(cache.entries().count("/tmp/two.vst3") == 1);
+
+    cache.erase("/tmp/does-not-exist.vst3");
+    REQUIRE(cache.size() == 1);
+
+    cache.clear();
+    REQUIRE(cache.size() == 0);
+
+    cache.put("/tmp/after-clear.vst3", sample_info());
+    REQUIRE(cache.size() == 1);
+}
+
+TEST_CASE("ScanCache from_json rejects non-array entries without replacing cache",
+          "[scan_cache][codecov]") {
+    HostScanCache cache;
+    cache.put("/tmp/existing.vst3", sample_info());
+
+    REQUIRE_FALSE(cache.from_json(R"({
+        "schema_version": 1,
+        "entries": {"path": "/tmp/not-an-array.vst3"}
+    })"));
+    REQUIRE(cache.size() == 1);
+    REQUIRE(cache.entries().count("/tmp/existing.vst3") == 1);
+}
+
+TEST_CASE("ScanCache duplicate JSON entries keep the last valid record",
+          "[scan_cache][codecov]") {
+    HostScanCache cache;
+    REQUIRE(cache.from_json(R"({
+        "schema_version": 1,
+        "entries": [
+            {
+                "path": "/tmp/duplicate.clap",
+                "mtime": 1,
+                "size": 2,
+                "name": "First",
+                "manufacturer": "Pulp",
+                "version": "1.0",
+                "plugin_path": "/tmp/duplicate.clap",
+                "unique_id": "first-id",
+                "format": "clap",
+                "is_instrument": false,
+                "is_effect": true,
+                "num_inputs": 1,
+                "num_outputs": 1
+            },
+            {
+                "path": "/tmp/duplicate.clap",
+                "mtime": 3,
+                "size": 4,
+                "name": "Second",
+                "manufacturer": "Pulp",
+                "version": "2.0",
+                "plugin_path": "/tmp/duplicate.clap",
+                "unique_id": "second-id",
+                "format": "lv2",
+                "is_instrument": true,
+                "is_effect": false,
+                "num_inputs": 0,
+                "num_outputs": 2
+            }
+        ]
+    })"));
+
+    REQUIRE(cache.size() == 1);
+    const auto& entry = cache.entries().at("/tmp/duplicate.clap");
+    REQUIRE(entry.mtime == 3);
+    REQUIRE(entry.size == 4);
+    REQUIRE(entry.info.name == "Second");
+    REQUIRE(entry.info.unique_id == "second-id");
+    REQUIRE(entry.info.format == PluginFormat::LV2);
+    REQUIRE(entry.info.is_instrument);
+    REQUIRE_FALSE(entry.info.is_effect);
+    REQUIRE(entry.info.num_inputs == 0);
+    REQUIRE(entry.info.num_outputs == 2);
+}
+
+TEST_CASE("ScanCache save_to creates nested parent directories",
+          "[scan_cache][codecov]") {
+    TempFile f;
+    const auto root = f.path.parent_path() / (f.path.filename().string() + "-dir");
+    const auto cache_path = root / "nested" / "scan-cache.json";
+
+    HostScanCache a;
+    a.put("/tmp/nested-cache.vst3", sample_info());
+    REQUIRE(a.save_to(cache_path.string()));
+    REQUIRE(fs::exists(cache_path));
+
+    HostScanCache b;
+    REQUIRE(b.load_from(cache_path.string()));
+    REQUIRE(b.size() == 1);
+    REQUIRE(b.entries().at("/tmp/nested-cache.vst3").info.name == "Delay");
+
+    std::error_code ec;
+    fs::remove_all(root, ec);
+}

--- a/test/test_test_signal.cpp
+++ b/test/test_test_signal.cpp
@@ -162,6 +162,145 @@ TEST_CASE("TestSignalSource: reset clears state", "[format][test_signal]") {
     REQUIRE_THAT(buf2[0], WithinAbs(0.0f, 0.01f));
 }
 
+TEST_CASE("TestSignalSource: active flag follows config type",
+          "[format][test_signal][coverage][phase3]") {
+    TestSignalSource src;
+    REQUIRE_FALSE(src.is_active());
+
+    src.set_config({TestSignalType::sine, 440.0f, 0.5f});
+    REQUIRE(src.is_active());
+
+    src.set_config({TestSignalType::file, 440.0f, 0.5f});
+    REQUIRE(src.is_active());
+
+    src.set_config({TestSignalType::none, 440.0f, 0.5f});
+    REQUIRE_FALSE(src.is_active());
+}
+
+TEST_CASE("TestSignalSource: config returns the last audio-thread-applied config",
+          "[format][test_signal][coverage][phase3]") {
+    TestSignalSource src;
+    auto initial = src.config();
+    REQUIRE(initial.type == TestSignalType::none);
+    REQUIRE(initial.sine_frequency_hz == 440.0f);
+    REQUIRE(initial.sine_amplitude == 0.5f);
+
+    src.set_config({TestSignalType::sine, 220.0f, 0.25f});
+    REQUIRE(src.config().type == TestSignalType::none);
+
+    float sample = -1.0f;
+    float* output = &sample;
+    src.fill(&output, 1, 1);
+
+    auto applied = src.config();
+    REQUIRE(applied.type == TestSignalType::sine);
+    REQUIRE(applied.sine_frequency_hz == 220.0f);
+    REQUIRE(applied.sine_amplitude == 0.25f);
+}
+
+TEST_CASE("TestSignalSource: deterministic sine samples at quarter-cycle boundaries",
+          "[format][test_signal][coverage][phase3]") {
+    TestSignalSource src;
+    src.set_sample_rate(4.0);
+    src.set_config({TestSignalType::sine, 1.0f, 0.75f});
+
+    std::vector<float> buf(4, 0.0f);
+    float* output = buf.data();
+    src.fill(&output, 1, 4);
+
+    REQUIRE_THAT(buf[0], WithinAbs(0.0f, 0.0001f));
+    REQUIRE_THAT(buf[1], WithinAbs(0.75f, 0.0001f));
+    REQUIRE_THAT(buf[2], WithinAbs(0.0f, 0.0001f));
+    REQUIRE_THAT(buf[3], WithinAbs(-0.75f, 0.0001f));
+}
+
+TEST_CASE("TestSignalSource: amplitude-only config changes keep phase continuity",
+          "[format][test_signal][coverage][phase3]") {
+    TestSignalSource src;
+    src.set_sample_rate(4.0);
+    src.set_config({TestSignalType::sine, 1.0f, 1.0f});
+
+    float first = -1.0f;
+    float* first_output = &first;
+    src.fill(&first_output, 1, 1);
+    REQUIRE_THAT(first, WithinAbs(0.0f, 0.0001f));
+
+    src.set_config({TestSignalType::sine, 1.0f, 0.25f});
+    float second = -1.0f;
+    float* second_output = &second;
+    src.fill(&second_output, 1, 1);
+
+    REQUIRE_THAT(second, WithinAbs(0.25f, 0.0001f));
+}
+
+TEST_CASE("TestSignalSource: frequency changes reset sine phase",
+          "[format][test_signal][coverage][phase3]") {
+    TestSignalSource src;
+    src.set_sample_rate(4.0);
+    src.set_config({TestSignalType::sine, 1.0f, 1.0f});
+
+    float first = -1.0f;
+    float* first_output = &first;
+    src.fill(&first_output, 1, 1);
+    REQUIRE_THAT(first, WithinAbs(0.0f, 0.0001f));
+
+    src.set_config({TestSignalType::sine, 2.0f, 1.0f});
+    float after_change = -1.0f;
+    float* changed_output = &after_change;
+    src.fill(&changed_output, 1, 1);
+
+    REQUIRE_THAT(after_change, WithinAbs(0.0f, 0.0001f));
+}
+
+TEST_CASE("TestSignalSource: zero-amplitude sine stays active but silent",
+          "[format][test_signal][coverage][phase3]") {
+    TestSignalSource src;
+    src.set_sample_rate(48000.0);
+    src.set_config({TestSignalType::sine, 440.0f, 0.0f});
+    REQUIRE(src.is_active());
+
+    std::vector<float> buf(64, 1.0f);
+    float* output = buf.data();
+    src.fill(&output, 1, static_cast<int>(buf.size()));
+
+    for (float sample : buf) {
+        REQUIRE(sample == 0.0f);
+    }
+    REQUIRE(src.is_active());
+}
+
+TEST_CASE("TestSignalSource: file mode without loaded data is silent and not playing",
+          "[format][test_signal][coverage][phase3]") {
+    TestSignalSource src;
+    src.set_config({TestSignalType::file, 440.0f, 1.0f});
+    REQUIRE(src.is_active());
+
+    src.play();
+    REQUIRE_FALSE(src.is_playing());
+    REQUIRE_FALSE(src.has_file());
+
+    std::vector<float> buf(8, -1.0f);
+    float* output = buf.data();
+    src.fill(&output, 1, static_cast<int>(buf.size()));
+
+    for (float sample : buf) {
+        REQUIRE(sample == 0.0f);
+    }
+    REQUIRE(src.file_position() == 0);
+}
+
+TEST_CASE("TestSignalSource: loop flag toggles independently of loaded file state",
+          "[format][test_signal][coverage][phase3]") {
+    TestSignalSource src;
+    REQUIRE_FALSE(src.is_looping());
+
+    src.set_loop(true);
+    REQUIRE(src.is_looping());
+
+    src.set_loop(false);
+    REQUIRE_FALSE(src.is_looping());
+}
+
 TEST_CASE("TestSignalSource: invalid file load and unload reset playback state",
           "[format][test_signal][file]") {
     TestSignalSource src;
@@ -195,6 +334,70 @@ TEST_CASE("TestSignalSource: invalid file load and unload reset playback state",
     src.unload_file();
     REQUIRE_FALSE(src.has_file());
     REQUIRE_FALSE(src.is_playing());
+    REQUIRE(src.file_position() == 0);
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("TestSignalSource: loading a new file rewinds and stops existing playback",
+          "[format][test_signal][file][coverage][phase3]") {
+    TestSignalSource src;
+    src.set_config({TestSignalType::file, 440.0f, 1.0f});
+
+    auto first_path = unique_temp_wav_path("-first.wav");
+    auto second_path = unique_temp_wav_path("-second.wav");
+    std::filesystem::remove(first_path);
+    std::filesystem::remove(second_path);
+    REQUIRE(pulp::audio::write_wav_file(first_path.string(), make_test_audio()));
+    REQUIRE(pulp::audio::write_wav_file(second_path.string(), make_test_audio()));
+
+    REQUIRE(src.load_file(first_path.string()));
+    src.play();
+    REQUIRE(src.is_playing());
+
+    float buf[2] = {-1.0f, -1.0f};
+    float* output = buf;
+    src.fill(&output, 1, 2);
+    REQUIRE(src.file_position() == 2);
+
+    REQUIRE(src.load_file(second_path.string()));
+    REQUIRE(src.has_file());
+    REQUIRE_FALSE(src.is_playing());
+    REQUIRE(src.file_position() == 0);
+    REQUIRE(src.file_data() != nullptr);
+    REQUIRE(src.file_data()->num_frames() == 3);
+
+    std::filesystem::remove(first_path);
+    std::filesystem::remove(second_path);
+}
+
+TEST_CASE("TestSignalSource: reset stops file playback and rewinds without unloading",
+          "[format][test_signal][file][coverage][phase3]") {
+    TestSignalSource src;
+    src.set_config({TestSignalType::file, 440.0f, 1.0f});
+
+    auto path = unique_temp_wav_path(".wav");
+    std::filesystem::remove(path);
+    REQUIRE(pulp::audio::write_wav_file(path.string(), make_test_audio()));
+    REQUIRE(src.load_file(path.string()));
+
+    src.play();
+    float played[2] = {-1.0f, -1.0f};
+    float* played_output = played;
+    src.fill(&played_output, 1, 2);
+    REQUIRE(src.file_position() == 2);
+    REQUIRE(src.is_playing());
+
+    src.reset();
+    REQUIRE(src.has_file());
+    REQUIRE_FALSE(src.is_playing());
+    REQUIRE(src.file_position() == 0);
+
+    float silent[2] = {-1.0f, -1.0f};
+    float* silent_output = silent;
+    src.fill(&silent_output, 1, 2);
+    REQUIRE(silent[0] == 0.0f);
+    REQUIRE(silent[1] == 0.0f);
     REQUIRE(src.file_position() == 0);
 
     std::filesystem::remove(path);

--- a/test/test_xml_zip.cpp
+++ b/test/test_xml_zip.cpp
@@ -111,6 +111,45 @@ TEST_CASE("XmlDocument invalid XML", "[runtime][xml]") {
     REQUIRE_FALSE(doc.error().empty());
 }
 
+TEST_CASE("XmlDocument parse failure marks invalid and later success clears error",
+          "[runtime][xml][coverage]") {
+    XmlDocument doc;
+    REQUIRE(doc.parse(R"(<root name="before"><child>old</child></root>)"));
+    REQUIRE(doc.is_valid());
+    REQUIRE(doc.root_name() == "root");
+
+    REQUIRE_FALSE(doc.parse("<root><broken></root>"));
+    REQUIRE_FALSE(doc.is_valid());
+    REQUIRE_FALSE(doc.error().empty());
+
+    REQUIRE(doc.parse(R"(<next name="after"><child>new</child></next>)"));
+    REQUIRE(doc.is_valid());
+    REQUIRE(doc.error().empty());
+    REQUIRE(doc.root_name() == "next");
+    REQUIRE(doc.root_attribute("name") == std::optional<std::string>{"after"});
+    REQUIRE(doc.xpath_string("//child") == std::optional<std::string>{"new"});
+}
+
+TEST_CASE("XmlDocument load_file failure clears prior state and save_file reports bad paths",
+          "[runtime][xml][coverage]") {
+    TemporaryFile tmp(".xml");
+
+    XmlDocument doc;
+    REQUIRE(doc.parse("<settings><theme>dark</theme></settings>"));
+    REQUIRE(doc.save_file(tmp.path_string()));
+
+    XmlDocument loaded;
+    REQUIRE(loaded.load_file(tmp.path_string()));
+    REQUIRE(loaded.xpath_string("//theme") == std::optional<std::string>{"dark"});
+
+    REQUIRE_FALSE(loaded.load_file(tmp.path_string() + ".missing"));
+    REQUIRE_FALSE(loaded.is_valid());
+    REQUIRE_FALSE(loaded.error().empty());
+    REQUIRE(loaded.root_name().empty());
+
+    REQUIRE_FALSE(doc.save_file(tmp.path_string() + "/nested.xml"));
+}
+
 TEST_CASE("XmlDocument empty document queries are inert",
           "[runtime][xml][coverage][issue-641]") {
     XmlDocument doc;
@@ -202,6 +241,27 @@ TEST_CASE("xml_generate escapes text content", "[runtime][xml]") {
     REQUIRE(xml.find("A&amp;B &lt;Default&gt;") != std::string::npos);
 }
 
+TEST_CASE("xml_generate supports empty roots and escaped element names from callers",
+          "[runtime][xml][coverage]") {
+    auto empty = xml_generate("empty", {});
+    XmlDocument empty_doc;
+    REQUIRE(empty_doc.parse(empty));
+    REQUIRE(empty_doc.root_name() == "empty");
+    REQUIRE(empty_doc.xpath_strings("//*").size() == 1);
+
+    auto xml = xml_generate("preset", {
+        {"amp", "Tom & Jerry"},
+        {"apostrophe", "can't"},
+        {"quote", R"("quoted")"},
+    });
+    XmlDocument doc;
+    REQUIRE(doc.parse(xml));
+    REQUIRE(doc.xpath_string("//amp") == std::optional<std::string>{"Tom & Jerry"});
+    REQUIRE(doc.xpath_string("//apostrophe") == std::optional<std::string>{"can't"});
+    REQUIRE(doc.xpath_string("//quote") == std::optional<std::string>{R"("quoted")"});
+    REQUIRE(xml.find("Tom &amp; Jerry") != std::string::npos);
+}
+
 // ── ZIP/GZIP compression ────────────────────────────────────────────────
 
 TEST_CASE("gzip compress/decompress round-trip", "[runtime][zip]") {
@@ -253,6 +313,35 @@ TEST_CASE("gzip binary data round-trip", "[runtime][zip]") {
     auto decompressed = gzip_decompress(compressed->data(), compressed->size());
     REQUIRE(decompressed.has_value());
     REQUIRE(*decompressed == data);
+}
+
+TEST_CASE("gzip_decompress_string preserves embedded NUL bytes",
+          "[runtime][zip][coverage]") {
+    const std::vector<uint8_t> original = {
+        'p', 'u', 'l', 'p', 0x00, 'b', 'i', 'n', 0x00, 0xff,
+    };
+    auto compressed = gzip_compress(original.data(), original.size());
+    REQUIRE(compressed.has_value());
+
+    auto decompressed = gzip_decompress_string(compressed->data(), compressed->size());
+    REQUIRE(decompressed.has_value());
+    REQUIRE(decompressed->size() == original.size());
+    REQUIRE(std::memcmp(decompressed->data(), original.data(), original.size()) == 0);
+}
+
+TEST_CASE("deflate compression levels round-trip edge settings",
+          "[runtime][zip][coverage]") {
+    const std::string payload = "level check level check level check";
+    for (int level : {0, 9}) {
+        INFO("level: " << level);
+        auto compressed = deflate_compress(
+            reinterpret_cast<const uint8_t*>(payload.data()), payload.size(), level);
+        REQUIRE(compressed.has_value());
+
+        auto decompressed = deflate_decompress(compressed->data(), compressed->size());
+        REQUIRE(decompressed.has_value());
+        REQUIRE(std::string(decompressed->begin(), decompressed->end()) == payload);
+    }
 }
 
 // ── RFC 1952 gzip wire-format compliance (issue-468 follow-up) ──────────
@@ -346,6 +435,27 @@ TEST_CASE("gzip_decompress accepts optional RFC 1952 header fields", "[runtime][
     with_metadata.insert(with_metadata.end(), compressed->begin() + 10, compressed->end());
 
     auto out = gzip_decompress_string(with_metadata.data(), with_metadata.size());
+    REQUIRE(out.has_value());
+    REQUIRE(*out == original);
+}
+
+TEST_CASE("gzip_decompress accepts FTEXT flag and empty optional strings",
+          "[runtime][zip][coverage]") {
+    const std::string original = "text flag payload";
+    auto compressed = gzip_compress(original);
+    REQUIRE(compressed.has_value());
+    REQUIRE(compressed->size() > 18);
+
+    std::vector<uint8_t> with_flags = {
+        0x1f, 0x8b, 0x08, 0x19,  // FTEXT | FNAME | FCOMMENT
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0xff,
+        0x00,                    // empty FNAME
+        0x00,                    // empty FCOMMENT
+    };
+    with_flags.insert(with_flags.end(), compressed->begin() + 10, compressed->end());
+
+    auto out = gzip_decompress_string(with_flags.data(), with_flags.size());
     REQUIRE(out.has_value());
     REQUIRE(*out == original);
 }
@@ -452,4 +562,20 @@ TEST_CASE("gzip_decompress rejects trailing garbage after the last member",
     g->push_back('?');
     auto out = gzip_decompress(g->data(), g->size());
     REQUIRE_FALSE(out.has_value());
+}
+
+TEST_CASE("gzip_decompress rejects an invalid concatenated member header",
+          "[runtime][zip][coverage]") {
+    auto first = gzip_compress(std::string{"first"});
+    REQUIRE(first.has_value());
+
+    std::vector<uint8_t> concat;
+    concat.insert(concat.end(), first->begin(), first->end());
+    concat.insert(concat.end(), {
+        0x1f, 0x8b, 0x00, 0x00,  // bad compression method
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0xff,
+    });
+
+    REQUIRE_FALSE(gzip_decompress(concat.data(), concat.size()).has_value());
 }


### PR DESCRIPTION
## Summary
- expand runtime coverage for AsyncStream, stream helpers, XML/ZIP, environment helpers, C string copy, timers, and i18n locale handling
- expand format/host coverage for TestSignalSource playback edges, scan cache persistence, and scan blacklist parsing
- batch seven related test areas into one GitHub-hosted CI run to reduce macOS runner pressure

## Local validation
- cmake --build build --target pulp-test-async-stream pulp-test-stream pulp-test-test-signal pulp-test-xml-zip pulp-test-runtime pulp-test-scan-cache pulp-test-scan-blacklist pulp-test-i18n -j$(sysctl -n hw.ncpu)
- ctest --test-dir build -R "AsyncStream|Stream|TestSignalSource|XmlDocument|xml_generate|gzip|deflate|Runtime (environment helpers|GMT helper|C string copy)|HighResolutionTimer|i18n system_locale|blacklisting a missing plugin|duplicate blacklist records|unknown percent escapes|nested blacklist parent|ScanCache put on a missing path|ScanCache erase and clear|non-array entries|duplicate JSON entries|ScanCache save_to creates nested" --output-on-failure
- ./build/test/pulp-test-runtime
- ./build/test/pulp-test-i18n
- ./build/test/pulp-test-test-signal
- ./build/test/pulp-test-xml-zip
- ./build/test/pulp-test-scan-cache
- ./build/test/pulp-test-scan-blacklist
- git diff --check origin/main...HEAD

No Namespace or SSH validation was dispatched. GitHub-hosted PR checks should be the merge gate.