### PR TITLE
test: batch runtime and audio coverage edges

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-# codecov.yml — Codecov config for public/#566 Phase 1 (measurement baseline).
+# codecov.yml - Codecov config for public/#566 Phase 1 (measurement baseline).
 #
 # Primary consumers (in order): Pulp developers, dispatched agents, CI
 # enforcement, contributors reading PR comments. Public dashboard is a
@@ -12,14 +12,14 @@
 # Phase 2 adds ci/coverage-targets.yaml alongside this for the diff-cover
 # gate; Phase 4 introduces doc_path_map.json to prevent drift.
 
-# Notification gating — wait for all 4 platform coverage uploads before
+# Notification gating - wait for all 4 platform coverage uploads before
 # the bot computes + posts the patch coverage report. Without this,
 # Codecov posts as soon as it sees ANY upload (often Linux first, since
 # its build is fastest), which means Apple-only or Windows-only tested
 # paths get reported as 0% covered against partial data. PR #1873 was a
 # textbook example: a CLAP-fixture test that ran only on macOS was
 # reported as "0% patch coverage" by the bot because the macOS upload
-# hadn't arrived (and never did — see follow-up issue on the coverage
+# hadn't arrived (and never did - see follow-up issue on the coverage
 # workflow's `cancel-in-progress: true` concurrency policy that wipes
 # in-flight runs on force-push).
 #
@@ -32,7 +32,7 @@
 #
 # If you add or remove a coverage uploader, bump this number to match
 # or Codecov will silently wait forever for the missing one and never
-# post. After 7d it gives up and posts whatever it has — by then the
+# post. After 7d it gives up and posts whatever it has - by then the
 # PR has long since merged with a stale report.
 codecov:
   notify:
@@ -40,7 +40,7 @@ codecov:
 
 coverage:
   status:
-    # Project-wide status: "did we get worse?" Not a hard gate — we
+    # Project-wide status: "did we get worse?" Not a hard gate - we
     # already have continue-on-error on the coverage job and Phase 3
     # is where per-PR enforcement lands.
     project:
@@ -52,11 +52,11 @@ coverage:
     # Patch status: "is new code covered?" Advisory in the sense that
     # branch-protection does NOT require this check (so a sub-threshold
     # PR can still merge), but the check status now accurately reflects
-    # the threshold check — `success` if ≥75%, `failure` if <75%.
+    # the threshold check - `success` if >=75%, `failure` if <75%.
     #
     # Previously `informational: true` hardwired the status to `success`
     # even when patch coverage was 0%, which deceived devs reading the
-    # check line. The bot still posted a "❌ Patch coverage is X%"
+    # check line. The bot still posted a "[fail] Patch coverage is X%"
     # comment, but the status check itself said success, masking the
     # gap. Flipping to enforcing makes the signal accurate without
     # changing merge behavior (codecov/patch is not in
@@ -76,9 +76,9 @@ coverage:
 # so Codecov and our local tooling count the same set of files.
 # External FetchContent sources (Dawn, Skia, mbedTLS, QuickJS,
 # Catch2, etc.) and our test trees are never counted as coverage-
-# bearing. See planning/coverage-tooling-decision-2026-04-21.md §4.
+# bearing. See planning/coverage-tooling-decision-2026-04-21.md section 4.
 #
-# `ignore` is a TOP-LEVEL key in Codecov config — nesting it under
+# `ignore` is a TOP-LEVEL key in Codecov config - nesting it under
 # `coverage:` silently no-ops, which would count files we explicitly
 # want excluded and skew the baseline metrics. See Codecov config
 # schema: https://docs.codecov.com/docs/codecov-yaml
@@ -106,7 +106,7 @@ ignore:
   # harness implementation, so Codecov must not count the tests as
   # patch-coverable product code.
   - "tools/harness/visual/tests/**"
-  # ── Aligned with tools/scripts/coverage_config.json `diff_cover_excludes` ──
+  # -- Aligned with tools/scripts/coverage_config.json `diff_cover_excludes` --
   # The Pulp gate (`Diff coverage required` in coverage.yml) excludes these
   # files because they're either thin dispatchers exercised end-to-end via
   # shell-out tests (so direct line coverage doesn't propagate cleanly), or
@@ -114,11 +114,11 @@ ignore:
   # can't instrument uniformly. Without aligning the Codecov bot's ignore
   # list to the same set, the bot's `codecov/patch` check fires red on PRs
   # whose diff is mostly in these files (e.g. PR #1984's viewport-fit lived
