### PR TITLE
test(osc): batch codec and bundle coverage edges

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-# codecov.yml — Codecov config for public/#566 Phase 1 (measurement baseline).
+# codecov.yml - Codecov config for public/#566 Phase 1 (measurement baseline).
 #
 # Primary consumers (in order): Pulp developers, dispatched agents, CI
 # enforcement, contributors reading PR comments. Public dashboard is a
@@ -12,14 +12,14 @@
 # Phase 2 adds ci/coverage-targets.yaml alongside this for the diff-cover
 # gate; Phase 4 introduces doc_path_map.json to prevent drift.
 
-# Notification gating — wait for all 4 platform coverage uploads before
+# Notification gating - wait for all 4 platform coverage uploads before
 # the bot computes + posts the patch coverage report. Without this,
 # Codecov posts as soon as it sees ANY upload (often Linux first, since
 # its build is fastest), which means Apple-only or Windows-only tested
 # paths get reported as 0% covered against partial data. PR #1873 was a
 # textbook example: a CLAP-fixture test that ran only on macOS was
 # reported as "0% patch coverage" by the bot because the macOS upload
-# hadn't arrived (and never did — see follow-up issue on the coverage
+# hadn't arrived (and never did - see follow-up issue on the coverage
 # workflow's `cancel-in-progress: true` concurrency policy that wipes
 # in-flight runs on force-push).
 #
@@ -32,7 +32,7 @@
 #
 # If you add or remove a coverage uploader, bump this number to match
 # or Codecov will silently wait forever for the missing one and never
-# post. After 7d it gives up and posts whatever it has — by then the
+# post. After 7d it gives up and posts whatever it has - by then the
 # PR has long since merged with a stale report.
 codecov:
   notify:
@@ -40,7 +40,7 @@ codecov:
 
 coverage:
   status:
-    # Project-wide status: "did we get worse?" Not a hard gate — we
+    # Project-wide status: "did we get worse?" Not a hard gate - we
     # already have continue-on-error on the coverage job and Phase 3
     # is where per-PR enforcement lands.
     project:
@@ -52,11 +52,11 @@ coverage:
     # Patch status: "is new code covered?" Advisory in the sense that
     # branch-protection does NOT require this check (so a sub-threshold
     # PR can still merge), but the check status now accurately reflects
-    # the threshold check — `success` if ≥75%, `failure` if <75%.
+    # the threshold check - `success` if >=75%, `failure` if <75%.
     #
     # Previously `informational: true` hardwired the status to `success`
     # even when patch coverage was 0%, which deceived devs reading the
-    # check line. The bot still posted a "❌ Patch coverage is X%"
+    # check line. The bot still posted a "[fail] Patch coverage is X%"
     # comment, but the status check itself said success, masking the
     # gap. Flipping to enforcing makes the signal accurate without
     # changing merge behavior (codecov/patch is not in
@@ -76,9 +76,9 @@ coverage:
 # so Codecov and our local tooling count the same set of files.
 # External FetchContent sources (Dawn, Skia, mbedTLS, QuickJS,
 # Catch2, etc.) and our test trees are never counted as coverage-
-# bearing. See planning/coverage-tooling-decision-2026-04-21.md §4.
+# bearing. See planning/coverage-tooling-decision-2026-04-21.md section 4.
 #
-# `ignore` is a TOP-LEVEL key in Codecov config — nesting it under
+# `ignore` is a TOP-LEVEL key in Codecov config - nesting it under
 # `coverage:` silently no-ops, which would count files we explicitly
 # want excluded and skew the baseline metrics. See Codecov config
 # schema: https://docs.codecov.com/docs/codecov-yaml
@@ -106,7 +106,7 @@ ignore:
   # harness implementation, so Codecov must not count the tests as
   # patch-coverable product code.
   - "tools/harness/visual/tests/**"
-  # ── Aligned with tools/scripts/coverage_config.json `diff_cover_excludes` ──
+  # -- Aligned with tools/scripts/coverage_config.json `diff_cover_excludes` --
   # The Pulp gate (`Diff coverage required` in coverage.yml) excludes these
   # files because they're either thin dispatchers exercised end-to-end via
   # shell-out tests (so direct line coverage doesn't propagate cleanly), or
