### PR TITLE
test: batch runtime primitive coverage edges

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-# codecov.yml — Codecov config for public/#566 Phase 1 (measurement baseline).
+# codecov.yml - Codecov config for public/#566 Phase 1 (measurement baseline).
 #
 # Primary consumers (in order): Pulp developers, dispatched agents, CI
 # enforcement, contributors reading PR comments. Public dashboard is a
@@ -12,14 +12,14 @@
 # Phase 2 adds ci/coverage-targets.yaml alongside this for the diff-cover
 # gate; Phase 4 introduces doc_path_map.json to prevent drift.
 
-# Notification gating — wait for all 4 platform coverage uploads before
+# Notification gating - wait for all 4 platform coverage uploads before
 # the bot computes + posts the patch coverage report. Without this,
 # Codecov posts as soon as it sees ANY upload (often Linux first, since
 # its build is fastest), which means Apple-only or Windows-only tested
 # paths get reported as 0% covered against partial data. PR #1873 was a
 # textbook example: a CLAP-fixture test that ran only on macOS was
 # reported as "0% patch coverage" by the bot because the macOS upload
-# hadn't arrived (and never did — see follow-up issue on the coverage
+# hadn't arrived (and never did - see follow-up issue on the coverage
 # workflow's `cancel-in-progress: true` concurrency policy that wipes
 # in-flight runs on force-push).
 #
@@ -32,7 +32,7 @@
 #
 # If you add or remove a coverage uploader, bump this number to match
 # or Codecov will silently wait forever for the missing one and never
-# post. After 7d it gives up and posts whatever it has — by then the
+# post. After 7d it gives up and posts whatever it has - by then the
 # PR has long since merged with a stale report.
 codecov:
   notify:
@@ -40,7 +40,7 @@ codecov:
 
 coverage:
   status:
-    # Project-wide status: "did we get worse?" Not a hard gate — we
+    # Project-wide status: "did we get worse?" Not a hard gate - we
     # already have continue-on-error on the coverage job and Phase 3
     # is where per-PR enforcement lands.
     project:
@@ -52,11 +52,11 @@ coverage:
     # Patch status: "is new code covered?" Advisory in the sense that
     # branch-protection does NOT require this check (so a sub-threshold
     # PR can still merge), but the check status now accurately reflects
-    # the threshold check — `success` if ≥75%, `failure` if <75%.
+    # the threshold check - `success` if >=75%, `failure` if <75%.
     #
     # Previously `informational: true` hardwired the status to `success`
     # even when patch coverage was 0%, which deceived devs reading the
-    # check line. The bot still posted a "❌ Patch coverage is X%"
+    # check line. The bot still posted a "[fail] Patch coverage is X%"
     # comment, but the status check itself said success, masking the
     # gap. Flipping to enforcing makes the signal accurate without
     # changing merge behavior (codecov/patch is not in
@@ -76,9 +76,9 @@ coverage:
 # so Codecov and our local tooling count the same set of files.
 # External FetchContent sources (Dawn, Skia, mbedTLS, QuickJS,
 # Catch2, etc.) and our test trees are never counted as coverage-
-# bearing. See planning/coverage-tooling-decision-2026-04-21.md §4.
+# bearing. See planning/coverage-tooling-decision-2026-04-21.md section 4.
 #
-# `ignore` is a TOP-LEVEL key in Codecov config — nesting it under
+# `ignore` is a TOP-LEVEL key in Codecov config - nesting it under
 # `coverage:` silently no-ops, which would count files we explicitly
 # want excluded and skew the baseline metrics. See Codecov config
 # schema: https://docs.codecov.com/docs/codecov-yaml
@@ -106,7 +106,7 @@ ignore:
   # harness implementation, so Codecov must not count the tests as
   # patch-coverable product code.
   - "tools/harness/visual/tests/**"
