### PR TITLE
feat(create): default new projects to Release; --debug opts in

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -1114,3 +1114,8 @@ Gotchas:
   invalidate `~/.pulp/cache`.** The new version means the filename
   misses on the old cache and the user gets a fresh download
   automatically.
+- **`pulp create` defaults to `CMAKE_BUILD_TYPE=Release`; `--debug` opts in** (2026-05). Was Debug-default historically, which silently produced ~5-10× slower binaries because `pulp build`'s incremental configure doesn't re-pass `-DCMAKE_BUILD_TYPE` (so the create-time value sticks for the project's lifetime). Two call sites in `cmd_create.cpp` both honor the flag — keep them in lockstep when adding new configure paths. Intentionally NOT mirrored:
+    - `cmd_project.cpp`'s `bump --verify-build` keeps Debug — throwaway verify build, faster compile, binary isn't run.
+    - `validate-build.sh` keeps Debug — that's the validator's job (catches debug-only assertion failures).
+    - `cli_common.cpp`'s SDK install path already used Release.
+  Follow-up scope (not done yet): `pulp build --debug` / `--release` that force a reconfigure of an existing `build/` directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v01060"></a>
+## [0.107.0]
+
 ## [0.106.0] - 2026-05-17
 
 - feat(design-import): V2 wire-up — emit registerShortcut + synthetic keydown re-dispatch ([#2119](https://github.com/danielraffel/pulp/pull/2119))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.106.0
+    VERSION 0.107.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/tools/cli/cmd_create.cpp
+++ b/tools/cli/cmd_create.cpp
@@ -120,6 +120,12 @@ int cmd_create(const std::vector<std::string>& args) {
     // instead of exact-pin. `--pin` opts into exact-version pinning at
     // create-time for users who want reproducibility from day one.
     bool pin_at_create = false;
+    // 2026-05 build-default flip: scaffolded projects default to Release
+    // builds. Debug is opt-in via `--debug` for developers who need
+    // assertions / faster iteration. Was Debug-by-default; that
+    // silently shipped 5–10× slower binaries for users running the
+    // resulting app and didn't match the "build the app" mental model.
+    bool debug_build = false;
     for (size_t i = 0; i < args.size(); ++i) {
         if (args[i] == "--type" && i + 1 < args.size()) { type = args[++i]; continue; }
         if (args[i] == "--mpe") { mpe_mode = true; continue; }
@@ -133,6 +139,7 @@ int cmd_create(const std::vector<std::string>& args) {
         if (args[i] == "--no-build") { no_build = true; continue; }
         if (args[i] == "--no-interactive" || args[i] == "--ci") { ci_mode = true; continue; }
         if (args[i] == "--pin") { pin_at_create = true; continue; }
+        if (args[i] == "--debug") { debug_build = true; continue; }
         if (args[i] == "--help" || args[i] == "-h") {
             std::cout << "pulp create — create a new plugin project\n\n";
             std::cout << "Usage: pulp create <name> [options]\n\n";
@@ -147,6 +154,7 @@ int cmd_create(const std::vector<std::string>& args) {
             std::cout << "  --no-build                           Skip build after scaffolding\n";
             std::cout << "  --no-interactive, --ci               Non-interactive mode (use defaults)\n";
             std::cout << "  --pin                                Write the current SDK version into pulp.toml (default: floating, tracks latest)\n";
+            std::cout << "  --debug                              Configure CMAKE_BUILD_TYPE=Debug (default: Release)\n";
             std::cout << "\nDefault behavior: create a standalone product project, even inside the Pulp repo.\n";
             std::cout << "Inside the repo, the default location is next to the repo root unless\n";
             std::cout << "PULP_PROJECTS_DIR or ~/.pulp/config.toml overrides it.\n";
@@ -628,7 +636,7 @@ int cmd_create(const std::vector<std::string>& args) {
 
         std::string configure_cmd = "cmake -S " + out_dir.string()
             + " -B " + (out_dir / "build").string()
-            + " -DCMAKE_BUILD_TYPE=Debug"
+            + " -DCMAKE_BUILD_TYPE=" + (debug_build ? "Debug" : "Release")
             + " -DCMAKE_PREFIX_PATH=" + sdk_dir.string();
         append_windows_visual_studio_generator_args(configure_cmd);
         int rc = run_with_spinner(configure_cmd, "Configuring");
@@ -655,7 +663,8 @@ int cmd_create(const std::vector<std::string>& args) {
         auto example_rel_dir = fs::relative(out_dir, root / "examples");
         std::string configure_cmd = "cmake -S " + shell_quote(root) + " -B "
                                   + shell_quote(root / "build")
-                                  + " -DCMAKE_BUILD_TYPE=Debug";
+                                  + " -DCMAKE_BUILD_TYPE="
+                                  + (debug_build ? "Debug" : "Release");
         append_windows_visual_studio_generator_args(configure_cmd);
         int rc = run_with_spinner(configure_cmd, "Configuring");
         if (rc != 0) {


### PR DESCRIPTION
## Summary

Flip `pulp create`'s default `CMAKE_BUILD_TYPE` from `Debug` to `Release`. Add `--debug` for opt-in.

## Why

Today every project scaffolded by `pulp create` lands with `-DCMAKE_BUILD_TYPE=Debug` hardcoded — no way to override at create time. `pulp build` doesn't pass `-DCMAKE_BUILD_TYPE` on incremental configures, so the Debug setting sticks for the project's lifetime. The result: users running the resulting binary get a **~5-10× slowdown** on animated / JS-driven UIs versus what they'd see in a Release build. The LOUD perf warning in `CMakeLists.txt` exists for exactly this class of footgun, but it only fires when Skia-link is also missing.

"Build the app" should produce the fast build.

## After

* `pulp create <name>` → `-DCMAKE_BUILD_TYPE=Release`.
* `pulp create <name> --debug` → `-DCMAKE_BUILD_TYPE=Debug`.
* Both code paths (standalone-mode + in-tree-mode) honor the flag.
* `--help` documents the new flag and the new default.

## Intentionally NOT changed

* `pulp project bump --verify-build` keeps Debug — throwaway verify build, faster compile, binary isn't run by anyone.
* `validate-build.sh` keeps Debug — that's the validator's job (catches debug-only assertion failures).
* The SDK install path in `cli_common.cpp` already used Release.

## Follow-up scope (not this PR)

* `pulp build --debug` / `pulp build --release` that force a reconfigure of an existing build dir.
* Mirror the same flag through the Rust CLI's `pulp project` path (only `bump-verify` calls it today — see issue tracker).

## Test plan

- [x] Local build of `pulp-cli` succeeds.
- [ ] CI matrix.
- [ ] Manual: `pulp create scratch --no-build` then inspect `pulp.toml`/`CMakeLists.txt` for the new shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
