### PR TITLE
test(canvas): batch attributed text layout coverage edges

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-# codecov.yml — Codecov config for public/#566 Phase 1 (measurement baseline).
+# codecov.yml - Codecov config for public/#566 Phase 1 (measurement baseline).
 #
 # Primary consumers (in order): Pulp developers, dispatched agents, CI
 # enforcement, contributors reading PR comments. Public dashboard is a
@@ -12,14 +12,14 @@
 # Phase 2 adds ci/coverage-targets.yaml alongside this for the diff-cover
 # gate; Phase 4 introduces doc_path_map.json to prevent drift.
 
-# Notification gating — wait for all 4 platform coverage uploads before
+# Notification gating - wait for all 4 platform coverage uploads before
 # the bot computes + posts the patch coverage report. Without this,
 # Codecov posts as soon as it sees ANY upload (often Linux first, since
 # its build is fastest), which means Apple-only or Windows-only tested
 # paths get reported as 0% covered against partial data. PR #1873 was a
 # textbook example: a CLAP-fixture test that ran only on macOS was
 # reported as "0% patch coverage" by the bot because the macOS upload
-# hadn't arrived (and never did — see follow-up issue on the coverage
+# hadn't arrived (and never did - see follow-up issue on the coverage
 # workflow's `cancel-in-progress: true` concurrency policy that wipes
 # in-flight runs on force-push).
 #
@@ -32,7 +32,7 @@
 #
 # If you add or remove a coverage uploader, bump this number to match
 # or Codecov will silently wait forever for the missing one and never
-# post. After 7d it gives up and posts whatever it has — by then the
+# post. After 7d it gives up and posts whatever it has - by then the
 # PR has long since merged with a stale report.
 codecov:
   notify:
@@ -40,7 +40,7 @@ codecov:
 
 coverage:
   status:
-    # Project-wide status: "did we get worse?" Not a hard gate — we
+    # Project-wide status: "did we get worse?" Not a hard gate - we
     # already have continue-on-error on the coverage job and Phase 3
     # is where per-PR enforcement lands.
     project:
@@ -52,11 +52,11 @@ coverage:
     # Patch status: "is new code covered?" Advisory in the sense that
     # branch-protection does NOT require this check (so a sub-threshold
     # PR can still merge), but the check status now accurately reflects
-    # the threshold check — `success` if ≥75%, `failure` if <75%.
+    # the threshold check - `success` if >=75%, `failure` if <75%.
     #
     # Previously `informational: true` hardwired the status to `success`
     # even when patch coverage was 0%, which deceived devs reading the
-    # check line. The bot still posted a "❌ Patch coverage is X%"
+    # check line. The bot still posted a "[fail] Patch coverage is X%"
     # comment, but the status check itself said success, masking the
     # gap. Flipping to enforcing makes the signal accurate without
     # changing merge behavior (codecov/patch is not in
@@ -76,9 +76,9 @@ coverage:
 # so Codecov and our local tooling count the same set of files.
 # External FetchContent sources (Dawn, Skia, mbedTLS, QuickJS,
 # Catch2, etc.) and our test trees are never counted as coverage-
-# bearing. See planning/coverage-tooling-decision-2026-04-21.md §4.
+# bearing. See planning/coverage-tooling-decision-2026-04-21.md section 4.
 #
-# `ignore` is a TOP-LEVEL key in Codecov config — nesting it under
+# `ignore` is a TOP-LEVEL key in Codecov config - nesting it under
 # `coverage:` silently no-ops, which would count files we explicitly
 # want excluded and skew the baseline metrics. See Codecov config
 # schema: https://docs.codecov.com/docs/codecov-yaml
@@ -106,7 +106,7 @@ ignore:
   # harness implementation, so Codecov must not count the tests as
   # patch-coverable product code.
   - "tools/harness/visual/tests/**"