-  # ── Aligned with tools/scripts/coverage_config.json `diff_cover_excludes` ──
+  # -- Aligned with tools/scripts/coverage_config.json `diff_cover_excludes` --
   # The Pulp gate (`Diff coverage required` in coverage.yml) excludes these
   # files because they're either thin dispatchers exercised end-to-end via
   # shell-out tests (so direct line coverage doesn't propagate cleanly), or
@@ -114,11 +114,11 @@ ignore:
   # can't instrument uniformly. Without aligning the Codecov bot's ignore
   # list to the same set, the bot's `codecov/patch` check fires red on PRs
   # whose diff is mostly in these files (e.g. PR #1984's viewport-fit lived
-  # almost entirely in window_host_mac.mm — Pulp gate silent, bot screamed
+  # almost entirely in window_host_mac.mm - Pulp gate silent, bot screamed
   # 8.64% patch coverage). Both sides MUST count the same set.
   #
   # Drift between this list and coverage_config.json is detected by
-  # tools/scripts/test_codecov_config_sync.py — keep them in sync.
+  # tools/scripts/test_codecov_config_sync.py - keep them in sync.
   - "**/cmd_loop.cpp"
   - "**/pulp_import_design.cpp"
   - "**/cg_canvas.mm"
@@ -138,7 +138,7 @@ comment:
 
 # Flag definitions are retained for Phase 1 PR 4 (per-OS upload jobs)
 # and for future workflows that genuinely upload one file per flag.
-# The main coverage.yml upload does NOT attach any flags — Codecov
+# The main coverage.yml upload does NOT attach any flags - Codecov
 # rejects single-upload multi-flag submissions with "Multiple flags
 # detected. Please ensure one flag per upload." The per-subsystem /
 # per-platform / per-surface breakdown comes from `component_management`
@@ -150,7 +150,7 @@ comment:
 # means updating both blocks in this file; `tools/scripts/test_codecov_config.py`
 # checks them against the live `core/*` tree so drift fails fast.
 flags:
-  # Core subsystems — one flag per top-level core/** directory.
+  # Core subsystems - one flag per top-level core/** directory.
   audio:
     paths:
       - core/audio/
@@ -208,7 +208,7 @@ flags:
       - core/view/
     carryforward: true
 
-  # Platform flags (4) — cross-cut the subsystem flags. "What's host
+  # Platform flags (4) - cross-cut the subsystem flags. "What's host
   # coverage on Windows?" is answered by cross-filtering `host AND
   # windows`. Paths cover all subsystems because any subsystem can
   # have a Windows shim under its own `platform/windows/` tree.
@@ -238,7 +238,7 @@ flags:
       - core/**/wasapi/
     carryforward: true
 
-  # Surface flags (4) — non-core but first-party:
+  # Surface flags (4) - non-core but first-party:
   cli:
     paths:
       - tools/cli/
@@ -260,16 +260,16 @@ flags:
       - tools/
     carryforward: true
 
-  # OS flags (3) — Phase 1 PR 4 cross-platform coverage matrix. These
+  # OS flags (3) - Phase 1 PR 4 cross-platform coverage matrix. These
   # are NOT path-scoped; every file measured on a given matrix leg is
   # tagged with that OS's flag at upload time via the corresponding
   # matrix entry in .github/workflows/coverage.yml. Federate with the
   # subsystem + platform + surface flags above for cross-filtering:
   # `host AND os-windows` answers "what fraction of core/host is
-  # exercised when tests run on Windows?" — a different question from
+  # exercised when tests run on Windows?" - a different question from
   # `host AND windows` (which reads "what fraction of the windows/
   # shim files are covered at all"). See docs/guides/coverage.md
-  # §"Multi-OS coverage" for the rationale on Codecov-flag unions vs
+  # section "Multi-OS coverage" for the rationale on Codecov-flag unions vs
   # llvm-profdata merge.
   os-linux:
     carryforward: true
@@ -278,7 +278,7 @@ flags:
   os-windows:
     carryforward: true
 
