### PR TITLE
test(runtime): batch network stream socket coverage edges

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-# codecov.yml — Codecov config for public/#566 Phase 1 (measurement baseline).
+# codecov.yml - Codecov config for public/#566 Phase 1 (measurement baseline).
 #
 # Primary consumers (in order): Pulp developers, dispatched agents, CI
 # enforcement, contributors reading PR comments. Public dashboard is a
@@ -12,14 +12,14 @@
 # Phase 2 adds ci/coverage-targets.yaml alongside this for the diff-cover
 # gate; Phase 4 introduces doc_path_map.json to prevent drift.
 
-# Notification gating — wait for all 4 platform coverage uploads before
+# Notification gating - wait for all 4 platform coverage uploads before
 # the bot computes + posts the patch coverage report. Without this,
 # Codecov posts as soon as it sees ANY upload (often Linux first, since
 # its build is fastest), which means Apple-only or Windows-only tested
 # paths get reported as 0% covered against partial data. PR #1873 was a
 # textbook example: a CLAP-fixture test that ran only on macOS was
 # reported as "0% patch coverage" by the bot because the macOS upload
-# hadn't arrived (and never did — see follow-up issue on the coverage
+# hadn't arrived (and never did - see follow-up issue on the coverage
 # workflow's `cancel-in-progress: true` concurrency policy that wipes
 # in-flight runs on force-push).
 #
@@ -32,7 +32,7 @@
 #
 # If you add or remove a coverage uploader, bump this number to match
 # or Codecov will silently wait forever for the missing one and never
-# post. After 7d it gives up and posts whatever it has — by then the
+# post. After 7d it gives up and posts whatever it has - by then the
 # PR has long since merged with a stale report.
 codecov:
   notify:
@@ -40,7 +40,7 @@ codecov:
 
 coverage:
   status:
-    # Project-wide status: "did we get worse?" Not a hard gate — we
+    # Project-wide status: "did we get worse?" Not a hard gate - we
     # already have continue-on-error on the coverage job and Phase 3
     # is where per-PR enforcement lands.
     project:
@@ -52,11 +52,11 @@ coverage:
     # Patch status: "is new code covered?" Advisory in the sense that
     # branch-protection does NOT require this check (so a sub-threshold
     # PR can still merge), but the check status now accurately reflects
-    # the threshold check — `success` if ≥75%, `failure` if <75%.
+    # the threshold check - `success` if >=75%, `failure` if <75%.
     #
     # Previously `informational: true` hardwired the status to `success`
     # even when patch coverage was 0%, which deceived devs reading the
-    # check line. The bot still posted a "❌ Patch coverage is X%"
+    # check line. The bot still posted a "[fail] Patch coverage is X%"
     # comment, but the status check itself said success, masking the
     # gap. Flipping to enforcing makes the signal accurate without
     # changing merge behavior (codecov/patch is not in
@@ -76,9 +76,9 @@ coverage:
 # so Codecov and our local tooling count the same set of files.
 # External FetchContent sources (Dawn, Skia, mbedTLS, QuickJS,
 # Catch2, etc.) and our test trees are never counted as coverage-
-# bearing. See planning/coverage-tooling-decision-2026-04-21.md §4.
+# bearing. See planning/coverage-tooling-decision-2026-04-21.md section 4.
 #
-# `ignore` is a TOP-LEVEL key in Codecov config — nesting it under
+# `ignore` is a TOP-LEVEL key in Codecov config - nesting it under
 # `coverage:` silently no-ops, which would count files we explicitly
 # want excluded and skew the baseline metrics. See Codecov config
 # schema: https://docs.codecov.com/docs/codecov-yaml
@@ -106,7 +106,7 @@ ignore:
   # harness implementation, so Codecov must not count the tests as
   # patch-coverable product code.
   - "tools/harness/visual/tests/**"
-  # ── Aligned with tools/scripts/coverage_config.json `diff_cover_excludes` ──
+  # -- Aligned with tools/scripts/coverage_config.json `diff_cover_excludes` --
   # The Pulp gate (`Diff coverage required` in coverage.yml) excludes these
   # files because they're either thin dispatchers exercised end-to-end via
   # shell-out tests (so direct line coverage doesn't propagate cleanly), or