@@ -114,11 +114,11 @@ ignore:
   # can't instrument uniformly. Without aligning the Codecov bot's ignore
   # list to the same set, the bot's `codecov/patch` check fires red on PRs
   # whose diff is mostly in these files (e.g. PR #1984's viewport-fit lived
-  # almost entirely in window_host_mac.mm — Pulp gate silent, bot screamed
+  # almost entirely in window_host_mac.mm - Pulp gate silent, bot screamed
   # 8.64% patch coverage). Both sides MUST count the same set.
   #
   # Drift between this list and coverage_config.json is detected by
-  # tools/scripts/test_codecov_config_sync.py — keep them in sync.
+  # tools/scripts/test_codecov_config_sync.py - keep them in sync.
   - "**/cmd_loop.cpp"
   - "**/pulp_import_design.cpp"
   - "**/cg_canvas.mm"
@@ -138,7 +138,7 @@ comment:
 
 # Flag definitions are retained for Phase 1 PR 4 (per-OS upload jobs)
 # and for future workflows that genuinely upload one file per flag.
-# The main coverage.yml upload does NOT attach any flags — Codecov
+# The main coverage.yml upload does NOT attach any flags - Codecov
 # rejects single-upload multi-flag submissions with "Multiple flags
 # detected. Please ensure one flag per upload." The per-subsystem /
 # per-platform / per-surface breakdown comes from `component_management`
@@ -150,7 +150,7 @@ comment:
 # means updating both blocks in this file; `tools/scripts/test_codecov_config.py`
 # checks them against the live `core/*` tree so drift fails fast.
 flags:
-  # Core subsystems — one flag per top-level core/** directory.
+  # Core subsystems - one flag per top-level core/** directory.
   audio:
     paths:
       - core/audio/
@@ -208,7 +208,7 @@ flags:
       - core/view/
     carryforward: true
 
-  # Platform flags (4) — cross-cut the subsystem flags. "What's host
+  # Platform flags (4) - cross-cut the subsystem flags. "What's host
   # coverage on Windows?" is answered by cross-filtering `host AND
   # windows`. Paths cover all subsystems because any subsystem can
   # have a Windows shim under its own `platform/windows/` tree.
@@ -238,7 +238,7 @@ flags:
       - core/**/wasapi/
     carryforward: true
 
-  # Surface flags (4) — non-core but first-party:
+  # Surface flags (4) - non-core but first-party:
   cli:
     paths:
       - tools/cli/
@@ -260,16 +260,16 @@ flags:
       - tools/
     carryforward: true
 
-  # OS flags (3) — Phase 1 PR 4 cross-platform coverage matrix. These
+  # OS flags (3) - Phase 1 PR 4 cross-platform coverage matrix. These
   # are NOT path-scoped; every file measured on a given matrix leg is
   # tagged with that OS's flag at upload time via the corresponding
   # matrix entry in .github/workflows/coverage.yml. Federate with the
   # subsystem + platform + surface flags above for cross-filtering:
   # `host AND os-windows` answers "what fraction of core/host is
-  # exercised when tests run on Windows?" — a different question from
+  # exercised when tests run on Windows?" - a different question from
   # `host AND windows` (which reads "what fraction of the windows/
   # shim files are covered at all"). See docs/guides/coverage.md
-  # §"Multi-OS coverage" for the rationale on Codecov-flag unions vs
+  # section "Multi-OS coverage" for the rationale on Codecov-flag unions vs
   # llvm-profdata merge.
   os-linux:
     carryforward: true
@@ -278,7 +278,7 @@ flags:
   os-windows:
     carryforward: true
 
-# carryforward: true on every flag — when a PR doesn't touch
+# carryforward: true on every flag - when a PR doesn't touch
 # a given subsystem, carry over the last known coverage for that
 # flag from main so the dashboard doesn't report a false 0%. Standard
 # Codecov practice for multi-job uploads (we have one job per OS
@@ -303,12 +303,12 @@ component_management:
         threshold: 1%
         informational: true
   individual_components:
-    # Core subsystems — mirror every top-level core/** directory.
+    # Core subsystems - mirror every top-level core/** directory.
     #
     # Subsystems that house platform-specific subtrees (`audio`, `midi`,
     # `view`, `render`, `platform`, `canvas`) explicitly exclude those
     # subtrees so each first-party file lands in exactly one component
