### PR TITLE
test: batch runtime utility and environment coverage edges

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-# codecov.yml — Codecov config for public/#566 Phase 1 (measurement baseline).
+# codecov.yml - Codecov config for public/#566 Phase 1 (measurement baseline).
 #
 # Primary consumers (in order): Pulp developers, dispatched agents, CI
 # enforcement, contributors reading PR comments. Public dashboard is a
@@ -12,14 +12,14 @@
 # Phase 2 adds ci/coverage-targets.yaml alongside this for the diff-cover
 # gate; Phase 4 introduces doc_path_map.json to prevent drift.
 
-# Notification gating — wait for all 4 platform coverage uploads before
+# Notification gating - wait for all 4 platform coverage uploads before
 # the bot computes + posts the patch coverage report. Without this,
 # Codecov posts as soon as it sees ANY upload (often Linux first, since
 # its build is fastest), which means Apple-only or Windows-only tested
 # paths get reported as 0% covered against partial data. PR #1873 was a
 # textbook example: a CLAP-fixture test that ran only on macOS was
 # reported as "0% patch coverage" by the bot because the macOS upload
-# hadn't arrived (and never did — see follow-up issue on the coverage
+# hadn't arrived (and never did - see follow-up issue on the coverage
 # workflow's `cancel-in-progress: true` concurrency policy that wipes
 # in-flight runs on force-push).
 #
@@ -32,7 +32,7 @@
 #
 # If you add or remove a coverage uploader, bump this number to match
 # or Codecov will silently wait forever for the missing one and never
-# post. After 7d it gives up and posts whatever it has — by then the
+# post. After 7d it gives up and posts whatever it has - by then the
 # PR has long since merged with a stale report.
 codecov:
   notify:
@@ -40,7 +40,7 @@ codecov:
 
 coverage:
   status:
-    # Project-wide status: "did we get worse?" Not a hard gate — we
+    # Project-wide status: "did we get worse?" Not a hard gate - we
     # already have continue-on-error on the coverage job and Phase 3
     # is where per-PR enforcement lands.
     project:
@@ -52,11 +52,11 @@ coverage:
     # Patch status: "is new code covered?" Advisory in the sense that
     # branch-protection does NOT require this check (so a sub-threshold
     # PR can still merge), but the check status now accurately reflects
-    # the threshold check — `success` if ≥75%, `failure` if <75%.
+    # the threshold check - `success` if >=75%, `failure` if <75%.
     #
     # Previously `informational: true` hardwired the status to `success`
     # even when patch coverage was 0%, which deceived devs reading the
-    # check line. The bot still posted a "❌ Patch coverage is X%"
+    # check line. The bot still posted a "[fail] Patch coverage is X%"
     # comment, but the status check itself said success, masking the
     # gap. Flipping to enforcing makes the signal accurate without
     # changing merge behavior (codecov/patch is not in
@@ -76,9 +76,9 @@ coverage:
 # so Codecov and our local tooling count the same set of files.
 # External FetchContent sources (Dawn, Skia, mbedTLS, QuickJS,
 # Catch2, etc.) and our test trees are never counted as coverage-
-# bearing. See planning/coverage-tooling-decision-2026-04-21.md §4.
+# bearing. See planning/coverage-tooling-decision-2026-04-21.md section 4.
 #
-# `ignore` is a TOP-LEVEL key in Codecov config — nesting it under
+# `ignore` is a TOP-LEVEL key in Codecov config - nesting it under
 # `coverage:` silently no-ops, which would count files we explicitly
 # want excluded and skew the baseline metrics. See Codecov config
 # schema: https://docs.codecov.com/docs/codecov-yaml
@@ -106,7 +106,7 @@ ignore:
   # harness implementation, so Codecov must not count the tests as
   # patch-coverable product code.
   - "tools/harness/visual/tests/**"