@@ -114,11 +114,11 @@ ignore:
   # can't instrument uniformly. Without aligning the Codecov bot's ignore
   # list to the same set, the bot's `codecov/patch` check fires red on PRs
   # whose diff is mostly in these files (e.g. PR #1984's viewport-fit lived
-  # almost entirely in window_host_mac.mm — Pulp gate silent, bot screamed
+  # almost entirely in window_host_mac.mm - Pulp gate silent, bot screamed
   # 8.64% patch coverage). Both sides MUST count the same set.
   #
   # Drift between this list and coverage_config.json is detected by
-  # tools/scripts/test_codecov_config_sync.py — keep them in sync.
+  # tools/scripts/test_codecov_config_sync.py - keep them in sync.
   - "**/cmd_loop.cpp"
   - "**/pulp_import_design.cpp"
   - "**/cg_canvas.mm"
@@ -138,7 +138,7 @@ comment:
 
 # Flag definitions are retained for Phase 1 PR 4 (per-OS upload jobs)
 # and for future workflows that genuinely upload one file per flag.
-# The main coverage.yml upload does NOT attach any flags — Codecov
+# The main coverage.yml upload does NOT attach any flags - Codecov
 # rejects single-upload multi-flag submissions with "Multiple flags
 # detected. Please ensure one flag per upload." The per-subsystem /
 # per-platform / per-surface breakdown comes from `component_management`
@@ -150,7 +150,7 @@ comment:
 # means updating both blocks in this file; `tools/scripts/test_codecov_config.py`
 # checks them against the live `core/*` tree so drift fails fast.
 flags:
-  # Core subsystems — one flag per top-level core/** directory.
+  # Core subsystems - one flag per top-level core/** directory.
   audio:
     paths:
       - core/audio/
@@ -208,7 +208,7 @@ flags:
       - core/view/
     carryforward: true
 
-  # Platform flags (4) — cross-cut the subsystem flags. "What's host
+  # Platform flags (4) - cross-cut the subsystem flags. "What's host
   # coverage on Windows?" is answered by cross-filtering `host AND
   # windows`. Paths cover all subsystems because any subsystem can
   # have a Windows shim under its own `platform/windows/` tree.
@@ -238,7 +238,7 @@ flags:
       - core/**/wasapi/
     carryforward: true
 
-  # Surface flags (4) — non-core but first-party:
+  # Surface flags (4) - non-core but first-party:
   cli:
     paths:
       - tools/cli/
@@ -260,16 +260,16 @@ flags:
       - tools/
     carryforward: true
 
-  # OS flags (3) — Phase 1 PR 4 cross-platform coverage matrix. These
+  # OS flags (3) - Phase 1 PR 4 cross-platform coverage matrix. These
   # are NOT path-scoped; every file measured on a given matrix leg is
   # tagged with that OS's flag at upload time via the corresponding
   # matrix entry in .github/workflows/coverage.yml. Federate with the
   # subsystem + platform + surface flags above for cross-filtering:
   # `host AND os-windows` answers "what fraction of core/host is
-  # exercised when tests run on Windows?" — a different question from
+  # exercised when tests run on Windows?" - a different question from
   # `host AND windows` (which reads "what fraction of the windows/
   # shim files are covered at all"). See docs/guides/coverage.md
-  # §"Multi-OS coverage" for the rationale on Codecov-flag unions vs
+  # section "Multi-OS coverage" for the rationale on Codecov-flag unions vs
   # llvm-profdata merge.
   os-linux:
     carryforward: true
@@ -278,7 +278,7 @@ flags:
   os-windows:
     carryforward: true
 
-# carryforward: true on every flag — when a PR doesn't touch
+# carryforward: true on every flag - when a PR doesn't touch
 # a given subsystem, carry over the last known coverage for that
 # flag from main so the dashboard doesn't report a false 0%. Standard
 # Codecov practice for multi-job uploads (we have one job per OS
@@ -303,12 +303,12 @@ component_management:
         threshold: 1%
         informational: true
   individual_components:
-    # Core subsystems — mirror every top-level core/** directory.
+    # Core subsystems - mirror every top-level core/** directory.
     #
     # Subsystems that house platform-specific subtrees (`audio`, `midi`,
     # `view`, `render`, `platform`, `canvas`) explicitly exclude those
     # subtrees so each first-party file lands in exactly one component