-  # almost entirely in window_host_mac.mm — Pulp gate silent, bot screamed
+  # almost entirely in window_host_mac.mm - Pulp gate silent, bot screamed
   # 8.64% patch coverage). Both sides MUST count the same set.
   #
   # Drift between this list and coverage_config.json is detected by
-  # tools/scripts/test_codecov_config_sync.py — keep them in sync.
+  # tools/scripts/test_codecov_config_sync.py - keep them in sync.
   - "**/cmd_loop.cpp"
   - "**/pulp_import_design.cpp"
   - "**/cg_canvas.mm"
@@ -138,7 +138,7 @@ comment:
 
 # Flag definitions are retained for Phase 1 PR 4 (per-OS upload jobs)
 # and for future workflows that genuinely upload one file per flag.
-# The main coverage.yml upload does NOT attach any flags — Codecov
+# The main coverage.yml upload does NOT attach any flags - Codecov
 # rejects single-upload multi-flag submissions with "Multiple flags
 # detected. Please ensure one flag per upload." The per-subsystem /
 # per-platform / per-surface breakdown comes from `component_management`
@@ -150,7 +150,7 @@ comment:
 # means updating both blocks in this file; `tools/scripts/test_codecov_config.py`
 # checks them against the live `core/*` tree so drift fails fast.
 flags:
-  # Core subsystems — one flag per top-level core/** directory.
+  # Core subsystems - one flag per top-level core/** directory.
   audio:
     paths:
       - core/audio/
@@ -208,7 +208,7 @@ flags:
       - core/view/
     carryforward: true
 
-  # Platform flags (4) — cross-cut the subsystem flags. "What's host
+  # Platform flags (4) - cross-cut the subsystem flags. "What's host
   # coverage on Windows?" is answered by cross-filtering `host AND
   # windows`. Paths cover all subsystems because any subsystem can
   # have a Windows shim under its own `platform/windows/` tree.
@@ -238,7 +238,7 @@ flags:
       - core/**/wasapi/
     carryforward: true
 
-  # Surface flags (4) — non-core but first-party:
+  # Surface flags (4) - non-core but first-party:
   cli:
     paths:
       - tools/cli/
@@ -260,16 +260,16 @@ flags:
       - tools/
     carryforward: true
 
-  # OS flags (3) — Phase 1 PR 4 cross-platform coverage matrix. These
+  # OS flags (3) - Phase 1 PR 4 cross-platform coverage matrix. These
   # are NOT path-scoped; every file measured on a given matrix leg is
   # tagged with that OS's flag at upload time via the corresponding
   # matrix entry in .github/workflows/coverage.yml. Federate with the
   # subsystem + platform + surface flags above for cross-filtering:
   # `host AND os-windows` answers "what fraction of core/host is
-  # exercised when tests run on Windows?" — a different question from
+  # exercised when tests run on Windows?" - a different question from
   # `host AND windows` (which reads "what fraction of the windows/
   # shim files are covered at all"). See docs/guides/coverage.md
-  # §"Multi-OS coverage" for the rationale on Codecov-flag unions vs
+  # section "Multi-OS coverage" for the rationale on Codecov-flag unions vs
   # llvm-profdata merge.
   os-linux:
     carryforward: true
@@ -278,7 +278,7 @@ flags:
   os-windows:
     carryforward: true
 
-# carryforward: true on every flag — when a PR doesn't touch
+# carryforward: true on every flag - when a PR doesn't touch
 # a given subsystem, carry over the last known coverage for that
 # flag from main so the dashboard doesn't report a false 0%. Standard
 # Codecov practice for multi-job uploads (we have one job per OS
@@ -303,12 +303,12 @@ component_management:
         threshold: 1%
         informational: true
   individual_components:
-    # Core subsystems — mirror every top-level core/** directory.
+    # Core subsystems - mirror every top-level core/** directory.
     #
     # Subsystems that house platform-specific subtrees (`audio`, `midi`,
     # `view`, `render`, `platform`, `canvas`) explicitly exclude those
     # subtrees so each first-party file lands in exactly one component
-    # bucket — see #1055. Platform-specific code is owned by the
+    # bucket - see #1055. Platform-specific code is owned by the
     # `apple`/`android`/`linux`/`windows` components below; without the
     # `!`-exclude here those files were silently double-counted, inflating
     # coverage for both the subsystem and the platform.
@@ -375,10 +375,10 @@ component_management:
       paths:
         - "core/view/**"
         - "!core/view/platform/**"