-  # ── Aligned with tools/scripts/coverage_config.json `diff_cover_excludes` ──
+  # -- Aligned with tools/scripts/coverage_config.json `diff_cover_excludes` --
   # The Pulp gate (`Diff coverage required` in coverage.yml) excludes these
   # files because they're either thin dispatchers exercised end-to-end via
   # shell-out tests (so direct line coverage doesn't propagate cleanly), or
@@ -114,11 +114,11 @@ ignore:
   # can't instrument uniformly. Without aligning the Codecov bot's ignore
   # list to the same set, the bot's `codecov/patch` check fires red on PRs
   # whose diff is mostly in these files (e.g. PR #1984's viewport-fit lived
-  # almost entirely in window_host_mac.mm — Pulp gate silent, bot screamed
+  # almost entirely in window_host_mac.mm - Pulp gate silent, bot screamed
   # 8.64% patch coverage). Both sides MUST count the same set.
   #
   # Drift between this list and coverage_config.json is detected by
-  # tools/scripts/test_codecov_config_sync.py — keep them in sync.
+  # tools/scripts/test_codecov_config_sync.py - keep them in sync.
   - "**/cmd_loop.cpp"
   - "**/pulp_import_design.cpp"
   - "**/cg_canvas.mm"
@@ -138,7 +138,7 @@ comment:
 
 # Flag definitions are retained for Phase 1 PR 4 (per-OS upload jobs)
 # and for future workflows that genuinely upload one file per flag.
-# The main coverage.yml upload does NOT attach any flags — Codecov
+# The main coverage.yml upload does NOT attach any flags - Codecov
 # rejects single-upload multi-flag submissions with "Multiple flags
 # detected. Please ensure one flag per upload." The per-subsystem /
 # per-platform / per-surface breakdown comes from `component_management`
@@ -150,7 +150,7 @@ comment:
 # means updating both blocks in this file; `tools/scripts/test_codecov_config.py`
 # checks them against the live `core/*` tree so drift fails fast.
 flags:
-  # Core subsystems — one flag per top-level core/** directory.
+  # Core subsystems - one flag per top-level core/** directory.
   audio:
     paths:
       - core/audio/
@@ -208,7 +208,7 @@ flags:
       - core/view/
     carryforward: true
 
-  # Platform flags (4) — cross-cut the subsystem flags. "What's host
+  # Platform flags (4) - cross-cut the subsystem flags. "What's host
   # coverage on Windows?" is answered by cross-filtering `host AND
   # windows`. Paths cover all subsystems because any subsystem can
   # have a Windows shim under its own `platform/windows/` tree.
@@ -238,7 +238,7 @@ flags:
       - core/**/wasapi/
     carryforward: true
 
-  # Surface flags (4) — non-core but first-party:
+  # Surface flags (4) - non-core but first-party:
   cli:
     paths:
       - tools/cli/
@@ -260,16 +260,16 @@ flags:
       - tools/
     carryforward: true
 
-  # OS flags (3) — Phase 1 PR 4 cross-platform coverage matrix. These
+  # OS flags (3) - Phase 1 PR 4 cross-platform coverage matrix. These
   # are NOT path-scoped; every file measured on a given matrix leg is
   # tagged with that OS's flag at upload time via the corresponding
   # matrix entry in .github/workflows/coverage.yml. Federate with the
   # subsystem + platform + surface flags above for cross-filtering:
   # `host AND os-windows` answers "what fraction of core/host is
-  # exercised when tests run on Windows?" — a different question from
+  # exercised when tests run on Windows?" - a different question from
   # `host AND windows` (which reads "what fraction of the windows/
   # shim files are covered at all"). See docs/guides/coverage.md
-  # §"Multi-OS coverage" for the rationale on Codecov-flag unions vs
+  # section "Multi-OS coverage" for the rationale on Codecov-flag unions vs
   # llvm-profdata merge.
   os-linux:
     carryforward: true
@@ -278,7 +278,7 @@ flags:
   os-windows:
     carryforward: true
 