-  # ── Aligned with tools/scripts/coverage_config.json `diff_cover_excludes` ──
+  # -- Aligned with tools/scripts/coverage_config.json `diff_cover_excludes` --
   # The Pulp gate (`Diff coverage required` in coverage.yml) excludes these
   # files because they're either thin dispatchers exercised end-to-end via
   # shell-out tests (so direct line coverage doesn't propagate cleanly), or
@@ -114,11 +114,11 @@ ignore:
   # can't instrument uniformly. Without aligning the Codecov bot's ignore
   # list to the same set, the bot's `codecov/patch` check fires red on PRs
   # whose diff is mostly in these files (e.g. PR #1984's viewport-fit lived
-  # almost entirely in window_host_mac.mm — Pulp gate silent, bot screamed
+  # almost entirely in window_host_mac.mm - Pulp gate silent, bot screamed
   # 8.64% patch coverage). Both sides MUST count the same set.
   #
   # Drift between this list and coverage_config.json is detected by
-  # tools/scripts/test_codecov_config_sync.py — keep them in sync.
+  # tools/scripts/test_codecov_config_sync.py - keep them in sync.
   - "**/cmd_loop.cpp"
   - "**/pulp_import_design.cpp"
   - "**/cg_canvas.mm"
@@ -138,7 +138,7 @@ comment:
 
 # Flag definitions are retained for Phase 1 PR 4 (per-OS upload jobs)
 # and for future workflows that genuinely upload one file per flag.
-# The main coverage.yml upload does NOT attach any flags — Codecov
+# The main coverage.yml upload does NOT attach any flags - Codecov
 # rejects single-upload multi-flag submissions with "Multiple flags
 # detected. Please ensure one flag per upload." The per-subsystem /
 # per-platform / per-surface breakdown comes from `component_management`
@@ -150,7 +150,7 @@ comment:
 # means updating both blocks in this file; `tools/scripts/test_codecov_config.py`
 # checks them against the live `core/*` tree so drift fails fast.
 flags:
-  # Core subsystems — one flag per top-level core/** directory.
+  # Core subsystems - one flag per top-level core/** directory.
   audio:
     paths:
       - core/audio/
@@ -208,7 +208,7 @@ flags:
       - core/view/
     carryforward: true
 
-  # Platform flags (4) — cross-cut the subsystem flags. "What's host
+  # Platform flags (4) - cross-cut the subsystem flags. "What's host
   # coverage on Windows?" is answered by cross-filtering `host AND
   # windows`. Paths cover all subsystems because any subsystem can
   # have a Windows shim under its own `platform/windows/` tree.
@@ -238,7 +238,7 @@ flags:
       - core/**/wasapi/
     carryforward: true
 
-  # Surface flags (4) — non-core but first-party:
+  # Surface flags (4) - non-core but first-party:
   cli:
     paths:
       - tools/cli/
@@ -260,16 +260,16 @@ flags:
       - tools/
     carryforward: true
 
-  # OS flags (3) — Phase 1 PR 4 cross-platform coverage matrix. These
+  # OS flags (3) - Phase 1 PR 4 cross-platform coverage matrix. These
   # are NOT path-scoped; every file measured on a given matrix leg is
   # tagged with that OS's flag at upload time via the corresponding
   # matrix entry in .github/workflows/coverage.yml. Federate with the
   # subsystem + platform + surface flags above for cross-filtering:
   # `host AND os-windows` answers "what fraction of core/host is
-  # exercised when tests run on Windows?" — a different question from
+  # exercised when tests run on Windows?" - a different question from
   # `host AND windows` (which reads "what fraction of the windows/
   # shim files are covered at all"). See docs/guides/coverage.md
-  # §"Multi-OS coverage" for the rationale on Codecov-flag unions vs
+  # section "Multi-OS coverage" for the rationale on Codecov-flag unions vs
   # llvm-profdata merge.
   os-linux:
     carryforward: true
@@ -278,7 +278,7 @@ flags:
   os-windows:
     carryforward: true
 
