### PR TITLE
test(view): batch lifecycle widget coverage edges

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-# codecov.yml — Codecov config for public/#566 Phase 1 (measurement baseline).
+# codecov.yml - Codecov config for public/#566 Phase 1 (measurement baseline).
 #
 # Primary consumers (in order): Pulp developers, dispatched agents, CI
 # enforcement, contributors reading PR comments. Public dashboard is a
@@ -12,14 +12,14 @@
 # Phase 2 adds ci/coverage-targets.yaml alongside this for the diff-cover
 # gate; Phase 4 introduces doc_path_map.json to prevent drift.
 
-# Notification gating — wait for all 4 platform coverage uploads before
+# Notification gating - wait for all 4 platform coverage uploads before
 # the bot computes + posts the patch coverage report. Without this,
 # Codecov posts as soon as it sees ANY upload (often Linux first, since
 # its build is fastest), which means Apple-only or Windows-only tested
 # paths get reported as 0% covered against partial data. PR #1873 was a
 # textbook example: a CLAP-fixture test that ran only on macOS was
 # reported as "0% patch coverage" by the bot because the macOS upload
-# hadn't arrived (and never did — see follow-up issue on the coverage
+# hadn't arrived (and never did - see follow-up issue on the coverage
 # workflow's `cancel-in-progress: true` concurrency policy that wipes
 # in-flight runs on force-push).
 #
@@ -32,7 +32,7 @@
 #
 # If you add or remove a coverage uploader, bump this number to match
 # or Codecov will silently wait forever for the missing one and never
-# post. After 7d it gives up and posts whatever it has — by then the
+# post. After 7d it gives up and posts whatever it has - by then the
 # PR has long since merged with a stale report.
 codecov:
   notify:
@@ -40,7 +40,7 @@ codecov:
 
 coverage:
   status:
-    # Project-wide status: "did we get worse?" Not a hard gate — we
+    # Project-wide status: "did we get worse?" Not a hard gate - we
     # already have continue-on-error on the coverage job and Phase 3
     # is where per-PR enforcement lands.
     project:
@@ -52,11 +52,11 @@ coverage:
     # Patch status: "is new code covered?" Advisory in the sense that
     # branch-protection does NOT require this check (so a sub-threshold
     # PR can still merge), but the check status now accurately reflects
-    # the threshold check — `success` if ≥75%, `failure` if <75%.
+    # the threshold check - `success` if >=75%, `failure` if <75%.
     #
     # Previously `informational: true` hardwired the status to `success`
     # even when patch coverage was 0%, which deceived devs reading the
-    # check line. The bot still posted a "❌ Patch coverage is X%"
+    # check line. The bot still posted a "[fail] Patch coverage is X%"
     # comment, but the status check itself said success, masking the
     # gap. Flipping to enforcing makes the signal accurate without
     # changing merge behavior (codecov/patch is not in
@@ -76,9 +76,9 @@ coverage:
 # so Codecov and our local tooling count the same set of files.
 # External FetchContent sources (Dawn, Skia, mbedTLS, QuickJS,
 # Catch2, etc.) and our test trees are never counted as coverage-
-# bearing. See planning/coverage-tooling-decision-2026-04-21.md §4.
+# bearing. See planning/coverage-tooling-decision-2026-04-21.md section 4.
 #
-# `ignore` is a TOP-LEVEL key in Codecov config — nesting it under
+# `ignore` is a TOP-LEVEL key in Codecov config - nesting it under
 # `coverage:` silently no-ops, which would count files we explicitly
 # want excluded and skew the baseline metrics. See Codecov config
 # schema: https://docs.codecov.com/docs/codecov-yaml
@@ -106,7 +106,7 @@ ignore:
   # harness implementation, so Codecov must not count the tests as
   # patch-coverable product code.
   - "tools/harness/visual/tests/**"
-  # ── Aligned with tools/scripts/coverage_config.json `diff_cover_excludes` ──
+  # -- Aligned with tools/scripts/coverage_config.json `diff_cover_excludes` --
   # The Pulp gate (`Diff coverage required` in coverage.yml) excludes these
   # files because they're either thin dispatchers exercised end-to-end via
   # shell-out tests (so direct line coverage doesn't propagate cleanly), or