-# carryforward: true on every flag — when a PR doesn't touch
+# carryforward: true on every flag - when a PR doesn't touch
 # a given subsystem, carry over the last known coverage for that
 # flag from main so the dashboard doesn't report a false 0%. Standard
 # Codecov practice for multi-job uploads (we have one job per OS
@@ -303,12 +303,12 @@ component_management:
         threshold: 1%
         informational: true
   individual_components:
-    # Core subsystems — mirror every top-level core/** directory.
+    # Core subsystems - mirror every top-level core/** directory.
     #
     # Subsystems that house platform-specific subtrees (`audio`, `midi`,
     # `view`, `render`, `platform`, `canvas`) explicitly exclude those
     # subtrees so each first-party file lands in exactly one component
-    # bucket — see #1055. Platform-specific code is owned by the
+    # bucket - see #1055. Platform-specific code is owned by the
     # `apple`/`android`/`linux`/`windows` components below; without the
     # `!`-exclude here those files were silently double-counted, inflating
     # coverage for both the subsystem and the platform.
@@ -375,10 +375,10 @@ component_management:
       paths:
         - "core/view/**"
         - "!core/view/platform/**"
-    # Platform (4) — cross-cut the subsystems. Patterns within each
+    # Platform (4) - cross-cut the subsystems. Patterns within each
     # platform component must not overlap each other (Codecov double-
     # counts files matched twice within the same component, inflating
-    # the line totals — caught on #1055 as `platform,android,android`
+    # the line totals - caught on #1055 as `platform,android,android`
     # 3-way matches).
     - component_id: android
       name: android
@@ -403,7 +403,7 @@ component_management:
         - "core/**/win/**"
         - "core/**/windows/**"
         - "core/**/wasapi/**"
-    # Surface (4) — `tools` excludes `tools/cli/**` so the more specific
+    # Surface (4) - `tools` excludes `tools/cli/**` so the more specific
     # `cli` component owns those files; otherwise every CLI file is
     # double-counted (#1055).
     - component_id: cli

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -124,6 +124,23 @@ TEST_CASE("AES empty plaintext", "[crypto][aes]") {
     REQUIRE(decrypted->empty());
 }
 