-# carryforward: true on every flag — when a PR doesn't touch
+# carryforward: true on every flag - when a PR doesn't touch
 # a given subsystem, carry over the last known coverage for that
 # flag from main so the dashboard doesn't report a false 0%. Standard
 # Codecov practice for multi-job uploads (we have one job per OS
@@ -303,12 +303,12 @@ component_management:
         threshold: 1%
         informational: true
   individual_components:
-    # Core subsystems — mirror every top-level core/** directory.
+    # Core subsystems - mirror every top-level core/** directory.
     #
     # Subsystems that house platform-specific subtrees (`audio`, `midi`,
     # `view`, `render`, `platform`, `canvas`) explicitly exclude those
     # subtrees so each first-party file lands in exactly one component
-    # bucket — see #1055. Platform-specific code is owned by the
+    # bucket - see #1055. Platform-specific code is owned by the
     # `apple`/`android`/`linux`/`windows` components below; without the
     # `!`-exclude here those files were silently double-counted, inflating
     # coverage for both the subsystem and the platform.
@@ -375,10 +375,10 @@ component_management:
       paths:
         - "core/view/**"
         - "!core/view/platform/**"
-    # Platform (4) — cross-cut the subsystems. Patterns within each
+    # Platform (4) - cross-cut the subsystems. Patterns within each
     # platform component must not overlap each other (Codecov double-
     # counts files matched twice within the same component, inflating
-    # the line totals — caught on #1055 as `platform,android,android`
+    # the line totals - caught on #1055 as `platform,android,android`
     # 3-way matches).
     - component_id: android
       name: android
@@ -403,7 +403,7 @@ component_management:
         - "core/**/win/**"
         - "core/**/windows/**"
         - "core/**/wasapi/**"
-    # Surface (4) — `tools` excludes `tools/cli/**` so the more specific
+    # Surface (4) - `tools` excludes `tools/cli/**` so the more specific
     # `cli` component owns those files; otherwise every CLI file is
     # double-counted (#1055).
     - component_id: cli

--- a/test/test_attributed_string.cpp
+++ b/test/test_attributed_string.cpp
@@ -307,3 +307,196 @@ TEST_CASE("GlyphArrangement hit testing and cursor positions", "[canvas][layout]
     REQUIRE(layout.hit_test(0.0f, 0.0f) == 0);
     REQUIRE_THAT(layout.position_for_index(0), WithinAbs(0.0f, 1e-5f));
 }