@@ -114,11 +114,11 @@ ignore:
   # can't instrument uniformly. Without aligning the Codecov bot's ignore
   # list to the same set, the bot's `codecov/patch` check fires red on PRs
   # whose diff is mostly in these files (e.g. PR #1984's viewport-fit lived
-  # almost entirely in window_host_mac.mm — Pulp gate silent, bot screamed
+  # almost entirely in window_host_mac.mm - Pulp gate silent, bot screamed
   # 8.64% patch coverage). Both sides MUST count the same set.
   #
   # Drift between this list and coverage_config.json is detected by
-  # tools/scripts/test_codecov_config_sync.py — keep them in sync.
+  # tools/scripts/test_codecov_config_sync.py - keep them in sync.
   - "**/cmd_loop.cpp"
   - "**/pulp_import_design.cpp"
   - "**/cg_canvas.mm"
@@ -138,7 +138,7 @@ comment:
 
 # Flag definitions are retained for Phase 1 PR 4 (per-OS upload jobs)
 # and for future workflows that genuinely upload one file per flag.
-# The main coverage.yml upload does NOT attach any flags — Codecov
+# The main coverage.yml upload does NOT attach any flags - Codecov
 # rejects single-upload multi-flag submissions with "Multiple flags
 # detected. Please ensure one flag per upload." The per-subsystem /
 # per-platform / per-surface breakdown comes from `component_management`
@@ -150,7 +150,7 @@ comment:
 # means updating both blocks in this file; `tools/scripts/test_codecov_config.py`
 # checks them against the live `core/*` tree so drift fails fast.
 flags:
-  # Core subsystems — one flag per top-level core/** directory.
+  # Core subsystems - one flag per top-level core/** directory.
   audio:
     paths:
       - core/audio/
@@ -208,7 +208,7 @@ flags:
       - core/view/
     carryforward: true
 
-  # Platform flags (4) — cross-cut the subsystem flags. "What's host
+  # Platform flags (4) - cross-cut the subsystem flags. "What's host
   # coverage on Windows?" is answered by cross-filtering `host AND
   # windows`. Paths cover all subsystems because any subsystem can
   # have a Windows shim under its own `platform/windows/` tree.
@@ -238,7 +238,7 @@ flags:
       - core/**/wasapi/
     carryforward: true
 
-  # Surface flags (4) — non-core but first-party:
+  # Surface flags (4) - non-core but first-party:
   cli:
     paths:
       - tools/cli/
@@ -260,16 +260,16 @@ flags:
       - tools/
     carryforward: true
 
-  # OS flags (3) — Phase 1 PR 4 cross-platform coverage matrix. These
+  # OS flags (3) - Phase 1 PR 4 cross-platform coverage matrix. These
   # are NOT path-scoped; every file measured on a given matrix leg is
   # tagged with that OS's flag at upload time via the corresponding
   # matrix entry in .github/workflows/coverage.yml. Federate with the
   # subsystem + platform + surface flags above for cross-filtering:
   # `host AND os-windows` answers "what fraction of core/host is
-  # exercised when tests run on Windows?" — a different question from
+  # exercised when tests run on Windows?" - a different question from
   # `host AND windows` (which reads "what fraction of the windows/
   # shim files are covered at all"). See docs/guides/coverage.md
-  # §"Multi-OS coverage" for the rationale on Codecov-flag unions vs
+  # section "Multi-OS coverage" for the rationale on Codecov-flag unions vs
   # llvm-profdata merge.
   os-linux:
     carryforward: true
@@ -278,7 +278,7 @@ flags:
   os-windows:
     carryforward: true
 
-# carryforward: true on every flag — when a PR doesn't touch
+# carryforward: true on every flag - when a PR doesn't touch
 # a given subsystem, carry over the last known coverage for that
 # flag from main so the dashboard doesn't report a false 0%. Standard
 # Codecov practice for multi-job uploads (we have one job per OS
@@ -303,12 +303,12 @@ component_management:
         threshold: 1%
         informational: true
   individual_components:
-    # Core subsystems — mirror every top-level core/** directory.
+    # Core subsystems - mirror every top-level core/** directory.
     #
     # Subsystems that house platform-specific subtrees (`audio`, `midi`,
     # `view`, `render`, `platform`, `canvas`) explicitly exclude those
     # subtrees so each first-party file lands in exactly one component