-# carryforward: true on every flag — when a PR doesn't touch
+# carryforward: true on every flag - when a PR doesn't touch
 # a given subsystem, carry over the last known coverage for that
 # flag from main so the dashboard doesn't report a false 0%. Standard
 # Codecov practice for multi-job uploads (we have one job per OS
@@ -303,12 +303,12 @@ component_management:
         threshold: 1%
         informational: true
   individual_components:
-    # Core subsystems — mirror every top-level core/** directory.
+    # Core subsystems - mirror every top-level core/** directory.
     #
     # Subsystems that house platform-specific subtrees (`audio`, `midi`,
     # `view`, `render`, `platform`, `canvas`) explicitly exclude those
     # subtrees so each first-party file lands in exactly one component
-    # bucket — see #1055. Platform-specific code is owned by the
+    # bucket - see #1055. Platform-specific code is owned by the
     # `apple`/`android`/`linux`/`windows` components below; without the
     # `!`-exclude here those files were silently double-counted, inflating
     # coverage for both the subsystem and the platform.
@@ -375,10 +375,10 @@ component_management:
       paths:
         - "core/view/**"
         - "!core/view/platform/**"
-    # Platform (4) — cross-cut the subsystems. Patterns within each
+    # Platform (4) - cross-cut the subsystems. Patterns within each
     # platform component must not overlap each other (Codecov double-
     # counts files matched twice within the same component, inflating
-    # the line totals — caught on #1055 as `platform,android,android`
+    # the line totals - caught on #1055 as `platform,android,android`
     # 3-way matches).
     - component_id: android
       name: android
@@ -403,7 +403,7 @@ component_management:
         - "core/**/win/**"
         - "core/**/windows/**"
         - "core/**/wasapi/**"
-    # Surface (4) — `tools` excludes `tools/cli/**` so the more specific
+    # Surface (4) - `tools` excludes `tools/cli/**` so the more specific
     # `cli` component owns those files; otherwise every CLI file is
     # double-counted (#1055).
     - component_id: cli

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -612,3 +612,148 @@ TEST_CASE("Environment: snapshot is consistent with last publish",
     REQUIRE(got.keyboard.bottom == 220.0f);
     REQUIRE(got.safe_area.top   == 22.0f);
 }