-    # bucket — see #1055. Platform-specific code is owned by the
+    # bucket - see #1055. Platform-specific code is owned by the
     # `apple`/`android`/`linux`/`windows` components below; without the
     # `!`-exclude here those files were silently double-counted, inflating
     # coverage for both the subsystem and the platform.
@@ -375,10 +375,10 @@ component_management:
       paths:
         - "core/view/**"
         - "!core/view/platform/**"
-    # Platform (4) — cross-cut the subsystems. Patterns within each
+    # Platform (4) - cross-cut the subsystems. Patterns within each
     # platform component must not overlap each other (Codecov double-
     # counts files matched twice within the same component, inflating
-    # the line totals — caught on #1055 as `platform,android,android`
+    # the line totals - caught on #1055 as `platform,android,android`
     # 3-way matches).
     - component_id: android
       name: android
@@ -403,7 +403,7 @@ component_management:
         - "core/**/win/**"
         - "core/**/windows/**"
         - "core/**/wasapi/**"
-    # Surface (4) — `tools` excludes `tools/cli/**` so the more specific
+    # Surface (4) - `tools` excludes `tools/cli/**` so the more specific
     # `cli` component owns those files; otherwise every CLI file is
     # double-counted (#1055).
     - component_id: cli

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -4,6 +4,8 @@
 #include <pulp/runtime/network_stream.hpp>
 #include <pulp/runtime/socket.hpp>
 
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstring>
@@ -20,6 +22,15 @@ std::optional<std::uint16_t> try_bind_loopback(Socket& server, std::uint16_t por
     if (!server.bind("127.0.0.1", port)) return std::nullopt;
     if (!server.listen(1)) return std::nullopt;
     return port;
+}
+
+std::optional<std::uint16_t> try_bind_udp(Socket& socket,
+                                          std::uint16_t start,
+                                          std::string_view address = "127.0.0.1") {
+    for (std::uint16_t port = start; port < start + 120; ++port) {
+        if (socket.bind(address, port)) return port;
+    }
+    return std::nullopt;
 }
 
 }  // namespace