+TEST_CASE("AES binary plaintext preserves embedded zero bytes",
+          "[crypto][aes][coverage][phase3]") {
+    uint8_t key[32] = {};
+    uint8_t iv[16] = {};
+    std::memset(key, 0x33, 32);
+    std::memset(iv, 0x77, 16);
+
+    const std::vector<uint8_t> plaintext = {0x00, 0x01, 0xff, 0x00, 0x7f, 0x80};
+    auto encrypted = aes_encrypt(plaintext.data(), plaintext.size(), key, iv);
+    REQUIRE(encrypted.has_value());
+    REQUIRE(encrypted->size() == 16);
+
+    auto decrypted = aes_decrypt(encrypted->data(), encrypted->size(), key, iv);
+    REQUIRE(decrypted.has_value());
+    REQUIRE(*decrypted == plaintext);
+}
+
 TEST_CASE("AES exact block plaintext adds and removes full padding block",
           "[crypto][aes][coverage][issue-641]") {
     uint8_t key[32] = {};
@@ -162,6 +179,15 @@ TEST_CASE("AES decrypt rejects non-block-aligned ciphertext", "[crypto][aes]") {
     uint8_t ciphertext[15] = {};
 
     auto result = aes_decrypt(ciphertext, sizeof(ciphertext), key, iv);
+    REQUIRE_FALSE(result.has_value());
+}
+
+TEST_CASE("AES decrypt rejects empty ciphertext",
+          "[crypto][aes][coverage][phase3]") {
+    uint8_t key[32] = {};
+    uint8_t iv[16] = {};
+
+    auto result = aes_decrypt(nullptr, 0, key, iv);
     REQUIRE_FALSE(result.has_value());
 }
 
@@ -218,4 +244,13 @@ TEST_CASE("Machine ID is non-empty", "[crypto][machine_id]") {
     REQUIRE_FALSE(id.empty());
     // Should not be all zeros
     REQUIRE(id != std::string(64, '0'));
+}
+
+TEST_CASE("Machine ID is lowercase hexadecimal",
+          "[crypto][machine_id][coverage][phase3]") {
+    auto id = machine_id();
+    REQUIRE(id.size() == 64);
+    REQUIRE(std::all_of(id.begin(), id.end(), [](unsigned char c) {
+        return std::isdigit(c) || (c >= 'a' && c <= 'f');
+    }));
 }

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -78,6 +78,13 @@ TEST_CASE("BigInteger large numbers", "[crypto][bigint]") {
     REQUIRE(c.to_string() == "1000000000000000000");
 }
 
+TEST_CASE("BigInteger invalid decimal and hex parse as zero",
+          "[crypto][bigint][coverage][phase3]") {
+    REQUIRE(BigInteger::from_string("not-a-number").is_zero());
+    REQUIRE(BigInteger::from_hex("not-hex").is_zero());
+    REQUIRE(BigInteger::from_string("").is_zero());
+}
+
 TEST_CASE("BigInteger copy move hex and bit-count helpers", "[crypto][bigint][coverage][issue-656]") {
     auto value = BigInteger::from_hex("0100");
     REQUIRE(value.to_string() == "256");
@@ -151,6 +158,17 @@ TEST_CASE("LicenseValidator parse payload", "[crypto][license]") {
     // Without a public key set, signature verification fails
     auto status = validator.validate(encoded);
     REQUIRE(status == LicenseStatus::InvalidSignature);
+}
+
+TEST_CASE("LicenseValidator invalid public key keeps valid payload unsigned",
+          "[crypto][license][coverage][phase3]") {
+    LicenseValidator validator;
+    validator.set_public_key("not a pem public key");
+
+    std::string payload = "{\"product_id\":\"PulpSynth\",\"issued\":1700000000}";
+    std::string key = base64_encode(payload) + "." + base64_encode("signature");
+
+    REQUIRE(validator.validate(key) == LicenseStatus::InvalidSignature);
 }
 
 TEST_CASE("LicenseValidator validate_and_parse extracts info", "[crypto][license]") {
@@ -240,6 +258,22 @@ TEST_CASE("LicenseValidator validate_file trims line endings", "[crypto][license
     TemporaryFile tmp(".license");
     std::string payload = "{\"product_id\":\"PulpSynth\",\"issued\":1700000000}";
     std::string key = base64_encode(payload) + "." + base64_encode("signature") + "\r\n";
+
+    {
+        std::ofstream out(tmp.path());
+        REQUIRE(out.good());
+        out << key;
+    }
+
+    LicenseValidator validator;
+    REQUIRE(validator.validate_file(tmp.path_string()) == LicenseStatus::InvalidSignature);
+}
+
+TEST_CASE("LicenseValidator validate_file trims repeated CRLF endings",
+          "[crypto][license][coverage][phase3]") {
+    TemporaryFile tmp(".license");
+    std::string payload = "{\"product_id\":\"PulpSynth\",\"issued\":1700000000}";
+    std::string key = base64_encode(payload) + "." + base64_encode("signature") + "\r\n\n";
 
     {
         std::ofstream out(tmp.path());

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -416,15 +416,19 @@ TEST_CASE("FileStream reopen closes the previous handle",
     REQUIRE(stream.flush());
     stream.close();
 
-    FileStream first_reader(first.string(), FileStream::Mode::Read);
-    std::uint8_t first_out = 0;
-    REQUIRE(first_reader.read(&first_out, 1).ok());
-    REQUIRE(first_out == 'a');
+    {
+        FileStream first_reader(first.string(), FileStream::Mode::Read);
+        std::uint8_t first_out = 0;
+        REQUIRE(first_reader.read(&first_out, 1).ok());
+        REQUIRE(first_out == 'a');
+    }
 
-    FileStream second_reader(second.string(), FileStream::Mode::Read);
-    std::uint8_t second_out[2]{};
-    REQUIRE(second_reader.read(second_out, sizeof(second_out)).bytes == sizeof(second_out));
-    REQUIRE(std::memcmp(second_out, b, sizeof(b)) == 0);
+    {
+        FileStream second_reader(second.string(), FileStream::Mode::Read);
+        std::uint8_t second_out[2]{};
+        REQUIRE(second_reader.read(second_out, sizeof(second_out)).bytes == sizeof(second_out));
+        REQUIRE(std::memcmp(second_out, b, sizeof(b)) == 0);
+    }
 
     std::filesystem::remove(first);
     std::filesystem::remove(second);

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -376,6 +376,60 @@ TEST_CASE("MemoryStream clear keeps closed streams closed",
     REQUIRE(stream.write(&byte, 1).closed());
 }
 
+TEST_CASE("MemoryStream appends without rewinding the read cursor",
+          "[stream][memory][coverage][phase3]") {
+    MemoryStream stream(std::vector<std::uint8_t>{1, 2, 3});
+    std::uint8_t out[4]{};
+
+    auto first = stream.read(out, 2);
+    REQUIRE(first.ok());
+    REQUIRE(first.bytes == 2);
+    REQUIRE(stream.read_position() == 2);
+
+    const std::uint8_t extra[] = {4, 5};
+    auto wrote = stream.write(extra, sizeof(extra));
+    REQUIRE(wrote.ok());
+    REQUIRE(wrote.bytes == sizeof(extra));
+    REQUIRE(stream.size() == 5);
+    REQUIRE(stream.read_position() == 2);
+
+    auto tail = stream.read(out, sizeof(out));
+    REQUIRE(tail.ok());
+    REQUIRE(tail.bytes == 3);
+    REQUIRE(out[0] == 3);
+    REQUIRE(out[1] == 4);
+    REQUIRE(out[2] == 5);
+}
+
+TEST_CASE("FileStream reopen closes the previous handle",
+          "[stream][file][coverage][phase3]") {
+    auto first = make_temp_path("pulp_stream_reopen_first");
+    auto second = make_temp_path("pulp_stream_reopen_second");
+    const std::uint8_t a[] = {'a'};
+    const std::uint8_t b[] = {'b', 'b'};
+
+    FileStream stream(first.string(), FileStream::Mode::Write);
+    REQUIRE(stream.is_open());
+    REQUIRE(stream.write(a, sizeof(a)).ok());
+    REQUIRE(stream.open(second.string(), FileStream::Mode::Write));
+    REQUIRE(stream.write(b, sizeof(b)).ok());
+    REQUIRE(stream.flush());
+    stream.close();
+
+    FileStream first_reader(first.string(), FileStream::Mode::Read);
+    std::uint8_t first_out = 0;
+    REQUIRE(first_reader.read(&first_out, 1).ok());
+    REQUIRE(first_out == 'a');
+
+    FileStream second_reader(second.string(), FileStream::Mode::Read);
+    std::uint8_t second_out[2]{};
+    REQUIRE(second_reader.read(second_out, sizeof(second_out)).bytes == sizeof(second_out));
+    REQUIRE(std::memcmp(second_out, b, sizeof(b)) == 0);
+
+    std::filesystem::remove(first);
+    std::filesystem::remove(second);
+}
+
 TEST_CASE("TcpStream closed state rejects I/O and survives move assignment",
           "[stream][tcp][coverage][issue-641]") {
     TcpStream first;
@@ -411,6 +465,26 @@ TEST_CASE("HttpStream invalid URLs fail without external transport",
 
     stream.close();
     REQUIRE(stream.read(out.data(), out.size()).closed());
+}
+
+TEST_CASE("HttpStream fetch resets a closed stream before reporting new failure",
+          "[stream][http][coverage][phase3]") {
+    HttpStream stream;
+    stream.close();
+
+    HttpStream::Request request;
+    request.url = "ftp://127.0.0.1/nope";
+    request.timeout_seconds = 1;
+
+    REQUIRE_FALSE(stream.fetch(request));
+    REQUIRE_FALSE(stream.is_open());
+    REQUIRE(stream.status_code() == 0);
+    REQUIRE(stream.transport_error() == "Invalid URL");
+
+    std::uint8_t byte = 0;
+    auto read = stream.read(&byte, 1);
+    REQUIRE_FALSE(read.ok());
+    REQUIRE(read.error == StreamError::IoError);
 }
 
 TEST_CASE("NamedPipe closed and missing endpoints fail closed", "[stream][named_pipe][issue-641]") {

--- a/test/test_v3_gaps.cpp
+++ b/test/test_v3_gaps.cpp
@@ -320,10 +320,26 @@ TEST_CASE("is_prime known values", "[runtime][primes]") {
     REQUIRE_FALSE(pulp::runtime::is_prime(100));
 }
 
+TEST_CASE("is_prime rejects small and square composites",
+          "[runtime][primes][coverage][phase3]") {
+    REQUIRE_FALSE(pulp::runtime::is_prime(0));
+    REQUIRE_FALSE(pulp::runtime::is_prime(1));
+    REQUIRE_FALSE(pulp::runtime::is_prime(9));
+    REQUIRE_FALSE(pulp::runtime::is_prime(49));
+    REQUIRE_FALSE(pulp::runtime::is_prime(121));
+}
+
 TEST_CASE("generate_prime", "[runtime][primes]") {
     auto p = pulp::runtime::generate_prime(16);
     REQUIRE(p > 0);
     REQUIRE(pulp::runtime::is_prime(p));
+}
+
+TEST_CASE("generate_prime rejects unsupported bit widths",
+          "[runtime][primes][coverage][phase3]") {
+    REQUIRE(pulp::runtime::generate_prime(0) == 0);
+    REQUIRE(pulp::runtime::generate_prime(1) == 0);
+    REQUIRE(pulp::runtime::generate_prime(63) == 0);
 }
 
 TEST_CASE("sieve_primes", "[runtime][primes]") {
@@ -331,6 +347,14 @@ TEST_CASE("sieve_primes", "[runtime][primes]") {
     REQUIRE(primes.size() == 25);  // 25 primes below 100
     REQUIRE(primes[0] == 2);
     REQUIRE(primes.back() == 97);
+}
+
+TEST_CASE("sieve_primes handles small limits",
+          "[runtime][primes][coverage][phase3]") {
+    REQUIRE(pulp::runtime::sieve_primes(0).empty());
+    REQUIRE(pulp::runtime::sieve_primes(1).empty());
+    REQUIRE(pulp::runtime::sieve_primes(2) == std::vector<uint32_t>{2});
+    REQUIRE(pulp::runtime::sieve_primes(3) == std::vector<uint32_t>{2, 3});
 }
 
 // ── Expression evaluator ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add focused crypto and identity primitive edge coverage
- add license validator and BigInteger failure-path coverage
- add stream lifecycle/reopen/read-position coverage
- add prime helper boundary coverage

## Local validation
- `git diff --check`
- `cmake --build build --target pulp-test-crypto pulp-test-license pulp-test-stream pulp-test-v3-gaps -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-crypto`
- `./build/test/pulp-test-license`
- `./build/test/pulp-test-stream`
- `./build/test/pulp-test-v3-gaps "*prime*"`
- `PULP_DIFF_COVER_CTEST_REGEX=... tools/scripts/local_diff_cover.sh`

No Namespace/SSH validation dispatched; GitHub-hosted CI is the merge gate.