-    # bucket — see #1055. Platform-specific code is owned by the
+    # bucket - see #1055. Platform-specific code is owned by the
     # `apple`/`android`/`linux`/`windows` components below; without the
     # `!`-exclude here those files were silently double-counted, inflating
     # coverage for both the subsystem and the platform.
@@ -375,10 +375,10 @@ component_management:
       paths:
         - "core/view/**"
         - "!core/view/platform/**"
-    # Platform (4) — cross-cut the subsystems. Patterns within each
+    # Platform (4) - cross-cut the subsystems. Patterns within each
     # platform component must not overlap each other (Codecov double-
     # counts files matched twice within the same component, inflating
-    # the line totals — caught on #1055 as `platform,android,android`
+    # the line totals - caught on #1055 as `platform,android,android`
     # 3-way matches).
     - component_id: android
       name: android
@@ -403,7 +403,7 @@ component_management:
         - "core/**/win/**"
         - "core/**/windows/**"
         - "core/**/wasapi/**"
-    # Surface (4) — `tools` excludes `tools/cli/**` so the more specific
+    # Surface (4) - `tools` excludes `tools/cli/**` so the more specific
     # `cli` component owns those files; otherwise every CLI file is
     # double-counted (#1055).
     - component_id: cli

--- a/test/test_osc.cpp
+++ b/test/test_osc.cpp
@@ -8,6 +8,9 @@
 #include <cstring>
 #include <limits>
 #include <mutex>
+#include <string_view>
+#include <variant>
+#include <vector>
 
 using namespace pulp::osc;
 using Catch::Matchers::WithinAbs;
@@ -17,6 +20,13 @@ namespace {
 constexpr uint16_t kOscHostnameTestPort = 29876;
 constexpr uint16_t kOscInvalidPacketPort = 29877;
 constexpr uint16_t kOscStopIdempotentPort = 29878;
+
+void append_osc_string(std::vector<uint8_t>& data, std::string_view text) {
+    data.insert(data.end(), text.begin(), text.end());
+    data.push_back(0);
+    while (data.size() % 4 != 0)
+        data.push_back(0);
+}
 
 } // namespace
 
@@ -68,6 +78,23 @@ TEST_CASE("OSC Message defaults cover empty and wrong-type accessors",
     REQUIRE(msg.get_int(0, 9) == 9);
     REQUIRE(msg.get_float(1, 3.0f) == 3.0f);
     REQUIRE(msg.get_string(2, "blob") == "blob");
+}
+
+TEST_CASE("OSC Message add overloads preserve fluent chaining and argument types",
+          "[osc][message][codecov]") {
+    Message msg("/chain");
+    auto* returned = &msg.add(7)
+        .add(0.5f)
+        .add(std::string("name"))
+        .add(std::vector<uint8_t>{0x10, 0x20, 0x30});
+
+    REQUIRE(returned == &msg);
+    REQUIRE(msg.args.size() == 4);
+    REQUIRE(std::holds_alternative<int32_t>(msg.args[0]));
+    REQUIRE(std::holds_alternative<float>(msg.args[1]));
+    REQUIRE(std::holds_alternative<std::string>(msg.args[2]));
+    REQUIRE(std::holds_alternative<std::vector<uint8_t>>(msg.args[3]));
+    REQUIRE(std::get<std::vector<uint8_t>>(msg.args[3]).back() == 0x30);
 }
 
 // ── Encoding/Decoding ────────────────────────────────────────────────────────