@@ -42,6 +53,23 @@ TEST_CASE("IPv4 validation rejects malformed addresses",
     REQUIRE_FALSE(is_valid_ipv4("1.2.3"));
     REQUIRE_FALSE(is_valid_ipv4("1.2.3.4.5"));
     REQUIRE_FALSE(is_valid_ipv4(" 127.0.0.1"));
+}
+
+TEST_CASE("IPv4 validation rejects decorated dotted quads",
+          "[network_stream][ip-address][phase3]") {
+    REQUIRE_FALSE(is_valid_ipv4("127.0.0.1:80"));
+    REQUIRE_FALSE(is_valid_ipv4("127.0.0.1/32"));
+    REQUIRE_FALSE(is_valid_ipv4("127.0.0.1\n"));
+    REQUIRE_FALSE(is_valid_ipv4("\t127.0.0.1"));
+    REQUIRE_FALSE(is_valid_ipv4("http://127.0.0.1"));
+}
+
+TEST_CASE("IPv4 validation accepts private network examples",
+          "[network_stream][ip-address][phase3]") {
+    REQUIRE(is_valid_ipv4("10.0.0.1"));
+    REQUIRE(is_valid_ipv4("172.16.0.1"));
+    REQUIRE(is_valid_ipv4("192.168.0.1"));
+    REQUIRE(is_valid_ipv4("169.254.10.20"));
 }
 
 TEST_CASE("local IPv4 helpers return valid fallback or interface addresses",
@@ -234,6 +262,278 @@ TEST_CASE("TcpStream detects peer-close on the next read",
         std::this_thread::sleep_for(5ms);
     }
     REQUIRE(saw_close);
+
+    stream.close();
+    server_thread.join();
+}
+
+// ── Socket edge cases ───────────────────────────────────────────────────
+
+TEST_CASE("Socket reports failures before create",
+          "[network_stream][socket][phase3]") {
+    Socket socket;
+    std::array<std::uint8_t, 4> buffer{1, 2, 3, 4};
+    std::string from = "unchanged";
+    std::uint16_t from_port = 99;
+
+    REQUIRE_FALSE(socket.is_open());
+    REQUIRE_FALSE(socket.bind("127.0.0.1", 1));
+    REQUIRE_FALSE(socket.listen());
+    REQUIRE_FALSE(socket.accept().has_value());
+    REQUIRE(socket.send(buffer.data(), buffer.size()) == -1);
+    REQUIRE(socket.send("payload") == -1);
+    REQUIRE(socket.send_to(buffer.data(), buffer.size(), "127.0.0.1", 1) == -1);
+    REQUIRE(socket.receive(buffer.data(), buffer.size()) == -1);
+    REQUIRE(socket.receive_from(buffer.data(), buffer.size(), from, from_port) == -1);
+    REQUIRE(from == "unchanged");
+    REQUIRE(from_port == 99);
+}
+
+TEST_CASE("Socket create close and recreate toggles open state",
+          "[network_stream][socket][phase3]") {
+    Socket socket;
+    REQUIRE(socket.create(SocketType::UDP));
+    REQUIRE(socket.is_open());
+    socket.close();
+    REQUIRE_FALSE(socket.is_open());
+
+    REQUIRE(socket.create(SocketType::TCP));
+    REQUIRE(socket.is_open());
+    socket.close();
+    socket.close();
+    REQUIRE_FALSE(socket.is_open());
+}
+
+TEST_CASE("UDP socket round-trips datagrams on loopback",
+          "[network_stream][socket][udp][phase3]") {
+    Socket receiver;
+    REQUIRE(receiver.create(SocketType::UDP));
+    auto port = try_bind_udp(receiver, 45601);
+    if (!port) {
+        SUCCEED("could not bind UDP loopback; skipping");
+        return;
+    }
+
+    Socket sender;
+    REQUIRE(sender.create(SocketType::UDP));
+    const std::array<std::uint8_t, 5> payload{'p', 'u', 'l', 'p', '!'};
+    REQUIRE(sender.send_to(payload.data(), payload.size(), "127.0.0.1", *port)
+            == static_cast<int>(payload.size()));
+
+    std::array<std::uint8_t, 16> buffer{};
+    std::string from;
+    std::uint16_t from_port = 0;
+    auto received = receiver.receive_from(buffer.data(), buffer.size(), from, from_port);
+    REQUIRE(received == static_cast<int>(payload.size()));
+    REQUIRE(std::equal(payload.begin(), payload.end(), buffer.begin()));
+    REQUIRE(from == "127.0.0.1");
+    REQUIRE(from_port != 0);
+}
+
+TEST_CASE("UDP bind accepts empty address as wildcard",
+          "[network_stream][socket][udp][phase3]") {
+    Socket receiver;
+    REQUIRE(receiver.create(SocketType::UDP));
+    auto port = try_bind_udp(receiver, 45731, "");
+    if (!port) {
+        SUCCEED("could not bind UDP wildcard; skipping");
+        return;
+    }
+
+    Socket sender;
+    REQUIRE(sender.create(SocketType::UDP));
+    const std::array<std::uint8_t, 3> payload{'a', 'n', 'y'};
+    REQUIRE(sender.send_to(payload.data(), payload.size(), "127.0.0.1", *port)
+            == static_cast<int>(payload.size()));
+
+    std::array<std::uint8_t, 8> buffer{};
+    std::string from;
+    std::uint16_t from_port = 0;
+    REQUIRE(receiver.receive_from(buffer.data(), buffer.size(), from, from_port)
+            == static_cast<int>(payload.size()));
+    REQUIRE(std::equal(payload.begin(), payload.end(), buffer.begin()));
+}
+
+TEST_CASE("UDP socket move construction transfers the descriptor",
+          "[network_stream][socket][udp][phase3]") {
+    Socket receiver;
+    REQUIRE(receiver.create(SocketType::UDP));
+    auto port = try_bind_udp(receiver, 45861);
+    if (!port) {
+        SUCCEED("could not bind UDP loopback; skipping");
+        return;
+    }
+
+    Socket moved(std::move(receiver));
+    REQUIRE_FALSE(receiver.is_open());
+    REQUIRE(moved.is_open());
+
+    Socket sender;
+    REQUIRE(sender.create(SocketType::UDP));
+    const std::array<std::uint8_t, 1> payload{0x42};
+    REQUIRE(sender.send_to(payload.data(), payload.size(), "127.0.0.1", *port)
+            == static_cast<int>(payload.size()));
+
+    std::array<std::uint8_t, 4> buffer{};
+    std::string from;
+    std::uint16_t from_port = 0;
+    REQUIRE(moved.receive_from(buffer.data(), buffer.size(), from, from_port) == 1);
+    REQUIRE(buffer[0] == 0x42);
+}
+
+TEST_CASE("UDP socket move assignment transfers the descriptor",
+          "[network_stream][socket][udp][phase3]") {
+    Socket receiver;
+    REQUIRE(receiver.create(SocketType::UDP));
+    auto port = try_bind_udp(receiver, 45991);
+    if (!port) {
+        SUCCEED("could not bind UDP loopback; skipping");
+        return;
+    }
+
+    Socket moved;
+    REQUIRE(moved.create(SocketType::UDP));
+    moved = std::move(receiver);
+    REQUIRE_FALSE(receiver.is_open());
+    REQUIRE(moved.is_open());
+
+    Socket sender;
+    REQUIRE(sender.create(SocketType::UDP));
+    const std::array<std::uint8_t, 2> payload{9, 7};
+    REQUIRE(sender.send_to(payload.data(), payload.size(), "127.0.0.1", *port)
+            == static_cast<int>(payload.size()));
+
+    std::array<std::uint8_t, 4> buffer{};
+    std::string from;
+    std::uint16_t from_port = 0;
+    REQUIRE(moved.receive_from(buffer.data(), buffer.size(), from, from_port)
+            == static_cast<int>(payload.size()));
+    REQUIRE(buffer[0] == 9);
+    REQUIRE(buffer[1] == 7);
+}
+
+TEST_CASE("UDP socket self move assignment preserves descriptor",
+          "[network_stream][socket][udp][phase3]") {
+    Socket receiver;
+    REQUIRE(receiver.create(SocketType::UDP));
+    auto port = try_bind_udp(receiver, 46121);
+    if (!port) {
+        SUCCEED("could not bind UDP loopback; skipping");
+        return;
+    }
+
+    auto* same = &receiver;
+    receiver = std::move(*same);
+    REQUIRE(receiver.is_open());
+
+    Socket sender;
+    REQUIRE(sender.create(SocketType::UDP));
+    const std::array<std::uint8_t, 1> payload{0x7f};
+    REQUIRE(sender.send_to(payload.data(), payload.size(), "127.0.0.1", *port)
+            == static_cast<int>(payload.size()));
+
+    std::array<std::uint8_t, 4> buffer{};
+    std::string from;
+    std::uint16_t from_port = 0;
+    REQUIRE(receiver.receive_from(buffer.data(), buffer.size(), from, from_port) == 1);
+    REQUIRE(buffer[0] == 0x7f);
+}
+
+TEST_CASE("UDP socket rejects TCP-only listen and accept",
+          "[network_stream][socket][udp][phase3]") {
+    Socket socket;
+    REQUIRE(socket.create(SocketType::UDP));
+    REQUIRE_FALSE(socket.listen());
+    REQUIRE_FALSE(socket.accept().has_value());
+}
+
+TEST_CASE("TcpStream can wrap an accepted Socket",
+          "[network_stream][tcp][socket][phase3]") {
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+
+    std::uint16_t port = 0;
+    for (std::uint16_t candidate = 46251; candidate < 46330; ++candidate) {
+        if (auto bound = try_bind_loopback(listener, candidate)) {
+            port = *bound;
+            break;
+        }
+    }
+    if (port == 0) {
+        SUCCEED("could not bind loopback port; skipping");
+        return;
+    }
+
+    std::atomic<bool> ready{false};
+    std::atomic<bool> done{false};
+    std::thread server_thread([&] {
+        ready.store(true);
+        auto accepted = listener.accept();
+        if (!accepted) return;
+        TcpStream stream(std::move(*accepted));
+        std::array<std::uint8_t, 8> buffer{};
+        auto read = stream.read(buffer.data(), buffer.size());
+        if (read.ok()) {
+            const std::array<std::uint8_t, 2> reply{'o', 'k'};
+            auto written = stream.write(reply.data(), reply.size());
+            done.store(written.ok());
+        }
+        stream.close();
+    });
+    while (!ready.load()) std::this_thread::sleep_for(1ms);
+
+    Socket client;
+    REQUIRE(client.create(SocketType::TCP));
+    REQUIRE(client.connect("127.0.0.1", port));
+    REQUIRE(client.send("hello") == 5);
+    std::array<std::uint8_t, 4> reply{};
+    REQUIRE(client.receive(reply.data(), reply.size()) == 2);
+    REQUIRE(reply[0] == 'o');
+    REQUIRE(reply[1] == 'k');
+    client.close();
+
+    server_thread.join();
+    REQUIRE(done.load());
+}
+
+TEST_CASE("TcpStream zero-byte I/O succeeds while connected",
+          "[network_stream][tcp][phase3]") {
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+
+    std::uint16_t port = 0;
+    for (std::uint16_t candidate = 46331; candidate < 46410; ++candidate) {
+        if (auto bound = try_bind_loopback(listener, candidate)) {
+            port = *bound;
+            break;
+        }
+    }
+    if (port == 0) {
+        SUCCEED("could not bind loopback port; skipping");
+        return;
+    }
+
+    std::atomic<bool> ready{false};
+    std::thread server_thread([&] {
+        ready.store(true);
+        auto accepted = listener.accept();
+        if (accepted) {
+            std::this_thread::sleep_for(100ms);
+            accepted->close();
+        }
+    });
+    while (!ready.load()) std::this_thread::sleep_for(1ms);
+
+    TcpStream stream;
+    REQUIRE(stream.connect("127.0.0.1", port));
+    std::array<std::uint8_t, 1> byte{0xaa};
+    auto zero_read = stream.read(byte.data(), 0);
+    auto zero_write = stream.write(byte.data(), 0);
+    REQUIRE(zero_read.ok());
+    REQUIRE(zero_read.bytes == 0);
+    REQUIRE(zero_write.ok());
+    REQUIRE(zero_write.bytes == 0);
+    REQUIRE(byte[0] == 0xaa);
 
     stream.close();
     server_thread.join();

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -482,17 +482,31 @@ TEST_CASE("TcpStream can wrap an accepted Socket",
     });
     while (!ready.load()) std::this_thread::sleep_for(1ms);
 