-    # bucket — see #1055. Platform-specific code is owned by the
+    # bucket - see #1055. Platform-specific code is owned by the
     # `apple`/`android`/`linux`/`windows` components below; without the
     # `!`-exclude here those files were silently double-counted, inflating
     # coverage for both the subsystem and the platform.
@@ -375,10 +375,10 @@ component_management:
       paths:
         - "core/view/**"
         - "!core/view/platform/**"
-    # Platform (4) — cross-cut the subsystems. Patterns within each
+    # Platform (4) - cross-cut the subsystems. Patterns within each
     # platform component must not overlap each other (Codecov double-
     # counts files matched twice within the same component, inflating
-    # the line totals — caught on #1055 as `platform,android,android`
+    # the line totals - caught on #1055 as `platform,android,android`
     # 3-way matches).
     - component_id: android
       name: android
@@ -403,7 +403,7 @@ component_management:
         - "core/**/win/**"
         - "core/**/windows/**"
         - "core/**/wasapi/**"
-    # Surface (4) — `tools` excludes `tools/cli/**` so the more specific
+    # Surface (4) - `tools` excludes `tools/cli/**` so the more specific
     # `cli` component owns those files; otherwise every CLI file is
     # double-counted (#1055).
     - component_id: cli

--- a/core/view/src/frame_clock.cpp
+++ b/core/view/src/frame_clock.cpp
@@ -9,12 +9,21 @@ void FrameClock::tick(float dt) {
     time_ += dt;
     ++frame_;
 
-    // Tick all subscribers, removing those that return false
-    for (auto& sub : subscribers_) {
-        if (sub.active) {
-            if (!sub.callback(dt)) {
-                sub.active = false;
-            }
+    const auto count = subscribers_.size();
+
+    for (std::size_t i = 0; i < count && i < subscribers_.size(); ++i) {
+        if (!subscribers_[i].active) {
+            continue;
+        }
+
+        const int id = subscribers_[i].id;
+        auto callback = subscribers_[i].callback;
+        const bool keep = callback(dt);
+
+        auto it = std::find_if(subscribers_.begin(), subscribers_.end(),
+            [id](const Subscriber& s) { return s.id == id; });
+        if (it != subscribers_.end() && !keep) {
+            it->active = false;
         }
     }
 

--- a/test/test_frame_clock.cpp
+++ b/test/test_frame_clock.cpp
@@ -170,3 +170,83 @@ TEST_CASE("FrameClock zero dt is valid", "[view][frame_clock]") {
     REQUIRE(called == 1);
     REQUIRE_THAT(clock.time(), WithinAbs(0.0, 0.001));
 }
+
+TEST_CASE("FrameClock subscriber added during tick starts on the next frame",
+          "[view][frame_clock][coverage][phase3]") {
+    FrameClock clock;
+    int first_calls = 0;
+    int added_calls = 0;
+    bool added = false;
+
+    clock.subscribe([&](float) {
+        ++first_calls;
+        if (!added) {
+            added = true;
+            clock.subscribe([&](float) {
+                ++added_calls;
+                return true;
+            });
+        }
+        return true;
+    });
+
+    clock.tick(0.010f);
+    REQUIRE(first_calls == 1);
+    REQUIRE(added_calls == 0);
+    REQUIRE(clock.has_active_subscribers());
+
+    clock.tick(0.020f);
+    REQUIRE(first_calls == 2);
+    REQUIRE(added_calls == 1);
+}
+
+TEST_CASE("FrameClock subscriber can unsubscribe itself while returning true",
+          "[view][frame_clock][coverage][phase3]") {
+    FrameClock clock;
+    int id = 0;
+    int calls = 0;
+    id = clock.subscribe([&](float) {
+        ++calls;
+        clock.unsubscribe(id);
+        return true;
+    });
+
+    clock.tick(0.016f);
+    REQUIRE(calls == 1);
+    REQUIRE_FALSE(clock.has_active_subscribers());
+
+    clock.tick(0.016f);
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("FrameClock false-return compaction preserves later active subscribers",
+          "[view][frame_clock][coverage][phase3]") {
+    FrameClock clock;
+    int first = 0;
+    int second = 0;
+    int third = 0;
+
+    clock.subscribe([&](float) {
+        ++first;
+        return false;
+    });
+    clock.subscribe([&](float) {
+        ++second;
+        return true;
+    });
+    clock.subscribe([&](float) {
+        ++third;
+        return false;
+    });
+
+    clock.tick(0.016f);
+    REQUIRE(first == 1);
+    REQUIRE(second == 1);
+    REQUIRE(third == 1);
+    REQUIRE(clock.has_active_subscribers());
+
+    clock.tick(0.016f);
+    REQUIRE(first == 1);
+    REQUIRE(second == 2);
+    REQUIRE(third == 1);
+}

--- a/test/test_panel.cpp
+++ b/test/test_panel.cpp
@@ -1,12 +1,26 @@
 // Automated test for Panel widget
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/view/widgets.hpp>
 #include <pulp/view/theme.hpp>
 #include <pulp/canvas/canvas.hpp>
 
+using Catch::Matchers::WithinAbs;
 using namespace pulp::view;
 using pulp::canvas::RecordingCanvas;
 using pulp::canvas::DrawCommand;
+
+namespace {
+
+const DrawCommand* first_command(const RecordingCanvas& canvas, DrawCommand::Type type) {
+    for (const auto& command : canvas.commands()) {
+        if (command.type == type)
+            return &command;
+    }
+    return nullptr;
+}
+
+} // namespace
 
 TEST_CASE("Panel: default token names", "[panel]") {
     Panel panel;
@@ -53,4 +67,79 @@ TEST_CASE("Panel: zero border width skips border", "[panel]") {
             has_stroke = true;
     }
     REQUIRE_FALSE(has_stroke);
+}
+
+TEST_CASE("Panel: custom theme tokens drive fill and stroke colors",
+          "[panel][coverage][phase3]") {
+    Theme theme;
+    theme.colors["panel.fill"] = color_from_hex(0x112233);
+    theme.colors["panel.stroke"] = color_from_hex(0x445566);
+
+    Panel panel;
+    panel.set_theme(theme);
+    panel.set_bounds({0, 0, 120, 60});
+    panel.set_background_token("panel.fill");
+    panel.set_border_token("panel.stroke");
+
+    RecordingCanvas canvas;
+    panel.paint(canvas);
+
+    auto* fill = first_command(canvas, DrawCommand::Type::set_fill_color);
+    auto* stroke = first_command(canvas, DrawCommand::Type::set_stroke_color);
+    REQUIRE(fill != nullptr);
+    REQUIRE(stroke != nullptr);
+    REQUIRE(fill->color.r8() == 0x11);
+    REQUIRE(fill->color.g8() == 0x22);
+    REQUIRE(fill->color.b8() == 0x33);
+    REQUIRE(stroke->color.r8() == 0x44);
+    REQUIRE(stroke->color.g8() == 0x55);
+    REQUIRE(stroke->color.b8() == 0x66);
+}
+
+TEST_CASE("Panel: missing theme tokens use documented fallback colors",
+          "[panel][coverage][phase3]") {
+    Panel panel;
+    panel.set_theme(Theme{});
+    panel.set_bounds({0, 0, 80, 40});
+    panel.set_background_token("missing.fill");
+    panel.set_border_token("missing.stroke");
+
+    RecordingCanvas canvas;
+    panel.paint(canvas);
+
+    auto* fill = first_command(canvas, DrawCommand::Type::set_fill_color);
+    auto* stroke = first_command(canvas, DrawCommand::Type::set_stroke_color);
+    REQUIRE(fill != nullptr);
+    REQUIRE(stroke != nullptr);
+    REQUIRE(fill->color.r8() == 45);
+    REQUIRE(fill->color.g8() == 45);
+    REQUIRE(fill->color.b8() == 60);
+    REQUIRE(stroke->color.r8() == 80);
+    REQUIRE(stroke->color.g8() == 80);
+    REQUIRE(stroke->color.b8() == 100);
+}
+
+TEST_CASE("Panel: border geometry is inset and radius is clamped by border width",
+          "[panel][coverage][phase3]") {
+    Panel panel;
+    panel.set_bounds({0, 0, 100, 50});
+    panel.set_corner_radius(3.0f);
+    panel.set_border_width(8.0f);
+
+    RecordingCanvas canvas;
+    panel.paint(canvas);
+
+    auto* line_width = first_command(canvas, DrawCommand::Type::set_line_width);
+    auto* fill = first_command(canvas, DrawCommand::Type::fill_rounded_rect);
+    auto* stroke = first_command(canvas, DrawCommand::Type::stroke_rounded_rect);
+    REQUIRE(line_width != nullptr);
+    REQUIRE(fill != nullptr);
+    REQUIRE(stroke != nullptr);
+    REQUIRE_THAT(line_width->f[0], WithinAbs(8.0f, 0.001f));
+    REQUIRE_THAT(fill->f[4], WithinAbs(3.0f, 0.001f));
+    REQUIRE_THAT(stroke->f[0], WithinAbs(4.0f, 0.001f));
+    REQUIRE_THAT(stroke->f[1], WithinAbs(4.0f, 0.001f));
+    REQUIRE_THAT(stroke->f[2], WithinAbs(92.0f, 0.001f));
+    REQUIRE_THAT(stroke->f[3], WithinAbs(42.0f, 0.001f));
+    REQUIRE_THAT(stroke->f[4], WithinAbs(0.0f, 0.001f));
 }

--- a/test/test_splash_screen.cpp
+++ b/test/test_splash_screen.cpp
@@ -107,3 +107,70 @@ TEST_CASE("SplashScreen paint records default text and image paths",
     REQUIRE(image_canvas.count(DrawCommand::Type::draw_image) == 1);
     REQUIRE(has_image(image_canvas, "assets/splash.png"));
 }
+
+TEST_CASE("SplashScreen manual dismiss waits for fade-out before callback",
+          "[view][splash][coverage][phase3]") {
+    SplashScreen splash;
+    splash.set_fade_in(0.1f);
+    splash.set_duration(10.0f);
+    splash.set_fade_out(0.5f);
+
+    int dismissed = 0;
+    splash.on_dismissed = [&] { ++dismissed; };
+
+    splash.show();
+    REQUIRE(splash.advance(0.1f));
+    splash.dismiss();
+    REQUIRE(splash.is_showing());
+    REQUIRE(splash.advance(0.25f));
+    REQUIRE(dismissed == 0);
+
+    REQUIRE_FALSE(splash.advance(0.25f));
+    REQUIRE_FALSE(splash.is_showing());
+    REQUIRE(dismissed == 1);
+}
+
+TEST_CASE("SplashScreen show restarts state after hidden dismiss",
+          "[view][splash][coverage][phase3]") {
+    SplashScreen splash;
+    splash.set_fade_in(0.2f);
+    splash.set_duration(0.2f);
+    splash.set_fade_out(0.2f);
+
+    splash.dismiss();
+    REQUIRE_FALSE(splash.is_showing());
+    REQUIRE_FALSE(splash.advance(1.0f));
+
+    splash.show();
+    REQUIRE(splash.is_showing());
+    REQUIRE(splash.advance(0.1f));
+
+    RecordingCanvas canvas;
+    splash.paint(canvas);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(has_text(canvas, "Loading..."));
+}
+
+TEST_CASE("SplashScreen can be shown again after completion",
+          "[view][splash][coverage][phase3]") {
+    SplashScreen splash;
+    splash.set_fade_in(0.01f);
+    splash.set_duration(0.01f);
+    splash.set_fade_out(0.01f);
+
+    int dismissed = 0;
+    splash.on_dismissed = [&] { ++dismissed; };
+
+    splash.show();
+    REQUIRE(splash.advance(0.01f));
+    REQUIRE(splash.advance(0.01f));
+    REQUIRE_FALSE(splash.advance(0.01f));
+    REQUIRE(dismissed == 1);
+
+    splash.show();
+    REQUIRE(splash.is_showing());
+    REQUIRE(splash.advance(0.01f));
+    REQUIRE(splash.advance(0.01f));
+    REQUIRE_FALSE(splash.advance(0.01f));
+    REQUIRE(dismissed == 2);
+}

--- a/test/test_window_manager.cpp
+++ b/test/test_window_manager.cpp
@@ -455,3 +455,75 @@ TEST_CASE("WindowManager all window types", "[view][multiwindow]") {
 
     REQUIRE(mgr.window_count() == 5);
 }
+
+TEST_CASE("WindowManager replacing a message handler drops the previous callback",
+          "[view][multiwindow][coverage][phase3]") {
+    WindowManager mgr;
+    View root;
+    StubWindowHost host;
+    auto id = mgr.register_window(&host, &root, WindowType::main);
+
+    int first = 0;
+    int second = 0;
+    mgr.set_message_handler(id, [&](const WindowMessage&) { ++first; });
+    mgr.set_message_handler(id, [&](const WindowMessage& msg) {
+        REQUIRE(msg.type == "replace");
+        ++second;
+    });
+
+    WindowMessage msg;
+    msg.type = "replace";
+    mgr.send_message(id, msg);
+    REQUIRE(first == 0);
+    REQUIRE(second == 1);
+}
+
+TEST_CASE("WindowManager saved state captures visibility and restore preserves other windows",
+          "[view][multiwindow][coverage][phase3]") {
+    WindowManager mgr;
+    View first_root;
+    View second_root;
+    StubWindowHost first_host;
+    StubWindowHost second_host;
+    auto first = mgr.register_window(&first_host, &first_root, WindowType::main);
+    auto second = mgr.register_window(&second_host, &second_root, WindowType::dialog);
+
+    WindowState hidden;
+    hidden.x = 12.0f;
+    hidden.y = 34.0f;
+    hidden.width = 640.0f;
+    hidden.height = 480.0f;
+    hidden.screen_id = 7;
+    hidden.is_visible = false;
+    mgr.restore_state(first, hidden);
+
+    WindowState ignored;
+    ignored.x = 99.0f;
+    mgr.restore_state(99999, ignored);
+
+    auto states = mgr.save_all_states();
+    REQUIRE(states.size() == 2);
+    REQUIRE(states.at(first).x == 12.0f);
+    REQUIRE(states.at(first).screen_id == 7);
+    REQUIRE_FALSE(states.at(first).is_visible);
+    REQUIRE(states.at(second).is_visible);
+    REQUIRE(states.at(second).width == 400.0f);
+}
+
+TEST_CASE("WindowManager shared theme getter and later registration stay in sync",
+          "[view][multiwindow][coverage][phase3]") {
+    WindowManager mgr;
+    Theme theme = Theme::dark();
+    theme.colors["bg.primary"] = color_from_hex(0x123456);
+    mgr.set_shared_theme(theme);
+
+    REQUIRE(mgr.shared_theme().color("bg.primary")->r8() == 0x12);
+
+    View root;
+    StubWindowHost host;
+    mgr.register_window(&host, &root, WindowType::palette);
+    auto resolved = root.resolve_color("bg.primary");
+    REQUIRE(resolved.r8() == 0x12);
+    REQUIRE(resolved.g8() == 0x34);
+    REQUIRE(resolved.b8() == 0x56);
+}


### PR DESCRIPTION
## Summary
- add FrameClock coverage for in-tick subscription, self-unsubscribe, and compaction preserving active subscribers
- add WindowManager coverage for message handler replacement, saved visibility state, and shared theme propagation
- add SplashScreen lifecycle coverage for manual dismissal, hidden restart, and repeated show completion
- add Panel paint coverage for theme token colors, fallback colors, and inset border geometry

## Local validation
- `git diff --check`
- `cmake --build build --target pulp-test-frame-clock pulp-test-window-manager pulp-test-splash-screen pulp-test-panel -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-frame-clock "[coverage][phase3]"`
- `./build/test/pulp-test-window-manager "[coverage][phase3]"`
- `./build/test/pulp-test-splash-screen "[coverage][phase3]"`
- `./build/test/pulp-test-panel "[coverage][phase3]"`
- `PULP_DIFF_COVER_CTEST_REGEX='FrameClock subscriber added during tick starts on the next frame|FrameClock subscriber can unsubscribe itself while returning true|FrameClock false-return compaction preserves later active subscribers|WindowManager replacing a message handler drops the previous callback|WindowManager saved state captures visibility and restore preserves other windows|WindowManager shared theme getter and later registration stay in sync|SplashScreen manual dismiss waits for fade-out before callback|SplashScreen show restarts state after hidden dismiss|SplashScreen can be shown again after completion|Panel: custom theme tokens drive fill and stroke colors|Panel: missing theme tokens use documented fallback colors|Panel: border geometry is inset and radius is clamped by border width' tools/scripts/local_diff_cover.sh`