### PR TITLE
feat(design-import): Phase A — default shortcuts (source-matched heuristic)

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -612,3 +612,29 @@ If you add a new shortcut shape detector to the extractor, mirror it in:
 - The synthetic-event emitter that produces the `KeyboardEvent`-shaped JS object
 
 Test coverage lives in `test/test_design_import.cpp` (E2E roundtrip — codegen → WidgetBridge → React-style handler). The roundtrip exercises both the registerShortcut emission and the synthetic-keydown re-dispatch; failing either half is a hard test failure.
+
+## Default shortcuts (Phase A — source-matched, #2128)
+
+On top of the V2 extractor, the import pass auto-binds platform-convention chords (`Cmd+,` Settings, `Cmd+?` Help, bare `?` cheatsheet, `Cmd+N/O/S/F`, plus Win/Linux `Ctrl`/`F1` variants) when the dev's React source has a recognizable component. Lives in `core/view/src/design_import.cpp::detect_default_shortcuts(...)` + `apply_default_shortcuts(...)`. Accepted defaults are lowered into `DetectedShortcut` form and ride the V2 codegen path with no fork.
+
+Hard rule (encoded): **a wrong auto-binding is worse than no binding**. Detector requires ≥2 signals to fire and emits a `collision` entry (no bind) when multiple candidates compete.
+
+Signals scored per (component, pattern):
+1. Component name keyword match (`SettingsModal`, `HelpPanel`, etc.)
+2. `role="dialog"` / `role="alertdialog"` / `role="menu"` / `role="listbox"` in body
+3. `aria-label="..."` text in body containing pattern keyword
+4. `<h1>`/`<h2>`/`<h3>` heading text matching pattern keyword
+5. `<kbd>` tag presence (cheatsheet disambiguator — required for cheatsheet match)
+6. **Canonical-name bonus**: exact `<Pattern>{Modal,Dialog,Panel,Popover,Sheet,Window,Drawer}` shape counts as a second signal on its own. Real apps (Spectr's `SettingsModal`, `HelpPopover`) use inline-styled divs without ARIA, so the strict ≥2 ARIA-shape gate would skip every one of them. Generic non-canonical names (`SettingsList`) still require a real second signal.
+
+Body-window extraction stops at the next top-level component declaration — otherwise sibling components bleed into each other (a cheatsheet `<kbd>` in `ShortcutsModal` would wrongly count as a signal for an adjacent `SettingsModal` defined right above it).
+
+Cross-platform emission: the CLI runs at import time, but the generated `ui.js` ships to multiple platforms. The import driver emits BOTH macOS and Win/Linux variants for any default with a platform delta (Help: `Cmd+?` + `F1`; Settings: `Cmd+,` + `Ctrl+,`). At runtime only the chord matching the physical key fires its `registerShortcut` entry (exact-mask match on the bridge side).
+
+JS-literal escape: any key string interpolated into `key: '...'` MUST be backslash- and quote-escaped — `key_string_to_keycode` accepts all printable ASCII (incl. `'` and `\`), so a source with `e.key === "'"` would otherwise produce syntactically-invalid JS. The `emit_binding` lambda escapes at emission time.
+
+CLI surface:
+- `--no-default-shortcuts` opts out (default ON)
+- `<name>.defaults.json` diagnostic written alongside `shortcuts.json` showing accepted candidates + collisions
+
+What's NOT in Phase A: Pulp-framework defaults for the built-in `SettingsPanel` Audio/MIDI sub-tabs (`Cmd+Opt+A` / `Cmd+Opt+M`). Phase B follow-up — needs `TabPanel` select-tab JS API + standalone-only emission gate. Spec: `planning/2026-05-16-default-keyboard-shortcuts.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v01060"></a>
+## [0.107.0]
+
 ## [0.106.0] - 2026-05-17
 
 - feat(design-import): V2 wire-up — emit registerShortcut + synthetic keydown re-dispatch ([#2119](https://github.com/danielraffel/pulp/pull/2119))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.106.0
+    VERSION 0.107.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/design_import.hpp
+++ b/core/view/include/pulp/view/design_import.hpp
@@ -456,6 +456,109 @@ std::vector<DetectedShortcut> extract_keyboard_shortcuts(
 /// across runs.
 std::string serialize_detected_shortcuts(const std::vector<DetectedShortcut>& shortcuts);
 
+// ── Default shortcuts (pulp #2116 Phase A — source-matched only) ────────
+//
+// On top of the V1+V2 extractor (which captures shortcuts the developer
+// *already wrote*), the default-shortcuts pass adds bindings the developer
+// *would expect* per platform convention but didn't write: `Cmd+,` for
+// Settings, `Cmd+?` / `F1` for Help, bare `?` for a shortcut cheatsheet,
+// `Cmd+S` for Save, etc.
+//
+// Hard rule: a wrong auto-binding is worse than no binding. The detector
+// requires AT LEAST TWO independent signals (component name, ARIA role,
+// modal heading, trigger icon, content shape) before firing, and emits a
+// `default_collision` entry instead of a binding when multiple modals
+// look like the same pattern.
+//
+// What this pass does NOT cover: Pulp-framework-provided surfaces (Audio /
+// MIDI Settings tabs in standalone). Those need a separate codegen path
+// that drives the TabPanel select-tab API and are gated on the build mode
+// — tracked as Phase B in planning/2026-05-16-default-keyboard-shortcuts.md.
+
+/// Which platform-convention surface a default binding maps to. Used by
+/// `detect_default_shortcuts` to label matches and by `generate_pulp_js`
+/// to skip Pulp-framework-provided rows that don't exist on the target.
+enum class DefaultShortcutPattern {
+    settings,    // Settings / Preferences modal
+    help,        // Help / About / Documentation modal (prose-style)
+    cheatsheet,  // Shortcut cheatsheet modal (<kbd>-list style)
+    new_file,    // "New" button
+    open_file,   // "Open" button
+    save_file,   // "Save" button
+    find,        // Find / Search input
+};
+
+/// One default-binding emission produced by the source heuristic. A
+/// `DefaultShortcut` is appended into `CodeGenOptions::shortcuts` as a
+/// `DetectedShortcut` (with `pattern = "default:<name>"`) so it flows
+/// through the V2 codegen path with no fork — same registerShortcut +
+/// synthetic-keydown thunk as an extracted shortcut.
+struct DefaultShortcutCandidate {
+    DefaultShortcutPattern pattern;
+    /// Component name / identifier that won the match — for traceability
+    /// in `shortcuts.json` and for the developer's mental model.
+    std::string target;
+    /// "high" (≥3 signals) or "medium" (exactly 2). The detector only
+    /// emits bindings for high+medium — anything weaker is dropped.
+    std::string confidence;
+    /// Source signals that fired, in order. Surfaced in `shortcuts.json`
+    /// so a reviewer can audit the heuristic.
+    std::vector<std::string> signals;
+};
+
+/// One unresolved candidate set — emitted when multiple components match
+/// the same pattern with comparable confidence. No binding fires; the
+/// caller can decide whether to triage manually or accept the ambiguity.
+struct DefaultShortcutCollision {
+    DefaultShortcutPattern pattern;
+    std::vector<std::string> candidates;  // component names
+    std::string reason;
+};
+
+/// Result of running `detect_default_shortcuts`. The accepted bindings
+/// are mapped to DetectedShortcut form by `apply_default_shortcuts` and
+/// fed through the V2 codegen; collisions go into shortcuts.json as
+/// diagnostic-only entries.
+struct DefaultShortcutScan {
+    std::vector<DefaultShortcutCandidate> accepted;
+    std::vector<DefaultShortcutCollision> collisions;
+};
+
+/// Static-scan a TSX/JS source string for components matching the
+/// platform-convention defaults table. Signals: component identifier
+/// (`SettingsModal`, `HelpDialog`, `ShortcutsCheatsheet`, etc.), `role=`
+/// attribute, `aria-label=` text, modal heading text, presence of
+/// `<kbd>` tags (cheatsheet disambiguator). Conservative — requires ≥2
+/// signals to fire; multiple-candidate matches go into `collisions` not
+/// `accepted`.
+///
+/// Already-extracted shortcuts (`existing_extracted`) suppress the same-
+/// chord default so a developer's hand-written binding always wins.
+///
+/// Pure lexical pass; no JSX parsing. Returns an empty scan when no
+/// patterns match. Never throws.
+DefaultShortcutScan detect_default_shortcuts(
+    const std::string& source,
+    const std::vector<DetectedShortcut>& existing_extracted);
+
+/// Convert accepted candidates from `detect_default_shortcuts` into the
+/// `DetectedShortcut` form that V2 codegen expects. The platform chord
+/// is selected based on `target_platform`: macOS gets the Cmd / Cmd+?
+/// chords, Win/Linux get Ctrl / F1. `pattern` is namespaced with a
+/// `"default:"` prefix so manifest readers can tell auto-bound from
+/// extracted entries at a glance.
+enum class TargetPlatform { macos, win_linux };
+
+std::vector<DetectedShortcut> apply_default_shortcuts(
+    const std::vector<DefaultShortcutCandidate>& accepted,
+    TargetPlatform platform);
+
+/// Render the auto-bound defaults + collisions into JSON for emission
+/// alongside the extracted-shortcuts manifest. Mirror of
+/// `serialize_detected_shortcuts` shape but namespaced under
+/// `"defaults"` and `"collisions"` top-level keys.
+std::string serialize_default_shortcut_scan(const DefaultShortcutScan& scan);
+
 /// Heuristic: does this HTML look like a JS-bundler entry (React, Vue,
 /// Svelte, @pulp/react, generic webpack/vite/bun output) rather than a
 /// hand-authored Claude Design page? The static-HTML parser only sees

--- a/core/view/src/design_import.cpp
+++ b/core/view/src/design_import.cpp
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <map>
 #include <unordered_set>
+#include <set>
 
 namespace pulp::view {
 
@@ -505,16 +506,360 @@ std::string serialize_detected_shortcuts(const std::vector<DetectedShortcut>& sh
     return choc::json::toString(root, /*useLineBreaks=*/true);
 }
 
+// ── Default shortcuts (Phase A: source-matched) ─────────────────────────
+
+namespace {
+
+const char* pattern_name(DefaultShortcutPattern p) {
+    switch (p) {
+        case DefaultShortcutPattern::settings:   return "settings";
+        case DefaultShortcutPattern::help:       return "help";
+        case DefaultShortcutPattern::cheatsheet: return "cheatsheet";
+        case DefaultShortcutPattern::new_file:   return "new";
+        case DefaultShortcutPattern::open_file:  return "open";
+        case DefaultShortcutPattern::save_file:  return "save";
+        case DefaultShortcutPattern::find:       return "find";
+    }
+    return "unknown";
+}
+
+bool icontains(const std::string& haystack, const std::string& needle) {
+    if (needle.empty() || haystack.size() < needle.size()) return false;
+    auto it = std::search(
+        haystack.begin(), haystack.end(),
+        needle.begin(), needle.end(),
+        [](char a, char b) {
+            return std::tolower(static_cast<unsigned char>(a))
+                == std::tolower(static_cast<unsigned char>(b));
+        });
+    return it != haystack.end();
+}
+
+// Find all top-level JSX/identifier names that look like component
+// declarations or usages — a lexical pass over the source, no parser.
+// Captures `function FooBar(`, `const FooBar =`, `class FooBar`,
+// and JSX opening tags `<FooBar`. Lowercased dedupe.
+std::vector<std::string> collect_component_names(const std::string& source) {
+    std::vector<std::string> names;
+    auto seen = std::set<std::string>{};
+
+    auto add = [&](const std::string& n) {
+        if (n.empty() || !std::isupper(static_cast<unsigned char>(n[0]))) return;
+        auto lower = n;
+        for (auto& c : lower) c = std::tolower(static_cast<unsigned char>(c));
+        if (seen.insert(lower).second) names.push_back(n);
+    };
+
+    // function FooBar( ... )
+    {
+        std::regex re(R"(\bfunction\s+([A-Z][A-Za-z0-9_]*)\s*\()");
+        auto begin = std::sregex_iterator(source.begin(), source.end(), re);
+        auto end   = std::sregex_iterator();
+        for (auto it = begin; it != end; ++it) add((*it)[1].str());
+    }
+    // const FooBar = ... / let FooBar = ...
+    {
+        std::regex re(R"(\b(?:const|let|var)\s+([A-Z][A-Za-z0-9_]*)\s*=)");
+        auto begin = std::sregex_iterator(source.begin(), source.end(), re);
+        auto end   = std::sregex_iterator();
+        for (auto it = begin; it != end; ++it) add((*it)[1].str());
+    }
+    // class FooBar ...
+    {
+        std::regex re(R"(\bclass\s+([A-Z][A-Za-z0-9_]*)\b)");
+        auto begin = std::sregex_iterator(source.begin(), source.end(), re);
+        auto end   = std::sregex_iterator();
+        for (auto it = begin; it != end; ++it) add((*it)[1].str());
+    }
+    // <FooBar  (JSX opening tag) — captures usages even if component is imported
+    {
+        std::regex re(R"(<([A-Z][A-Za-z0-9_]*))");
+        auto begin = std::sregex_iterator(source.begin(), source.end(), re);
+        auto end   = std::sregex_iterator();
+        for (auto it = begin; it != end; ++it) add((*it)[1].str());
+    }
+    return names;
+}
+
+// Map a pattern to the keyword set the component name + ARIA + heading
+// signals should match.  Order matters for cheatsheet vs help disambig:
+// cheatsheet is checked first; if it matches AND <kbd> appears nearby,
+// it's a cheatsheet; otherwise help/about/docs wins on prose modals.
+const std::vector<std::string>& pattern_keywords(DefaultShortcutPattern p) {
+    static const std::vector<std::string> kw_settings    = {"settings", "preferences", "preference", "options"};
+    static const std::vector<std::string> kw_help        = {"help", "about", "documentation", "docs"};
+    static const std::vector<std::string> kw_cheatsheet  = {"cheatsheet", "shortcuts", "shortcutshelp", "keyboardshortcuts", "keymap"};
+    static const std::vector<std::string> kw_new         = {"newproject", "newfile", "newdocument", "newbutton"};
+    static const std::vector<std::string> kw_open        = {"openfile", "openproject", "opendocument", "openbutton"};
+    static const std::vector<std::string> kw_save        = {"savefile", "savebutton", "savedocument", "saveproject"};
+    static const std::vector<std::string> kw_find        = {"searchinput", "searchbox", "findbox", "findinput"};
+    switch (p) {
+        case DefaultShortcutPattern::settings:   return kw_settings;
+        case DefaultShortcutPattern::help:       return kw_help;
+        case DefaultShortcutPattern::cheatsheet: return kw_cheatsheet;
+        case DefaultShortcutPattern::new_file:   return kw_new;
+        case DefaultShortcutPattern::open_file:  return kw_open;
+        case DefaultShortcutPattern::save_file:  return kw_save;
+        case DefaultShortcutPattern::find:       return kw_find;
+    }
+    return kw_settings;
+}
+
+// Score one candidate component against one default pattern. Returns the
+// set of signals that fired; an empty result means "no match".
+std::vector<std::string> score_signals(
+    const std::string& source,
+    const std::string& component,
+    DefaultShortcutPattern pattern) {
+    std::vector<std::string> signals;
+
+    // Signal 1: component name contains a pattern keyword.
+    const auto& kws = pattern_keywords(pattern);
+    bool name_hit = false;
+    for (const auto& kw : kws) {
+        if (icontains(component, kw)) { name_hit = true; break; }
+    }
+    if (name_hit) signals.push_back("component-name:" + component);
+
+    // The remaining signals look at the body of the component declaration.
+    // Locate the definition, then truncate at the NEXT same-shape
+    // declaration so we don't bleed sibling components into this one's
+    // body (which would let `<kbd>` from a cheatsheet component count as
+    // a signal for an unrelated settings modal that happens to live in
+    // the same file).
+    std::string body;
+    {
+        std::regex decl_re(R"((?:function\s+|const\s+|let\s+|var\s+|class\s+))" + component + R"(\b)");
+        std::smatch m;
+        if (std::regex_search(source, m, decl_re)) {
+            size_t start = static_cast<size_t>(m.position(0));
+            size_t end = std::min(source.size(), start + 4000);
+
+            // Walk forward from start+1 (skip our own decl) and clamp `end`
+            // at the next top-level component declaration.
+            std::regex next_decl(
+                R"((?:function|const|let|var|class)\s+[A-Z][A-Za-z0-9_]*\b)");
+            auto search_from = source.begin() + start + 1;
+            auto search_to = source.begin() + end;
+            std::smatch next_m;
+            if (std::regex_search(search_from, search_to, next_m, next_decl)) {
+                end = static_cast<size_t>(start + 1 + next_m.position(0));
+            }
+            body = source.substr(start, end - start);
+        }
+    }
+
+    if (!body.empty()) {
+        // Signal 2: role="dialog" / role="alertdialog" / role="menu" in body.
+        if (std::regex_search(body,
+                std::regex(R"(role\s*=\s*['"](?:dialog|alertdialog|menu|listbox)['"])"))) {
+            signals.push_back("aria-role:dialog");
+        }
+
+        // Signal 3: aria-label or aria-labelledby referencing a pattern keyword.
+        for (const auto& kw : kws) {
+            std::regex aria_re(R"(aria-label\s*=\s*['"][^'"]*)" + kw + R"([^'"]*['"])",
+                               std::regex::icase);
+            if (std::regex_search(body, aria_re)) {
+                signals.push_back("aria-label:" + kw);
+                break;
+            }
+        }
+
+        // Signal 4: an <h1>/<h2>/<h3>/title text in body contains a pattern keyword.
+        for (const auto& kw : kws) {
+            std::regex h_re(R"(<h[1-3][^>]*>\s*[^<]*)" + kw + R"([^<]*</h[1-3]>)",
+                            std::regex::icase);
+            if (std::regex_search(body, h_re)) {
+                signals.push_back("heading:" + kw);
+                break;
+            }
+        }
+
+        // Signal 5 (cheatsheet disambiguator): <kbd> tag presence in body.
+        if (pattern == DefaultShortcutPattern::cheatsheet) {
+            if (body.find("<kbd") != std::string::npos) {
+                signals.push_back("kbd-tag-present");
+            }
+        }
+    }
+
+    return signals;
+}
+
+}  // namespace
+
+DefaultShortcutScan detect_default_shortcuts(
+    const std::string& source,
+    const std::vector<DetectedShortcut>& existing_extracted) {
+    DefaultShortcutScan scan;
+    if (source.empty()) return scan;
+
+    auto components = collect_component_names(source);
+
+    auto patterns = std::vector<DefaultShortcutPattern>{
+        DefaultShortcutPattern::settings,
+        DefaultShortcutPattern::help,
+        DefaultShortcutPattern::cheatsheet,
+        DefaultShortcutPattern::new_file,
+        DefaultShortcutPattern::open_file,
+        DefaultShortcutPattern::save_file,
+        DefaultShortcutPattern::find,
+    };
+
+    // Track which (key, mods) chords are already claimed by an extracted
+    // shortcut.  Extracted always wins — we suppress same-chord defaults.
+    auto extracted_claims = std::set<std::string>{};
+    for (const auto& s : existing_extracted) {
+        std::string sig = s.key;
+        for (const auto& m : s.modifiers) sig += "|" + m;
+        extracted_claims.insert(sig);
+    }
+    auto chord_for = [](DefaultShortcutPattern p) -> std::string {
+        // Used only for the extracted-shortcut collision check, so always
+        // use the macOS chord (extracted shortcuts in the source already
+        // collapse cross-platform via the meta||ctrl idiom).
+        switch (p) {
+            case DefaultShortcutPattern::settings:   return ",|meta";
+            case DefaultShortcutPattern::help:       return "?|meta";
+            case DefaultShortcutPattern::cheatsheet: return "?";  // bare
+            case DefaultShortcutPattern::new_file:   return "n|meta";
+            case DefaultShortcutPattern::open_file:  return "o|meta";
+            case DefaultShortcutPattern::save_file:  return "s|meta";
+            case DefaultShortcutPattern::find:       return "f|meta";
+        }
+        return "";
+    };
+
+    for (auto p : patterns) {
+        // Suppress this default if a same-chord extracted shortcut exists.
+        if (extracted_claims.count(chord_for(p))) continue;
+
+        struct Match { std::string component; std::vector<std::string> signals; };
+        std::vector<Match> matches;
+
+        for (const auto& comp : components) {
+            auto signals = score_signals(source, comp, p);
+            if (signals.size() >= 2) matches.push_back({comp, std::move(signals)});
+        }
+
+        // Cheatsheet vs help disambiguation: if a component matched as
+        // cheatsheet BUT had no <kbd> signal, demote it (a "ShortcutsModal"
+        // with prose only is really a help dialog).
+        if (p == DefaultShortcutPattern::cheatsheet) {
+            matches.erase(
+                std::remove_if(matches.begin(), matches.end(), [](const Match& m) {
+                    return std::find(m.signals.begin(), m.signals.end(),
+                                     std::string("kbd-tag-present")) == m.signals.end();
+                }),
+                matches.end());
+        }
+
+        if (matches.empty()) continue;
+
+        if (matches.size() == 1) {
+            scan.accepted.push_back(DefaultShortcutCandidate{
+                p, matches[0].component,
+                matches[0].signals.size() >= 3 ? "high" : "medium",
+                std::move(matches[0].signals)});
+        } else {
+            std::vector<std::string> candidate_names;
+            for (auto& m : matches) candidate_names.push_back(m.component);
+            scan.collisions.push_back(DefaultShortcutCollision{
+                p, std::move(candidate_names),
+                "multiple components match — no default bound"});
+        }
+    }
+
+    return scan;
+}
+
+std::vector<DetectedShortcut> apply_default_shortcuts(
+    const std::vector<DefaultShortcutCandidate>& accepted,
+    TargetPlatform platform) {
+    std::vector<DetectedShortcut> out;
+    out.reserve(accepted.size());
+    const bool mac = (platform == TargetPlatform::macos);
+
+    for (const auto& c : accepted) {
+        DetectedShortcut s;
+        s.pattern = std::string("default:") + pattern_name(c.pattern) + " (" + c.target + ")";
+        s.handler_excerpt = "auto-bound default: " + c.confidence;
+
+        switch (c.pattern) {
+            case DefaultShortcutPattern::settings:
+                s.key = ",";  s.modifiers = mac ? std::vector<std::string>{"meta"} : std::vector<std::string>{"ctrl"};
+                break;
+            case DefaultShortcutPattern::help:
+                if (mac) { s.key = "?"; s.modifiers = {"meta"}; }
+                else     { s.key = "F1"; s.modifiers = {}; }
+                break;
+            case DefaultShortcutPattern::cheatsheet:
+                // Bare `?` cross-platform. Focus-guard (#2120) suppresses
+                // it while a TextEditor has focus, so it's safe.
+                s.key = "?";  s.modifiers = {};
+                break;
+            case DefaultShortcutPattern::new_file:
+                s.key = "n";  s.modifiers = mac ? std::vector<std::string>{"meta"} : std::vector<std::string>{"ctrl"};
+                break;
+            case DefaultShortcutPattern::open_file:
+                s.key = "o";  s.modifiers = mac ? std::vector<std::string>{"meta"} : std::vector<std::string>{"ctrl"};
+                break;
+            case DefaultShortcutPattern::save_file:
+                s.key = "s";  s.modifiers = mac ? std::vector<std::string>{"meta"} : std::vector<std::string>{"ctrl"};
+                break;
+            case DefaultShortcutPattern::find:
+                s.key = "f";  s.modifiers = mac ? std::vector<std::string>{"meta"} : std::vector<std::string>{"ctrl"};
+                break;
+        }
+        out.push_back(std::move(s));
+    }
+    return out;
+}
+
+std::string serialize_default_shortcut_scan(const DefaultShortcutScan& scan) {
+    auto root = choc::value::createObject("");
+
+    auto defaults = choc::value::createEmptyArray();
+    for (const auto& c : scan.accepted) {
+        auto obj = choc::value::createObject("");
+        obj.addMember("pattern", std::string(pattern_name(c.pattern)));
+        obj.addMember("target", c.target);
+        obj.addMember("confidence", c.confidence);
+        auto sigs = choc::value::createEmptyArray();
+        for (const auto& s : c.signals) sigs.addArrayElement(s);
+        obj.addMember("signals", sigs);
+        defaults.addArrayElement(obj);
+    }
+    root.addMember("defaults", defaults);
+
+    auto collisions = choc::value::createEmptyArray();
+    for (const auto& col : scan.collisions) {
+        auto obj = choc::value::createObject("");
+        obj.addMember("pattern", std::string(pattern_name(col.pattern)));
+        auto cands = choc::value::createEmptyArray();
+        for (const auto& c : col.candidates) cands.addArrayElement(c);
+        obj.addMember("candidates", cands);
+        obj.addMember("reason", col.reason);
+        collisions.addArrayElement(obj);
+    }
+    root.addMember("collisions", collisions);
+
+    return choc::json::toString(root, /*useLineBreaks=*/true);
+}
+
 int key_string_to_keycode(const std::string& key) {
     if (key.empty()) return 0;
 
-    // Single ASCII printable — KeyCode for letters/digits is the ASCII
-    // code itself (per input_events.hpp). Lowercase for letters; digits
-    // map to KeyCode::num0..num9 which are also their ASCII codes.
+    // Single ASCII printable — KeyCode for letters/digits/punctuation
+    // is the ASCII code itself (per input_events.hpp). Lowercase for
+    // letters; everything else passes through as-is so `,`, `.`, `/`,
+    // `?` etc. map correctly. Outside ASCII printable range → 0 (the
+    // codegen layer treats 0 as unmapped and skips emission).
     if (key.size() == 1) {
-        char c = key[0];
-        if (c >= 'A' && c <= 'Z') c = static_cast<char>(c - 'A' + 'a');
-        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == ' ') {
+        unsigned char c = static_cast<unsigned char>(key[0]);
+        if (c >= 'A' && c <= 'Z') c = static_cast<unsigned char>(c - 'A' + 'a');
+        if (c >= 0x20 && c <= 0x7E) {  // printable ASCII (space..tilde)
             return static_cast<int>(c);
         }
     }

--- a/core/view/src/design_import.cpp
+++ b/core/view/src/design_import.cpp
@@ -4460,12 +4460,30 @@ std::string generate_pulp_js(const DesignIR& ir, const CodeGenOptions& opts) {
         // physical chord we're intercepting — so the bundled React
         // handler's `e.ctrlKey`, `e.metaKey`, `e.metaKey || e.ctrlKey`
         // checks all see the right state.
+        // Escape a key string for a single-quoted JS literal. Codex P1 on
+        // #2128: widening `key_string_to_keycode` to accept all printable
+        // ASCII let characters like `'` and `\` pass validation, but the
+        // generator interpolates them raw into `key: '...'`. A source
+        // with `e.key === "'"` produces syntactically-invalid JS and the
+        // whole script fails to load. Escape backslash + single-quote at
+        // emission time so any future printable-key default is safe too.
+        auto js_escape_single_quoted = [](const std::string& in) {
+            std::string out;
+            out.reserve(in.size() + 2);
+            for (char c : in) {
+                if (c == '\\' || c == '\'') out += '\\';
+                out += c;
+            }
+            return out;
+        };
+
         auto emit_binding = [&](int kc, int mask, const std::string& key_str,
                                 const std::string& handler) {
+            const std::string key_esc = js_escape_single_quoted(key_str);
             ss << "globalThis." << handler << " = function() {\n";
             ss << "    if (typeof __dispatch__ !== 'function') return;\n";
             ss << "    __dispatch__('__global__', 'keydown', {\n";
-            ss << "        key: '" << key_str << "',\n";
+            ss << "        key: '" << key_esc << "',\n";
             ss << "        keyCode: " << kc << ",\n";
             ss << "        ctrlKey: " << ((mask & kModCtrl) ? "true" : "false") << ",\n";
             ss << "        shiftKey: " << ((mask & kModShift) ? "true" : "false") << ",\n";

--- a/core/view/src/design_import.cpp
+++ b/core/view/src/design_import.cpp
@@ -621,6 +621,38 @@ std::vector<std::string> score_signals(
     }
     if (name_hit) signals.push_back("component-name:" + component);
 
+    // Signal 1b (canonical-name bonus): exact matches against the canonical
+    // shape `XYZ{Modal,Dialog,Panel,Popover,Sheet,Window,Drawer}` for the
+    // pattern carry enough specificity to be a second signal on their own.
+    // Real-world apps (Spectr's `SettingsModal`, `HelpPopover`) use
+    // inline-styled divs without `role="dialog"`, so the strict ≥2 ARIA-
+    // shape gate would skip every one of them. We only add this for
+    // structurally-unambiguous names — not generic "Settings*" with
+    // suffixes that could mean anything.
+    auto canonical_name_hit = [&](const std::string& comp) -> bool {
+        // Single-word root part (Settings, Preferences, Help, About,
+        // Shortcuts, ...) followed by exactly one of the canonical kind
+        // suffixes. Reject anything beyond that.
+        std::vector<std::string> kinds = {
+            "Modal", "Dialog", "Panel", "Popover", "Sheet", "Window", "Drawer"
+        };
+        for (const auto& kw : kws) {
+            // Title-case the keyword for prefix matching: settings → Settings
+            std::string root = kw;
+            if (!root.empty()) root[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(root[0])));
+            for (const auto& kind : kinds) {
+                if (comp == root + kind) return true;
+            }
+            // Also accept the canonical name itself with no suffix
+            // (HelpPopover is a kind already; same root). Reject single-
+            // word "Settings" alone — too generic.
+        }
+        return false;
+    };
+    if (name_hit && canonical_name_hit(component)) {
+        signals.push_back("canonical-name");
+    }
+
     // The remaining signals look at the body of the component declaration.
     // Locate the definition, then truncate at the NEXT same-shape
     // declaration so we don't bleed sibling components into this one's

--- a/test/test_design_import_shortcuts.cpp
+++ b/test/test_design_import_shortcuts.cpp
@@ -762,3 +762,56 @@ TEST_CASE("default shortcuts: E2E — codegen emits default thunks too",
     REQUIRE(js.find("metaKey: true") != std::string::npos);
     REQUIRE(js.find("key: ','") != std::string::npos);
 }
+
+TEST_CASE("default shortcuts: emitted JS escapes single-quote + backslash (Codex P1 #2128)",
+          "[design-import][shortcuts][defaults][v2]") {
+    // Widening key_string_to_keycode to accept all printable ASCII lets
+    // `'` and `\` pass validation. Without escaping at emission time
+    // the generated `key: '...'` literal becomes syntactically invalid
+    // JS and the whole script fails to load. Pin the escape.
+    CodeGenOptions opts;
+    opts.mode = CodeGenMode::native;
+    opts.include_comments = false;
+
+    DetectedShortcut quote;  quote.key = "'";  // single-quote literal
+    DetectedShortcut backslash; backslash.key = "\\";  // single backslash
+    opts.shortcuts = {quote, backslash};
+
+    DesignIR ir;
+    auto js = generate_pulp_js(ir, opts);
+
+    // Both literals appear escaped — `key: '\''` and `key: '\\'`.
+    REQUIRE(js.find("key: '\\''")  != std::string::npos);
+    REQUIRE(js.find("key: '\\\\'") != std::string::npos);
+    // No unescaped raw `key: '''` would tokenize as empty-string + stray
+    // quote — assert that doesn't appear.
+    REQUIRE(js.find("key: '''") == std::string::npos);
+}
+
+TEST_CASE("default shortcuts: apply_default_shortcuts win_linux maps File-menu chords correctly",
+          "[design-import][shortcuts][defaults]") {
+    // P2 follow-up — every Cmd-on-mac default has a Ctrl-on-win/linux
+    // counterpart. Pin all four so a future re-map doesn't silently
+    // drop one platform.
+    auto chord_for = [&](DefaultShortcutPattern p) {
+        pulp::view::DefaultShortcutCandidate c;
+        c.pattern = p; c.target = "x"; c.confidence = "medium";
+        auto mac = apply_default_shortcuts({c}, TargetPlatform::macos)[0];
+        auto win = apply_default_shortcuts({c}, TargetPlatform::win_linux)[0];
+        return std::make_pair(mac, win);
+    };
+    for (auto p : {DefaultShortcutPattern::new_file,
+                   DefaultShortcutPattern::open_file,
+                   DefaultShortcutPattern::save_file,
+                   DefaultShortcutPattern::find}) {
+        auto [mac, win] = chord_for(p);
+        REQUIRE(mac.key == win.key);
+        REQUIRE(mac.modifiers == std::vector<std::string>{"meta"});
+        REQUIRE(win.modifiers == std::vector<std::string>{"ctrl"});
+    }
+
+    // Cheatsheet bare `?` is platform-agnostic (same chord both sides).
+    auto [csm, csw] = chord_for(DefaultShortcutPattern::cheatsheet);
+    REQUIRE(csm.key == "?");          REQUIRE(csw.key == "?");
+    REQUIRE(csm.modifiers.empty());   REQUIRE(csw.modifiers.empty());
+}

--- a/test/test_design_import_shortcuts.cpp
+++ b/test/test_design_import_shortcuts.cpp
@@ -586,21 +586,40 @@ TEST_CASE("default shortcuts: high-confidence Settings modal fires",
     REQUIRE(scan.collisions.empty());
 }
 
-TEST_CASE("default shortcuts: medium-confidence fires with name+heading only",
+TEST_CASE("default shortcuts: canonical name fires with no body signals",
           "[design-import][shortcuts][defaults]") {
+    // Real-world apps (Spectr's `SettingsModal`, `HelpPopover`) use inline-
+    // styled divs without role="dialog" or aria-label. The canonical-name
+    // bonus catches `<Pattern>Modal/Dialog/Panel/Popover/Sheet/Window/Drawer`
+    // exact shapes so those don't slip through. Single-signal + canonical
+    // suffix = 2 signals → fires at medium confidence.
     auto scan = detect_default_shortcuts(R"JS(
-        function HelpPanel() { return <div><h2>Help</h2><p>...</p></div>; }
+        function SettingsModal() { return <div />; }
+    )JS", {});
+    REQUIRE(scan.accepted.size() == 1);
+    REQUIRE(scan.accepted[0].pattern == DefaultShortcutPattern::settings);
+    REQUIRE(scan.accepted[0].confidence == "medium");
+}
+
+TEST_CASE("default shortcuts: non-canonical name + heading fires at medium",
+          "[design-import][shortcuts][defaults]") {
+    // `HelpFooter` is NOT a canonical kind suffix, so we need a second
+    // real signal — the heading provides it. Two signals → medium.
+    auto scan = detect_default_shortcuts(R"JS(
+        function HelpFooter() { return <div><h2>Help</h2><p>...</p></div>; }
     )JS", {});
     REQUIRE(scan.accepted.size() == 1);
     REQUIRE(scan.accepted[0].confidence == "medium");
     REQUIRE(scan.accepted[0].pattern == DefaultShortcutPattern::help);
 }
 
-TEST_CASE("default shortcuts: single-signal does NOT fire (conservative)",
+TEST_CASE("default shortcuts: non-canonical single-signal still does NOT fire",
           "[design-import][shortcuts][defaults]") {
-    // Name only — no role / aria / heading. Below the ≥2-signal bar.
+    // `SettingsList` is name-only AND non-canonical (List isn't in the
+    // modal-kind suffix set). Should NOT fire — `<SettingsList>` is the
+    // grouping widget, not the modal itself.
     auto scan = detect_default_shortcuts(R"JS(
-        function SettingsModal() { return <div />; }
+        function SettingsList() { return <ul />; }
     )JS", {});
     REQUIRE(scan.accepted.empty());
     REQUIRE(scan.collisions.empty());

--- a/test/test_design_import_shortcuts.cpp
+++ b/test/test_design_import_shortcuts.cpp
@@ -208,7 +208,10 @@ TEST_CASE("key_string_to_keycode maps DOM key names", "[design-import][shortcuts
 TEST_CASE("key_string_to_keycode returns 0 for unknown", "[design-import][shortcuts][v2]") {
     REQUIRE(key_string_to_keycode("") == 0);
     REQUIRE(key_string_to_keycode("Boop") == 0);
-    REQUIRE(key_string_to_keycode("@") == 0);  // not in alphanumeric range
+    // Printable ASCII (incl. punctuation) is accepted now; "@" maps to 0x40.
+    REQUIRE(key_string_to_keycode("@") == 0x40);
+    // Non-printable / non-ASCII still returns 0.
+    REQUIRE(key_string_to_keycode(std::string(1, '\x01')) == 0);
 }
 
 TEST_CASE("modifier_strings_to_mask combines bits + 'meta' maps to kModCmd", "[design-import][shortcuts][v2]") {
@@ -549,4 +552,194 @@ TEST_CASE("E2E roundtrip: extract -> codegen -> WidgetBridge -> React-style hand
     REQUIRE(fired_field(4, "key").toString()         == "n");
     REQUIRE(fired_field(4, "ctrlKey").getWithDefault<bool>(false) == true);
     REQUIRE(fired_field(4, "metaKey").getWithDefault<bool>(true)  == false);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Phase A — default shortcuts (source-matched). Heuristic detector +
+// apply step + collision behavior. Spec: planning/2026-05-16-default-
+// keyboard-shortcuts.md.
+// ────────────────────────────────────────────────────────────────────────
+
+using pulp::view::DefaultShortcutPattern;
+using pulp::view::detect_default_shortcuts;
+using pulp::view::apply_default_shortcuts;
+using pulp::view::serialize_default_shortcut_scan;
+using pulp::view::TargetPlatform;
+
+TEST_CASE("default shortcuts: high-confidence Settings modal fires",
+          "[design-import][shortcuts][defaults]") {
+    auto scan = detect_default_shortcuts(R"JS(
+        function SettingsModal({ onClose }) {
+            return (
+                <div role="dialog" aria-label="Settings">
+                    <h1>Settings</h1>
+                    <button onClick={onClose}>Close</button>
+                </div>
+            );
+        }
+    )JS", /*existing=*/{});
+
+    REQUIRE(scan.accepted.size() == 1);
+    REQUIRE(scan.accepted[0].pattern == DefaultShortcutPattern::settings);
+    REQUIRE(scan.accepted[0].target == "SettingsModal");
+    REQUIRE(scan.accepted[0].confidence == "high");
+    REQUIRE(scan.collisions.empty());
+}
+
+TEST_CASE("default shortcuts: medium-confidence fires with name+heading only",
+          "[design-import][shortcuts][defaults]") {
+    auto scan = detect_default_shortcuts(R"JS(
+        function HelpPanel() { return <div><h2>Help</h2><p>...</p></div>; }
+    )JS", {});
+    REQUIRE(scan.accepted.size() == 1);
+    REQUIRE(scan.accepted[0].confidence == "medium");
+    REQUIRE(scan.accepted[0].pattern == DefaultShortcutPattern::help);
+}
+
+TEST_CASE("default shortcuts: single-signal does NOT fire (conservative)",
+          "[design-import][shortcuts][defaults]") {
+    // Name only — no role / aria / heading. Below the ≥2-signal bar.
+    auto scan = detect_default_shortcuts(R"JS(
+        function SettingsModal() { return <div />; }
+    )JS", {});
+    REQUIRE(scan.accepted.empty());
+    REQUIRE(scan.collisions.empty());
+}
+
+TEST_CASE("default shortcuts: multiple Settings candidates → COLLISION, no bind",
+          "[design-import][shortcuts][defaults]") {
+    auto scan = detect_default_shortcuts(R"JS(
+        function AppSettingsModal() {
+            return <div role="dialog" aria-label="Settings"><h1>Settings</h1></div>;
+        }
+        function TrackSettingsModal() {
+            return <div role="dialog" aria-label="Settings"><h1>Settings</h1></div>;
+        }
+    )JS", {});
+    REQUIRE(scan.accepted.empty());
+    REQUIRE(scan.collisions.size() == 1);
+    REQUIRE(scan.collisions[0].pattern == DefaultShortcutPattern::settings);
+    REQUIRE(scan.collisions[0].candidates.size() == 2);
+}
+
+TEST_CASE("default shortcuts: cheatsheet vs help disambiguation via <kbd>",
+          "[design-import][shortcuts][defaults]") {
+    auto scan = detect_default_shortcuts(R"JS(
+        function ShortcutsModal() {
+            return (
+                <div role="dialog" aria-label="Keyboard shortcuts">
+                    <h1>Shortcuts</h1>
+                    <kbd>Cmd+S</kbd> — save
+                    <kbd>Cmd+,</kbd> — settings
+                </div>
+            );
+        }
+    )JS", {});
+    REQUIRE(scan.accepted.size() == 1);
+    REQUIRE(scan.accepted[0].pattern == DefaultShortcutPattern::cheatsheet);
+    bool has_kbd_sig = false;
+    for (const auto& s : scan.accepted[0].signals) {
+        if (s == "kbd-tag-present") { has_kbd_sig = true; break; }
+    }
+    REQUIRE(has_kbd_sig);
+}
+
+TEST_CASE("default shortcuts: extracted shortcut suppresses same-chord default",
+          "[design-import][shortcuts][defaults]") {
+    // Developer already wrote Cmd+, manually. Don't double-bind.
+    pulp::view::DetectedShortcut hand_written;
+    hand_written.key = ",";
+    hand_written.modifiers = {"meta"};
+    auto scan = detect_default_shortcuts(R"JS(
+        function SettingsModal() {
+            return <div role="dialog" aria-label="Settings"><h1>Settings</h1></div>;
+        }
+    )JS", {hand_written});
+    REQUIRE(scan.accepted.empty());
+}
+
+TEST_CASE("default shortcuts: apply_default_shortcuts maps per-platform chords",
+          "[design-import][shortcuts][defaults]") {
+    pulp::view::DefaultShortcutCandidate settings;
+    settings.pattern = DefaultShortcutPattern::settings;
+    settings.target = "SettingsModal";
+    settings.confidence = "high";
+
+    auto mac = apply_default_shortcuts({settings}, TargetPlatform::macos);
+    REQUIRE(mac.size() == 1);
+    REQUIRE(mac[0].key == ",");
+    REQUIRE(mac[0].modifiers == std::vector<std::string>{"meta"});
+
+    auto win = apply_default_shortcuts({settings}, TargetPlatform::win_linux);
+    REQUIRE(win.size() == 1);
+    REQUIRE(win[0].key == ",");
+    REQUIRE(win[0].modifiers == std::vector<std::string>{"ctrl"});
+
+    // Help: bare F1 on Win/Linux, Cmd+? on mac.
+    pulp::view::DefaultShortcutCandidate help;
+    help.pattern = DefaultShortcutPattern::help;
+    help.target = "HelpPanel";
+    help.confidence = "medium";
+    auto help_mac = apply_default_shortcuts({help}, TargetPlatform::macos);
+    REQUIRE(help_mac[0].key == "?");
+    REQUIRE(help_mac[0].modifiers == std::vector<std::string>{"meta"});
+    auto help_win = apply_default_shortcuts({help}, TargetPlatform::win_linux);
+    REQUIRE(help_win[0].key == "F1");
+    REQUIRE(help_win[0].modifiers.empty());
+}
+
+TEST_CASE("default shortcuts: serialize_default_shortcut_scan emits stable JSON",
+          "[design-import][shortcuts][defaults]") {
+    pulp::view::DefaultShortcutScan scan;
+    pulp::view::DefaultShortcutCandidate c;
+    c.pattern = DefaultShortcutPattern::settings;
+    c.target = "SettingsModal";
+    c.confidence = "high";
+    c.signals = {"component-name:SettingsModal", "aria-role:dialog"};
+    scan.accepted.push_back(c);
+
+    pulp::view::DefaultShortcutCollision col;
+    col.pattern = DefaultShortcutPattern::help;
+    col.candidates = {"AppHelp", "TrackHelp"};
+    col.reason = "multiple components match — no default bound";
+    scan.collisions.push_back(col);
+
+    auto json = serialize_default_shortcut_scan(scan);
+    REQUIRE(json.find("\"defaults\"") != std::string::npos);
+    REQUIRE(json.find("\"settings\"") != std::string::npos);
+    REQUIRE(json.find("\"high\"") != std::string::npos);
+    REQUIRE(json.find("\"collisions\"") != std::string::npos);
+    REQUIRE(json.find("\"help\"") != std::string::npos);
+    REQUIRE(json.find("\"AppHelp\"") != std::string::npos);
+}
+
+TEST_CASE("default shortcuts: E2E — codegen emits default thunks too",
+          "[design-import][shortcuts][defaults][e2e]") {
+    // The defaults ride V2's existing codegen path (no fork). Verify the
+    // bound default produces registerShortcut + thunk just like an
+    // extracted entry.
+    auto scan = detect_default_shortcuts(R"JS(
+        function SettingsModal({ onClose }) {
+            return (
+                <div role="dialog" aria-label="Settings">
+                    <h1>Settings</h1>
+                </div>
+            );
+        }
+    )JS", {});
+    REQUIRE(scan.accepted.size() == 1);
+
+    CodeGenOptions opts;
+    opts.mode = CodeGenMode::native;
+    opts.include_comments = false;
+    opts.shortcuts = apply_default_shortcuts(scan.accepted, TargetPlatform::macos);
+
+    DesignIR ir;
+    auto js = generate_pulp_js(ir, opts);
+
+    // Cmd+, → keycode 44 (comma) + mask 16 (kModCmd) + a synthetic event
+    // with metaKey:true.
+    REQUIRE(js.find("registerShortcut(44, 16, '__pulpShortcutHandler_0')") != std::string::npos);
+    REQUIRE(js.find("metaKey: true") != std::string::npos);
+    REQUIRE(js.find("key: ','") != std::string::npos);
 }

--- a/tools/import-design/pulp_import_design.cpp
+++ b/tools/import-design/pulp_import_design.cpp
@@ -54,6 +54,7 @@ static void print_usage() {
     std::cout << "  --no-emit-classnames    Skip classname emission (claude only)\n";
     std::cout << "  --shortcuts <path>      Output keyboard-shortcut manifest (default: shortcuts.json)\n";
     std::cout << "  --no-import-shortcuts   Skip keyboard shortcut auto-import (default: import)\n";
+    std::cout << "  --no-default-shortcuts  Skip platform-convention defaults (Settings=Cmd+,, etc.) (default: enabled)\n";
     std::cout << "  --execute-bundle  Run the bundled React app in a headless JS engine and\n";
     std::cout << "                    walk the materialized DOM (--from claude only).\n";
     std::cout << "                    Falls back to the static parser on any harness failure.\n";
@@ -142,6 +143,11 @@ int main(int argc, char* argv[]) {
     std::string shortcuts_output = "shortcuts.json";
     bool shortcuts_output_explicit = false;
     bool import_shortcuts = true;
+    // Phase A defaults — auto-bind platform conventions (Cmd+, → Settings,
+    // etc.) when the source has a high-confidence component match. Default-on;
+    // `--no-default-shortcuts` opts out without affecting the source-extracted
+    // path above.
+    bool default_shortcuts = true;
     bool output_explicit = false;                         // pulp friction-fix #4
     bool tokens_file_explicit = false;                    // pulp friction-fix #4
     // pulp #1031 — versioned detect surface
@@ -225,6 +231,8 @@ int main(int argc, char* argv[]) {
             shortcuts_output_explicit = true;
         } else if (std::strcmp(argv[i], "--no-import-shortcuts") == 0) {
             import_shortcuts = false;
+        } else if (std::strcmp(argv[i], "--no-default-shortcuts") == 0) {
+            default_shortcuts = false;
         } else if (std::strcmp(argv[i], "--detect-only") == 0) {
             detect_only = true;
         } else if (std::strcmp(argv[i], "--report-new-format") == 0) {
@@ -508,8 +516,24 @@ int main(int argc, char* argv[]) {
     // JS, pencil) can route through the same call without per-source
     // branching here.
     std::vector<DetectedShortcut> detected_shortcuts;
+    DefaultShortcutScan default_scan;
     if (import_shortcuts) {
         detected_shortcuts = extract_keyboard_shortcuts(content, input_file);
+
+        // Phase A defaults — only fire when the developer's React source
+        // has a high-confidence match. `apply_default_shortcuts` lowers
+        // accepted DefaultShortcutCandidates into the same DetectedShortcut
+        // form so they ride V2's codegen path with no fork.  Suppressed
+        // chord-by-chord against `detected_shortcuts` so an extracted
+        // binding always wins.  Platform defaults macOS chords (Cmd+,,
+        // Cmd+?, etc.) — Win/Linux variants pick Ctrl/F1 at runtime.
+        if (default_shortcuts) {
+            default_scan = detect_default_shortcuts(content, detected_shortcuts);
+            auto defaults = apply_default_shortcuts(
+                default_scan.accepted, TargetPlatform::macos);
+            for (auto& d : defaults) detected_shortcuts.push_back(std::move(d));
+        }
+
         opts.shortcuts = detected_shortcuts;
     }
 
@@ -622,10 +646,33 @@ int main(int argc, char* argv[]) {
     if (import_shortcuts && !detected_shortcuts.empty()) {
         const auto shortcuts_json = serialize_detected_shortcuts(detected_shortcuts);
         if (write_file(shortcuts_output, shortcuts_json)) {
+            const size_t extracted_count = detected_shortcuts.size()
+                                         - default_scan.accepted.size();
             std::cout << "Wrote " << shortcuts_output
                       << " (" << detected_shortcuts.size() << " shortcut"
                       << (detected_shortcuts.size() == 1 ? "" : "s")
+                      << " — " << extracted_count << " extracted, "
+                      << default_scan.accepted.size() << " platform-default"
                       << " — bound natively via registerShortcut())\n";
+        }
+    }
+
+    // Phase A — diagnostic dump of the defaults scan alongside the bound
+    // manifest. Writes even when no defaults fired, so a reviewer can see
+    // *why* (collisions, low confidence). Mirror naming convention.
+    if (import_shortcuts && default_shortcuts &&
+        (!default_scan.accepted.empty() || !default_scan.collisions.empty())) {
+        std::string defaults_path = shortcuts_output;
+        const auto dot = defaults_path.rfind('.');
+        defaults_path = (dot == std::string::npos)
+            ? defaults_path + ".defaults.json"
+            : defaults_path.substr(0, dot) + ".defaults.json";
+        const auto defaults_json = serialize_default_shortcut_scan(default_scan);
+        if (write_file(defaults_path, defaults_json)) {
+            std::cout << "Wrote " << defaults_path
+                      << " (" << default_scan.accepted.size() << " accepted, "
+                      << default_scan.collisions.size() << " collisions"
+                      << " — Phase A source-matched defaults)\n";
         }
     }
 

--- a/tools/import-design/pulp_import_design.cpp
+++ b/tools/import-design/pulp_import_design.cpp
@@ -523,15 +523,40 @@ int main(int argc, char* argv[]) {
         // Phase A defaults — only fire when the developer's React source
         // has a high-confidence match. `apply_default_shortcuts` lowers
         // accepted DefaultShortcutCandidates into the same DetectedShortcut
-        // form so they ride V2's codegen path with no fork.  Suppressed
+        // form so they ride V2's codegen path with no fork. Suppressed
         // chord-by-chord against `detected_shortcuts` so an extracted
-        // binding always wins.  Platform defaults macOS chords (Cmd+,,
-        // Cmd+?, etc.) — Win/Linux variants pick Ctrl/F1 at runtime.
+        // binding always wins.
+        //
+        // Codex P2 on #2128: the import CLI runs at build time, but the
+        // generated ui.js ships to many platforms (mac standalone, win
+        // standalone, plugin hosts on either). Emit BOTH macOS and
+        // Win/Linux variants — at runtime only the chord matching the
+        // physical key press fires its registerShortcut entry, so the
+        // user gets the right native binding on each platform without
+        // platform detection at codegen time. Mirrors the V2 dual emit
+        // for `metaKey||ctrlKey` (per-platform handlers, exact-mask
+        // match on the bridge side).
         if (default_shortcuts) {
             default_scan = detect_default_shortcuts(content, detected_shortcuts);
-            auto defaults = apply_default_shortcuts(
+            auto mac_defaults = apply_default_shortcuts(
                 default_scan.accepted, TargetPlatform::macos);
-            for (auto& d : defaults) detected_shortcuts.push_back(std::move(d));
+            auto win_defaults = apply_default_shortcuts(
+                default_scan.accepted, TargetPlatform::win_linux);
+            for (auto& d : mac_defaults) detected_shortcuts.push_back(std::move(d));
+            // Skip Win/Linux variants whose chord (key + mask) already
+            // came in via the mac pass — happens for keys without a
+            // platform delta (e.g. bare `?` for cheatsheet emits the
+            // same binding under both platforms).
+            for (auto& d : win_defaults) {
+                bool dup = false;
+                for (const auto& existing : detected_shortcuts) {
+                    if (existing.key == d.key && existing.modifiers == d.modifiers) {
+                        dup = true;
+                        break;
+                    }
+                }
+                if (!dup) detected_shortcuts.push_back(std::move(d));
+            }
         }
 
         opts.shortcuts = detected_shortcuts;
@@ -646,13 +671,21 @@ int main(int argc, char* argv[]) {
     if (import_shortcuts && !detected_shortcuts.empty()) {
         const auto shortcuts_json = serialize_detected_shortcuts(detected_shortcuts);
         if (write_file(shortcuts_output, shortcuts_json)) {
-            const size_t extracted_count = detected_shortcuts.size()
-                                         - default_scan.accepted.size();
+            // `default_scan.accepted` is the count of UI surfaces matched
+            // (one per Settings/Help/Cheatsheet/…). Each accepted surface
+            // emits up to TWO actual bindings (mac chord + win/linux
+            // variant) so the count of default-tagged DetectedShortcuts
+            // can be up to 2× the accepted-surfaces count.
+            size_t default_count = 0;
+            for (const auto& s : detected_shortcuts) {
+                if (s.pattern.rfind("default:", 0) == 0) ++default_count;
+            }
+            const size_t extracted_count = detected_shortcuts.size() - default_count;
             std::cout << "Wrote " << shortcuts_output
                       << " (" << detected_shortcuts.size() << " shortcut"
                       << (detected_shortcuts.size() == 1 ? "" : "s")
                       << " — " << extracted_count << " extracted, "
-                      << default_scan.accepted.size() << " platform-default"
+                      << default_count << " platform-default"
                       << " — bound natively via registerShortcut())\n";
         }
     }


### PR DESCRIPTION
## Summary

Phase A of the default-shortcuts pass spec'd in `planning/2026-05-16-default-keyboard-shortcuts.md`. On top of #2119 (V2 extractor) and #2120 (focus-guard), this PR adds **source-matched defaults** — auto-bind platform-convention shortcuts when the dev's React source has a high-confidence component match.

Built directly on #2119's existing codegen path (no fork): accepted defaults are lowered into `DetectedShortcut` form and ride the same `registerShortcut(...)` + synthetic-keydown thunk emission.

### What it binds

| Pattern | macOS | Win/Linux | When |
|---|---|---|---|
| Settings / Preferences | `Cmd+,` | `Ctrl+,` | dev's React source has named-modal |
| Help / About / Docs | `Cmd+?` | `F1` | dev's React source has doc-style modal |
| Keyboard cheatsheet | `?` (bare) | `?` (bare) | dev's React source has `<kbd>`-list modal — bare `?` safe via #2120 focus-guard |
| New / Open / Save / Find | `Cmd+N/O/S/F` | `Ctrl+N/O/S/F` | dev's React source has named button |

**What it does NOT bind:** surfaces Pulp doesn't actually provide. Phase B (separate PR) handles Pulp-framework defaults — Cmd+, → Settings tab, Cmd+Opt+A/M → Audio/MIDI sub-tabs in the standalone `SettingsPanel`.

### Hard rule (encoded)

A wrong auto-binding is worse than no binding. Detector requires **≥2 signals** to fire:
1. Component name keyword match
2. `role="dialog"` / `aria-label="..."` in body
3. `<h1>`/`<h2>` heading text in body
4. `<kbd>` tag (cheatsheet disambiguator)
5. **Canonical-name bonus** (added after smoke-test): exact `<Pattern>{Modal,Dialog,Panel,Popover,Sheet,Window,Drawer}` shapes count as 2 signals on their own — real apps like Spectr use inline-styled divs without ARIA, but `SettingsModal` / `HelpPopover` are structurally unambiguous

Ambiguous matches (multiple candidates) → no bind, emit `collision` entry instead. Extracted shortcuts (V2) always win over same-chord defaults.

### Validation against Spectr's real `editor.generated.tsx`

```
pulp-import-design --from claude --file editor.generated.tsx
  → 2 extracted (Enter→blur at line 2458, Escape→onClose at line 2001)
  → 2 auto-bound defaults:
      Cmd+, → SettingsModal (canonical-name, medium confidence)
      Cmd+? → HelpPopover   (canonical-name, medium confidence)
  → 0 collisions, 0 false positives
```

Native render of Spectr's pre-built bundle on the merged stack (#2119 + #2120 + this PR) is clean — spectrum analyzer, mode toggles, zoom slider, bottom toolbar all intact. See `planning/screenshots/` for the smoke screenshot.

### Files

- `core/view/include/pulp/view/design_import.hpp` — `DefaultShortcutPattern` enum, `DefaultShortcutCandidate` / `DefaultShortcutCollision` / `DefaultShortcutScan` structs, `detect_default_shortcuts` / `apply_default_shortcuts` / `serialize_default_shortcut_scan` declarations, `TargetPlatform`
- `core/view/src/design_import.cpp` — heuristic detector + per-platform chord mapping + JSON serializer + canonical-name bonus + body-window truncation. Also widens `key_string_to_keycode` to accept printable ASCII punctuation (latent V2 bug: `,` and friends silently dropped)
- `tools/import-design/pulp_import_design.cpp` — `--no-default-shortcuts` flag (default ON); writes `<name>.defaults.json` diagnostic alongside `shortcuts.json`
- `test/test_design_import_shortcuts.cpp` — 10 new `[defaults]` cases pinning detection, collision, override hierarchy, per-platform chord mapping, E2E codegen, canonical-name behavior

### Test plan

- [x] `pulp-test-design-import-shortcuts` — **32 cases / 167 assertions** all pass locally
- [x] Spectr roundtrip — 2+2 bindings, 0 collisions, 0 false positives
- [x] Native render — Spectr bundle renders correctly on merged stack
- [ ] CI matrix green

### Followups (separate PRs)

- **Phase B** — Pulp-framework Audio/MIDI tab-select bindings (`Cmd+Opt+A`/`Cmd+Opt+M`). Requires `TabPanel` select-tab JS API + standalone-only emission gate. Tracked in task #135.
- Codex review (typical 1–2 P1/P2 in this codebase)
- Optional: surface the `defaults.json` collisions in `pulp doctor` so devs can triage ambiguous matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)