+    bool client_ok = true;
     Socket client;
-    REQUIRE(client.create(SocketType::TCP));
-    REQUIRE(client.connect("127.0.0.1", port));
-    REQUIRE(client.send("hello") == 5);
+    client_ok = client.create(SocketType::TCP);
+    CHECK(client_ok);
+    if (client_ok) {
+        client_ok = client.connect("127.0.0.1", port);
+        CHECK(client_ok);
+    }
+    if (client_ok) {
+        client_ok = client.send("hello") == 5;
+        CHECK(client_ok);
+    }
     std::array<std::uint8_t, 4> reply{};
-    REQUIRE(client.receive(reply.data(), reply.size()) == 2);
-    REQUIRE(reply[0] == 'o');
-    REQUIRE(reply[1] == 'k');
+    if (client_ok) {
+        client_ok = client.receive(reply.data(), reply.size()) == 2;
+        CHECK(client_ok);
+    }
+    if (client_ok) {
+        CHECK(reply[0] == 'o');
+        CHECK(reply[1] == 'k');
+    }
     client.close();
 
     server_thread.join();
+    REQUIRE(client_ok);
     REQUIRE(done.load());
 }
 
@@ -525,18 +539,22 @@ TEST_CASE("TcpStream zero-byte I/O succeeds while connected",
     while (!ready.load()) std::this_thread::sleep_for(1ms);
 
     TcpStream stream;
-    REQUIRE(stream.connect("127.0.0.1", port));
+    bool client_ok = stream.connect("127.0.0.1", port);
+    CHECK(client_ok);
     std::array<std::uint8_t, 1> byte{0xaa};
-    auto zero_read = stream.read(byte.data(), 0);
-    auto zero_write = stream.write(byte.data(), 0);
-    REQUIRE(zero_read.ok());
-    REQUIRE(zero_read.bytes == 0);
-    REQUIRE(zero_write.ok());
-    REQUIRE(zero_write.bytes == 0);
-    REQUIRE(byte[0] == 0xaa);
+    if (client_ok) {
+        auto zero_read = stream.read(byte.data(), 0);
+        auto zero_write = stream.write(byte.data(), 0);
+        CHECK(zero_read.ok());
+        CHECK(zero_read.bytes == 0);
+        CHECK(zero_write.ok());
+        CHECK(zero_write.bytes == 0);
+        CHECK(byte[0] == 0xaa);
+    }
 
     stream.close();
     server_thread.join();
+    REQUIRE(client_ok);
 }
 
 // ── HttpStream edge cases ───────────────────────────────────────────────

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -17,6 +17,20 @@ using namespace std::chrono_literals;
 
 namespace {
 
+struct ThreadJoiner {
+    std::thread& thread;
+
+    ~ThreadJoiner() {
+        join();
+    }
+
+    void join() {
+        if (thread.joinable()) {
+            thread.join();
+        }
+    }
+};
+
 // Pick an ephemeral port and return the bound listener + its actual port.
 std::optional<std::uint16_t> try_bind_loopback(Socket& server, std::uint16_t port) {
     if (!server.bind("127.0.0.1", port)) return std::nullopt;
@@ -121,6 +135,7 @@ TEST_CASE("TcpStream round-trips bytes on loopback", "[network_stream]") {
         client->close();
         server_done.store(true);
     });
+    ThreadJoiner join_server{server_thread};
 
     // Wait for the server to be listening before connecting.
     while (!server_ready.load()) std::this_thread::sleep_for(1ms);
@@ -151,7 +166,7 @@ TEST_CASE("TcpStream round-trips bytes on loopback", "[network_stream]") {
     REQUIRE(std::memcmp(recv, payload, sizeof(payload)) == 0);
 
     stream.close();
-    server_thread.join();
+    join_server.join();
     REQUIRE(server_done.load());
 }
 
@@ -245,6 +260,7 @@ TEST_CASE("TcpStream detects peer-close on the next read",
         if (!client) return;
         client->close();  // immediate peer-close
     });