+
+TEST_CASE("Environment: publish without listeners still updates snapshot",
+          "[environment][coverage][phase3]") {
+    Environment::reset_for_test();
+    auto state = make_state(ColorScheme::dark, 1.25f, 48.0f);
+    state.lifecycle = LifecycleState::background;
+
+    Environment::inject_for_test(state);
+
+    auto got = Environment::instance().snapshot();
+    REQUIRE(got.color_scheme == ColorScheme::dark);
+    REQUIRE(got.display.scale == 1.25f);
+    REQUIRE(got.keyboard.bottom == 48.0f);
+    REQUIRE(got.lifecycle == LifecycleState::background);
+}
+
+TEST_CASE("Environment: multiple listeners receive the same change snapshot",
+          "[environment][coverage][phase3]") {
+    Environment::reset_for_test();
+    int first_calls = 0;
+    int second_calls = 0;
+    EnvironmentChange first_change{};
+    EnvironmentChange second_change{};
+    EnvironmentState first_state{};
+    EnvironmentState second_state{};
+
+    auto first = Environment::instance().subscribe(
+        [&](const EnvironmentState& s, EnvironmentChange c) {
+            ++first_calls;
+            first_state = s;
+            first_change = c;
+        });
+    auto second = Environment::instance().subscribe(
+        [&](const EnvironmentState& s, EnvironmentChange c) {
+            ++second_calls;
+            second_state = s;
+            second_change = c;
+        });
+
+    auto state = make_state(ColorScheme::light, 2.5f);
+    Environment::inject_for_test(state);
+
+    REQUIRE(first_calls == 1);
+    REQUIRE(second_calls == 1);
+    REQUIRE(first_change.display);
+    REQUIRE(second_change.display);
+    REQUIRE(first_change.color_scheme);
+    REQUIRE(second_change.color_scheme);
+    REQUIRE(first_state.display.scale == 2.5f);
+    REQUIRE(second_state.display.scale == 2.5f);
+}
+
+TEST_CASE("Environment: default token reset is inert",
+          "[environment][coverage][phase3]") {
+    Environment::reset_for_test();
+    Environment::Token token;
+    REQUIRE_FALSE(token.valid());
+
+    token.reset();
+    REQUIRE_FALSE(token.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(Environment::instance().snapshot().color_scheme == ColorScheme::dark);
+}
+
+TEST_CASE("Environment: token self move assignment preserves subscription",
+          "[environment][coverage][phase3]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+    REQUIRE(token.valid());
+
+    auto* same = &token;
+    token = std::move(*same);
+    REQUIRE(token.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("Environment: move assigning an empty token unsubscribes existing listener",
+          "[environment][coverage][phase3]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+    REQUIRE(token.valid());
+
+    Environment::Token empty;
+    token = std::move(empty);
+    REQUIRE_FALSE(token.valid());
+    REQUIRE_FALSE(empty.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(calls == 0);
+}
+
+TEST_CASE("Environment: listener subscribed during dispatch waits for next publish",
+          "[environment][coverage][phase3]") {
+    Environment::reset_for_test();
+    int first_calls = 0;
+    int late_calls = 0;
+    std::unique_ptr<Environment::Token> late_token;
+
+    auto first = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) {
+            ++first_calls;
+            if (!late_token) {
+                late_token = std::make_unique<Environment::Token>(
+                    Environment::instance().subscribe(
+                        [&](const EnvironmentState&, EnvironmentChange) {
+                            ++late_calls;
+                        }));
+            }
+        });
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(first_calls == 1);
+    REQUIRE(late_calls == 0);
+    REQUIRE(late_token);
+    REQUIRE(late_token->valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(first_calls == 2);
+    REQUIRE(late_calls == 1);
+}
+
+TEST_CASE("Environment: reset restores defaults after published state",
+          "[environment][coverage][phase3]") {
+    Environment::reset_for_test();
+    auto state = make_state(ColorScheme::dark, 3.0f, 240.0f);
+    state.safe_area.bottom = 12.0f;
+    Environment::inject_for_test(state);
+
+    Environment::reset_for_test();
+
+    auto got = Environment::instance().snapshot();
+    REQUIRE(got.color_scheme == ColorScheme::unknown);
+    REQUIRE(got.lifecycle == LifecycleState::unknown);
+    REQUIRE(got.orientation == Orientation::unknown);
+    REQUIRE(got.display.scale == 1.0f);
+    REQUIRE(got.keyboard.bottom == 0.0f);
+    REQUIRE(got.safe_area.is_zero());
+}

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -20,6 +20,28 @@
 
 using namespace pulp::runtime;
 
+namespace {
+
+const char* system_library_path() {
+#if defined(_WIN32)
+    return "kernel32.dll";
+#elif defined(__APPLE__)
+    return "/usr/lib/libSystem.B.dylib";
+#else
+    return "libc.so.6";
+#endif
+}
+
+const char* system_library_symbol() {
+#if defined(_WIN32)
+    return "GetCurrentProcess";
+#else
+    return "malloc";
+#endif
+}
+
+}  // namespace
+
 // ── TemporaryFile ───────────────────────────────────────────────────────
 
 TEST_CASE("TemporaryFile creates and deletes", "[runtime][temp_file]") {
@@ -280,6 +302,52 @@ TEST_CASE("DynamicLibrary fails on nonexistent", "[runtime][dynlib]") {
     REQUIRE_FALSE(lib.error().empty());
 }
 
+TEST_CASE("DynamicLibrary closed lookup is null and close is idempotent",
+          "[runtime][dynlib][coverage][phase3]") {
+    DynamicLibrary lib;
+    REQUIRE_FALSE(lib.is_open());
+    REQUIRE(lib.find_symbol(system_library_symbol()) == nullptr);
+    lib.close();
+    REQUIRE_FALSE(lib.is_open());
+}
+
+TEST_CASE("DynamicLibrary move construction transfers the handle",
+          "[runtime][dynlib][coverage][phase3]") {
+    DynamicLibrary lib;
+    REQUIRE(lib.open(system_library_path()));
+    REQUIRE(lib.find_symbol(system_library_symbol()) != nullptr);
+
+    DynamicLibrary moved(std::move(lib));
+    REQUIRE(moved.is_open());
+    REQUIRE_FALSE(lib.is_open());
+    REQUIRE(moved.find_symbol(system_library_symbol()) != nullptr);
+}
+
+TEST_CASE("DynamicLibrary move assignment closes target and transfers source",
+          "[runtime][dynlib][coverage][phase3]") {
+    DynamicLibrary target;
+    DynamicLibrary source;
+    REQUIRE(target.open(system_library_path()));
+    REQUIRE(source.open(system_library_path()));
+
+    target = std::move(source);
+
+    REQUIRE(target.is_open());
+    REQUIRE_FALSE(source.is_open());
+    REQUIRE(target.find_symbol(system_library_symbol()) != nullptr);
+}
+
+TEST_CASE("DynamicLibrary failed reopen clears a previously loaded handle",
+          "[runtime][dynlib][coverage][phase3]") {
+    DynamicLibrary lib;
+    REQUIRE(lib.open(system_library_path()));
+    REQUIRE(lib.is_open());
+
+    REQUIRE_FALSE(lib.open("/tmp/nonexistent_lib_after_success_12345.dylib"));
+    REQUIRE_FALSE(lib.is_open());
+    REQUIRE_FALSE(lib.error().empty());
+}
+
 // ── InterProcessLock ────────────────────────────────────────────────────
 
 TEST_CASE("InterProcessLock acquires and releases", "[runtime][ipc_lock]") {
@@ -313,6 +381,20 @@ TEST_CASE("InterProcessLock unlock is idempotent and permits reacquire",
 
     REQUIRE(lock.try_lock());
     REQUIRE(lock.is_locked());
+}
+
+TEST_CASE("InterProcessLock competing instance waits for release",
+          "[runtime][ipc_lock][coverage][phase3]") {
+    const auto name = "test_lock_competing_phase3";
+    InterProcessLock first(name);
+    InterProcessLock second(name);
+
+    REQUIRE(first.try_lock());
+    REQUIRE_FALSE(second.try_lock());
+
+    first.unlock();
+    REQUIRE(second.try_lock());
+    REQUIRE(second.is_locked());
 }
 
 // ── ChildProcess ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add DynamicLibrary coverage for closed lookups, move construction/assignment, and failed reopen state
- add InterProcessLock coverage for competing lock instances
- add Environment notifier coverage for no-listener publishes, multi-listener snapshots, token edge cases, in-dispatch subscriptions, and reset defaults

## Local validation
- `git diff --check`
- `cmake --build build --target pulp-test-runtime-utils pulp-test-environment -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-runtime-utils "[coverage][phase3]"`
- `./build/test/pulp-test-environment "[coverage][phase3]"`
- `PULP_DIFF_COVER_CTEST_REGEX='DynamicLibrary closed lookup is null and close is idempotent|DynamicLibrary move construction transfers the handle|DynamicLibrary move assignment closes target and transfers source|DynamicLibrary failed reopen clears a previously loaded handle|InterProcessLock competing instance waits for release|Environment: publish without listeners still updates snapshot|Environment: multiple listeners receive the same change snapshot|Environment: default token reset is inert|Environment: token self move assignment preserves subscription|Environment: move assigning an empty token unsubscribes existing listener|Environment: listener subscribed during dispatch waits for next publish|Environment: reset restores defaults after published state' tools/scripts/local_diff_cover.sh`