-    # Platform (4) — cross-cut the subsystems. Patterns within each
+    # Platform (4) - cross-cut the subsystems. Patterns within each
     # platform component must not overlap each other (Codecov double-
     # counts files matched twice within the same component, inflating
-    # the line totals — caught on #1055 as `platform,android,android`
+    # the line totals - caught on #1055 as `platform,android,android`
     # 3-way matches).
     - component_id: android
       name: android
@@ -403,7 +403,7 @@ component_management:
         - "core/**/win/**"
         - "core/**/windows/**"
         - "core/**/wasapi/**"
-    # Surface (4) — `tools` excludes `tools/cli/**` so the more specific
+    # Surface (4) - `tools` excludes `tools/cli/**` so the more specific
     # `cli` component owns those files; otherwise every CLI file is
     # double-counted (#1055).
     - component_id: cli

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -315,6 +315,56 @@ TEST_CASE("ChannelSet immersive layout preserves documented speaker order",
     REQUIRE(atmos.speakers[11] == Speaker::TopBackRight);
 }
 
+TEST_CASE("Buffer resize handles type changes and preserves new shape",
+          "[audio][buffer][coverage][phase3]") {
+    Buffer<double> buf(3, 2);
+    buf.channel(0)[0] = 1.0;
+    buf.channel(1)[1] = -2.0;
+
+    buf.resize(1, 5);
+    REQUIRE(buf.num_channels() == 1);
+    REQUIRE(buf.num_samples() == 5);
+    REQUIRE(buf.channel(0).size() == 5);
+
+    buf.clear();
+    for (auto sample : buf.channel(0)) {
+        REQUIRE(sample == 0.0);
+    }
+
+    buf.channel(0)[4] = 0.5;
+    auto view = buf.view();
+    REQUIRE(view.channel(0)[4] == 0.5);
+}
+
+TEST_CASE("BufferView supports zero-sample clears without touching channel pointers",
+          "[audio][buffer][coverage][phase3]") {
+    float left = 1.0f;
+    float right = -1.0f;
+    float* ptrs[2] = {&left, &right};
+
+    BufferView<float> view(ptrs, 2, 0);
+    REQUIRE(view.empty());
+    REQUIRE(view.num_channels() == 2);
+    REQUIRE(view.num_samples() == 0);
+    REQUIRE(view.channel_ptr(0) == &left);
+    REQUIRE(view.channel_ptr(1) == &right);
+
+    view.clear();
+    REQUIRE(left == 1.0f);
+    REQUIRE(right == -1.0f);
+}
+
+TEST_CASE("ChannelSet discrete layouts compare by speaker map not display name",
+          "[audio][channel-set][coverage][phase3]") {
+    auto named = ChannelSet::discrete(3);
+    auto renamed = named;
+    renamed.name = "Three unnamed channels";
+
+    REQUIRE(named == renamed);
+    REQUIRE(named.size() == 3);
+    REQUIRE_FALSE(named == ChannelSet::lrc());
+}
+
 #if defined(__APPLE__) && !TARGET_OS_IPHONE
 TEST_CASE("CoreAudio system enumerates devices", "[audio][coreaudio]") {
     auto system = create_audio_system();

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -1,6 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/runtime/identity.hpp>
 #include <set>
+#include <string>
+#include <unordered_map>
 #include <unordered_set>
 
 using namespace pulp::runtime;
@@ -123,6 +125,28 @@ TEST_CASE("Uuid parsing accepts uppercase dashed and compact hex",
     REQUIRE(Uuid::from_string("0123456789ABCDEFFEDCBA9876543210") == id);
 }
 
+TEST_CASE("Uuid parsing rejects short, long, and whitespace-padded values",
+          "[runtime][identity][coverage][phase3]") {
+    REQUIRE(Uuid::from_string("").is_nil());
+    REQUIRE(Uuid::from_string("00112233445566778899aabbccddee").is_nil());
+    REQUIRE(Uuid::from_string("00112233445566778899aabbccddeeff00").is_nil());
+    REQUIRE(Uuid::from_string(" 00112233-4455-6677-8899-aabbccddeeff").is_nil());
+    REQUIRE(Uuid::from_string("00112233-4455-6677-8899-aabbccddeeff ").is_nil());
+    REQUIRE(Uuid::from_string("00112233-4455-6677-8899-aabbccddee-ff").is_nil());
+}
+
+TEST_CASE("Uuid formatting preserves leading zero bytes",
+          "[runtime][identity][coverage][phase3]") {
+    Uuid id;
+    id.hi = 0x0001020304050607ULL;
+    id.lo = 0x08090a0b0c0d0e0fULL;
+
+    REQUIRE(id.to_hex() == "000102030405060708090a0b0c0d0e0f");
+    REQUIRE(id.to_string() == "00010203-0405-0607-0809-0a0b0c0d0e0f");
+    REQUIRE(Uuid::from_string(id.to_string()) == id);
+    REQUIRE(Uuid::from_string(id.to_hex()) == id);
+}
+
 TEST_CASE("Uuid ordering sorts by high word before low word",
           "[runtime][identity][issue-641]") {
     Uuid low{1, 999};
@@ -189,6 +213,39 @@ TEST_CASE("Typed identity nil and hashing are stable", "[runtime][identity][issu
     objects.insert(object);
     objects.insert(object);
     REQUIRE(objects.size() == 1);
+}
+
+TEST_CASE("Typed identity wrappers compare and hash deterministic values",
+          "[runtime][identity][coverage][phase3]") {
+    auto first = ObjectId::from_string("00000000-0000-0000-0000-000000000001");
+    auto second = ObjectId::from_string("00000000-0000-0000-0000-000000000002");
+
+    REQUIRE(first != second);
+    REQUIRE(first < second);
+    REQUIRE_FALSE(second < first);
+    REQUIRE(first.to_string() == "00000000-0000-0000-0000-000000000001");
+
+    std::unordered_map<ObjectId, std::string> objects;
+    objects[first] = "one";
+    objects[second] = "two";
+    objects[first] = "updated";
+
+    REQUIRE(objects.size() == 2);
+    REQUIRE(objects[first] == "updated");
+    REQUIRE(objects[second] == "two");
+}
+
+TEST_CASE("EventEnvelope defaults are nil and empty before attribution",
+          "[runtime][identity][coverage][phase3]") {
+    EventEnvelope env;
+
+    REQUIRE(env.timestamp == 0.0);
+    REQUIRE(env.session_id.is_nil());
+    REQUIRE(env.object_id.is_nil());
+    REQUIRE(env.run_id.is_nil());
+    REQUIRE(env.correlation_id.is_nil());
+    REQUIRE(env.actor.empty());
+    REQUIRE(env.action.empty());
 }
 
 TEST_CASE("EventEnvelope", "[runtime][identity]") {

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -394,3 +394,87 @@ TEST_CASE("JsonRpcPeer dispatches incoming error responses with data",
     REQUIRE(error->data_json.find(R"("retry")") != std::string::npos);
     REQUIRE(error->data_json.find("false") != std::string::npos);
 }
+
+TEST_CASE("JsonRpcPeer replies to null id requests and notification gaps",
+          "[json_rpc][coverage][phase3]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::vector<std::string> replies;
+    pair.first->on_message([&](const Message& message) {
+        replies.emplace_back(message.as_text());
+    });
+
+    JsonRpcPeer server(*pair.second);
+    server.register_method("null_id", [](std::string_view params) {
+        REQUIRE(params == "[1]");
+        return JsonRpcResult::ok(R"({"ok":true})");
+    });
+
+    REQUIRE(pair.first->send_text(
+        R"json({"jsonrpc":"2.0","id":null,"method":"null_id","params":[1]})json"));
+    REQUIRE(replies.size() == 1);
+    REQUIRE(replies.back().find(R"("id":null)") != std::string::npos);
+    REQUIRE(replies.back().find(R"("ok")") != std::string::npos);
+
+    REQUIRE(pair.first->send_text(
+        R"json({"jsonrpc":"2.0","method":"missing_notification","params":{"ignored":true}})json"));
+    REQUIRE(replies.size() == 1);
+}
+
+TEST_CASE("JsonRpcPeer unregisters a replacement handler cleanly",
+          "[json_rpc][coverage][phase3]") {
+    auto pair = MemoryMessageChannel::make_pair();
+    JsonRpcPeer client(*pair.first);
+    JsonRpcPeer server(*pair.second);
+
+    server.register_method("replaceable", [](std::string_view) {
+        return JsonRpcResult::ok("1");
+    });
+    server.register_method("replaceable", [](std::string_view) {
+        return JsonRpcResult::ok("2");
+    });
+
+    std::atomic<int> callbacks{0};
+    std::string first_result;
+    REQUIRE(client.send_request("replaceable", "[]", [&](const JsonRpcResult& response) {
+        first_result = response.result_json;
+        callbacks.fetch_add(1);
+    }));
+    REQUIRE(wait_until([&] { return callbacks.load() == 1; }));
+    REQUIRE(first_result == "2");
+
+    server.register_method("replaceable", nullptr);
+    std::optional<JsonRpcError> error;
+    REQUIRE(client.send_request("replaceable", "[]", [&](const JsonRpcResult& response) {
+        error = response.error;
+        callbacks.fetch_add(1);
+    }));
+    REQUIRE(wait_until([&] { return callbacks.load() == 2; }));
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == -32601);
+}
+
+TEST_CASE("JsonRpcPeer ignores malformed response payloads without firing callbacks",
+          "[json_rpc][coverage][phase3]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string outbound_request;
+    pair.second->on_message([&](const Message& message) {
+        outbound_request.assign(message.as_text());
+    });
+
+    JsonRpcPeer client(*pair.first);
+    std::atomic<int> callbacks{0};
+    REQUIRE(client.send_request("manual", "", [&](const JsonRpcResult&) {
+        callbacks.fetch_add(1);
+    }));
+    REQUIRE(outbound_request.find(R"("id":1)") != std::string::npos);
+
+    pair.second->send_text("{not-json");
+    pair.second->send_text(R"json({"jsonrpc":"2.0","id":1})json");
+    std::this_thread::sleep_for(10ms);
+    REQUIRE(callbacks.load() == 0);
+
+    pair.second->send_text(R"json({"jsonrpc":"2.0","id":1,"result":true})json");
+    REQUIRE(wait_until([&] { return callbacks.load() == 1; }));
+}

--- a/test/test_memory_message_channel.cpp
+++ b/test/test_memory_message_channel.cpp
@@ -224,3 +224,59 @@ TEST_CASE("MemoryMessageChannel peer destruction closes the survivor",
     left->close();
     REQUIRE(left_closed == 1);
 }
+
+TEST_CASE("MemoryMessageChannel close callback can send no further messages",
+          "[runtime][message_channel][coverage][phase3]") {
+    auto [left, right] = MemoryMessageChannel::make_pair();
+
+    int left_closed = 0;
+    bool send_from_close = true;
+    left->on_closed([&] {
+        ++left_closed;
+        send_from_close = left->send_text("after-close-callback");
+    });
+
+    right->close();
+
+    REQUIRE(left_closed == 1);
+    REQUIRE_FALSE(send_from_close);
+    REQUIRE_FALSE(left->is_open());
+    REQUIRE_FALSE(right->is_open());
+}
+
+TEST_CASE("MemoryMessageChannel sender observes peer callback replacement during delivery",
+          "[runtime][message_channel][coverage][phase3]") {
+    auto [left, right] = MemoryMessageChannel::make_pair();
+
+    int first_calls = 0;
+    int second_calls = 0;
+    right->on_message([&](const Message&) {
+        ++first_calls;
+        right->on_message([&](const Message&) {
+            ++second_calls;
+        });
+    });
+
+    REQUIRE(left->send_text("first"));
+    REQUIRE(left->send_text("second"));
+
+    REQUIRE(first_calls == 1);
+    REQUIRE(second_calls == 1);
+}
+
+TEST_CASE("MemoryMessageChannel self close does not invoke a late replacement callback",
+          "[runtime][message_channel][coverage][phase3]") {
+    auto [left, right] = MemoryMessageChannel::make_pair();
+
+    int closed = 0;
+    left->on_closed([&] {
+        ++closed;
+        left->on_closed([&] { ++closed; });
+    });
+
+    left->close();
+    left->close();
+    right->close();
+
+    REQUIRE(closed == 1);
+}


### PR DESCRIPTION
## Summary
- add focused JSON-RPC peer edge coverage
- add memory message channel lifecycle/replacement coverage
- add identity wrapper, UUID, and event envelope coverage
- add audio buffer/channel-set edge coverage

## Local validation
- cmake --build build --target pulp-test-json-rpc pulp-test-memory-message-channel pulp-test-identity pulp-test-audio -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-json-rpc
- ./build/test/pulp-test-memory-message-channel
- ./build/test/pulp-test-identity
- ./build/test/pulp-test-audio
- PULP_DIFF_COVER_CTEST_REGEX=... tools/scripts/local_diff_cover.sh

No Namespace/SSH validation dispatched; GitHub-hosted CI is the merge gate.