@@ -145,6 +172,71 @@ TEST_CASE("OSC 4-byte alignment", "[osc][codec]") {
     auto decoded = decode(data.data(), data.size());
     REQUIRE(decoded.address == "/a");
     REQUIRE(decoded.get_int(0) == 42);
+}
+
+TEST_CASE("OSC encode with no arguments emits an empty type-tag section",
+          "[osc][codec][codecov]") {
+    Message msg("/plain");
+
+    auto data = encode(msg);
+    auto decoded = decode(data.data(), data.size());
+
+    REQUIRE(data.size() == 12);
+    REQUIRE(decoded.address == "/plain");
+    REQUIRE(decoded.args.empty());
+    REQUIRE(data[8] == ',');
+    REQUIRE(data[9] == 0);
+}
+
+TEST_CASE("OSC decode accepts explicit comma tag with no arguments",
+          "[osc][codec][codecov]") {
+    std::vector<uint8_t> data;
+    append_osc_string(data, "/empty-tags");
+    append_osc_string(data, ",");
+
+    auto decoded = decode(data.data(), data.size());
+
+    REQUIRE(decoded.address == "/empty-tags");
+    REQUIRE(decoded.args.empty());
+}
+
+TEST_CASE("OSC decode ignores unknown type tags without adding arguments",
+          "[osc][codec][codecov]") {
+    std::vector<uint8_t> data;
+    append_osc_string(data, "/unknown-tags");
+    append_osc_string(data, ",TFNz");
+
+    auto decoded = decode(data.data(), data.size());
+
+    REQUIRE(decoded.address == "/unknown-tags");
+    REQUIRE(decoded.args.empty());
+}
+
+TEST_CASE("OSC decode handles non-null-terminated bounded address payload",
+          "[osc][codec][codecov]") {
+    const std::vector<uint8_t> data{'/', 'b', 'a', 'r'};
+
+    auto decoded = decode(data.data(), data.size());
+
+    REQUIRE(decoded.address == "/bar");
+    REQUIRE(decoded.args.empty());
+}
+
+TEST_CASE("OSC encode/decode preserves blob payloads at padding boundaries",
+          "[osc][codec][codecov]") {
+    Message msg("/blob-padding");
+    msg.add(std::vector<uint8_t>{0x01, 0x02, 0x03});
+    msg.add(std::vector<uint8_t>{0x04, 0x05, 0x06, 0x07});
+
+    auto data = encode(msg);
+    auto decoded = decode(data.data(), data.size());
+
+    REQUIRE(decoded.address == "/blob-padding");
+    REQUIRE(decoded.args.size() == 2);
+    REQUIRE(std::get<std::vector<uint8_t>>(decoded.args[0])
+            == std::vector<uint8_t>{0x01, 0x02, 0x03});
+    REQUIRE(std::get<std::vector<uint8_t>>(decoded.args[1])
+            == std::vector<uint8_t>{0x04, 0x05, 0x06, 0x07});
 }
 
 // ── UDP sender/receiver ─────────────────────────────────────────────────────

--- a/test/test_osc_bundle.cpp
+++ b/test/test_osc_bundle.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/osc/bundle.hpp>
+#include <memory>
 
 #if defined(_WIN32)
 #ifndef NOMINMAX
@@ -61,6 +62,15 @@ TEST_CASE("OSC TimeTag keeps fractional unix seconds near one-second boundary",
     REQUIRE_FALSE(tt == TimeTag::from_unix(12345.0));
 }
 