+    ThreadJoiner join_server{server_thread};
     while (!server_ready.load()) std::this_thread::sleep_for(1ms);
 
     TcpStream stream;
@@ -264,7 +280,7 @@ TEST_CASE("TcpStream detects peer-close on the next read",
     REQUIRE(saw_close);
 
     stream.close();
-    server_thread.join();
+    join_server.join();
 }
 
 // ── Socket edge cases ───────────────────────────────────────────────────
@@ -480,6 +496,7 @@ TEST_CASE("TcpStream can wrap an accepted Socket",
         }
         stream.close();
     });
+    ThreadJoiner join_server{server_thread};
     while (!ready.load()) std::this_thread::sleep_for(1ms);
 
     bool client_ok = true;
@@ -505,7 +522,7 @@ TEST_CASE("TcpStream can wrap an accepted Socket",
     }
     client.close();
 
-    server_thread.join();
+    join_server.join();
     REQUIRE(client_ok);
     REQUIRE(done.load());
 }
@@ -536,6 +553,7 @@ TEST_CASE("TcpStream zero-byte I/O succeeds while connected",
             accepted->close();
         }
     });
+    ThreadJoiner join_server{server_thread};
     while (!ready.load()) std::this_thread::sleep_for(1ms);
 
     TcpStream stream;