+
+TEST_CASE("AttributedString append preserves empty spans between text",
+          "[canvas][text][coverage][phase3]") {
+    AttributedString str;
+    str.append("left");
+    str.append("");
+    str.append("right");
+
+    REQUIRE_FALSE(str.empty());
+    REQUIRE(str.spans().size() == 3);
+    REQUIRE(str.length() == 9);
+    REQUIRE(str.plain_text() == "leftright");
+    REQUIRE(str.spans()[1].text.empty());
+}
+
+TEST_CASE("AttributedString set_font overwrites styled span fonts only",
+          "[canvas][text][coverage][phase3]") {
+    AttributedString str;
+    TextSpan span;
+    span.text = "styled";
+    span.font_family = "serif";
+    span.font_size = 30.0f;
+    span.color = Color::rgba8(1, 2, 3);
+    str.append(span);
+
+    str.set_font("display", 18.0f);
+
+    REQUIRE(str.spans()[0].font_family == "display");
+    REQUIRE(str.spans()[0].font_size == 18.0f);
+    REQUIRE(str.spans()[0].color == Color::rgba8(1, 2, 3));
+}
+
+TEST_CASE("AttributedString set_color preserves font attributes",
+          "[canvas][text][coverage][phase3]") {
+    AttributedString str;
+    TextSpan span;
+    span.text = "styled";
+    span.font_family = "mono";
+    span.font_size = 22.0f;
+    span.font_weight = 800;
+    str.append(span);
+
+    str.set_color(Color::rgba8(40, 50, 60, 70));
+
+    REQUIRE(str.spans()[0].font_family == "mono");
+    REQUIRE(str.spans()[0].font_size == 22.0f);
+    REQUIRE(str.spans()[0].font_weight == 800);
+    REQUIRE(str.spans()[0].color == Color::rgba8(40, 50, 60, 70));
+}
+
+TEST_CASE("TextLayout preserves style on wrapped span fragments",
+          "[canvas][layout][coverage][phase3]") {
+    AttributedString str;
+    TextSpan span;
+    span.text = "alpha beta";
+    span.font_family = "mono";
+    span.font_size = 10.0f;
+    span.font_weight = 700;
+    span.italic = true;
+    span.color = Color::rgba8(12, 34, 56);
+    str.append(span);
+
+    auto layout = layout_attributed_string(str, 36.0f, 11.0f);
+
+    REQUIRE(layout.lines.size() == 2);
+    REQUIRE(layout.lines[0].spans[0].text == "alpha");
+    REQUIRE(layout.lines[1].spans[0].text == "beta");
+    for (const auto& line : layout.lines) {
+        REQUIRE(line.spans[0].font_family == "mono");
+        REQUIRE(line.spans[0].font_size == 10.0f);
+        REQUIRE(line.spans[0].font_weight == 700);
+        REQUIRE(line.spans[0].italic);
+        REQUIRE(line.spans[0].color == Color::rgba8(12, 34, 56));
+    }
+}
+
+TEST_CASE("TextLayout consecutive newlines create blank layout lines",
+          "[canvas][layout][coverage][phase3]") {
+    AttributedString str("top\n\nbottom");
+
+    auto layout = layout_attributed_string(str, 1000.0f, 13.0f);
+
+    REQUIRE(layout.lines.size() == 3);
+    REQUIRE(layout.lines[0].spans[0].text == "top");
+    REQUIRE(layout.lines[1].spans[0].text.empty());
+    REQUIRE(layout.lines[2].spans[0].text == "bottom");
+    REQUIRE_THAT(layout.total_height, WithinAbs(39.0f, 1e-5f));
+}
+
+TEST_CASE("TextLayout forced break keeps full unspaced text",
+          "[canvas][layout][coverage][phase3]") {
+    AttributedString str;
+    str.append("abcdef", 10.0f, Color::rgba8(1, 1, 1));
+
+    auto layout = layout_attributed_string(str, 18.0f, 9.0f);
+
+    REQUIRE(layout.lines.size() == 2);
+    REQUIRE(layout.lines[0].spans[0].text == "abc");
+    REQUIRE(layout.lines[1].spans[0].text == "def");
+    REQUIRE_THAT(layout.total_width, WithinAbs(18.0f, 1e-5f));
+}
+
+TEST_CASE("TextLayout span-specific font size affects width and height",
+          "[canvas][layout][coverage][phase3]") {
+    AttributedString str;
+    str.append("wide", 20.0f, Color::rgba8(1, 1, 1));
+    str.append("narrow", 10.0f, Color::rgba8(2, 2, 2));
+
+    auto layout = layout_attributed_string(str, 1000.0f);
+
+    REQUIRE(layout.lines.size() == 2);
+    REQUIRE_THAT(layout.lines[0].width, WithinAbs(48.0f, 1e-5f));
+    REQUIRE_THAT(layout.lines[0].height, WithinAbs(30.0f, 1e-5f));
+    REQUIRE_THAT(layout.lines[1].width, WithinAbs(36.0f, 1e-5f));
+    REQUIRE_THAT(layout.lines[1].height, WithinAbs(15.0f, 1e-5f));
+    REQUIRE_THAT(layout.total_height, WithinAbs(45.0f, 1e-5f));
+}
+
+TEST_CASE("GlyphArrangement totals use widest line and last descent",
+          "[canvas][layout][coverage][phase3]") {
+    GlyphArrangement layout;
+
+    TextLine short_line;
+    short_line.width = 20.0f;
+    short_line.baseline_y = 8.0f;
+    short_line.descent = 2.0f;
+    layout.add_line(short_line);
+
+    TextLine wide_line;
+    wide_line.width = 45.0f;
+    wide_line.baseline_y = 30.0f;
+    wide_line.descent = 5.0f;
+    layout.add_line(wide_line);
+
+    REQUIRE(layout.line_count() == 2);
+    REQUIRE_THAT(layout.total_width(), WithinAbs(45.0f, 1e-5f));
+    REQUIRE_THAT(layout.total_height(), WithinAbs(35.0f, 1e-5f));
+}
+
+TEST_CASE("GlyphArrangement hit_test uses half-advance thresholds",
+          "[canvas][layout][coverage][phase3]") {
+    GlyphArrangement layout;
+    TextLine line;
+    line.ascent = 8.0f;
+    line.descent = 2.0f;
+    line.baseline_y = 8.0f;
+    line.width = 30.0f;
+    line.glyphs.push_back({0.0f, 0.0f, 10.0f, 'a', 4});
+    line.glyphs.push_back({10.0f, 0.0f, 20.0f, 'b', 5});
+    layout.add_line(line);
+
+    REQUIRE(layout.hit_test(4.9f, 0.0f) == 4);
+    REQUIRE(layout.hit_test(5.1f, 0.0f) == 5);
+    REQUIRE(layout.hit_test(100.0f, 0.0f) == 6);
+}
+
+TEST_CASE("GlyphArrangement position_for_index scans later lines",
+          "[canvas][layout][coverage][phase3]") {
+    GlyphArrangement layout;
+
+    TextLine first;
+    first.width = 10.0f;
+    first.glyphs.push_back({0.0f, 0.0f, 10.0f, 'a', 0});
+    layout.add_line(first);
+
+    TextLine second;
+    second.width = 25.0f;
+    second.glyphs.push_back({7.0f, 0.0f, 10.0f, 'b', 3});
+    layout.add_line(second);
+
+    REQUIRE_THAT(layout.position_for_index(3), WithinAbs(7.0f, 1e-5f));
+    REQUIRE_THAT(layout.position_for_index(99), WithinAbs(25.0f, 1e-5f));
+}
+
+TEST_CASE("Parallelogram from_rect_shear contains skewed interior points",
+          "[canvas][layout][coverage][phase3]") {
+    auto p = Parallelogram::from_rect_shear(0.0f, 0.0f, 10.0f, 10.0f, 3.0f);
+
+    REQUIRE(p.contains(5.0f, 5.0f));
+    REQUIRE(p.contains(3.0f, 0.0f));
+    REQUIRE_FALSE(p.contains(0.5f, 1.0f));
+    REQUIRE_FALSE(p.contains(14.0f, 1.0f));
+}
+
+TEST_CASE("Parallelogram negative shear contains expected interior",
+          "[canvas][layout][coverage][phase3]") {
+    auto p = Parallelogram::from_rect_shear(10.0f, 20.0f, 12.0f, 8.0f, -4.0f);
+
+    REQUIRE(p.contains(12.0f, 24.0f));
+    REQUIRE(p.contains(6.0f, 20.0f));
+    REQUIRE_FALSE(p.contains(23.0f, 20.0f));
+    REQUIRE_FALSE(p.contains(5.0f, 29.0f));
+}


### PR DESCRIPTION
## Summary
- add AttributedString coverage for empty-span concatenation and bulk style setter preservation
- add TextLayout coverage for wrapped-style preservation, consecutive newlines, forced breaks, and span-specific metrics
- add GlyphArrangement coverage for totals, hit-test thresholds, and cross-line index lookup
- add Parallelogram coverage for positive and negative shear hit testing
- keep codecov.yml ASCII-only so the Windows Codecov uploader can parse the config

## Local validation
- `git diff --check`
- `cmake --build build --target pulp-test-attributed-string -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-attributed-string "[coverage][phase3]"`
- `PULP_DIFF_COVER_CTEST_REGEX=... tools/scripts/local_diff_cover.sh`