+TEST_CASE("OSC TimeTag converts fractional halves without losing the fraction",
+          "[osc][bundle][timetag][codecov]") {
+    auto tt = TimeTag::from_unix(1000.5);
+
+    REQUIRE(tt.seconds == 2208989800u);
+    REQUIRE(tt.fraction == 0x80000000u);
+    REQUIRE_THAT(tt.to_unix(), WithinAbs(1000.5, 0.000001));
+}
+
 // ── Bundle construction ─────────────────────────────────────────────────
 
 TEST_CASE("OSC Bundle add message", "[osc][bundle]") {
@@ -97,6 +107,37 @@ TEST_CASE("OSC default BundleElement is an empty message element",
     REQUIRE_FALSE(elem.is_bundle());
     REQUIRE(elem.message().address.empty());
     REQUIRE(elem.message().args.empty());
+}
+
+TEST_CASE("OSC BundleElement takes ownership of unique_ptr bundles",
+          "[osc][bundle][codecov]") {
+    auto nested = std::make_unique<Bundle>();
+    nested->timetag = TimeTag::from_unix(42.0);
+    Message msg("/owned");
+    msg.add(5);
+    nested->add(std::move(msg));
+
+    BundleElement elem(std::move(nested));
+
+    REQUIRE(elem.is_bundle());
+    REQUIRE_FALSE(elem.is_message());
+    REQUIRE(elem.bundle().timetag == TimeTag::from_unix(42.0));
+    REQUIRE(elem.bundle().elements.size() == 1);
+    REQUIRE(elem.bundle().elements[0].message().address == "/owned");
+}
+
+TEST_CASE("OSC BundleElement value constructor copies nested bundle content",
+          "[osc][bundle][codecov]") {
+    Bundle nested;
+    Message msg("/value-copy");
+    msg.add(std::string("payload"));
+    nested.add(std::move(msg));
+
+    BundleElement elem(std::move(nested));
+
+    REQUIRE(elem.is_bundle());
+    REQUIRE(elem.bundle().elements.size() == 1);
+    REQUIRE(elem.bundle().elements[0].message().get_string(0) == "payload");
 }
 
 // ── Bundle serialization ────────────────────────────────────────────────
@@ -143,6 +184,20 @@ TEST_CASE("OSC Bundle serialize/deserialize round-trip", "[osc][bundle]") {
     REQUIRE(restored->elements.size() == 2);
     REQUIRE(restored->elements[0].is_message());
     REQUIRE(restored->elements[0].message().address == "/volume");
+}
+
+TEST_CASE("OSC Bundle serialize preserves non-immediate timetag bytes",
+          "[osc][bundle][codecov]") {
+    Bundle bundle;
+    bundle.timetag = {0x01020304u, 0xA0B0C0D0u};
+
+    auto data = bundle.serialize();
+    auto restored = Bundle::deserialize(data.data(), data.size());
+
+    REQUIRE(data.size() == 16);
+    REQUIRE(restored.has_value());
+    REQUIRE(restored->timetag.seconds == 0x01020304u);
+    REQUIRE(restored->timetag.fraction == 0xA0B0C0D0u);
 }
 
 // ── Address pattern matching ────────────────────────────────────────────
@@ -268,6 +323,14 @@ TEST_CASE("Bundle::deserialize rejects malformed message element",
     REQUIRE_FALSE(Bundle::deserialize(buf.data(), buf.size()).has_value());
 }
 
+TEST_CASE("Bundle::deserialize rejects zero-sized elements",
+          "[osc][bundle][deserialize-edge][codecov]") {
+    auto buf = make_empty_bundle_bytes();
+    append_u32(buf, 0);
+
+    REQUIRE_FALSE(Bundle::deserialize(buf.data(), buf.size()).has_value());
+}
+
 // ── Bundle round-trip edges ────────────────────────────────────────────
 
 TEST_CASE("Empty Bundle serialize/deserialize round-trip",
@@ -334,6 +397,26 @@ TEST_CASE("Bundle deep nesting (3 levels) round-trips",
     const auto& l3 = l2.elements[0].bundle();
     REQUIRE(l3.elements[0].is_message());
     REQUIRE(l3.elements[0].message().get_int(0) == 42);
+}
+
+TEST_CASE("Bundle round-trip preserves blob and float message arguments",
+          "[osc][bundle][roundtrip][codecov]") {
+    Bundle bundle;
+    Message msg("/mixed");
+    msg.add(std::vector<uint8_t>{0xAA, 0xBB});
+    msg.add(1.25f);
+    bundle.add(std::move(msg));
+
+    auto data = bundle.serialize();
+    auto restored = Bundle::deserialize(data.data(), data.size());
+
+    REQUIRE(restored.has_value());
+    REQUIRE(restored->elements.size() == 1);
+    const auto& restored_msg = restored->elements[0].message();
+    REQUIRE(restored_msg.address == "/mixed");
+    REQUIRE(std::get<std::vector<uint8_t>>(restored_msg.args[0])
+            == std::vector<uint8_t>{0xAA, 0xBB});
+    REQUIRE_THAT(restored_msg.get_float(1), WithinAbs(1.25, 0.001));
 }
 
 // ── Address pattern: character class ───────────────────────────────────


### PR DESCRIPTION
## Summary
- add OSC message/codec coverage for fluent argument building, empty tags, unknown tags, bounded payloads, and blob padding
- add OSC bundle coverage for timetag fractions, BundleElement ownership/copying, non-immediate timetags, malformed element sizes, and mixed payload round-trips

## Local validation
- `git diff --check`
- `cmake --build build --target pulp-test-osc pulp-test-osc-bundle -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-osc`
- `./build/test/pulp-test-osc-bundle`
- `PULP_DIFF_COVER_CTEST_REGEX='...' tools/scripts/local_diff_cover.sh`