@@ -553,7 +571,7 @@ TEST_CASE("TcpStream zero-byte I/O succeeds while connected",
     }
 
     stream.close();
-    server_thread.join();
+    join_server.join();
     REQUIRE(client_ok);
 }
 


### PR DESCRIPTION
## Summary
- add IPv4 validation edge coverage for decorated/private dotted-quads
- add Socket/TcpStream loopback coverage for unopened operations, create/close state, UDP datagram flow, wildcard binds, move semantics, TCP-only guards, accepted-socket wrapping, and zero-byte stream I/O

## Local validation
- `git diff --check`
- `cmake --build build --target pulp-test-network-stream -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-network-stream`
- `PULP_DIFF_COVER_CTEST_REGEX='IPv4 validation rejects decorated dotted quads|IPv4 validation accepts private network examples|Socket reports failures before create|Socket create close and recreate toggles open state|UDP socket round-trips datagrams on loopback|UDP bind accepts empty address as wildcard|UDP socket move construction transfers the descriptor|UDP socket move assignment transfers the descriptor|UDP socket self move assignment preserves descriptor|UDP socket rejects TCP-only listen and accept|TcpStream can wrap an accepted Socket|TcpStream zero-byte I/O succeeds while connected' tools/scripts/local_diff_cover.sh`