### PR TITLE
feat(motion): agent-first motion observability (Phases 0-7)

### DIFF
--- a/.agents/skills/motion/SKILL.md
+++ b/.agents/skills/motion/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: motion
+description: Agent-first motion observability for Pulp views and animations. Single entry point for two paths — runtime scalar/geometry tracing (samples values + view geometry over time, attachable at runtime over the inspector wire, emits Start/End burst-framed events) and pixel-truth visual analysis (SSIM + diff heatmaps + keyframe sprites from frame sequences). Use when an animation timing / direction / easing / scroll / drift is suspect, when an imported design needs verification, or when a transition / GPU effect has no observable scalar.
+---
+
+# Motion
+
+Diagnose animation, scroll, and transition behavior with the framework's
+agent-first motion observability system. Two paths share one skill — pick
+based on what's observable.
+
+## Quick decision
+
+| You have | Path | Tool |
+|---|---|---|
+| A running app + a node id + a scalar / geometry of interest | **Runtime trace** | `Motion.startTrace` over the inspector wire |
+| A captured frame sequence (no app instrumentation available) | **Visual analysis** | `tools/motion/visual/analyze_sequence.py` |
+| A previously recorded `.motion.jsonl` fixture | **Replay + assert** | `motion::replay_fixture` + `motion::assert_matches` |
+| Imported design + intent doc (e.g. "fade in 350 ms ease-out") | **Both** | Record a fixture from the import, assert timing/monotonicity |
+
+## Path A — Runtime trace
+
+The runtime path attaches a trace at runtime over the inspector wire, no
+source instrumentation, no cleanup phase to forget.
+
+### 1. Confirm the complaint as a measurable property
+
+Translate "looks off" into a metric and a target. Example mappings:
+
+- "fade is slow" → `opacity` scalar, settling time > X ms
+- "card slides too far" → `frame` geometry, final `minY` mismatch
+- "two cards drift" → two `frame` traces, deltas correlate
+- "scroll jumps on restore" → child-of-ScrollView geometry, presentation source
+
+### 2. Start the host with the motion server enabled
+
+```bash
+PULP_MOTION_SERVER=1 ./build/examples/ui-preview/pulp-ui-preview
+# Motion inspector listening on port 9147
+```
+
+### 3. Attach a trace
+
+Send a `Motion.startTrace` request (TCP port 9147, line-delimited JSON):
+
+```jsonc
+{ "id": 1, "method": "Motion.startTrace",
+  "params": {
+    "view_name": "Card",
+    "fps": 30,
+    "metrics": [{
+      "kind": "geometry",
+      "name": "frame",
+      "node_id": "card",
+      "properties": ["minX","minY","width","height"],
+      "space": "window",
+      "source": "presentation"
+    }]
+  }
+}
+```
+
+Response: `{ "trace_id": 1 }`.
+
+Stream of events: `Motion.start`, `Motion.sample` (one per change), `Motion.end`
+(with deltas).
+
+### 4. Trigger the interaction
+
+Drive the app — click, hover, type, fire whatever causes the suspected
+animation. The motion server emits events as the values change.
+
+### 5. Stop the trace
+
+```jsonc
+{ "id": 2, "method": "Motion.stopTrace", "params": { "trace_id": 1 } }
+```
+
+### 6. Compare against intent
+
+Did the trace match? Use the dedicated assertion helpers — do not conflate
+continuity, monotonicity, settling time, and overshoot into a single number.
+
+```cpp
+auto samples = motion::extract_scalar(events, "Card", "frame", "minY");
+REQUIRE(motion::is_monotonic(samples));
+REQUIRE(motion::settling_time_seconds(samples) < 0.7);
+REQUIRE(motion::overshoot(samples) < 0.05);
+REQUIRE(motion::final_value(samples) == Catch::Approx(120.0).margin(1.0));
+```
+
+## Path B — Visual analysis
+
+Use when no scalar is observable (transitions, GPU filters, mask compositing,
+opacity-only effects you suspect aren't rendering).
+
+### 1. Capture a frame sequence
+
+Any source: a host window-capture loop, an `ffmpeg` extraction from a screen
+recording, scripted PNG dumps. Land sequential frames in a directory:
+
+```
+captures/card-open/
+  frame_0000.png
+  frame_0001.png
+  …
+```
+
+### 2. Run the pipeline
+
+```bash
+pip install -r tools/motion/visual/requirements.txt
+python3 -m tools.motion.visual.analyze_sequence \
+    --frames-dir ./captures/card-open/ \
+    --output     ./reports/card-open/ \
+    --keyframes 2
+```
+
+### 3. Read the report
+
+The pipeline writes `analysis.json` (machine-readable), `summary.md`
+(agent-readable), `diff/diff_NNNN_NNNN.png` (pairwise heatmaps), and
+`keyframes.png` (sprite). The JSON carries `schema_version` — refuse unknown
+versions.
+
+Pair conclusions with evidence: cite pair index, SSIM, mean diff, and which
+artifacts you read. Confidence below 0.7 means escalate (more pairs, longer
+window, or fall back to a runtime trace if instrumentation is possible).
+
+## Path C — Fixtures (record / replay / assert)
+
+A fixture is the on-disk form of a motion stream — a versioned JSONL file. Use
+fixtures to:
+
+- Land a golden alongside a feature; regress against it in CI.
+- Validate that an imported design's motion matches its source intent.
+- Reproduce a bug deterministically by replaying a captured run offline.
+
+### Record
+
+```cpp
+auto sink = motion::make_fixture_sink("test/motion/goldens/card-open.motion.jsonl");
+int sid = Coordinator::instance().add_sink(std::move(sink));
+// ... run the animation ...
+Coordinator::instance().remove_sink(sid);  // closes the file
+```
+
+### Replay
+
+```cpp
+std::vector<motion::SampleEvent> replayed;
+motion::replay_fixture("captures/card-open.motion.jsonl",
+                       motion::make_buffer_sink(&replayed));
+```
+
+### Assert
+
+```cpp
+auto golden   = motion::load_fixture("test/motion/goldens/card-open.motion.jsonl");
+auto captured = motion::load_fixture("/tmp/run.motion.jsonl");
+auto diff     = motion::assert_matches(golden, captured);
+REQUIRE(diff.matches());  // or inspect diff.differences on failure
+```
+
+`FixtureMatchOptions { component_epsilon, timing_epsilon_seconds,
+require_same_event_count }` controls tolerances.
+
+## Agent contract
+
+Apply these on every motion debugging run:
+
+1. State the complaint as a measurable target before instrumenting.
+2. Use runtime trace by default. Drop to visual analysis only when no scalar
+   is observable.
+3. Pick the metric, space, and source explicitly. Defaults are reasonable,
+   but the intent should be obvious from your request.
+4. Keep continuity, monotonicity, settling time, and overshoot as separate
+   assertions. Do not write a single "smoothness" check that conflates them.
+5. Cite evidence with frame indices, sample timestamps, and metric values when
+   reporting. "Looks wrong" without evidence is not a finding.
+6. Land a golden fixture when fixing a bug — the next regression should fail
+   in CI, not after a user reports it.
+
+## Env knobs (standalone `pulp-ui-preview`)
+
+| Variable | Effect |
+|---|---|
+| `PULP_MOTION_LOG=1` | Install the default log sink + enable tracing |
+| `PULP_MOTION_SERVER=1` | Start the Motion inspector server on port 9147 |
+| `PULP_MOTION_FIREHOSE=1` | Broadcast every `publish_*` call to all sinks |
+
+## Files this skill covers
+
+- `core/view/include/pulp/view/motion.hpp` — public C++ API
+- `core/view/src/motion.cpp` — Coordinator, geometry walker, fixture I/O, assertions
+- `inspect/include/pulp/inspect/motion_inspector.hpp` — Motion inspector bridge
+- `inspect/src/motion_inspector.cpp` — protocol handler + event broadcaster
+- `tools/motion/visual/analyze_sequence.py` — visual analysis CLI
+- `tools/motion/visual/test_self_check.py` — pipeline self-check
+- `examples/ui-preview/main.cpp` — env-knob wiring for the standalone host
+- `docs/guides/motion-observability.md` — full guide
+
+## Gotchas
+
+- Visual-analysis Python deps (numpy, Pillow, scikit-image) are intentionally
+  not bundled in plugin/app artifacts. The CTest entry exits 3 (Skipped) when
+  they are missing — that's expected on bare CI runners.
+- Window / Screen geometry spaces currently collapse onto ViewGlobal; window-
+  origin and screen-origin offsets land when the host surfaces them. Use
+  `ViewGlobal` for portable code.
+- ScrollView's `paint_all` override does not apply base View transforms when
+  painting children. The presentation walker matches this quirk: a child of a
+  ScrollView with `scale` set on the ScrollView itself reports as if the scale
+  were not there. This is correct relative to what is painted.
+- Fixture loaders reject unknown `motion_fixture_version` values. Bumping the
+  schema is a deliberate break — write a migration tool, do not silently
+  accept old goldens.
+- Per-(view, metric) `epsilon` is sticky on the first publish; subsequent
+  publishes inherit it. Pass `PublishOptions` only when you want to configure
+  the threshold for that key.

--- a/.agents/skills/motion/SKILL.md
+++ b/.agents/skills/motion/SKILL.md
@@ -200,11 +200,36 @@ Apply these on every motion debugging run:
 - `examples/ui-preview/main.cpp` — env-knob wiring for the standalone host
 - `docs/guides/motion-observability.md` — full guide
 
+## Provenance
+
+Every trace can carry a `Provenance` envelope that flows through the fixture
+to agents reading a golden weeks later:
+
+```cpp
+auto handle = motion::Coordinator::instance()
+    .trace("Card", { 60 })
+    .with_provenance({ "tween", "Card.opacity", __FILE__, __LINE__ })
+    .value("opacity", [&]{ return opacity; })
+    .attach();
+```
+
+The envelope shows up on the trace's `TraceStarted` event and in the JSONL
+fixture. When you read a fixture and the burst looks wrong, the provenance
+tells you which file / Figma node / animator the trace was attached to —
+without grepping.
+
 ## Gotchas
 
 - Visual-analysis Python deps (numpy, Pillow, scikit-image) are intentionally
   not bundled in plugin/app artifacts. The CTest entry exits 3 (Skipped) when
   they are missing — that's expected on bare CI runners.
+- Fixture schema is at version 2. The loader rejects unknown versions; v1
+  fixtures are rejected outright (no v1 producer ships in the framework). Bumping
+  the schema is a deliberate break — write a migration tool, don't silently
+  accept old goldens.
+- `TraceStarted` is emitted once per trace registration on the first tick
+  after attach. Tests that count events should either filter it out or pass
+  through `data_event_count(buffer)`.
 - Window / Screen geometry spaces currently collapse onto ViewGlobal; window-
   origin and screen-origin offsets land when the host surfaces them. Use
   `ViewGlobal` for portable code.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.40.0"
+  "version": "0.41.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
 - test: batch runtime and host coverage edges ([#2122](https://github.com/danielraffel/pulp/pull/2122))
 
 <a id="v01060"></a>
+## [0.41.0]
+
 ## [0.106.0] - 2026-05-17
 
 - feat(design-import): V2 wire-up — emit registerShortcut + synthetic keydown re-dispatch ([#2119](https://github.com/danielraffel/pulp/pull/2119))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.107.0
+    VERSION 0.108.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -186,6 +186,7 @@ target_sources(pulp-view PRIVATE
     src/widgets/svg_line.cpp
     src/visualization_bridge.cpp
     src/frame_clock.cpp
+    src/motion.cpp
     src/window_manager.cpp
     src/eq_curve_view.cpp
     src/midi_keyboard.cpp

--- a/core/view/include/pulp/view/motion.hpp
+++ b/core/view/include/pulp/view/motion.hpp
@@ -68,6 +68,46 @@ struct SampleEvent {
 /// Render the canonical `[PulpMotion][view][metric] ...` line for a sample event.
 std::string format_line(const SampleEvent& e);
 
+// ── Publish channel (Phase 3) ────────────────────────────────────────
+//
+// `publish_value()` is the entry point for any code that wants to make
+// its scalar / structured values observable without taking a
+// FrameClock sampler subscription. Typical callers are animation
+// primitives — a `Tween`, a CSS `TransitionSpec`, a JS rAF callback —
+// that already advance once per frame; calling publish at the same
+// tick site avoids the doubled-sampling cost.
+//
+// Routing:
+//   - When `Coordinator::tracing_enabled()` is false, publish is a
+//     no-op (cheap, branch-predictable; safe to leave in hot paths).
+//   - When `Coordinator::firehose()` is true, the published value fans
+//     out as a Sample event to every installed sink, with the same
+//     epsilon / Start/End burst semantics as sampler-driven traces.
+//   - When `firehose()` is false and no subscription is wired (Phase 5
+//     adds the subscription filter), publish is also a no-op.
+//
+// Filter-scoped subscriptions land in Phase 5 alongside the
+// `pulp motion trace --selector <id>` CLI surface; the publish channel
+// is the underlying primitive both modes share.
+
+struct PublishOptions {
+    int precision = 3;
+    double epsilon = 0.0001;
+};
+
+/// Single-component publish.
+void publish_value(std::string view_name,
+                   std::string metric_name,
+                   double value,
+                   PublishOptions opts = {});
+
+/// Multi-component publish (e.g., a 2D point or a geometry rect).
+/// Components are sorted by name before emission so log lines are stable.
+void publish_components(std::string view_name,
+                        std::string metric_name,
+                        std::vector<std::pair<std::string, double>> components,
+                        PublishOptions opts = {});
+
 // ── Sinks ────────────────────────────────────────────────────────────
 
 using Sink = std::function<void(const SampleEvent&)>;
@@ -204,6 +244,16 @@ public:
 
     /// Cumulative count of SampleEvents dispatched since `reset()`. For tests.
     std::size_t emitted_event_count() const noexcept;
+
+    // ── Phase 3: publish-channel internals ────────────────────────────
+    /// Called by `publish_value` / `publish_components`. Public so the
+    /// free functions can reach it without becoming friends; callers
+    /// should prefer the `publish_*` free functions for forward
+    /// compatibility.
+    void publish_internal(std::string view_name,
+                          std::string metric_name,
+                          std::vector<std::pair<std::string, double>> components,
+                          PublishOptions opts);
 
 private:
     Coordinator();

--- a/core/view/include/pulp/view/motion.hpp
+++ b/core/view/include/pulp/view/motion.hpp
@@ -50,10 +50,45 @@ struct TraceOptions {
     int fps = 15;
 };
 
+// ── Provenance envelope (Phase 7) ────────────────────────────────────
+//
+// Opaque metadata describing *where* a trace came from. Carried on
+// TraceStarted (trace-level) and on burst Start events (burst-level).
+// Phase 7 ships the shape + plumbing; the richer adapters that fill
+// it from each animation surface (Tween / CSS / AnimatorSet / JS rAF
+// / design-import) land in Phase 9.
+
+struct Provenance {
+    std::string source_kind;   ///< "tween" | "css-transition" | "animator-set"
+                               ///< | "rAF" | "design-import" | "user" | "publish"
+    std::string source_id;     ///< Free-form id, e.g. "Card.opacity tween" or
+                               ///< "figma:LevelMeter/Panel" or "import:claude:1234"
+    std::string source_file;   ///< Optional, e.g. __FILE__ at attach site
+    int source_line = 0;       ///< Optional, e.g. __LINE__ at attach site
+
+    bool is_set() const noexcept {
+        return !source_kind.empty() || !source_id.empty() ||
+               !source_file.empty() || source_line != 0;
+    }
+};
+
 // ── Sample event ─────────────────────────────────────────────────────
+//
+// Per-tick or per-publish event in a motion stream. Schema v2 carries
+// stable identifiers (trace_id / metric_id / burst_id) so fixtures can
+// be compared by identity instead of position — reordered identical
+// bursts no longer false-fail an `assert_matches`.
 
 struct SampleEvent {
-    enum class Kind { Baseline, Sample, Start, End };
+    enum class Kind {
+        TraceStarted,  ///< Emitted once per trace registration. Carries
+                       ///< the trace's provenance envelope.
+        Baseline,      ///< First sample of a metric.
+        Sample,        ///< Value sample within a change burst.
+        Start,         ///< Burst opened (value drifted off baseline / last
+                       ///< stable).
+        End,           ///< Burst closed (value stabilized). Carries deltas.
+    };
 
     Kind kind = Kind::Baseline;
     std::string view_name;
@@ -61,6 +96,18 @@ struct SampleEvent {
     double t_seconds = 0.0;                  ///< Monotonic FrameClock::time().
     std::uint64_t frame = 0;                 ///< Monotonic FrameClock::frame().
     int precision = 3;
+
+    // Stable identifiers (schema v2). Sampler-driven traces get a
+    // positive `trace_id` from `register_trace`; publishes use 0 to
+    // signal the publish channel. `metric_id` is the metric's index
+    // within its trace (or 0 for publish). `burst_id` increments at
+    // each Start within a given (trace_id, metric_id).
+    int trace_id = 0;
+    int metric_id = 0;
+    int burst_id = 0;
+
+    Provenance provenance;  ///< Populated on TraceStarted; empty otherwise.
+
     std::vector<std::pair<std::string, double>> components;  ///< Sorted by name.
     std::vector<std::pair<std::string, double>> deltas;      ///< End events only.
 };
@@ -132,7 +179,7 @@ void publish_components(std::string view_name,
 // Lines are separated by `\n`; the first line is the header:
 //   {"motion_fixture_version":1}
 
-constexpr int kFixtureSchemaVersion = 1;
+constexpr int kFixtureSchemaVersion = 2;
 
 // (`make_fixture_sink` and `replay_fixture` are declared below
 // alongside the other Sink helpers so the `using Sink = …` typedef is
@@ -295,6 +342,10 @@ public:
                            GeometrySpace space = GeometrySpace::Window,
                            GeometrySource source = GeometrySource::Layout,
                            int precision = 2, double epsilon = 0.1);
+
+    /// Attach a provenance envelope to the trace. Emitted once on
+    /// the trace's `TraceStarted` event.
+    TraceBuilder& with_provenance(Provenance p);
 
     /// Register the trace with the coordinator and return an owning handle.
     TraceHandle attach();

--- a/core/view/include/pulp/view/motion.hpp
+++ b/core/view/include/pulp/view/motion.hpp
@@ -108,6 +108,114 @@ void publish_components(std::string view_name,
                         std::vector<std::pair<std::string, double>> components,
                         PublishOptions opts = {});
 
+// ── Record / replay fixtures (Phase 5) ───────────────────────────────
+//
+// A fixture is the on-disk form of a motion stream — one JSONL event
+// per line, preceded by a header line carrying the schema version. The
+// format is deliberately stable so checked-in goldens survive long
+// after the recording session.
+//
+// Layered intent:
+//   - `make_fixture_sink(path)` is a Sink that writes events to disk
+//     as they're emitted. Plug it into the Coordinator's sink set to
+//     record everything an active trace produces.
+//   - `replay_fixture(path, sink)` re-emits a fixture's events to any
+//     sink without running the original UI. Lets analyzers /
+//     assertions work offline on a captured run.
+//   - `assert_matches(golden, captured, opts)` compares two fixtures
+//     and returns a structured diff agents can act on.
+//
+// Fixture version 1 schema (one event per line, sorted-key JSON):
+//   {"kind":"baseline|sample|start|end",
+//    "view":"…","metric":"…","t":…,"frame":…,"precision":N,
+//    "components":{"k":v,…}, "deltas":{"k":v,…}}
+// Lines are separated by `\n`; the first line is the header:
+//   {"motion_fixture_version":1}
+
+constexpr int kFixtureSchemaVersion = 1;
+
+// (`make_fixture_sink` and `replay_fixture` are declared below
+// alongside the other Sink helpers so the `using Sink = …` typedef is
+// visible at their declaration site.)
+
+/// Load a fixture file into memory. Returns events in file order.
+/// Empty vector on missing / unreadable / unknown-version files.
+std::vector<SampleEvent> load_fixture(const std::string& path);
+
+/// Comparison result from `assert_matches`. Empty `differences` means
+/// the captured run matched the golden within tolerances.
+struct FixtureDiff {
+    struct Item {
+        std::string kind;      ///< "missing-event", "extra-event",
+                               ///< "component-drift", "timing-drift"
+        std::string view_name;
+        std::string metric_name;
+        std::string component_name;
+        std::string detail;
+        double observed = 0.0;
+        double expected = 0.0;
+    };
+    std::vector<Item> differences;
+    bool matches() const noexcept { return differences.empty(); }
+};
+
+struct FixtureMatchOptions {
+    double component_epsilon = 0.05;
+    double timing_epsilon_seconds = 0.05;
+    bool require_same_event_count = true;
+};
+
+FixtureDiff assert_matches(const std::vector<SampleEvent>& golden,
+                           const std::vector<SampleEvent>& captured,
+                           FixtureMatchOptions opts = {});
+
+// ── Assertion helpers (Phase 5) ──────────────────────────────────────
+//
+// Each helper operates on a flat sequence of scalars extracted from
+// the captured events. Use `extract_scalar(events, view, metric, comp)`
+// to pull the time-ordered series, then pass it to the assertion.
+// Helpers favor explicit semantics over heuristics — `is_monotonic` is
+// strictly monotonic (with epsilon), `settling_time_seconds` is "time
+// from first change to final stable value", etc.
+
+/// Flatten a fixture's events into a (time, value) series for one
+/// (view, metric, component) triple. Includes Baseline + Sample only;
+/// Start / End markers are skipped.
+struct ScalarSample { double t = 0.0; double value = 0.0; };
+std::vector<ScalarSample> extract_scalar(
+    const std::vector<SampleEvent>& events,
+    std::string_view view_name,
+    std::string_view metric_name,
+    std::string_view component_name = "value");
+
+/// Strict monotonicity check with epsilon. Direction inferred from the
+/// first non-zero change. Returns false if any subsequent change
+/// reverses direction beyond epsilon.
+bool is_monotonic(const std::vector<ScalarSample>& samples,
+                  double epsilon = 1e-6);
+
+/// Time from first change above epsilon to last change above epsilon.
+/// 0.0 if fewer than 2 changes.
+double settling_time_seconds(const std::vector<ScalarSample>& samples,
+                             double epsilon = 1e-6);
+
+/// Overshoot relative to the final value: max excursion beyond the
+/// final value's direction from the first stable region. Reported as a
+/// fraction of total displacement (0.0 = clean, 0.1 = 10% overshoot).
+double overshoot(const std::vector<ScalarSample>& samples,
+                 double epsilon = 1e-6);
+
+/// Time from t0 to the first change above epsilon.
+double start_delay_seconds(const std::vector<ScalarSample>& samples,
+                           double epsilon = 1e-6);
+
+/// Standard deviation of inter-sample intervals — proxy for frame-pacing
+/// jitter when the sampler is run at a fixed FPS.
+double frame_jitter_seconds(const std::vector<ScalarSample>& samples);
+
+/// Returns the last sample's value, or NaN when empty.
+double final_value(const std::vector<ScalarSample>& samples);
+
 // ── Sinks ────────────────────────────────────────────────────────────
 
 using Sink = std::function<void(const SampleEvent&)>;
@@ -118,6 +226,16 @@ Sink make_log_sink();
 /// Sink that appends events to a caller-owned buffer. For tests and
 /// in-process consumers; the buffer pointer must outlive the sink.
 Sink make_buffer_sink(std::vector<SampleEvent>* buffer);
+
+/// Sink that appends each `SampleEvent` as a JSONL line to `path`.
+/// Opens the file (truncates) on first event. Subsequent events
+/// append. Closes implicitly when the returned Sink is dropped.
+/// Pair with `Coordinator::add_sink(make_fixture_sink(path))`.
+Sink make_fixture_sink(std::string path);
+
+/// Read a fixture file from disk and dispatch each event to `sink`.
+/// Returns the number of events replayed, or `-1` on parse error.
+int replay_fixture(const std::string& path, const Sink& sink);
 
 // ── Forward declarations ─────────────────────────────────────────────
 

--- a/core/view/include/pulp/view/motion.hpp
+++ b/core/view/include/pulp/view/motion.hpp
@@ -1,0 +1,223 @@
+#pragma once
+
+/// @file motion.hpp
+/// Agent-first motion observability: sample view geometry, scroll
+/// state, and arbitrary scalar values at a chosen FPS, emit
+/// epsilon-bounded change-only events with Start/End burst framing,
+/// and route them to pluggable sinks (log lines and structured
+/// events). Off by default; activate with
+/// `Coordinator::set_tracing_enabled(true)`.
+
+#include <pulp/view/geometry.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace pulp::view {
+
+class FrameClock;
+class View;
+
+namespace motion {
+
+// ── Geometry taxonomy ────────────────────────────────────────────────
+
+enum class GeometrySource {
+    Layout,        ///< Yoga-computed bounds, ignoring paint-time transforms.
+    Presentation,  ///< After paint_all() composition. Phase 0 falls back to Layout.
+};
+
+enum class GeometrySpace {
+    ViewLocal,    ///< Origin at the target view's top-left, in its own frame.
+    ViewGlobal,   ///< Root-view coordinate space.
+    Window,       ///< Phase 0: same as ViewGlobal. Phase 2 adds window origin.
+    Screen,       ///< Phase 0: same as ViewGlobal. Phase 2 adds screen offset.
+};
+
+enum class GeometryProperty {
+    MinX, MinY, MaxX, MaxY,
+    MidX, MidY,
+    Width, Height,
+};
+
+// ── Trace options ────────────────────────────────────────────────────
+
+struct TraceOptions {
+    int fps = 15;
+};
+
+// ── Sample event ─────────────────────────────────────────────────────
+
+struct SampleEvent {
+    enum class Kind { Baseline, Sample, Start, End };
+
+    Kind kind = Kind::Baseline;
+    std::string view_name;
+    std::string metric_name;
+    double t_seconds = 0.0;                  ///< Monotonic FrameClock::time().
+    std::uint64_t frame = 0;                 ///< Monotonic FrameClock::frame().
+    int precision = 3;
+    std::vector<std::pair<std::string, double>> components;  ///< Sorted by name.
+    std::vector<std::pair<std::string, double>> deltas;      ///< End events only.
+};
+
+/// Render the canonical `[PulpMotion][view][metric] ...` line for a sample event.
+std::string format_line(const SampleEvent& e);
+
+// ── Sinks ────────────────────────────────────────────────────────────
+
+using Sink = std::function<void(const SampleEvent&)>;
+
+/// Sink that writes one log line per event via `pulp::runtime::log_debug`.
+Sink make_log_sink();
+
+/// Sink that appends events to a caller-owned buffer. For tests and
+/// in-process consumers; the buffer pointer must outlive the sink.
+Sink make_buffer_sink(std::vector<SampleEvent>* buffer);
+
+// ── Forward declarations ─────────────────────────────────────────────
+
+class Coordinator;
+class TraceBuilder;
+
+// ── Trace handle (RAII) ──────────────────────────────────────────────
+
+class TraceHandle {
+public:
+    TraceHandle() noexcept = default;
+    TraceHandle(TraceHandle&& other) noexcept;
+    TraceHandle& operator=(TraceHandle&& other) noexcept;
+    TraceHandle(const TraceHandle&) = delete;
+    TraceHandle& operator=(const TraceHandle&) = delete;
+    ~TraceHandle();
+
+    /// Remove the trace from its coordinator. Idempotent.
+    void detach();
+
+    bool is_attached() const noexcept { return coord_ != nullptr; }
+    int id() const noexcept { return id_; }
+
+private:
+    friend class Coordinator;
+    friend class TraceBuilder;
+    TraceHandle(int id, Coordinator* coord) noexcept
+        : id_(id), coord_(coord) {}
+
+    int id_ = 0;
+    Coordinator* coord_ = nullptr;
+};
+
+// ── Trace builder DSL ────────────────────────────────────────────────
+
+class TraceBuilder {
+public:
+    using ValueSampler = std::function<double()>;
+    using Component = std::pair<std::string, ValueSampler>;
+
+    /// Single-scalar metric. The sampler is invoked once per sampler tick.
+    TraceBuilder& value(std::string name, ValueSampler sampler,
+                        int precision = 3, double epsilon = 0.0001);
+
+    /// Multi-component metric (e.g., a 2D point). Components are sampled
+    /// together and emitted as one log line.
+    TraceBuilder& multi(std::string name, std::vector<Component> components,
+                        int precision = 3, double epsilon = 0.0001);
+
+    /// Geometry metric over a target view. Phase 0 implements
+    /// `source = Layout`; `Presentation` falls back to Layout.
+    TraceBuilder& geometry(std::string name,
+                           pulp::view::View& target,
+                           std::vector<GeometryProperty> props
+                               = {GeometryProperty::MinX, GeometryProperty::MinY,
+                                  GeometryProperty::Width, GeometryProperty::Height},
+                           GeometrySpace space = GeometrySpace::Window,
+                           GeometrySource source = GeometrySource::Layout,
+                           int precision = 2, double epsilon = 0.1);
+
+    /// Register the trace with the coordinator and return an owning handle.
+    TraceHandle attach();
+
+    /// Internal spec (PIMPL-style). Public so Coordinator can hold a
+    /// shared_ptr<Spec> in its public-API signature; clients should not
+    /// construct or inspect it directly.
+    struct Spec;
+
+private:
+    friend class Coordinator;
+    TraceBuilder(Coordinator* coord, std::string view_name, TraceOptions opts);
+
+    std::shared_ptr<Spec> spec_;
+    Coordinator* coord_ = nullptr;
+};
+
+// ── Coordinator ──────────────────────────────────────────────────────
+
+/// Process-wide singleton that owns one FrameClock subscription, holds
+/// the active trace set, and dispatches sample events to registered
+/// sinks. Off by default; call `set_tracing_enabled(true)` to start
+/// emitting events.
+class Coordinator {
+public:
+    /// Process-wide instance. Bound to a FrameClock via `bind()`.
+    static Coordinator& instance();
+
+    /// Bind the coordinator's single tick subscription to a FrameClock.
+    /// Replaces any prior binding.
+    void bind(pulp::view::FrameClock& clock);
+
+    /// Drop the FrameClock subscription. No effect if not bound.
+    void unbind();
+
+    bool is_bound() const noexcept;
+
+    /// Add a sink and return its id (for later removal).
+    int add_sink(Sink sink);
+    void remove_sink(int sink_id);
+    void clear_sinks();
+
+    /// Convenience: add the default `make_log_sink()` and return its id.
+    int install_default_log_sink();
+
+    /// Global tracing toggle. Off by default. When off, `on_tick` is a no-op.
+    void set_tracing_enabled(bool on);
+    bool tracing_enabled() const noexcept;
+
+    /// Filter-scope firehose toggle. Reserved for Phase 3 (animation auto-trace).
+    /// Phase 0 stores and exposes the flag; nothing consumes it yet.
+    void set_firehose(bool on);
+    bool firehose() const noexcept;
+
+    /// Start building a trace.
+    TraceBuilder trace(std::string view_name, TraceOptions opts = {});
+
+    /// Remove a trace by id (called automatically by TraceHandle destruction).
+    void detach(int trace_id);
+
+    /// Reset all state (binding, sinks, traces, counters). For tests.
+    void reset();
+
+    std::size_t active_trace_count() const noexcept;
+
+    /// Cumulative count of SampleEvents dispatched since `reset()`. For tests.
+    std::size_t emitted_event_count() const noexcept;
+
+private:
+    Coordinator();
+    ~Coordinator();
+    Coordinator(const Coordinator&) = delete;
+    Coordinator& operator=(const Coordinator&) = delete;
+
+    void on_tick(float dt);
+    int register_trace(std::shared_ptr<TraceBuilder::Spec> spec);
+    friend class TraceBuilder;
+
+    struct State;
+    std::unique_ptr<State> state_;
+};
+
+} // namespace motion
+} // namespace pulp::view

--- a/core/view/src/motion.cpp
+++ b/core/view/src/motion.cpp
@@ -7,11 +7,16 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
+#include <fstream>
 #include <iomanip>
 #include <limits>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <sstream>
+#include <string>
+#include <string_view>
 #include <vector>
 
 namespace pulp::view::motion {
@@ -816,6 +821,531 @@ void Coordinator::publish_internal(std::string view_name,
         }
     }
     for (auto& [sink, ev] : pending) sink(ev);
+}
+
+// ── Fixture record / replay (Phase 5) ────────────────────────────────
+
+namespace {
+
+const char* sample_kind_string(SampleEvent::Kind k) {
+    switch (k) {
+        case SampleEvent::Kind::Baseline: return "baseline";
+        case SampleEvent::Kind::Sample:   return "sample";
+        case SampleEvent::Kind::Start:    return "start";
+        case SampleEvent::Kind::End:      return "end";
+    }
+    return "?";
+}
+
+bool kind_from_string(std::string_view s, SampleEvent::Kind& out) {
+    if (s == "baseline") { out = SampleEvent::Kind::Baseline; return true; }
+    if (s == "sample")   { out = SampleEvent::Kind::Sample;   return true; }
+    if (s == "start")    { out = SampleEvent::Kind::Start;    return true; }
+    if (s == "end")      { out = SampleEvent::Kind::End;      return true; }
+    return false;
+}
+
+/// Minimal JSON escape for the strings we control (view, metric,
+/// component names). Escapes `"`, `\\`, and control characters with
+/// the standard `\\uNNNN` form so the JSONL stays parseable. We don't
+/// need full Unicode handling — the strings are ASCII identifiers in
+/// practice.
+std::string json_escape(std::string_view s) {
+    std::string out;
+    out.reserve(s.size() + 2);
+    for (char ch : s) {
+        unsigned char c = static_cast<unsigned char>(ch);
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n";  break;
+            case '\r': out += "\\r";  break;
+            case '\t': out += "\\t";  break;
+            default:
+                if (c < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+                    out += buf;
+                } else {
+                    out += static_cast<char>(c);
+                }
+        }
+    }
+    return out;
+}
+
+std::string format_number(double v) {
+    if (!std::isfinite(v)) return "null";
+    std::ostringstream ss;
+    ss << std::setprecision(15) << v;
+    return ss.str();
+}
+
+std::string serialize_components(
+    const std::vector<std::pair<std::string, double>>& comps
+) {
+    std::string out = "{";
+    bool first = true;
+    for (const auto& [k, v] : comps) {
+        if (!first) out += ",";
+        out += "\"" + json_escape(k) + "\":" + format_number(v);
+        first = false;
+    }
+    out += "}";
+    return out;
+}
+
+std::string serialize_event(const SampleEvent& e) {
+    std::ostringstream ss;
+    ss << "{\"kind\":\"" << sample_kind_string(e.kind) << "\""
+       << ",\"view\":\"" << json_escape(e.view_name) << "\""
+       << ",\"metric\":\"" << json_escape(e.metric_name) << "\""
+       << ",\"t\":" << format_number(e.t_seconds)
+       << ",\"frame\":" << e.frame
+       << ",\"precision\":" << e.precision
+       << ",\"components\":" << serialize_components(e.components)
+       << ",\"deltas\":" << serialize_components(e.deltas)
+       << "}";
+    return ss.str();
+}
+
+/// Hand-rolled JSON object parser limited to the shapes we emit.
+/// Returns false on syntax or extension errors.
+class FixtureLineParser {
+public:
+    explicit FixtureLineParser(const std::string& src) : s_(src) {}
+
+    bool parse_event(SampleEvent& out) {
+        SampleEvent e;
+        if (!expect('{')) return false;
+        bool first = true;
+        while (true) {
+            skip_ws();
+            if (peek() == '}') { ++pos_; break; }
+            if (!first && !expect(',')) return false;
+            first = false;
+            std::string key;
+            if (!parse_string(key) || !expect(':')) return false;
+            skip_ws();
+
+            if (key == "kind") {
+                std::string v;
+                if (!parse_string(v)) return false;
+                if (!kind_from_string(v, e.kind)) return false;
+            } else if (key == "view") {
+                if (!parse_string(e.view_name)) return false;
+            } else if (key == "metric") {
+                if (!parse_string(e.metric_name)) return false;
+            } else if (key == "t") {
+                if (!parse_number(e.t_seconds)) return false;
+            } else if (key == "frame") {
+                double f = 0; if (!parse_number(f)) return false;
+                e.frame = static_cast<std::uint64_t>(f);
+            } else if (key == "precision") {
+                double p = 0; if (!parse_number(p)) return false;
+                e.precision = static_cast<int>(p);
+            } else if (key == "components") {
+                if (!parse_components(e.components)) return false;
+            } else if (key == "deltas") {
+                if (!parse_components(e.deltas)) return false;
+            } else {
+                // Unknown key — skip its value tolerantly.
+                if (!skip_value()) return false;
+            }
+        }
+        out = std::move(e);
+        return true;
+    }
+
+    bool parse_header(int& version_out) {
+        if (!expect('{')) return false;
+        std::string key;
+        skip_ws();
+        if (peek() == '}') { ++pos_; version_out = 0; return false; }
+        if (!parse_string(key) || !expect(':')) return false;
+        if (key != "motion_fixture_version") return false;
+        double v = 0;
+        if (!parse_number(v)) return false;
+        skip_ws();
+        if (peek() == '}') { ++pos_; version_out = static_cast<int>(v); return true; }
+        return false;
+    }
+
+private:
+    const std::string& s_;
+    std::size_t pos_ = 0;
+
+    char peek() const { return pos_ < s_.size() ? s_[pos_] : '\0'; }
+    void skip_ws() { while (pos_ < s_.size() && std::isspace(static_cast<unsigned char>(s_[pos_]))) ++pos_; }
+    bool expect(char c) { skip_ws(); if (peek() != c) return false; ++pos_; return true; }
+
+    bool parse_string(std::string& out) {
+        skip_ws();
+        if (peek() != '"') return false;
+        ++pos_;
+        out.clear();
+        while (pos_ < s_.size() && s_[pos_] != '"') {
+            char c = s_[pos_++];
+            if (c == '\\' && pos_ < s_.size()) {
+                char esc = s_[pos_++];
+                switch (esc) {
+                    case '"':  out += '"';  break;
+                    case '\\': out += '\\'; break;
+                    case '/':  out += '/';  break;
+                    case 'n':  out += '\n'; break;
+                    case 'r':  out += '\r'; break;
+                    case 't':  out += '\t'; break;
+                    case 'b':  out += '\b'; break;
+                    case 'f':  out += '\f'; break;
+                    case 'u': {
+                        if (pos_ + 4 > s_.size()) return false;
+                        // We only emit ASCII (< 0x80) in `json_escape`, so any
+                        // `\\uNNNN` in our own fixtures will be < 0x80.
+                        unsigned int code = 0;
+                        for (int i = 0; i < 4; ++i) {
+                            char h = s_[pos_++];
+                            code <<= 4;
+                            if (h >= '0' && h <= '9') code |= (h - '0');
+                            else if (h >= 'a' && h <= 'f') code |= (h - 'a' + 10);
+                            else if (h >= 'A' && h <= 'F') code |= (h - 'A' + 10);
+                            else return false;
+                        }
+                        if (code >= 0x80) return false;
+                        out += static_cast<char>(code);
+                        break;
+                    }
+                    default: return false;
+                }
+            } else {
+                out += c;
+            }
+        }
+        if (peek() != '"') return false;
+        ++pos_;
+        return true;
+    }
+
+    bool parse_number(double& out) {
+        skip_ws();
+        std::size_t start = pos_;
+        if (peek() == '-' || peek() == '+') ++pos_;
+        bool any_digit = false;
+        while (pos_ < s_.size() && std::isdigit(static_cast<unsigned char>(s_[pos_]))) { ++pos_; any_digit = true; }
+        if (pos_ < s_.size() && s_[pos_] == '.') {
+            ++pos_;
+            while (pos_ < s_.size() && std::isdigit(static_cast<unsigned char>(s_[pos_]))) { ++pos_; any_digit = true; }
+        }
+        if (pos_ < s_.size() && (s_[pos_] == 'e' || s_[pos_] == 'E')) {
+            ++pos_;
+            if (pos_ < s_.size() && (s_[pos_] == '-' || s_[pos_] == '+')) ++pos_;
+            while (pos_ < s_.size() && std::isdigit(static_cast<unsigned char>(s_[pos_]))) { ++pos_; any_digit = true; }
+        }
+        if (!any_digit) return false;
+        try {
+            out = std::stod(s_.substr(start, pos_ - start));
+        } catch (...) {
+            return false;
+        }
+        return true;
+    }
+
+    bool parse_components(std::vector<std::pair<std::string, double>>& out) {
+        out.clear();
+        if (!expect('{')) return false;
+        skip_ws();
+        if (peek() == '}') { ++pos_; return true; }
+        while (true) {
+            std::string k;
+            if (!parse_string(k) || !expect(':')) return false;
+            double v;
+            if (!parse_number(v)) return false;
+            out.emplace_back(std::move(k), v);
+            skip_ws();
+            if (peek() == ',') { ++pos_; continue; }
+            if (peek() == '}') { ++pos_; return true; }
+            return false;
+        }
+    }
+
+    bool skip_value() {
+        skip_ws();
+        char c = peek();
+        if (c == '"') { std::string dummy; return parse_string(dummy); }
+        if (c == '{') {
+            ++pos_; int depth = 1;
+            while (pos_ < s_.size() && depth > 0) {
+                if (s_[pos_] == '{') ++depth;
+                else if (s_[pos_] == '}') --depth;
+                ++pos_;
+            }
+            return depth == 0;
+        }
+        if (c == '[') {
+            ++pos_; int depth = 1;
+            while (pos_ < s_.size() && depth > 0) {
+                if (s_[pos_] == '[') ++depth;
+                else if (s_[pos_] == ']') --depth;
+                ++pos_;
+            }
+            return depth == 0;
+        }
+        double n;
+        return parse_number(n);
+    }
+};
+
+/// Shared file handle owned by the sink lambda. Lazily opens on first
+/// event so empty traces don't create stale files. Header is written
+/// once; subsequent events are appended.
+struct FixtureFileSink {
+    std::string path;
+    std::shared_ptr<std::ofstream> stream;
+    bool header_written = false;
+
+    void ensure_open() {
+        if (!stream) {
+            stream = std::make_shared<std::ofstream>(path,
+                std::ios::out | std::ios::trunc | std::ios::binary);
+        }
+    }
+};
+
+}  // namespace
+
+Sink make_fixture_sink(std::string path) {
+    auto state = std::make_shared<FixtureFileSink>();
+    state->path = std::move(path);
+    return [state](const SampleEvent& e) {
+        state->ensure_open();
+        if (!state->stream || !state->stream->is_open()) return;
+        if (!state->header_written) {
+            *state->stream << "{\"motion_fixture_version\":"
+                           << kFixtureSchemaVersion << "}\n";
+            state->header_written = true;
+        }
+        *state->stream << serialize_event(e) << "\n";
+        state->stream->flush();
+    };
+}
+
+std::vector<SampleEvent> load_fixture(const std::string& path) {
+    std::vector<SampleEvent> out;
+    std::ifstream in(path, std::ios::in | std::ios::binary);
+    if (!in.is_open()) return out;
+    std::string line;
+    if (!std::getline(in, line)) return out;
+    FixtureLineParser header(line);
+    int version = 0;
+    if (!header.parse_header(version)) return out;
+    if (version != kFixtureSchemaVersion) return out;
+    while (std::getline(in, line)) {
+        if (line.empty()) continue;
+        SampleEvent e;
+        FixtureLineParser p(line);
+        if (!p.parse_event(e)) return {};
+        out.push_back(std::move(e));
+    }
+    return out;
+}
+
+int replay_fixture(const std::string& path, const Sink& sink) {
+    auto events = load_fixture(path);
+    if (events.empty()) return -1;
+    for (const auto& e : events) sink(e);
+    return static_cast<int>(events.size());
+}
+
+// ── assert_matches ──────────────────────────────────────────────────
+
+FixtureDiff assert_matches(const std::vector<SampleEvent>& golden,
+                           const std::vector<SampleEvent>& captured,
+                           FixtureMatchOptions opts) {
+    FixtureDiff diff;
+    const auto pos_kind = [](SampleEvent::Kind k) {
+        return k == SampleEvent::Kind::Baseline ||
+               k == SampleEvent::Kind::Sample ||
+               k == SampleEvent::Kind::Start ||
+               k == SampleEvent::Kind::End;
+    };
+    (void)pos_kind;
+
+    if (opts.require_same_event_count && golden.size() != captured.size()) {
+        FixtureDiff::Item item;
+        item.kind = "event-count-mismatch";
+        item.detail = "golden=" + std::to_string(golden.size()) +
+                      " captured=" + std::to_string(captured.size());
+        item.expected = static_cast<double>(golden.size());
+        item.observed = static_cast<double>(captured.size());
+        diff.differences.push_back(item);
+    }
+
+    const std::size_t n = std::min(golden.size(), captured.size());
+    for (std::size_t i = 0; i < n; ++i) {
+        const auto& g = golden[i];
+        const auto& c = captured[i];
+        if (g.kind != c.kind || g.view_name != c.view_name ||
+            g.metric_name != c.metric_name) {
+            FixtureDiff::Item item;
+            item.kind = "event-mismatch";
+            item.view_name = g.view_name;
+            item.metric_name = g.metric_name;
+            item.detail = "event #" + std::to_string(i);
+            diff.differences.push_back(item);
+            continue;
+        }
+        if (std::fabs(g.t_seconds - c.t_seconds) > opts.timing_epsilon_seconds) {
+            FixtureDiff::Item item;
+            item.kind = "timing-drift";
+            item.view_name = g.view_name;
+            item.metric_name = g.metric_name;
+            item.detail = "event #" + std::to_string(i);
+            item.observed = c.t_seconds;
+            item.expected = g.t_seconds;
+            diff.differences.push_back(item);
+        }
+        const auto compare = [&](const auto& gc, const auto& cc, const char* tag) {
+            if (gc.size() != cc.size()) {
+                FixtureDiff::Item item;
+                item.kind = "component-count-mismatch";
+                item.view_name = g.view_name;
+                item.metric_name = g.metric_name;
+                item.detail = tag;
+                item.observed = static_cast<double>(cc.size());
+                item.expected = static_cast<double>(gc.size());
+                diff.differences.push_back(item);
+                return;
+            }
+            for (std::size_t k = 0; k < gc.size(); ++k) {
+                if (gc[k].first != cc[k].first) {
+                    FixtureDiff::Item item;
+                    item.kind = "component-mismatch";
+                    item.view_name = g.view_name;
+                    item.metric_name = g.metric_name;
+                    item.component_name = gc[k].first;
+                    item.detail = std::string(tag) + ", expected name " +
+                                  gc[k].first + " got " + cc[k].first;
+                    diff.differences.push_back(item);
+                    continue;
+                }
+                if (std::fabs(gc[k].second - cc[k].second) > opts.component_epsilon) {
+                    FixtureDiff::Item item;
+                    item.kind = "component-drift";
+                    item.view_name = g.view_name;
+                    item.metric_name = g.metric_name;
+                    item.component_name = gc[k].first;
+                    item.detail = tag;
+                    item.observed = cc[k].second;
+                    item.expected = gc[k].second;
+                    diff.differences.push_back(item);
+                }
+            }
+        };
+        compare(g.components, c.components, "components");
+        compare(g.deltas, c.deltas, "deltas");
+    }
+    return diff;
+}
+
+// ── Assertion helpers ─────────────────────────────────────────────────
+
+std::vector<ScalarSample> extract_scalar(
+    const std::vector<SampleEvent>& events,
+    std::string_view view_name,
+    std::string_view metric_name,
+    std::string_view component_name
+) {
+    std::vector<ScalarSample> out;
+    for (const auto& e : events) {
+        if (e.view_name != view_name || e.metric_name != metric_name) continue;
+        if (e.kind != SampleEvent::Kind::Baseline &&
+            e.kind != SampleEvent::Kind::Sample) continue;
+        for (const auto& [k, v] : e.components) {
+            if (k == component_name) {
+                out.push_back({e.t_seconds, v});
+                break;
+            }
+        }
+    }
+    return out;
+}
+
+bool is_monotonic(const std::vector<ScalarSample>& samples, double epsilon) {
+    int direction = 0;
+    double prev = std::numeric_limits<double>::quiet_NaN();
+    for (const auto& s : samples) {
+        if (std::isnan(prev)) { prev = s.value; continue; }
+        const double dv = s.value - prev;
+        if (std::fabs(dv) <= epsilon) { prev = s.value; continue; }
+        const int dir = dv > 0 ? 1 : -1;
+        if (direction == 0) direction = dir;
+        else if (direction != dir) return false;
+        prev = s.value;
+    }
+    return true;
+}
+
+double settling_time_seconds(const std::vector<ScalarSample>& samples,
+                             double epsilon) {
+    double first_t = std::numeric_limits<double>::quiet_NaN();
+    double last_t = std::numeric_limits<double>::quiet_NaN();
+    double prev = std::numeric_limits<double>::quiet_NaN();
+    for (const auto& s : samples) {
+        if (std::isnan(prev)) { prev = s.value; continue; }
+        if (std::fabs(s.value - prev) > epsilon) {
+            if (std::isnan(first_t)) first_t = s.t;
+            last_t = s.t;
+            prev = s.value;
+        }
+    }
+    if (std::isnan(first_t) || std::isnan(last_t)) return 0.0;
+    return last_t - first_t;
+}
+
+double overshoot(const std::vector<ScalarSample>& samples, double epsilon) {
+    if (samples.size() < 2) return 0.0;
+    const double start = samples.front().value;
+    const double end = samples.back().value;
+    const double range = end - start;
+    if (std::fabs(range) <= epsilon) return 0.0;
+    double peak = end;
+    for (const auto& s : samples) {
+        if (range > 0 && s.value > peak) peak = s.value;
+        if (range < 0 && s.value < peak) peak = s.value;
+    }
+    const double excursion = peak - end;
+    return std::fabs(excursion) / std::fabs(range);
+}
+
+double start_delay_seconds(const std::vector<ScalarSample>& samples,
+                           double epsilon) {
+    if (samples.empty()) return 0.0;
+    const double t0 = samples.front().t;
+    const double v0 = samples.front().value;
+    for (const auto& s : samples) {
+        if (std::fabs(s.value - v0) > epsilon) return s.t - t0;
+    }
+    return 0.0;
+}
+
+double frame_jitter_seconds(const std::vector<ScalarSample>& samples) {
+    if (samples.size() < 3) return 0.0;
+    std::vector<double> deltas;
+    deltas.reserve(samples.size() - 1);
+    for (std::size_t i = 1; i < samples.size(); ++i) {
+        deltas.push_back(samples[i].t - samples[i - 1].t);
+    }
+    double mean = 0.0;
+    for (double d : deltas) mean += d;
+    mean /= static_cast<double>(deltas.size());
+    double var = 0.0;
+    for (double d : deltas) var += (d - mean) * (d - mean);
+    var /= static_cast<double>(deltas.size());
+    return std::sqrt(var);
+}
+
+double final_value(const std::vector<ScalarSample>& samples) {
+    if (samples.empty()) return std::numeric_limits<double>::quiet_NaN();
+    return samples.back().value;
 }
 
 }  // namespace pulp::view::motion

--- a/core/view/src/motion.cpp
+++ b/core/view/src/motion.cpp
@@ -289,6 +289,7 @@ struct TraceBuilder::Spec {
     std::string view_name;
     TraceOptions opts;
     std::vector<std::unique_ptr<MetricBase>> metrics;
+    Provenance provenance;
 };
 
 // ── TraceBuilder ──────────────────────────────────────────────────────
@@ -341,6 +342,11 @@ TraceBuilder& TraceBuilder::geometry(std::string name,
     return *this;
 }
 
+TraceBuilder& TraceBuilder::with_provenance(Provenance p) {
+    if (spec_) spec_->provenance = std::move(p);
+    return *this;
+}
+
 TraceHandle TraceBuilder::attach() {
     if (!coord_) return TraceHandle();
     const int id = coord_->register_trace(spec_);
@@ -382,6 +388,19 @@ std::string format_line(const SampleEvent& e) {
     std::ostringstream ss;
     ss << "[PulpMotion][" << e.view_name << "][" << e.metric_name << "]";
     switch (e.kind) {
+        case SampleEvent::Kind::TraceStarted:
+            ss << " -- TraceStarted trace_id=" << e.trace_id
+               << " frame=" << e.frame
+               << " t=" << fmt_double(e.t_seconds, 6) << " --";
+            if (e.provenance.is_set()) {
+                ss << " source=" << e.provenance.source_kind;
+                if (!e.provenance.source_id.empty())
+                    ss << " id=" << e.provenance.source_id;
+                if (!e.provenance.source_file.empty())
+                    ss << " at=" << e.provenance.source_file
+                       << ":" << e.provenance.source_line;
+            }
+            break;
         case SampleEvent::Kind::Baseline:
         case SampleEvent::Kind::Sample: {
             bool first = true;
@@ -393,11 +412,13 @@ std::string format_line(const SampleEvent& e) {
             break;
         }
         case SampleEvent::Kind::Start:
-            ss << " -- Start frame=" << e.frame
+            ss << " -- Start burst=" << e.burst_id
+               << " frame=" << e.frame
                << " t=" << fmt_double(e.t_seconds, 6) << " --";
             break;
         case SampleEvent::Kind::End:
-            ss << " -- End frame=" << e.frame
+            ss << " -- End burst=" << e.burst_id
+               << " frame=" << e.frame
                << " t=" << fmt_double(e.t_seconds, 6) << " --";
             for (const auto& [k, v] : e.deltas) {
                 ss << " " << k << "Delta=" << fmt_double(v, e.precision);
@@ -451,6 +472,8 @@ struct PerMetricState {
     std::vector<std::pair<std::string, double>> motion_start;
     bool has_baseline = false;
     bool in_motion = false;
+    int next_burst_id = 1;       // Phase 7: assigned at each Start.
+    int current_burst_id = 0;    // 0 between bursts; set on Start.
 };
 
 struct ActiveTrace {
@@ -458,6 +481,7 @@ struct ActiveTrace {
     std::shared_ptr<TraceBuilder::Spec> spec;
     std::vector<PerMetricState> metrics;
     double accum_seconds = 0.0;
+    bool needs_trace_started = true;  // Phase 7: emit TraceStarted on first tick.
 };
 
 struct PublishKey {
@@ -476,6 +500,8 @@ struct PublishState {
     std::vector<std::pair<std::string, double>> motion_start;
     bool has_baseline = false;
     bool in_motion = false;
+    int next_burst_id = 1;
+    int current_burst_id = 0;
 };
 
 struct Coordinator::State {
@@ -656,6 +682,25 @@ void Coordinator::on_tick(float dt) {
             state_->clock ? state_->clock->frame() : 0;
 
         for (auto& [trace_id, trace] : state_->traces) {
+            // Phase 7: emit TraceStarted once per trace on its first tick.
+            if (trace.needs_trace_started) {
+                SampleEvent ev;
+                ev.kind = SampleEvent::Kind::TraceStarted;
+                ev.view_name = trace.spec->view_name;
+                ev.t_seconds = t_now;
+                ev.frame = f_now;
+                ev.trace_id = trace.id;
+                ev.metric_id = 0;
+                ev.burst_id = 0;
+                ev.provenance = trace.spec->provenance;
+                for (const auto& [sid, sink] : state_->sinks) {
+                    (void)sid;
+                    pending.emplace_back(sink, ev);
+                }
+                state_->emitted_count++;
+                trace.needs_trace_started = false;
+            }
+
             const int fps = std::max(1, trace.spec->opts.fps);
             const double period = 1.0 / static_cast<double>(fps);
             trace.accum_seconds += static_cast<double>(dt);
@@ -684,6 +729,9 @@ void Coordinator::on_tick(float dt) {
                     e.t_seconds = t_now;
                     e.frame = f_now;
                     e.precision = mstate.precision;
+                    e.trace_id = trace.id;
+                    e.metric_id = static_cast<int>(i);
+                    e.burst_id = mstate.current_burst_id;
                     e.components = std::move(comps);
                     e.deltas = std::move(deltas);
                     for (const auto& [sid, sink] : state_->sinks) {
@@ -705,6 +753,7 @@ void Coordinator::on_tick(float dt) {
                                                        mstate.epsilon);
                 if (changed) {
                     if (!mstate.in_motion) {
+                        mstate.current_burst_id = mstate.next_burst_id++;
                         enqueue(SampleEvent::Kind::Start, {});
                         mstate.motion_start = mstate.last_emitted;
                         mstate.in_motion = true;
@@ -724,6 +773,7 @@ void Coordinator::on_tick(float dt) {
                     enqueue(SampleEvent::Kind::End, {}, std::move(deltas));
                     mstate.in_motion = false;
                     mstate.motion_start.clear();
+                    mstate.current_burst_id = 0;
                 }
             }
         }
@@ -779,6 +829,12 @@ void Coordinator::publish_internal(std::string view_name,
             e.t_seconds = t_now;
             e.frame = f_now;
             e.precision = pstate.precision;
+            // Phase 7: publish channel uses trace_id = 0 (reserved).
+            // metric_id = 0; (view_name, metric_name) already identifies
+            // the metric. burst_id increments per (view, metric).
+            e.trace_id = 0;
+            e.metric_id = 0;
+            e.burst_id = pstate.current_burst_id;
             e.components = std::move(comps);
             e.deltas = std::move(deltas);
             for (const auto& [sid, sink] : state_->sinks) {
@@ -798,6 +854,7 @@ void Coordinator::publish_internal(std::string view_name,
                                                    pstate.epsilon);
             if (changed) {
                 if (!pstate.in_motion) {
+                    pstate.current_burst_id = pstate.next_burst_id++;
                     enqueue(SampleEvent::Kind::Start, {});
                     pstate.motion_start = pstate.last_emitted;
                     pstate.in_motion = true;
@@ -817,6 +874,7 @@ void Coordinator::publish_internal(std::string view_name,
                 enqueue(SampleEvent::Kind::End, {}, std::move(deltas));
                 pstate.in_motion = false;
                 pstate.motion_start.clear();
+                pstate.current_burst_id = 0;
             }
         }
     }
@@ -829,19 +887,21 @@ namespace {
 
 const char* sample_kind_string(SampleEvent::Kind k) {
     switch (k) {
-        case SampleEvent::Kind::Baseline: return "baseline";
-        case SampleEvent::Kind::Sample:   return "sample";
-        case SampleEvent::Kind::Start:    return "start";
-        case SampleEvent::Kind::End:      return "end";
+        case SampleEvent::Kind::TraceStarted: return "trace-started";
+        case SampleEvent::Kind::Baseline:     return "baseline";
+        case SampleEvent::Kind::Sample:       return "sample";
+        case SampleEvent::Kind::Start:        return "start";
+        case SampleEvent::Kind::End:          return "end";
     }
     return "?";
 }
 
 bool kind_from_string(std::string_view s, SampleEvent::Kind& out) {
-    if (s == "baseline") { out = SampleEvent::Kind::Baseline; return true; }
-    if (s == "sample")   { out = SampleEvent::Kind::Sample;   return true; }
-    if (s == "start")    { out = SampleEvent::Kind::Start;    return true; }
-    if (s == "end")      { out = SampleEvent::Kind::End;      return true; }
+    if (s == "trace-started") { out = SampleEvent::Kind::TraceStarted; return true; }
+    if (s == "baseline")      { out = SampleEvent::Kind::Baseline;     return true; }
+    if (s == "sample")        { out = SampleEvent::Kind::Sample;       return true; }
+    if (s == "start")         { out = SampleEvent::Kind::Start;        return true; }
+    if (s == "end")           { out = SampleEvent::Kind::End;          return true; }
     return false;
 }
 
@@ -895,6 +955,16 @@ std::string serialize_components(
     return out;
 }
 
+std::string serialize_provenance(const Provenance& p) {
+    std::string out = "{";
+    out += "\"source_kind\":\"" + json_escape(p.source_kind) + "\"";
+    out += ",\"source_id\":\"" + json_escape(p.source_id) + "\"";
+    out += ",\"source_file\":\"" + json_escape(p.source_file) + "\"";
+    out += ",\"source_line\":" + std::to_string(p.source_line);
+    out += "}";
+    return out;
+}
+
 std::string serialize_event(const SampleEvent& e) {
     std::ostringstream ss;
     ss << "{\"kind\":\"" << sample_kind_string(e.kind) << "\""
@@ -903,9 +973,15 @@ std::string serialize_event(const SampleEvent& e) {
        << ",\"t\":" << format_number(e.t_seconds)
        << ",\"frame\":" << e.frame
        << ",\"precision\":" << e.precision
+       << ",\"trace_id\":" << e.trace_id
+       << ",\"metric_id\":" << e.metric_id
+       << ",\"burst_id\":" << e.burst_id
        << ",\"components\":" << serialize_components(e.components)
-       << ",\"deltas\":" << serialize_components(e.deltas)
-       << "}";
+       << ",\"deltas\":" << serialize_components(e.deltas);
+    if (e.provenance.is_set()) {
+        ss << ",\"provenance\":" << serialize_provenance(e.provenance);
+    }
+    ss << "}";
     return ss.str();
 }
 
@@ -948,6 +1024,17 @@ public:
                 if (!parse_components(e.components)) return false;
             } else if (key == "deltas") {
                 if (!parse_components(e.deltas)) return false;
+            } else if (key == "trace_id") {
+                double v = 0; if (!parse_number(v)) return false;
+                e.trace_id = static_cast<int>(v);
+            } else if (key == "metric_id") {
+                double v = 0; if (!parse_number(v)) return false;
+                e.metric_id = static_cast<int>(v);
+            } else if (key == "burst_id") {
+                double v = 0; if (!parse_number(v)) return false;
+                e.burst_id = static_cast<int>(v);
+            } else if (key == "provenance") {
+                if (!parse_provenance(e.provenance)) return false;
             } else {
                 // Unknown key — skip its value tolerantly.
                 if (!skip_value()) return false;
@@ -955,6 +1042,32 @@ public:
         }
         out = std::move(e);
         return true;
+    }
+
+    bool parse_provenance(Provenance& out) {
+        if (!expect('{')) return false;
+        skip_ws();
+        if (peek() == '}') { ++pos_; return true; }
+        while (true) {
+            std::string k;
+            if (!parse_string(k) || !expect(':')) return false;
+            if (k == "source_kind") {
+                if (!parse_string(out.source_kind)) return false;
+            } else if (k == "source_id") {
+                if (!parse_string(out.source_id)) return false;
+            } else if (k == "source_file") {
+                if (!parse_string(out.source_file)) return false;
+            } else if (k == "source_line") {
+                double n = 0; if (!parse_number(n)) return false;
+                out.source_line = static_cast<int>(n);
+            } else {
+                if (!skip_value()) return false;
+            }
+            skip_ws();
+            if (peek() == ',') { ++pos_; continue; }
+            if (peek() == '}') { ++pos_; return true; }
+            return false;
+        }
     }
 
     bool parse_header(int& version_out) {
@@ -1157,17 +1270,40 @@ int replay_fixture(const std::string& path, const Sink& sink) {
 
 // ── assert_matches ──────────────────────────────────────────────────
 
+namespace {
+
+/// Burst identity used to align events across two fixtures. For events
+/// without burst_id (TraceStarted, Baseline) we fall back to
+/// `(view, metric, kind, trace_id, metric_id)`.
+struct EventKey {
+    std::string view;
+    std::string metric;
+    SampleEvent::Kind kind;
+    int trace_id = 0;
+    int metric_id = 0;
+    int burst_id = 0;
+
+    bool operator<(const EventKey& o) const {
+        if (view != o.view) return view < o.view;
+        if (metric != o.metric) return metric < o.metric;
+        if (kind != o.kind) return kind < o.kind;
+        if (trace_id != o.trace_id) return trace_id < o.trace_id;
+        if (metric_id != o.metric_id) return metric_id < o.metric_id;
+        return burst_id < o.burst_id;
+    }
+};
+
+EventKey key_of(const SampleEvent& e) {
+    return { e.view_name, e.metric_name, e.kind,
+             e.trace_id, e.metric_id, e.burst_id };
+}
+
+}  // namespace
+
 FixtureDiff assert_matches(const std::vector<SampleEvent>& golden,
                            const std::vector<SampleEvent>& captured,
                            FixtureMatchOptions opts) {
     FixtureDiff diff;
-    const auto pos_kind = [](SampleEvent::Kind k) {
-        return k == SampleEvent::Kind::Baseline ||
-               k == SampleEvent::Kind::Sample ||
-               k == SampleEvent::Kind::Start ||
-               k == SampleEvent::Kind::End;
-    };
-    (void)pos_kind;
 
     if (opts.require_same_event_count && golden.size() != captured.size()) {
         FixtureDiff::Item item;
@@ -1179,70 +1315,111 @@ FixtureDiff assert_matches(const std::vector<SampleEvent>& golden,
         diff.differences.push_back(item);
     }
 
-    const std::size_t n = std::min(golden.size(), captured.size());
-    for (std::size_t i = 0; i < n; ++i) {
-        const auto& g = golden[i];
-        const auto& c = captured[i];
-        if (g.kind != c.kind || g.view_name != c.view_name ||
-            g.metric_name != c.metric_name) {
+    // Phase 7 — ID-keyed grouping. For each (view, metric, kind,
+    // trace_id, metric_id, burst_id) group, compare in arrival order
+    // within the group. Bursts that appear in different order across
+    // fixtures still match if their identity matches.
+    std::map<EventKey, std::vector<const SampleEvent*>> g_groups;
+    std::map<EventKey, std::vector<const SampleEvent*>> c_groups;
+    for (const auto& e : golden)   g_groups[key_of(e)].push_back(&e);
+    for (const auto& e : captured) c_groups[key_of(e)].push_back(&e);
+
+    const auto compare_components = [&](const SampleEvent& g,
+                                        const SampleEvent& c,
+                                        const auto& gc, const auto& cc,
+                                        const char* tag) {
+        if (gc.size() != cc.size()) {
             FixtureDiff::Item item;
-            item.kind = "event-mismatch";
+            item.kind = "component-count-mismatch";
             item.view_name = g.view_name;
             item.metric_name = g.metric_name;
-            item.detail = "event #" + std::to_string(i);
+            item.detail = tag;
+            item.observed = static_cast<double>(cc.size());
+            item.expected = static_cast<double>(gc.size());
+            diff.differences.push_back(item);
+            return;
+        }
+        for (std::size_t k = 0; k < gc.size(); ++k) {
+            if (gc[k].first != cc[k].first) {
+                FixtureDiff::Item item;
+                item.kind = "component-mismatch";
+                item.view_name = g.view_name;
+                item.metric_name = g.metric_name;
+                item.component_name = gc[k].first;
+                item.detail = std::string(tag) + ", expected name " +
+                              gc[k].first + " got " + cc[k].first;
+                diff.differences.push_back(item);
+                continue;
+            }
+            if (std::fabs(gc[k].second - cc[k].second) > opts.component_epsilon) {
+                FixtureDiff::Item item;
+                item.kind = "component-drift";
+                item.view_name = g.view_name;
+                item.metric_name = g.metric_name;
+                item.component_name = gc[k].first;
+                item.detail = tag;
+                item.observed = cc[k].second;
+                item.expected = gc[k].second;
+                diff.differences.push_back(item);
+            }
+        }
+    };
+
+    // Walk the golden groups; for each, pair up with the captured
+    // group's events in arrival order.
+    for (const auto& [key, g_list] : g_groups) {
+        auto it = c_groups.find(key);
+        if (it == c_groups.end()) {
+            FixtureDiff::Item item;
+            item.kind = "missing-event";
+            item.view_name = key.view;
+            item.metric_name = key.metric;
+            item.detail = "burst_id=" + std::to_string(key.burst_id);
             diff.differences.push_back(item);
             continue;
         }
-        if (std::fabs(g.t_seconds - c.t_seconds) > opts.timing_epsilon_seconds) {
+        const auto& c_list = it->second;
+        const std::size_t n = std::min(g_list.size(), c_list.size());
+        if (g_list.size() != c_list.size()) {
             FixtureDiff::Item item;
-            item.kind = "timing-drift";
-            item.view_name = g.view_name;
-            item.metric_name = g.metric_name;
-            item.detail = "event #" + std::to_string(i);
-            item.observed = c.t_seconds;
-            item.expected = g.t_seconds;
+            item.kind = "group-count-mismatch";
+            item.view_name = key.view;
+            item.metric_name = key.metric;
+            item.detail = "burst_id=" + std::to_string(key.burst_id);
+            item.observed = static_cast<double>(c_list.size());
+            item.expected = static_cast<double>(g_list.size());
             diff.differences.push_back(item);
         }
-        const auto compare = [&](const auto& gc, const auto& cc, const char* tag) {
-            if (gc.size() != cc.size()) {
+        for (std::size_t i = 0; i < n; ++i) {
+            const auto& g = *g_list[i];
+            const auto& c = *c_list[i];
+            if (std::fabs(g.t_seconds - c.t_seconds) > opts.timing_epsilon_seconds) {
                 FixtureDiff::Item item;
-                item.kind = "component-count-mismatch";
+                item.kind = "timing-drift";
                 item.view_name = g.view_name;
                 item.metric_name = g.metric_name;
-                item.detail = tag;
-                item.observed = static_cast<double>(cc.size());
-                item.expected = static_cast<double>(gc.size());
+                item.detail = "burst_id=" + std::to_string(g.burst_id);
+                item.observed = c.t_seconds;
+                item.expected = g.t_seconds;
                 diff.differences.push_back(item);
-                return;
             }
-            for (std::size_t k = 0; k < gc.size(); ++k) {
-                if (gc[k].first != cc[k].first) {
-                    FixtureDiff::Item item;
-                    item.kind = "component-mismatch";
-                    item.view_name = g.view_name;
-                    item.metric_name = g.metric_name;
-                    item.component_name = gc[k].first;
-                    item.detail = std::string(tag) + ", expected name " +
-                                  gc[k].first + " got " + cc[k].first;
-                    diff.differences.push_back(item);
-                    continue;
-                }
-                if (std::fabs(gc[k].second - cc[k].second) > opts.component_epsilon) {
-                    FixtureDiff::Item item;
-                    item.kind = "component-drift";
-                    item.view_name = g.view_name;
-                    item.metric_name = g.metric_name;
-                    item.component_name = gc[k].first;
-                    item.detail = tag;
-                    item.observed = cc[k].second;
-                    item.expected = gc[k].second;
-                    diff.differences.push_back(item);
-                }
-            }
-        };
-        compare(g.components, c.components, "components");
-        compare(g.deltas, c.deltas, "deltas");
+            compare_components(g, c, g.components, c.components, "components");
+            compare_components(g, c, g.deltas, c.deltas, "deltas");
+        }
     }
+
+    // Extra groups in captured that aren't in golden.
+    for (const auto& [key, _] : c_groups) {
+        if (g_groups.find(key) == g_groups.end()) {
+            FixtureDiff::Item item;
+            item.kind = "extra-event";
+            item.view_name = key.view;
+            item.metric_name = key.metric;
+            item.detail = "burst_id=" + std::to_string(key.burst_id);
+            diff.differences.push_back(item);
+        }
+    }
+
     return diff;
 }
 
@@ -1257,6 +1434,9 @@ std::vector<ScalarSample> extract_scalar(
     std::vector<ScalarSample> out;
     for (const auto& e : events) {
         if (e.view_name != view_name || e.metric_name != metric_name) continue;
+        // TraceStarted / Start / End are framing events with no
+        // sample components — skip them and pull only Baseline +
+        // Sample data.
         if (e.kind != SampleEvent::Kind::Baseline &&
             e.kind != SampleEvent::Kind::Sample) continue;
         for (const auto& [k, v] : e.components) {

--- a/core/view/src/motion.cpp
+++ b/core/view/src/motion.cpp
@@ -657,7 +657,26 @@ bool components_differ(
     if (a.size() != b.size()) return true;
     for (std::size_t i = 0; i < a.size(); ++i) {
         if (a[i].first != b[i].first) return true;
-        if (std::fabs(a[i].second - b[i].second) > epsilon) return true;
+        const double av = a[i].second;
+        const double bv = b[i].second;
+        // IEEE-754 special handling: a transition into or out of a
+        // non-finite value is meaningful (an animation going NaN/Inf
+        // is a debug signal, not a no-op). fabs(av - bv) would yield
+        // NaN and silently mask the change because NaN > epsilon is
+        // false.
+        const bool a_finite = std::isfinite(av);
+        const bool b_finite = std::isfinite(bv);
+        if (a_finite != b_finite) return true;
+        if (!a_finite && !b_finite) {
+            // Both non-finite: bitwise compare so NaN vs +Inf vs -Inf
+            // are all distinguishable. (NaN != NaN under ==, but
+            // memcmp distinguishes payloads — for our purposes any
+            // NaN-to-NaN is "still NaN," not a change.)
+            if (std::isnan(av) != std::isnan(bv)) return true;
+            if (!std::isnan(av) && av != bv) return true;
+            continue;
+        }
+        if (std::fabs(av - bv) > epsilon) return true;
     }
     return false;
 }
@@ -935,7 +954,15 @@ std::string json_escape(std::string_view s) {
 }
 
 std::string format_number(double v) {
-    if (!std::isfinite(v)) return "null";
+    // Non-finite values are emitted as quoted sentinels rather than
+    // JSON `null` so the fixture round-trips losslessly — NaN / Inf
+    // are exactly the values you most want to capture when an
+    // animation misbehaves. The parser below recognizes the same
+    // three sentinels and converts them back to the matching IEEE-754
+    // value.
+    if (std::isnan(v))               return "\"NaN\"";
+    if (std::isinf(v) && v > 0)      return "\"Infinity\"";
+    if (std::isinf(v) && v < 0)      return "\"-Infinity\"";
     std::ostringstream ss;
     ss << std::setprecision(15) << v;
     return ss.str();
@@ -1162,6 +1189,24 @@ private:
         return true;
     }
 
+    /// Accepts a numeric literal OR one of the quoted sentinels
+    /// `"NaN"`, `"Infinity"`, `"-Infinity"`. `format_number` writes
+    /// non-finite values as those sentinels so the round-trip
+    /// preserves NaN/Inf — typically the most diagnostic samples in a
+    /// misbehaving animation.
+    bool parse_number_or_sentinel(double& out) {
+        skip_ws();
+        if (peek() == '"') {
+            std::string s;
+            if (!parse_string(s)) return false;
+            if (s == "NaN")        { out = std::numeric_limits<double>::quiet_NaN(); return true; }
+            if (s == "Infinity")   { out = std::numeric_limits<double>::infinity();  return true; }
+            if (s == "-Infinity")  { out = -std::numeric_limits<double>::infinity(); return true; }
+            return false;
+        }
+        return parse_number(out);
+    }
+
     bool parse_components(std::vector<std::pair<std::string, double>>& out) {
         out.clear();
         if (!expect('{')) return false;
@@ -1171,7 +1216,7 @@ private:
             std::string k;
             if (!parse_string(k) || !expect(':')) return false;
             double v;
-            if (!parse_number(v)) return false;
+            if (!parse_number_or_sentinel(v)) return false;
             out.emplace_back(std::move(k), v);
             skip_ws();
             if (peek() == ',') { ++pos_; continue; }

--- a/core/view/src/motion.cpp
+++ b/core/view/src/motion.cpp
@@ -2,51 +2,208 @@
 
 #include <pulp/runtime/log.hpp>
 #include <pulp/view/frame_clock.hpp>
+#include <pulp/view/ui_components.hpp>
 #include <pulp/view/view.hpp>
 
 #include <algorithm>
 #include <cmath>
 #include <iomanip>
+#include <limits>
 #include <map>
 #include <mutex>
 #include <sstream>
+#include <vector>
 
 namespace pulp::view::motion {
 
-// ── Geometry walker (Layout source only in Phase 0) ──────────────────
+// ── Geometry walker — Layout + Presentation (Phase 2) ────────────────
+//
+// Layout source: walks parent `bounds().{x,y}` translations and ignores
+// paint-time transforms (transforms are paint-only per view.hpp).
+//
+// Presentation source: composes the full `paint_all()`-order affine
+// chain (bounds translate + transform-origin pivot + translate / rotate
+// / scale around it + the explicit 2D affine matrix) plus ScrollView's
+// child-offset translate for any ancestor scroll container. The chain
+// is built root-down, then the leaf's local-bounds corners are mapped
+// through it and the axis-aligned bounding box is reported.
 
 namespace {
 
-Rect layout_rect_in_global(const pulp::view::View& v) {
-    Rect r = v.bounds();
-    const pulp::view::View* p = v.parent();
-    while (p) {
-        const Rect pb = p->bounds();
-        r.x += pb.x;
-        r.y += pb.y;
-        p = p->parent();
+/// Column-major 2D affine. Maps (x, y) → (a·x + c·y + tx, b·x + d·y + ty).
+struct Mat2D {
+    float a = 1.0f, b = 0.0f, c = 0.0f, d = 1.0f, tx = 0.0f, ty = 0.0f;
+
+    static constexpr Mat2D identity() { return {}; }
+
+    /// Right-multiply: result = lhs * rhs. Mirrors `canvas.concat_*` ops
+    /// which post-multiply onto the current matrix.
+    static Mat2D multiply(const Mat2D& l, const Mat2D& r) {
+        return {
+            l.a * r.a + l.c * r.b,
+            l.b * r.a + l.d * r.b,
+            l.a * r.c + l.c * r.d,
+            l.b * r.c + l.d * r.d,
+            l.a * r.tx + l.c * r.ty + l.tx,
+            l.b * r.tx + l.d * r.ty + l.ty,
+        };
     }
-    return r;
+
+    static Mat2D translation(float x, float y) {
+        Mat2D m; m.tx = x; m.ty = y; return m;
+    }
+    static Mat2D scale_uniform(float s) {
+        Mat2D m; m.a = s; m.d = s; return m;
+    }
+    static Mat2D rotation_rad(float r) {
+        const float c = std::cos(r), s = std::sin(r);
+        Mat2D m;
+        m.a = c; m.b = s;
+        m.c = -s; m.d = c;
+        return m;
+    }
+    /// Raw affine in (a,b,c,d,e,f) form matching canvas::concat_transform.
+    static Mat2D affine(float a, float b, float c, float d, float e, float f) {
+        Mat2D m; m.a = a; m.b = b; m.c = c; m.d = d; m.tx = e; m.ty = f;
+        return m;
+    }
+
+    /// Apply the matrix to a 2D point.
+    void apply(float x, float y, float& out_x, float& out_y) const {
+        out_x = a * x + c * y + tx;
+        out_y = b * x + d * y + ty;
+    }
+};
+
+/// Compose this view's own paint-time transforms (translate + rotate +
+/// scale around transform-origin, then the full 2D matrix around the
+/// same origin when set explicitly). Excludes the leading
+/// `translate(bounds.x, bounds.y)` — callers compose that separately.
+Mat2D self_transform(const pulp::view::View& v) {
+    Mat2D m = Mat2D::identity();
+    const float w = v.bounds().width;
+    const float h = v.bounds().height;
+    const float ox = w * v.transform_origin_x();
+    const float oy = h * v.transform_origin_y();
+
+    const bool has_basic =
+        v.scale() != 1.0f || v.rotation() != 0.0f ||
+        v.translate_x() != 0.0f || v.translate_y() != 0.0f;
+    if (has_basic) {
+        m = Mat2D::multiply(m, Mat2D::translation(ox, oy));
+        if (v.translate_x() != 0.0f || v.translate_y() != 0.0f) {
+            m = Mat2D::multiply(m, Mat2D::translation(v.translate_x(),
+                                                      v.translate_y()));
+        }
+        if (v.rotation() != 0.0f) {
+            constexpr float kPi = 3.14159265358979323846f;
+            m = Mat2D::multiply(m, Mat2D::rotation_rad(v.rotation() * kPi / 180.0f));
+        }
+        if (v.scale() != 1.0f) {
+            m = Mat2D::multiply(m, Mat2D::scale_uniform(v.scale()));
+        }
+        m = Mat2D::multiply(m, Mat2D::translation(-ox, -oy));
+    }
+
+    if (v.has_transform_matrix()) {
+        float a, b, c, d, e, f;
+        v.get_transform_matrix(a, b, c, d, e, f);
+        const bool apply_origin = v.transform_origin_explicit();
+        if (apply_origin) m = Mat2D::multiply(m, Mat2D::translation(ox, oy));
+        m = Mat2D::multiply(m, Mat2D::affine(a, b, c, d, e, f));
+        if (apply_origin) m = Mat2D::multiply(m, Mat2D::translation(-ox, -oy));
+    }
+
+    return m;
+}
+
+/// Returns the parent-level paint contribution that the child sees on
+/// the canvas matrix when `parent` calls `paint_all` and then paints a
+/// child via `child->paint_all(canvas)`. For plain `View`, this is
+/// `translate(bounds.x, bounds.y) * self_transform`. For `ScrollView`,
+/// the override skips parent transforms and substitutes a scroll
+/// translate, so the contribution is
+/// `translate(bounds.x - scroll_x, bounds.y - scroll_y)`.
+Mat2D parent_to_child_origin(const pulp::view::View& parent) {
+    const auto& pb = parent.bounds();
+    if (auto* sv = dynamic_cast<const pulp::view::ScrollView*>(&parent)) {
+        return Mat2D::translation(pb.x - sv->scroll_x(), pb.y - sv->scroll_y());
+    }
+    Mat2D base = Mat2D::translation(pb.x, pb.y);
+    return Mat2D::multiply(base, self_transform(parent));
+}
+
+/// Build the matrix that maps `v`'s local coords into the global frame
+/// (root-relative). Walks root-down so multiplication order matches the
+/// canvas: M = T(root.bounds) * X(root) * T(c1.bounds) * X(c1) * …
+Mat2D local_to_global_matrix(const pulp::view::View& v,
+                             bool include_self_transform) {
+    std::vector<const pulp::view::View*> chain;
+    for (const pulp::view::View* p = &v; p; p = p->parent()) {
+        chain.push_back(p);
+    }
+    std::reverse(chain.begin(), chain.end());
+
+    Mat2D m = Mat2D::identity();
+    for (std::size_t i = 0; i < chain.size(); ++i) {
+        const pulp::view::View* node = chain[i];
+        const bool is_leaf = (i + 1 == chain.size());
+        if (!is_leaf) {
+            m = Mat2D::multiply(m, parent_to_child_origin(*node));
+        } else {
+            // Leaf: always apply its own bounds translate so we land
+            // on its top-left in parent's frame, then optionally its
+            // self transform.
+            m = Mat2D::multiply(m, Mat2D::translation(node->bounds().x,
+                                                       node->bounds().y));
+            if (include_self_transform) {
+                m = Mat2D::multiply(m, self_transform(*node));
+            }
+        }
+    }
+    return m;
+}
+
+/// Axis-aligned bounding box of the leaf's local rect `(0,0,w,h)` after
+/// being mapped through `m`.
+Rect aabb_local_through(const Mat2D& m, float w, float h) {
+    float xs[4]; float ys[4];
+    m.apply(0.f, 0.f, xs[0], ys[0]);
+    m.apply(w,   0.f, xs[1], ys[1]);
+    m.apply(0.f, h,   xs[2], ys[2]);
+    m.apply(w,   h,   xs[3], ys[3]);
+    float min_x = xs[0], max_x = xs[0], min_y = ys[0], max_y = ys[0];
+    for (int i = 1; i < 4; ++i) {
+        min_x = std::min(min_x, xs[i]);
+        max_x = std::max(max_x, xs[i]);
+        min_y = std::min(min_y, ys[i]);
+        max_y = std::max(max_y, ys[i]);
+    }
+    return { min_x, min_y, max_x - min_x, max_y - min_y };
+}
+
+Rect layout_rect_in_global(const pulp::view::View& v) {
+    const Mat2D m = local_to_global_matrix(v, /*include_self_transform=*/false);
+    return aabb_local_through(m, v.bounds().width, v.bounds().height);
+}
+
+Rect presentation_rect_in_global(const pulp::view::View& v) {
+    const Mat2D m = local_to_global_matrix(v, /*include_self_transform=*/true);
+    return aabb_local_through(m, v.bounds().width, v.bounds().height);
 }
 
 Rect resolve_geometry(pulp::view::View& v,
                       GeometrySpace space,
                       GeometrySource source) {
-    // Phase 0: Presentation falls back to Layout. Phase 2 ships the full
-    // paint_all()-order walker (transform-origin, transform_matrix,
-    // scroll, clip).
-    (void)source;
-    switch (space) {
-        case GeometrySpace::ViewLocal:
-            return { 0.0f, 0.0f, v.bounds().width, v.bounds().height };
-        case GeometrySpace::ViewGlobal:
-        case GeometrySpace::Window:
-        case GeometrySpace::Screen:
-            // Phase 0: Window/Screen collapse onto ViewGlobal. Phase 2
-            // adds window-origin and screen-origin offsets.
-            return layout_rect_in_global(v);
+    if (space == GeometrySpace::ViewLocal) {
+        return { 0.0f, 0.0f, v.bounds().width, v.bounds().height };
     }
-    return {};
+    // Window and Screen collapse onto ViewGlobal in Phase 2.
+    // Phase 6 adds window-origin / screen-origin offsets when the host
+    // exposes them.
+    return (source == GeometrySource::Presentation)
+               ? presentation_rect_in_global(v)
+               : layout_rect_in_global(v);
 }
 
 double extract_property(const Rect& r, GeometryProperty prop) {

--- a/core/view/src/motion.cpp
+++ b/core/view/src/motion.cpp
@@ -414,6 +414,28 @@ Sink make_buffer_sink(std::vector<SampleEvent>* buffer) {
     };
 }
 
+// ── Publish channel (Phase 3) ────────────────────────────────────────
+
+void publish_value(std::string view_name,
+                   std::string metric_name,
+                   double value,
+                   PublishOptions opts) {
+    std::vector<std::pair<std::string, double>> comps;
+    comps.emplace_back("value", value);
+    publish_components(std::move(view_name), std::move(metric_name),
+                       std::move(comps), opts);
+}
+
+void publish_components(std::string view_name,
+                        std::string metric_name,
+                        std::vector<std::pair<std::string, double>> components,
+                        PublishOptions opts) {
+    if (components.empty()) return;
+    Coordinator::instance().publish_internal(std::move(view_name),
+                                             std::move(metric_name),
+                                             std::move(components), opts);
+}
+
 // ── Coordinator internals ─────────────────────────────────────────────
 
 struct PerMetricState {
@@ -433,6 +455,24 @@ struct ActiveTrace {
     double accum_seconds = 0.0;
 };
 
+struct PublishKey {
+    std::string view_name;
+    std::string metric_name;
+    bool operator<(const PublishKey& o) const {
+        if (view_name != o.view_name) return view_name < o.view_name;
+        return metric_name < o.metric_name;
+    }
+};
+
+struct PublishState {
+    int precision = 3;
+    double epsilon = 0.0001;
+    std::vector<std::pair<std::string, double>> last_emitted;
+    std::vector<std::pair<std::string, double>> motion_start;
+    bool has_baseline = false;
+    bool in_motion = false;
+};
+
 struct Coordinator::State {
     mutable std::mutex mtx;
     pulp::view::FrameClock* clock = nullptr;
@@ -444,6 +484,10 @@ struct Coordinator::State {
     std::map<int, ActiveTrace> traces;
     int next_trace_id = 1;
     std::size_t emitted_count = 0;
+    // Per-(view, metric) burst state for publish_*. Independent of the
+    // sampler-driven trace map above so publishes and sampled traces
+    // don't interfere even on the same view/metric name.
+    std::map<PublishKey, PublishState> publish_states;
 };
 
 // ── Coordinator ───────────────────────────────────────────────────────
@@ -554,6 +598,7 @@ void Coordinator::reset() {
     std::lock_guard<std::mutex> lock(state_->mtx);
     state_->sinks.clear();
     state_->traces.clear();
+    state_->publish_states.clear();
     state_->tracing_enabled = false;
     state_->firehose = false;
     state_->emitted_count = 0;
@@ -675,6 +720,98 @@ void Coordinator::on_tick(float dt) {
                     mstate.in_motion = false;
                     mstate.motion_start.clear();
                 }
+            }
+        }
+    }
+    for (auto& [sink, ev] : pending) sink(ev);
+}
+
+// ── Coordinator::publish_internal (Phase 3) ───────────────────────────
+//
+// Defined after on_tick so `components_differ` (anonymous namespace
+// above) is in scope.
+
+void Coordinator::publish_internal(std::string view_name,
+                                   std::string metric_name,
+                                   std::vector<std::pair<std::string, double>> components,
+                                   PublishOptions opts) {
+    if (components.empty()) return;
+    sort_components(components);
+
+    // Same Baseline / Start / Sample / End burst-framing semantics as
+    // the sampler-driven coordinator path, just keyed by (view, metric)
+    // and only running when firehose is on (Phase 3 scope; Phase 5 adds
+    // filter-scoped subscriptions that match without firehose).
+    std::vector<std::pair<Sink, SampleEvent>> pending;
+    {
+        std::lock_guard<std::mutex> lock(state_->mtx);
+        if (!state_->tracing_enabled || state_->sinks.empty()) return;
+        if (!state_->firehose) return;
+
+        const double t_now =
+            state_->clock ? static_cast<double>(state_->clock->time()) : 0.0;
+        const std::uint64_t f_now =
+            state_->clock ? state_->clock->frame() : 0;
+
+        const PublishKey key{view_name, metric_name};
+        auto& pstate = state_->publish_states[key];
+        // Sticky: the first publish for a (view, metric) sets precision
+        // and epsilon. Subsequent calls inherit those so callers can
+        // omit `PublishOptions` on every tick without changing the
+        // per-key threshold.
+        if (!pstate.has_baseline) {
+            pstate.precision = opts.precision;
+            pstate.epsilon = opts.epsilon;
+        }
+
+        auto enqueue = [&](SampleEvent::Kind kind,
+                           std::vector<std::pair<std::string, double>> comps,
+                           std::vector<std::pair<std::string, double>> deltas = {}) {
+            SampleEvent e;
+            e.kind = kind;
+            e.view_name = view_name;
+            e.metric_name = metric_name;
+            e.t_seconds = t_now;
+            e.frame = f_now;
+            e.precision = pstate.precision;
+            e.components = std::move(comps);
+            e.deltas = std::move(deltas);
+            for (const auto& [sid, sink] : state_->sinks) {
+                (void)sid;
+                pending.emplace_back(sink, e);
+            }
+            state_->emitted_count++;
+        };
+
+        if (!pstate.has_baseline) {
+            enqueue(SampleEvent::Kind::Baseline, components);
+            pstate.last_emitted = components;
+            pstate.has_baseline = true;
+        } else {
+            const bool changed = components_differ(components,
+                                                   pstate.last_emitted,
+                                                   pstate.epsilon);
+            if (changed) {
+                if (!pstate.in_motion) {
+                    enqueue(SampleEvent::Kind::Start, {});
+                    pstate.motion_start = pstate.last_emitted;
+                    pstate.in_motion = true;
+                }
+                enqueue(SampleEvent::Kind::Sample, components);
+                pstate.last_emitted = components;
+            } else if (pstate.in_motion) {
+                std::vector<std::pair<std::string, double>> deltas;
+                deltas.reserve(components.size());
+                for (const auto& [name, cur] : components) {
+                    double start = 0.0;
+                    for (const auto& [sn, sv] : pstate.motion_start) {
+                        if (sn == name) { start = sv; break; }
+                    }
+                    deltas.emplace_back(name, cur - start);
+                }
+                enqueue(SampleEvent::Kind::End, {}, std::move(deltas));
+                pstate.in_motion = false;
+                pstate.motion_start.clear();
             }
         }
     }

--- a/core/view/src/motion.cpp
+++ b/core/view/src/motion.cpp
@@ -1,0 +1,527 @@
+#include <pulp/view/motion.hpp>
+
+#include <pulp/runtime/log.hpp>
+#include <pulp/view/frame_clock.hpp>
+#include <pulp/view/view.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <map>
+#include <mutex>
+#include <sstream>
+
+namespace pulp::view::motion {
+
+// ── Geometry walker (Layout source only in Phase 0) ──────────────────
+
+namespace {
+
+Rect layout_rect_in_global(const pulp::view::View& v) {
+    Rect r = v.bounds();
+    const pulp::view::View* p = v.parent();
+    while (p) {
+        const Rect pb = p->bounds();
+        r.x += pb.x;
+        r.y += pb.y;
+        p = p->parent();
+    }
+    return r;
+}
+
+Rect resolve_geometry(pulp::view::View& v,
+                      GeometrySpace space,
+                      GeometrySource source) {
+    // Phase 0: Presentation falls back to Layout. Phase 2 ships the full
+    // paint_all()-order walker (transform-origin, transform_matrix,
+    // scroll, clip).
+    (void)source;
+    switch (space) {
+        case GeometrySpace::ViewLocal:
+            return { 0.0f, 0.0f, v.bounds().width, v.bounds().height };
+        case GeometrySpace::ViewGlobal:
+        case GeometrySpace::Window:
+        case GeometrySpace::Screen:
+            // Phase 0: Window/Screen collapse onto ViewGlobal. Phase 2
+            // adds window-origin and screen-origin offsets.
+            return layout_rect_in_global(v);
+    }
+    return {};
+}
+
+double extract_property(const Rect& r, GeometryProperty prop) {
+    switch (prop) {
+        case GeometryProperty::MinX:   return r.x;
+        case GeometryProperty::MinY:   return r.y;
+        case GeometryProperty::MaxX:   return r.x + r.width;
+        case GeometryProperty::MaxY:   return r.y + r.height;
+        case GeometryProperty::MidX:   return r.x + r.width * 0.5;
+        case GeometryProperty::MidY:   return r.y + r.height * 0.5;
+        case GeometryProperty::Width:  return r.width;
+        case GeometryProperty::Height: return r.height;
+    }
+    return 0.0;
+}
+
+const char* property_name(GeometryProperty prop) {
+    switch (prop) {
+        case GeometryProperty::MinX:   return "minX";
+        case GeometryProperty::MinY:   return "minY";
+        case GeometryProperty::MaxX:   return "maxX";
+        case GeometryProperty::MaxY:   return "maxY";
+        case GeometryProperty::MidX:   return "midX";
+        case GeometryProperty::MidY:   return "midY";
+        case GeometryProperty::Width:  return "width";
+        case GeometryProperty::Height: return "height";
+    }
+    return "?";
+}
+
+std::string fmt_double(double v, int precision) {
+    std::ostringstream ss;
+    ss << std::fixed << std::setprecision(std::max(0, precision)) << v;
+    return ss.str();
+}
+
+}  // namespace
+
+// ── Metric specs ──────────────────────────────────────────────────────
+
+struct MetricBase {
+    std::string name;
+    int precision = 3;
+    double epsilon = 0.0001;
+    virtual ~MetricBase() = default;
+    virtual std::vector<std::pair<std::string, double>> sample() const = 0;
+};
+
+struct ValueMetric : MetricBase {
+    std::vector<std::pair<std::string, TraceBuilder::ValueSampler>> components;
+    std::vector<std::pair<std::string, double>> sample() const override {
+        std::vector<std::pair<std::string, double>> out;
+        out.reserve(components.size());
+        for (const auto& c : components) {
+            out.emplace_back(c.first, c.second());
+        }
+        return out;
+    }
+};
+
+struct GeometryMetric : MetricBase {
+    pulp::view::View* target = nullptr;
+    std::vector<GeometryProperty> props;
+    GeometrySpace space = GeometrySpace::Window;
+    GeometrySource source = GeometrySource::Layout;
+    std::vector<std::pair<std::string, double>> sample() const override {
+        std::vector<std::pair<std::string, double>> out;
+        if (!target) return out;
+        const Rect r = resolve_geometry(*target, space, source);
+        for (auto p : props) {
+            out.emplace_back(property_name(p), extract_property(r, p));
+        }
+        return out;
+    }
+};
+
+struct TraceBuilder::Spec {
+    std::string view_name;
+    TraceOptions opts;
+    std::vector<std::unique_ptr<MetricBase>> metrics;
+};
+
+// ── TraceBuilder ──────────────────────────────────────────────────────
+
+TraceBuilder::TraceBuilder(Coordinator* coord, std::string view_name,
+                           TraceOptions opts)
+    : spec_(std::make_shared<Spec>()), coord_(coord) {
+    spec_->view_name = std::move(view_name);
+    spec_->opts = opts;
+}
+
+TraceBuilder& TraceBuilder::value(std::string name, ValueSampler sampler,
+                                  int precision, double epsilon) {
+    auto m = std::make_unique<ValueMetric>();
+    m->name = std::move(name);
+    m->precision = precision;
+    m->epsilon = epsilon;
+    m->components.emplace_back("value", std::move(sampler));
+    spec_->metrics.push_back(std::move(m));
+    return *this;
+}
+
+TraceBuilder& TraceBuilder::multi(std::string name,
+                                  std::vector<Component> components,
+                                  int precision, double epsilon) {
+    auto m = std::make_unique<ValueMetric>();
+    m->name = std::move(name);
+    m->precision = precision;
+    m->epsilon = epsilon;
+    m->components = std::move(components);
+    spec_->metrics.push_back(std::move(m));
+    return *this;
+}
+
+TraceBuilder& TraceBuilder::geometry(std::string name,
+                                     pulp::view::View& target,
+                                     std::vector<GeometryProperty> props,
+                                     GeometrySpace space,
+                                     GeometrySource source,
+                                     int precision, double epsilon) {
+    auto m = std::make_unique<GeometryMetric>();
+    m->name = std::move(name);
+    m->precision = precision;
+    m->epsilon = epsilon;
+    m->target = &target;
+    m->props = std::move(props);
+    m->space = space;
+    m->source = source;
+    spec_->metrics.push_back(std::move(m));
+    return *this;
+}
+
+TraceHandle TraceBuilder::attach() {
+    if (!coord_) return TraceHandle();
+    const int id = coord_->register_trace(spec_);
+    return TraceHandle(id, coord_);
+}
+
+// ── TraceHandle ───────────────────────────────────────────────────────
+
+TraceHandle::TraceHandle(TraceHandle&& other) noexcept
+    : id_(other.id_), coord_(other.coord_) {
+    other.id_ = 0;
+    other.coord_ = nullptr;
+}
+
+TraceHandle& TraceHandle::operator=(TraceHandle&& other) noexcept {
+    if (this != &other) {
+        detach();
+        id_ = other.id_;
+        coord_ = other.coord_;
+        other.id_ = 0;
+        other.coord_ = nullptr;
+    }
+    return *this;
+}
+
+TraceHandle::~TraceHandle() { detach(); }
+
+void TraceHandle::detach() {
+    if (coord_) {
+        coord_->detach(id_);
+        coord_ = nullptr;
+        id_ = 0;
+    }
+}
+
+// ── format_line + sinks ───────────────────────────────────────────────
+
+std::string format_line(const SampleEvent& e) {
+    std::ostringstream ss;
+    ss << "[PulpMotion][" << e.view_name << "][" << e.metric_name << "]";
+    switch (e.kind) {
+        case SampleEvent::Kind::Baseline:
+        case SampleEvent::Kind::Sample: {
+            bool first = true;
+            for (const auto& [k, v] : e.components) {
+                ss << (first ? " " : " ");
+                ss << k << "=" << fmt_double(v, e.precision);
+                first = false;
+            }
+            break;
+        }
+        case SampleEvent::Kind::Start:
+            ss << " -- Start frame=" << e.frame
+               << " t=" << fmt_double(e.t_seconds, 6) << " --";
+            break;
+        case SampleEvent::Kind::End:
+            ss << " -- End frame=" << e.frame
+               << " t=" << fmt_double(e.t_seconds, 6) << " --";
+            for (const auto& [k, v] : e.deltas) {
+                ss << " " << k << "Delta=" << fmt_double(v, e.precision);
+            }
+            break;
+    }
+    return ss.str();
+}
+
+Sink make_log_sink() {
+    return [](const SampleEvent& e) {
+        pulp::runtime::log_debug("{}", format_line(e));
+    };
+}
+
+Sink make_buffer_sink(std::vector<SampleEvent>* buffer) {
+    return [buffer](const SampleEvent& e) {
+        if (buffer) buffer->push_back(e);
+    };
+}
+
+// ── Coordinator internals ─────────────────────────────────────────────
+
+struct PerMetricState {
+    int precision = 3;
+    double epsilon = 0.0001;
+    std::vector<std::pair<std::string, double>> current;
+    std::vector<std::pair<std::string, double>> last_emitted;
+    std::vector<std::pair<std::string, double>> motion_start;
+    bool has_baseline = false;
+    bool in_motion = false;
+};
+
+struct ActiveTrace {
+    int id = 0;
+    std::shared_ptr<TraceBuilder::Spec> spec;
+    std::vector<PerMetricState> metrics;
+    double accum_seconds = 0.0;
+};
+
+struct Coordinator::State {
+    mutable std::mutex mtx;
+    pulp::view::FrameClock* clock = nullptr;
+    int clock_sub_id = 0;
+    bool tracing_enabled = false;
+    bool firehose = false;
+    std::map<int, Sink> sinks;
+    int next_sink_id = 1;
+    std::map<int, ActiveTrace> traces;
+    int next_trace_id = 1;
+    std::size_t emitted_count = 0;
+};
+
+// ── Coordinator ───────────────────────────────────────────────────────
+
+Coordinator& Coordinator::instance() {
+    static Coordinator inst;
+    return inst;
+}
+
+Coordinator::Coordinator() : state_(std::make_unique<State>()) {}
+Coordinator::~Coordinator() { unbind(); }
+
+void Coordinator::bind(pulp::view::FrameClock& clock) {
+    unbind();
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    state_->clock = &clock;
+    state_->clock_sub_id = clock.subscribe([this](float dt) {
+        on_tick(dt);
+        return true;
+    });
+}
+
+void Coordinator::unbind() {
+    pulp::view::FrameClock* clock = nullptr;
+    int sub_id = 0;
+    {
+        std::lock_guard<std::mutex> lock(state_->mtx);
+        clock = state_->clock;
+        sub_id = state_->clock_sub_id;
+        state_->clock = nullptr;
+        state_->clock_sub_id = 0;
+    }
+    if (clock && sub_id) clock->unsubscribe(sub_id);
+}
+
+bool Coordinator::is_bound() const noexcept {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    return state_->clock != nullptr;
+}
+
+int Coordinator::add_sink(Sink sink) {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    const int id = state_->next_sink_id++;
+    state_->sinks.emplace(id, std::move(sink));
+    return id;
+}
+
+void Coordinator::remove_sink(int id) {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    state_->sinks.erase(id);
+}
+
+void Coordinator::clear_sinks() {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    state_->sinks.clear();
+}
+
+int Coordinator::install_default_log_sink() {
+    return add_sink(make_log_sink());
+}
+
+void Coordinator::set_tracing_enabled(bool on) {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    state_->tracing_enabled = on;
+}
+
+bool Coordinator::tracing_enabled() const noexcept {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    return state_->tracing_enabled;
+}
+
+void Coordinator::set_firehose(bool on) {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    state_->firehose = on;
+}
+
+bool Coordinator::firehose() const noexcept {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    return state_->firehose;
+}
+
+TraceBuilder Coordinator::trace(std::string view_name, TraceOptions opts) {
+    return TraceBuilder(this, std::move(view_name), opts);
+}
+
+int Coordinator::register_trace(std::shared_ptr<TraceBuilder::Spec> spec) {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    const int id = state_->next_trace_id++;
+    ActiveTrace t;
+    t.id = id;
+    t.spec = spec;
+    t.metrics.resize(spec->metrics.size());
+    for (std::size_t i = 0; i < spec->metrics.size(); ++i) {
+        t.metrics[i].precision = spec->metrics[i]->precision;
+        t.metrics[i].epsilon = spec->metrics[i]->epsilon;
+    }
+    state_->traces.emplace(id, std::move(t));
+    return id;
+}
+
+void Coordinator::detach(int trace_id) {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    state_->traces.erase(trace_id);
+}
+
+void Coordinator::reset() {
+    unbind();
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    state_->sinks.clear();
+    state_->traces.clear();
+    state_->tracing_enabled = false;
+    state_->firehose = false;
+    state_->emitted_count = 0;
+    state_->next_sink_id = 1;
+    state_->next_trace_id = 1;
+}
+
+std::size_t Coordinator::active_trace_count() const noexcept {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    return state_->traces.size();
+}
+
+std::size_t Coordinator::emitted_event_count() const noexcept {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    return state_->emitted_count;
+}
+
+namespace {
+
+bool components_differ(
+    const std::vector<std::pair<std::string, double>>& a,
+    const std::vector<std::pair<std::string, double>>& b,
+    double epsilon
+) {
+    if (a.size() != b.size()) return true;
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        if (a[i].first != b[i].first) return true;
+        if (std::fabs(a[i].second - b[i].second) > epsilon) return true;
+    }
+    return false;
+}
+
+void sort_components(std::vector<std::pair<std::string, double>>& v) {
+    std::sort(v.begin(), v.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+}
+
+}  // namespace
+
+void Coordinator::on_tick(float dt) {
+    // Collect events under lock, dispatch outside the lock.
+    std::vector<std::pair<Sink, SampleEvent>> pending;
+    {
+        std::lock_guard<std::mutex> lock(state_->mtx);
+        if (!state_->tracing_enabled || state_->sinks.empty()) return;
+
+        const double t_now =
+            state_->clock ? static_cast<double>(state_->clock->time()) : 0.0;
+        const std::uint64_t f_now =
+            state_->clock ? state_->clock->frame() : 0;
+
+        for (auto& [trace_id, trace] : state_->traces) {
+            const int fps = std::max(1, trace.spec->opts.fps);
+            const double period = 1.0 / static_cast<double>(fps);
+            trace.accum_seconds += static_cast<double>(dt);
+            if (trace.accum_seconds + 1e-9 < period) continue;
+            trace.accum_seconds -= period;
+            // Drift cap: if dt > 2 periods we sample once then reset the
+            // accumulator instead of bursting catch-up samples.
+            if (trace.accum_seconds > period * 2.0) trace.accum_seconds = 0.0;
+
+            for (std::size_t i = 0; i < trace.spec->metrics.size(); ++i) {
+                auto& metric = *trace.spec->metrics[i];
+                auto& mstate = trace.metrics[i];
+
+                auto sampled = metric.sample();
+                if (sampled.empty()) continue;
+                sort_components(sampled);
+                mstate.current = sampled;
+
+                auto enqueue = [&](SampleEvent::Kind kind,
+                                   std::vector<std::pair<std::string, double>> comps,
+                                   std::vector<std::pair<std::string, double>> deltas = {}) {
+                    SampleEvent e;
+                    e.kind = kind;
+                    e.view_name = trace.spec->view_name;
+                    e.metric_name = metric.name;
+                    e.t_seconds = t_now;
+                    e.frame = f_now;
+                    e.precision = mstate.precision;
+                    e.components = std::move(comps);
+                    e.deltas = std::move(deltas);
+                    for (const auto& [sid, sink] : state_->sinks) {
+                        (void)sid;
+                        pending.emplace_back(sink, e);
+                    }
+                    state_->emitted_count++;
+                };
+
+                if (!mstate.has_baseline) {
+                    enqueue(SampleEvent::Kind::Baseline, mstate.current);
+                    mstate.last_emitted = mstate.current;
+                    mstate.has_baseline = true;
+                    continue;
+                }
+
+                const bool changed = components_differ(mstate.current,
+                                                       mstate.last_emitted,
+                                                       mstate.epsilon);
+                if (changed) {
+                    if (!mstate.in_motion) {
+                        enqueue(SampleEvent::Kind::Start, {});
+                        mstate.motion_start = mstate.last_emitted;
+                        mstate.in_motion = true;
+                    }
+                    enqueue(SampleEvent::Kind::Sample, mstate.current);
+                    mstate.last_emitted = mstate.current;
+                } else if (mstate.in_motion) {
+                    std::vector<std::pair<std::string, double>> deltas;
+                    deltas.reserve(mstate.current.size());
+                    for (const auto& [name, cur] : mstate.current) {
+                        double start = 0.0;
+                        for (const auto& [sn, sv] : mstate.motion_start) {
+                            if (sn == name) { start = sv; break; }
+                        }
+                        deltas.emplace_back(name, cur - start);
+                    }
+                    enqueue(SampleEvent::Kind::End, {}, std::move(deltas));
+                    mstate.in_motion = false;
+                    mstate.motion_start.clear();
+                }
+            }
+        }
+    }
+    for (auto& [sink, ev] : pending) sink(ev);
+}
+
+}  // namespace pulp::view::motion

--- a/docs/guides/motion-observability.md
+++ b/docs/guides/motion-observability.md
@@ -80,15 +80,45 @@ of where the view actually renders.
 Each tick produces zero or more `SampleEvent`s. The lifecycle for a single
 metric:
 
-1. **`Baseline`** on the first tick — initial value sample.
-2. **`Start`** on the first tick after a baseline where the value changed
-   beyond the metric's epsilon.
-3. **`Sample`** while the value continues changing.
-4. **`End`** on the first stable tick after a change burst, carrying
+1. **`TraceStarted`** once per trace registration (first tick after attach).
+   Carries the trace's `Provenance` envelope and the stable `trace_id`.
+2. **`Baseline`** on the first tick — initial value sample.
+3. **`Start`** on the first tick after a baseline where the value changed
+   beyond the metric's epsilon. Each burst gets a new `burst_id`.
+4. **`Sample`** while the value continues changing.
+5. **`End`** on the first stable tick after a change burst, carrying
    per-component deltas from the start of the burst.
+
+Every event carries stable identifiers (`trace_id`, `metric_id`, `burst_id`)
+so a fixture comparison can align bursts by identity rather than position —
+reordered identical bursts no longer false-fail an `assert_matches`.
 
 Timestamps are monotonic from `FrameClock::time()` and `FrameClock::frame()` —
 deterministic on the scripted-capture path, no wall-clock drift in CI.
+
+### Provenance
+
+A `Provenance` envelope describes where a trace came from — the animation
+primitive that emits it, the source file and line that registered it, or the
+imported-design node that authored it. Attach it on the builder:
+
+```cpp
+auto handle = Coordinator::instance()
+    .trace("Card", { 60 })
+    .with_provenance({ /*source_kind=*/"tween",
+                       /*source_id=*/"Card.opacity",
+                       /*source_file=*/__FILE__,
+                       /*source_line=*/__LINE__ })
+    .value("opacity", [&] { return opacity; })
+    .attach();
+```
+
+The envelope appears on the `TraceStarted` event and round-trips through
+fixtures. Agents reading a fixture can resolve "where does this animation
+live?" without grepping. The richer adapters that auto-populate provenance
+from `Tween` / CSS `TransitionSpec` / `AnimatorSet` / JS rAF / design-import
+land in a follow-up phase; today the envelope is opt-in via
+`with_provenance(...)`.
 
 ### Sinks
 

--- a/docs/guides/motion-observability.md
+++ b/docs/guides/motion-observability.md
@@ -1,0 +1,278 @@
+# Motion Observability Guide
+
+Pulp Motion is the framework's agent-first motion observability system. It turns
+"this animation feels wrong" into measurable, machine-readable evidence: a
+time-ordered stream of geometry and value samples with `Start` / `End` burst
+framing, monotonic timestamps, deterministic capture, runtime-attachable over
+the inspector wire, and a Python visual-analysis pipeline for pixel-truth
+fallback.
+
+The system is off by default — there is zero overhead when tracing is disabled.
+
+## When to use it
+
+| Symptom | Reach for |
+|---|---|
+| "This fade looks slow / late / fast" | `motion::trace(...).value(...)` on the opacity source, then `settling_time_seconds` |
+| "These two cards drift apart during a transition" | Two `motion::trace(...).geometry(...)` traces in the same coordinate space |
+| "Did anything actually move on screen?" | `GeometrySource::Presentation` + `GeometrySpace::Window` |
+| "ScrollView jumps when restored from state" | `motion::trace(...).geometry(...)` on a child of the scroll container — the walker honors the scroll offset |
+| "An imported Figma animation looks subtly off" | Record a fixture, assert against the imported intent (timing, monotonicity, settling time) |
+| "Frames look fine, the value series is correct, but the rendered effect is wrong" | Capture frames, run `tools/motion/visual/analyze_sequence.py` |
+
+## Core concepts
+
+### Coordinator
+
+`pulp::view::motion::Coordinator` is a process-wide singleton bound to a
+`FrameClock`. It owns one tick subscription and dispatches sample events to all
+registered sinks.
+
+```cpp
+#include <pulp/view/motion.hpp>
+using namespace pulp::view::motion;
+
+FrameClock clock;
+Coordinator::instance().bind(clock);
+Coordinator::instance().set_tracing_enabled(true);
+int log_sink = Coordinator::instance().install_default_log_sink();
+```
+
+When tracing is disabled (the default) the `FrameClock` callback is a single
+branch and returns immediately.
+
+### Trace builder DSL
+
+A trace declares one or more metrics on a logical "view" name. Metrics are
+sampled on each tick at the trace's configured FPS.
+
+```cpp
+double opacity = 1.0;
+auto handle = Coordinator::instance()
+    .trace("Card", { /*fps=*/30 })
+    .value("opacity", [&] { return opacity; })
+    .geometry("frame", card_view,
+              { GeometryProperty::MinX, GeometryProperty::MinY,
+                GeometryProperty::Width, GeometryProperty::Height },
+              GeometrySpace::Window, GeometrySource::Presentation)
+    .attach();
+```
+
+`TraceHandle` is RAII — when it goes out of scope the trace detaches. The
+metric label appears in log output and in inspector events.
+
+### Geometry source: Layout vs Presentation
+
+`GeometrySource::Layout` reports the Yoga-computed frame, ignoring paint-time
+transforms. `GeometrySource::Presentation` mirrors `View::paint_all()` exactly
+— transform-origin, translate / rotate / scale, the full 2D affine matrix, and
+ScrollView ancestor scroll offsets — and returns the axis-aligned bounding box
+of where the view actually renders.
+
+| Question | Source | Space |
+|---|---|---|
+| "Did Yoga move it?" | `Layout` | `ViewGlobal` |
+| "Did anything visible move on screen?" | `Presentation` | `Window` |
+| "Is it positioned correctly within its container?" | `Layout` | `ViewLocal` |
+
+### Sample event shape
+
+Each tick produces zero or more `SampleEvent`s. The lifecycle for a single
+metric:
+
+1. **`Baseline`** on the first tick — initial value sample.
+2. **`Start`** on the first tick after a baseline where the value changed
+   beyond the metric's epsilon.
+3. **`Sample`** while the value continues changing.
+4. **`End`** on the first stable tick after a change burst, carrying
+   per-component deltas from the start of the burst.
+
+Timestamps are monotonic from `FrameClock::time()` and `FrameClock::frame()` —
+deterministic on the scripted-capture path, no wall-clock drift in CI.
+
+### Sinks
+
+Sinks consume sample events. Three built-in sinks:
+
+| Sink | Purpose |
+|---|---|
+| `make_log_sink()` | Writes one `[PulpMotion][view][metric] key=value ...` line per event via `pulp::runtime::log_debug` |
+| `make_buffer_sink(buffer*)` | Appends events to a caller-owned `std::vector<SampleEvent>` (tests, in-process consumers) |
+| `make_fixture_sink(path)` | Writes a versioned JSONL fixture to disk — the artifact format |
+
+Custom sinks are any `std::function<void(const SampleEvent&)>`:
+
+```cpp
+Coordinator::instance().add_sink([](const SampleEvent& e) {
+    if (e.kind == SampleEvent::Kind::End && e.metric_name == "opacity") {
+        send_alert("fade burst ended: " + format_line(e));
+    }
+});
+```
+
+## Runtime attach via the inspector
+
+The `Motion.*` inspector domain lets agents attach traces over TCP without
+editing source. The standalone preview app exposes it behind
+`PULP_MOTION_SERVER=1`:
+
+```bash
+PULP_MOTION_SERVER=1 ./build/examples/ui-preview/pulp-ui-preview
+# "Motion inspector listening on port 9147"
+```
+
+Protocol requests:
+
+| Method | Params | Result |
+|---|---|---|
+| `Motion.startTrace` | `{view_name, fps, metrics:[{kind:"geometry",name,node_id,properties,space,source}]}` | `{trace_id}` |
+| `Motion.stopTrace` | `{trace_id}` | `{removed}` |
+| `Motion.snapshot` | `{}` | `{tracing_enabled, firehose, active_traces, inspector_traces, emitted_events}` |
+| `Motion.listTraces` | `{}` | `{trace_ids:[…]}` |
+
+The server broadcasts `Motion.start`, `Motion.sample`, and `Motion.end` events
+to all connected clients as samples are emitted. Subscribing clients receive a
+clean stream for the trace they registered — concurrent unrelated animations
+do not bleed into the stream unless the firehose is on (see below).
+
+### Env knobs in `pulp-ui-preview`
+
+| Variable | Effect |
+|---|---|
+| `PULP_MOTION_LOG=1` | Install the default log sink and enable tracing |
+| `PULP_MOTION_SERVER=1` | Start the inspector server + Motion domain on port 9147 |
+| `PULP_MOTION_FIREHOSE=1` | Enable the publish firehose so every `publish_value`/`publish_components` call broadcasts to all sinks |
+
+## The publish channel
+
+Animation primitives that already advance once per frame can publish their
+intermediate values without taking a sampler subscription:
+
+```cpp
+#include <pulp/view/motion.hpp>
+
+// Inside an animation's per-frame advance:
+pulp::view::motion::publish_value("Card", "opacity", current_opacity);
+```
+
+When `tracing_enabled` is false (default) `publish_value` is a single branch and
+returns. When `tracing_enabled` is true AND `firehose` is on, every publish
+fans out as a `SampleEvent` to all sinks. Filter-scoped subscriptions (publishes
+that route only to a single subscriber) are a future addition.
+
+Per-(view, metric) `precision` and `epsilon` are sticky — set on the first
+publish and inherited on subsequent calls so hot-path callers can omit
+`PublishOptions` every tick.
+
+## Fixtures (record / replay / assert)
+
+A fixture is the on-disk form of a motion stream — a versioned JSONL file that
+captures a complete run for replay, comparison, or CI gating.
+
+### Recording
+
+```cpp
+auto fixture_sink = pulp::view::motion::make_fixture_sink("/tmp/card-open.motion.jsonl");
+int sink_id = Coordinator::instance().add_sink(std::move(fixture_sink));
+// ... drive the animation ...
+Coordinator::instance().remove_sink(sink_id);  // closes the file
+```
+
+### Replay
+
+```cpp
+std::vector<SampleEvent> replayed;
+int n = pulp::view::motion::replay_fixture(
+    "/tmp/card-open.motion.jsonl",
+    pulp::view::motion::make_buffer_sink(&replayed));
+```
+
+### Compare
+
+```cpp
+auto golden   = pulp::view::motion::load_fixture("test/motion/goldens/card-open.motion.jsonl");
+auto captured = pulp::view::motion::load_fixture("/tmp/card-open.motion.jsonl");
+
+auto diff = pulp::view::motion::assert_matches(golden, captured);
+if (!diff.matches()) {
+    for (const auto& it : diff.differences) {
+        std::cerr << it.kind << " " << it.view_name << "." << it.metric_name
+                  << "." << it.component_name
+                  << " expected=" << it.expected << " observed=" << it.observed
+                  << " (" << it.detail << ")\n";
+    }
+}
+```
+
+`FixtureMatchOptions` controls per-component epsilon, timing epsilon, and
+whether event counts must match exactly.
+
+## Assertion helpers
+
+Use these for unit tests and for the assertion CLI. Each takes a `ScalarSample`
+series extracted with `extract_scalar(events, view, metric, component)`.
+
+| Helper | What it measures |
+|---|---|
+| `is_monotonic(samples, epsilon)` | Strict monotonicity — direction inferred from first non-zero change |
+| `settling_time_seconds(samples, epsilon)` | Time from first change to last change |
+| `start_delay_seconds(samples, epsilon)` | Time from t0 to first change above epsilon |
+| `overshoot(samples, epsilon)` | Peak excursion beyond final value, as a fraction of total displacement |
+| `frame_jitter_seconds(samples)` | Stddev of inter-sample intervals — frame-pacing jitter at fixed FPS |
+| `final_value(samples)` | Last sample value, NaN when empty |
+
+Helpers are split deliberately — combining continuity, monotonicity, and timing
+into a single heuristic obscures which property failed. Pin each concern in its
+own assertion.
+
+```cpp
+auto samples = extract_scalar(events, "Card", "opacity", "value");
+REQUIRE(is_monotonic(samples));
+REQUIRE(settling_time_seconds(samples) == Catch::Approx(0.6).margin(0.05));
+REQUIRE(overshoot(samples) < 0.05);
+```
+
+## Visual-analysis pipeline
+
+When a behavior is only observable in pixels (transitions, GPU filters, mask
+compositing), capture a frame sequence and run the Python pipeline:
+
+```bash
+pip install -r tools/motion/visual/requirements.txt
+python3 -m tools.motion.visual.analyze_sequence \
+    --frames-dir ./captures/card-open/ \
+    --output     ./reports/card-open/
+```
+
+Outputs:
+
+- `analysis.json` — per-frame metrics, pairwise SSIM + pixel diff, keyframes,
+  schema version
+- `summary.md` — agent-readable summary
+- `diff/diff_NNNN_NNNN.png` — pairwise pixel-diff heatmaps (capped at
+  `--max-diff-frames`)
+- `keyframes.png` — keyframe sprite (first, mid, last, plus top-delta pairs)
+
+The schema is versioned (`REPORT_SCHEMA_VERSION`) so downstream consumers can
+reject unknown formats. Dependencies (numpy, Pillow, scikit-image) are MIT /
+BSD / Apache 2.0 only and are not redistributed in plugin or app artifacts.
+
+## Architectural guarantees
+
+- **Off by default** — every entry point gates on `tracing_enabled()`. No cost
+  in shipping builds unless explicitly enabled.
+- **One sampler subscription** — the Coordinator holds a single `FrameClock`
+  subscription; per-trace accumulators decide when to sample.
+- **Monotonic timestamps** — events stamp `FrameClock::time()` and `frame()`,
+  not wall-clock, so CI runs on the scripted-capture path are deterministic.
+- **No silent data loss** — fixture loaders reject unknown schema versions
+  instead of accepting them.
+- **No external dependencies in the C++ layer** — the fixture parser is
+  hand-rolled to keep `core/view/motion` free of new JSON deps.
+
+## See also
+
+- [Animation Guide](animation.md) — `Tween`, `ValueAnimation`, CSS transitions
+- [Design Debugging](design-debugging.md) — visual regression workflows
+- [Custom Rendering](custom-rendering.md) — Skia / Dawn pipeline that produces
+  the frames the visual analyzer consumes

--- a/docs/status/docs-index.yaml
+++ b/docs/status/docs-index.yaml
@@ -49,6 +49,11 @@ docs:
     kind: example
     summary: Animated plugin UI with JS bridge and C++ examples
 
+  - slug: motion-observability
+    path: guides/motion-observability.md
+    kind: guide
+    summary: Agent-first motion observability — runtime scalar/geometry traces, presentation walker, fixtures (record/replay/assert), visual-analysis pipeline, inspector Motion.* domain
+
   - slug: parameters
     path: guides/parameters.md
     kind: guide

--- a/docs/status/modules.yaml
+++ b/docs/status/modules.yaml
@@ -98,6 +98,12 @@ modules:
       pulp import-design pipeline; design_import_designmd.cpp adds the Google DESIGN.md
       (Apache-2.0) reader, parsed via vendored yaml-cpp (MIT) — see
       reference/imports/designmd.md.
+      Motion observability subsystem (`pulp::view::motion`) — agent-first runtime
+      sampler bound to FrameClock with epsilon-bounded Start/End burst framing,
+      paint_all()-order presentation geometry walker, publish channel + firehose,
+      versioned JSONL record/replay fixtures, and assertion helpers (is_monotonic,
+      settling_time_seconds, overshoot, start_delay_seconds, frame_jitter_seconds).
+      Off by default; see guides/motion-observability.md.
     status: usable
     dependencies: [canvas, events, state]
     docs: reference/modules.md#view

--- a/examples/ui-preview/main.cpp
+++ b/examples/ui-preview/main.cpp
@@ -8,8 +8,12 @@
 #include <pulp/view/theme.hpp>
 #include <pulp/view/frame_clock.hpp>
 #include <pulp/view/inspector.hpp>
+#include <pulp/view/motion.hpp>
 #include <pulp/inspect/inspector_overlay.hpp>
+#include <pulp/inspect/inspector_server.hpp>
 #include <pulp/inspect/inspector_window.hpp>
+#include <pulp/inspect/domain_handler.hpp>
+#include <pulp/inspect/motion_inspector.hpp>
 #include <pulp/runtime/system.hpp>
 #include <pulp/view/screenshot.hpp>
 #include <pulp/view/script_engine.hpp>
@@ -609,6 +613,60 @@ int main(int argc, char* argv[]) {
         std::cout << (ok ? "Screenshot saved to " + screenshot_path + "\n" : "Screenshot failed\n");
         pulp::inspect::g_active_inspector = nullptr;
         return ok ? 0 : 1;
+    }
+
+    // ── Motion observability wiring ─────────────────────────────────
+    //
+    // Bind the motion coordinator to the FrameClock so traces sample
+    // each tick. The InspectorServer + MotionInspector pair come up
+    // only when PULP_MOTION_SERVER=1 (defaults to off so the example
+    // doesn't open a TCP port unexpectedly). Logs always go through
+    // the default log sink when PULP_MOTION_LOG=1. A scope guard
+    // unbinds the coordinator before the local FrameClock dies, so
+    // the singleton's destructor never touches a dangling pointer.
+    pulp::view::motion::Coordinator::instance().bind(clock);
+    int motion_log_sink_id = 0;
+    std::unique_ptr<pulp::inspect::InspectorServer> motion_server;
+    std::unique_ptr<pulp::inspect::MotionInspector> motion_inspector;
+    std::unique_ptr<pulp::inspect::DomainHandler> motion_dispatch;
+    struct MotionGuard {
+        int& log_sink_id;
+        std::unique_ptr<pulp::inspect::MotionInspector>& inspector_ref;
+        ~MotionGuard() {
+            inspector_ref.reset();
+            auto& c = pulp::view::motion::Coordinator::instance();
+            if (log_sink_id) c.remove_sink(log_sink_id);
+            c.unbind();
+        }
+    } motion_guard{motion_log_sink_id, motion_inspector};
+
+    if (pulp::runtime::get_env("PULP_MOTION_LOG")) {
+        motion_log_sink_id =
+            pulp::view::motion::Coordinator::instance().install_default_log_sink();
+        pulp::view::motion::Coordinator::instance().set_tracing_enabled(true);
+    }
+    if (pulp::runtime::get_env("PULP_MOTION_SERVER")) {
+        motion_server = std::make_unique<pulp::inspect::InspectorServer>();
+        if (motion_server->start()) {
+            motion_inspector = std::make_unique<pulp::inspect::MotionInspector>(
+                root, motion_server.get());
+            motion_dispatch = std::make_unique<pulp::inspect::DomainHandler>();
+            motion_dispatch->set_root_view(&root);
+            motion_dispatch->set_motion_inspector(motion_inspector.get());
+            auto* dispatch = motion_dispatch.get();
+            motion_server->set_request_handler(
+                [dispatch](const pulp::inspect::InspectorMessage& req) {
+                    return dispatch->handle(req);
+                });
+            motion_server->advertise_port();
+            std::cout << "Motion inspector listening on port "
+                      << motion_server->port() << "\n";
+            pulp::view::motion::Coordinator::instance().set_tracing_enabled(true);
+        } else {
+            std::cerr << "Motion inspector server failed to start; "
+                         "PULP_MOTION_SERVER ignored.\n";
+            motion_server.reset();
+        }
     }
 
     std::cout << "Hover over knobs to see glow animation\n";

--- a/examples/ui-preview/main.cpp
+++ b/examples/ui-preview/main.cpp
@@ -645,6 +645,14 @@ int main(int argc, char* argv[]) {
             pulp::view::motion::Coordinator::instance().install_default_log_sink();
         pulp::view::motion::Coordinator::instance().set_tracing_enabled(true);
     }
+    if (pulp::runtime::get_env("PULP_MOTION_FIREHOSE")) {
+        pulp::view::motion::Coordinator::instance().set_firehose(true);
+        pulp::view::motion::Coordinator::instance().set_tracing_enabled(true);
+        if (!motion_log_sink_id) {
+            motion_log_sink_id =
+                pulp::view::motion::Coordinator::instance().install_default_log_sink();
+        }
+    }
     if (pulp::runtime::get_env("PULP_MOTION_SERVER")) {
         motion_server = std::make_unique<pulp::inspect::InspectorServer>();
         if (motion_server->start()) {

--- a/inspect/CMakeLists.txt
+++ b/inspect/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(pulp-inspect PRIVATE
     src/inspector_server.cpp
     src/audio_inspector.cpp
     src/domain_handler.cpp
+    src/motion_inspector.cpp
 )
 
 target_link_libraries(pulp-inspect PUBLIC pulp::view pulp::render pulp::state pulp::events)

--- a/inspect/include/pulp/inspect/domain_handler.hpp
+++ b/inspect/include/pulp/inspect/domain_handler.hpp
@@ -12,6 +12,7 @@ class InspectorOverlay;
 class StateInspector;
 class ConsoleCapture;
 class AudioInspector;
+class MotionInspector;
 
 /// Handles inspector protocol requests by delegating to the appropriate
 /// inspector component. All data sources are optional — missing sources
@@ -26,6 +27,7 @@ public:
     void set_state_inspector(StateInspector* state) { state_ = state; }
     void set_console_capture(ConsoleCapture* console) { console_ = console; }
     void set_audio_inspector(AudioInspector* audio) { audio_ = audio; }
+    void set_motion_inspector(MotionInspector* motion) { motion_ = motion; }
     void set_render_pass_manager(render::RenderPassManager* rpm) { rpm_ = rpm; }
 
     /// Handle a protocol request. Returns a response message.
@@ -37,6 +39,7 @@ private:
     StateInspector* state_ = nullptr;
     ConsoleCapture* console_ = nullptr;
     AudioInspector* audio_ = nullptr;
+    MotionInspector* motion_ = nullptr;
     render::RenderPassManager* rpm_ = nullptr;
 
     // Domain handlers
@@ -49,6 +52,7 @@ private:
     InspectorMessage handle_runtime(const InspectorMessage& req);
     InspectorMessage handle_audio(const InspectorMessage& req);
     InspectorMessage handle_capture(const InspectorMessage& req);
+    InspectorMessage handle_motion(const InspectorMessage& req);
 };
 
 } // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/motion_inspector.hpp
+++ b/inspect/include/pulp/inspect/motion_inspector.hpp
@@ -1,0 +1,56 @@
+// motion_inspector.hpp — Bridges pulp::view::motion to the inspector
+// protocol. Exposes Motion.startTrace / .stopTrace / .snapshot /
+// .listTraces requests and broadcasts Motion.start / .sample / .end
+// events to inspector clients.
+
+#pragma once
+
+#include <pulp/inspect/protocol.hpp>
+#include <pulp/view/motion.hpp>
+
+#include <cstdint>
+#include <mutex>
+#include <unordered_map>
+
+namespace pulp::view { class View; }
+
+namespace pulp::inspect {
+
+class InspectorServer;
+
+class MotionInspector {
+public:
+    /// Construct with a root view for node-id lookup and an optional
+    /// InspectorServer for event broadcasting. Without a server, traces
+    /// still register and tick; events fan out to any sinks installed
+    /// directly on the coordinator.
+    MotionInspector(pulp::view::View& root, InspectorServer* server);
+    ~MotionInspector();
+
+    MotionInspector(const MotionInspector&) = delete;
+    MotionInspector& operator=(const MotionInspector&) = delete;
+
+    /// Handle a Motion.* request. Returns response message.
+    InspectorMessage handle(const InspectorMessage& req);
+
+    /// Number of currently-attached inspector traces.
+    std::size_t active_trace_count() const;
+
+private:
+    pulp::view::View* root_ = nullptr;
+    InspectorServer* server_ = nullptr;
+    int sink_id_ = 0;
+
+    mutable std::mutex mtx_;
+    std::unordered_map<std::int64_t, pulp::view::motion::TraceHandle> traces_;
+    std::int64_t next_inspector_id_ = 1;
+
+    InspectorMessage start_trace(const InspectorMessage& req);
+    InspectorMessage stop_trace(const InspectorMessage& req);
+    InspectorMessage snapshot(const InspectorMessage& req);
+    InspectorMessage list_traces(const InspectorMessage& req);
+
+    void broadcast_event(const pulp::view::motion::SampleEvent& e);
+};
+
+} // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/protocol.hpp
+++ b/inspect/include/pulp/inspect/protocol.hpp
@@ -80,6 +80,17 @@ namespace methods {
     // Capture domain
     constexpr auto kCaptureScreenshot     = "Capture.screenshot";
     constexpr auto kCaptureScreenshotNode = "Capture.screenshotNode";
+
+    // Motion domain — agent-first motion observability.
+    // Requests:
+    constexpr auto kMotionStartTrace = "Motion.startTrace";
+    constexpr auto kMotionStopTrace  = "Motion.stopTrace";
+    constexpr auto kMotionSnapshot   = "Motion.snapshot";
+    constexpr auto kMotionListTraces = "Motion.listTraces";
+    // Events (broadcast to subscribed clients):
+    constexpr auto kMotionStart  = "Motion.start";
+    constexpr auto kMotionSample = "Motion.sample";
+    constexpr auto kMotionEnd    = "Motion.end";
 }
 
 } // namespace pulp::inspect

--- a/inspect/src/domain_handler.cpp
+++ b/inspect/src/domain_handler.cpp
@@ -5,6 +5,7 @@
 #include <pulp/inspect/state_inspector.hpp>
 #include <pulp/inspect/console_capture.hpp>
 #include <pulp/inspect/audio_inspector.hpp>
+#include <pulp/inspect/motion_inspector.hpp>
 #include <pulp/view/inspector.hpp>
 #include <pulp/view/view.hpp>
 #include <pulp/render/render_pass.hpp>
@@ -36,8 +37,16 @@ InspectorMessage DomainHandler::handle(const InspectorMessage& req) {
     if (domain == "Runtime")     return handle_runtime(req);
     if (domain == "Audio")       return handle_audio(req);
     if (domain == "Capture")     return handle_capture(req);
+    if (domain == "Motion")      return handle_motion(req);
 
     return make_error(req.id, "Unknown domain: " + domain);
+}
+
+// ── Motion domain ───────────────────────────────────────────────────────────
+
+InspectorMessage DomainHandler::handle_motion(const InspectorMessage& req) {
+    if (!motion_) return make_error(req.id, "No motion inspector attached");
+    return motion_->handle(req);
 }
 
 // ── Inspector domain ────────────────────────────────────────────────────────

--- a/inspect/src/motion_inspector.cpp
+++ b/inspect/src/motion_inspector.cpp
@@ -53,20 +53,22 @@ GeometrySource parse_geometry_source(std::string_view s) {
 
 const char* sample_kind_to_string(SampleEvent::Kind k) {
     switch (k) {
-        case SampleEvent::Kind::Baseline: return "baseline";
-        case SampleEvent::Kind::Sample:   return "sample";
-        case SampleEvent::Kind::Start:    return "start";
-        case SampleEvent::Kind::End:      return "end";
+        case SampleEvent::Kind::TraceStarted: return "trace-started";
+        case SampleEvent::Kind::Baseline:     return "baseline";
+        case SampleEvent::Kind::Sample:       return "sample";
+        case SampleEvent::Kind::Start:        return "start";
+        case SampleEvent::Kind::End:          return "end";
     }
     return "?";
 }
 
 const char* event_method_for_kind(SampleEvent::Kind k) {
     switch (k) {
-        case SampleEvent::Kind::Baseline: return methods::kMotionSample;
-        case SampleEvent::Kind::Sample:   return methods::kMotionSample;
-        case SampleEvent::Kind::Start:    return methods::kMotionStart;
-        case SampleEvent::Kind::End:      return methods::kMotionEnd;
+        case SampleEvent::Kind::TraceStarted: return methods::kMotionStart;
+        case SampleEvent::Kind::Baseline:     return methods::kMotionSample;
+        case SampleEvent::Kind::Sample:       return methods::kMotionSample;
+        case SampleEvent::Kind::Start:        return methods::kMotionStart;
+        case SampleEvent::Kind::End:          return methods::kMotionEnd;
     }
     return methods::kMotionSample;
 }
@@ -267,11 +269,24 @@ void MotionInspector::broadcast_event(const SampleEvent& e) {
     params.addMember("kind", choc::value::createString(sample_kind_to_string(e.kind)));
     params.addMember("t", choc::value::createFloat64(e.t_seconds));
     params.addMember("frame", choc::value::createInt64(static_cast<int64_t>(e.frame)));
+    // Phase 7 stable identifiers — let clients align bursts on the
+    // wire the same way the fixture format aligns them.
+    params.addMember("trace_id", choc::value::createInt64(e.trace_id));
+    params.addMember("metric_id", choc::value::createInt64(e.metric_id));
+    params.addMember("burst_id", choc::value::createInt64(e.burst_id));
     if (!e.components.empty()) {
         params.addMember("components", components_to_object(e.components));
     }
     if (!e.deltas.empty()) {
         params.addMember("deltas", components_to_object(e.deltas));
+    }
+    if (e.provenance.is_set()) {
+        auto prov = choc::value::createObject("");
+        prov.addMember("source_kind", choc::value::createString(e.provenance.source_kind));
+        prov.addMember("source_id",   choc::value::createString(e.provenance.source_id));
+        prov.addMember("source_file", choc::value::createString(e.provenance.source_file));
+        prov.addMember("source_line", choc::value::createInt64(e.provenance.source_line));
+        params.addMember("provenance", prov);
     }
 
     InspectorMessage ev = make_event(event_method_for_kind(e.kind),

--- a/inspect/src/motion_inspector.cpp
+++ b/inspect/src/motion_inspector.cpp
@@ -1,0 +1,282 @@
+#include <pulp/inspect/motion_inspector.hpp>
+
+#include <pulp/inspect/inspector_server.hpp>
+#include <pulp/view/inspector.hpp>
+#include <pulp/view/motion.hpp>
+#include <pulp/view/view.hpp>
+
+#include <choc/text/choc_JSON.h>
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace pulp::inspect {
+
+namespace {
+
+using pulp::view::motion::Coordinator;
+using pulp::view::motion::GeometryProperty;
+using pulp::view::motion::GeometrySource;
+using pulp::view::motion::GeometrySpace;
+using pulp::view::motion::SampleEvent;
+using pulp::view::motion::TraceBuilder;
+using pulp::view::motion::TraceHandle;
+using pulp::view::motion::TraceOptions;
+
+GeometryProperty parse_geometry_property(std::string_view s) {
+    if (s == "minX")   return GeometryProperty::MinX;
+    if (s == "minY")   return GeometryProperty::MinY;
+    if (s == "maxX")   return GeometryProperty::MaxX;
+    if (s == "maxY")   return GeometryProperty::MaxY;
+    if (s == "midX")   return GeometryProperty::MidX;
+    if (s == "midY")   return GeometryProperty::MidY;
+    if (s == "width")  return GeometryProperty::Width;
+    if (s == "height") return GeometryProperty::Height;
+    return GeometryProperty::MinX;
+}
+
+GeometrySpace parse_geometry_space(std::string_view s) {
+    if (s == "view-local")  return GeometrySpace::ViewLocal;
+    if (s == "view-global") return GeometrySpace::ViewGlobal;
+    if (s == "window")      return GeometrySpace::Window;
+    if (s == "screen")      return GeometrySpace::Screen;
+    return GeometrySpace::Window;
+}
+
+GeometrySource parse_geometry_source(std::string_view s) {
+    if (s == "layout")       return GeometrySource::Layout;
+    if (s == "presentation") return GeometrySource::Presentation;
+    return GeometrySource::Layout;
+}
+
+const char* sample_kind_to_string(SampleEvent::Kind k) {
+    switch (k) {
+        case SampleEvent::Kind::Baseline: return "baseline";
+        case SampleEvent::Kind::Sample:   return "sample";
+        case SampleEvent::Kind::Start:    return "start";
+        case SampleEvent::Kind::End:      return "end";
+    }
+    return "?";
+}
+
+const char* event_method_for_kind(SampleEvent::Kind k) {
+    switch (k) {
+        case SampleEvent::Kind::Baseline: return methods::kMotionSample;
+        case SampleEvent::Kind::Sample:   return methods::kMotionSample;
+        case SampleEvent::Kind::Start:    return methods::kMotionStart;
+        case SampleEvent::Kind::End:      return methods::kMotionEnd;
+    }
+    return methods::kMotionSample;
+}
+
+choc::value::Value components_to_object(
+    const std::vector<std::pair<std::string, double>>& comps
+) {
+    auto obj = choc::value::createObject("");
+    for (const auto& [k, v] : comps) {
+        obj.addMember(k, choc::value::createFloat64(v));
+    }
+    return obj;
+}
+
+}  // namespace
+
+// ── MotionInspector ──────────────────────────────────────────────────
+
+MotionInspector::MotionInspector(pulp::view::View& root, InspectorServer* server)
+    : root_(&root), server_(server) {
+    sink_id_ = Coordinator::instance().add_sink(
+        [this](const SampleEvent& e) { broadcast_event(e); });
+}
+
+MotionInspector::~MotionInspector() {
+    if (sink_id_) {
+        Coordinator::instance().remove_sink(sink_id_);
+        sink_id_ = 0;
+    }
+    std::lock_guard<std::mutex> lock(mtx_);
+    traces_.clear();
+}
+
+std::size_t MotionInspector::active_trace_count() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return traces_.size();
+}
+
+InspectorMessage MotionInspector::handle(const InspectorMessage& req) {
+    if (req.method == methods::kMotionStartTrace) return start_trace(req);
+    if (req.method == methods::kMotionStopTrace)  return stop_trace(req);
+    if (req.method == methods::kMotionSnapshot)   return snapshot(req);
+    if (req.method == methods::kMotionListTraces) return list_traces(req);
+    return make_error(req.id, "Unknown Motion method: " + req.method);
+}
+
+InspectorMessage MotionInspector::start_trace(const InspectorMessage& req) {
+    if (!root_) return make_error(req.id, "MotionInspector has no root view");
+
+    choc::value::Value params;
+    try {
+        params = choc::json::parse(req.params_json);
+    } catch (...) {
+        return make_error(req.id, "Motion.startTrace: invalid params JSON");
+    }
+
+    std::string view_name = "Trace";
+    if (params.isObject() && params.hasObjectMember("view_name")) {
+        view_name = std::string(params["view_name"].getString());
+    }
+    int fps = 15;
+    if (params.isObject() && params.hasObjectMember("fps")) {
+        fps = static_cast<int>(params["fps"].getInt64());
+    }
+
+    TraceBuilder builder = Coordinator::instance().trace(view_name, {fps});
+
+    if (!params.isObject() || !params.hasObjectMember("metrics") ||
+        !params["metrics"].isArray()) {
+        return make_error(req.id, "Motion.startTrace: 'metrics' array required");
+    }
+
+    const auto& metrics = params["metrics"];
+    for (uint32_t i = 0; i < metrics.size(); ++i) {
+        const auto& m = metrics[i];
+        if (!m.isObject() || !m.hasObjectMember("kind")) {
+            return make_error(req.id, "Motion.startTrace: metric requires 'kind'");
+        }
+        std::string kind(m["kind"].getString());
+        std::string name = m.hasObjectMember("name")
+                               ? std::string(m["name"].getString())
+                               : kind;
+
+        if (kind == "geometry") {
+            if (!m.hasObjectMember("node_id")) {
+                return make_error(req.id, "Motion.startTrace: geometry requires 'node_id'");
+            }
+            std::string node_id(m["node_id"].getString());
+            auto* target = pulp::view::ViewInspector::find_by_id(*root_, node_id);
+            if (!target) {
+                return make_error(req.id,
+                                  "Motion.startTrace: node not found: " + node_id);
+            }
+            std::vector<GeometryProperty> props;
+            if (m.hasObjectMember("properties") && m["properties"].isArray()) {
+                const auto& parr = m["properties"];
+                for (uint32_t j = 0; j < parr.size(); ++j) {
+                    props.push_back(parse_geometry_property(parr[j].getString()));
+                }
+            }
+            if (props.empty()) {
+                props = {GeometryProperty::MinX, GeometryProperty::MinY,
+                         GeometryProperty::Width, GeometryProperty::Height};
+            }
+            const auto space = m.hasObjectMember("space")
+                                   ? parse_geometry_space(m["space"].getString())
+                                   : GeometrySpace::Window;
+            const auto source = m.hasObjectMember("source")
+                                    ? parse_geometry_source(m["source"].getString())
+                                    : GeometrySource::Layout;
+            builder.geometry(name, *target, std::move(props), space, source);
+        } else {
+            return make_error(req.id,
+                              "Motion.startTrace: unsupported metric kind: " + kind);
+        }
+    }
+
+    auto handle = builder.attach();
+    if (!handle.is_attached()) {
+        return make_error(req.id, "Motion.startTrace: attach failed");
+    }
+    Coordinator::instance().set_tracing_enabled(true);
+
+    std::int64_t inspector_id = 0;
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        inspector_id = next_inspector_id_++;
+        traces_.emplace(inspector_id, std::move(handle));
+    }
+
+    auto out = choc::value::createObject("");
+    out.addMember("trace_id", choc::value::createInt64(inspector_id));
+    return make_response(req.id, choc::json::toString(out, false));
+}
+
+InspectorMessage MotionInspector::stop_trace(const InspectorMessage& req) {
+    choc::value::Value params;
+    try {
+        params = choc::json::parse(req.params_json);
+    } catch (...) {
+        return make_error(req.id, "Motion.stopTrace: invalid params JSON");
+    }
+    if (!params.isObject() || !params.hasObjectMember("trace_id")) {
+        return make_error(req.id, "Motion.stopTrace: 'trace_id' required");
+    }
+    const std::int64_t id = params["trace_id"].getInt64();
+    bool removed = false;
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        auto it = traces_.find(id);
+        if (it != traces_.end()) {
+            traces_.erase(it);
+            removed = true;
+        }
+    }
+    auto out = choc::value::createObject("");
+    out.addMember("removed", choc::value::createBool(removed));
+    return make_response(req.id, choc::json::toString(out, false));
+}
+
+InspectorMessage MotionInspector::snapshot(const InspectorMessage& req) {
+    auto out = choc::value::createObject("");
+    out.addMember("tracing_enabled",
+                  choc::value::createBool(Coordinator::instance().tracing_enabled()));
+    out.addMember("firehose",
+                  choc::value::createBool(Coordinator::instance().firehose()));
+    out.addMember("active_traces",
+                  choc::value::createInt64(static_cast<int64_t>(
+                      Coordinator::instance().active_trace_count())));
+    out.addMember("inspector_traces",
+                  choc::value::createInt64(static_cast<int64_t>(active_trace_count())));
+    out.addMember("emitted_events",
+                  choc::value::createInt64(static_cast<int64_t>(
+                      Coordinator::instance().emitted_event_count())));
+    return make_response(req.id, choc::json::toString(out, false));
+}
+
+InspectorMessage MotionInspector::list_traces(const InspectorMessage& req) {
+    auto out = choc::value::createObject("");
+    auto arr = choc::value::createEmptyArray();
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        for (const auto& [id, handle] : traces_) {
+            (void)handle;
+            arr.addArrayElement(choc::value::createInt64(id));
+        }
+    }
+    out.addMember("trace_ids", arr);
+    return make_response(req.id, choc::json::toString(out, false));
+}
+
+void MotionInspector::broadcast_event(const SampleEvent& e) {
+    if (!server_) return;
+
+    auto params = choc::value::createObject("");
+    params.addMember("view_name", choc::value::createString(e.view_name));
+    params.addMember("metric_name", choc::value::createString(e.metric_name));
+    params.addMember("kind", choc::value::createString(sample_kind_to_string(e.kind)));
+    params.addMember("t", choc::value::createFloat64(e.t_seconds));
+    params.addMember("frame", choc::value::createInt64(static_cast<int64_t>(e.frame)));
+    if (!e.components.empty()) {
+        params.addMember("components", components_to_object(e.components));
+    }
+    if (!e.deltas.empty()) {
+        params.addMember("deltas", components_to_object(e.deltas));
+    }
+
+    InspectorMessage ev = make_event(event_method_for_kind(e.kind),
+                                     choc::json::toString(params, false));
+    server_->broadcast(ev);
+}
+
+} // namespace pulp::inspect

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1452,6 +1452,11 @@ add_executable(pulp-test-frame-clock test_frame_clock.cpp)
 target_link_libraries(pulp-test-frame-clock PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-frame-clock)
 
+# Motion (agent-first motion observability) — Phase 0 bedrock tests
+add_executable(pulp-test-motion test_motion.cpp)
+target_link_libraries(pulp-test-motion PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-motion)
+
 # Widget animation behavior tests
 add_executable(pulp-test-widget-animation test_widget_animation.cpp)
 target_link_libraries(pulp-test-widget-animation PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1465,6 +1465,14 @@ if(TARGET pulp::inspect)
     catch_discover_tests(pulp-test-motion-inspector)
 endif()
 
+# Motion end-to-end animation smoke — mirrors what a plugin author
+# would write: drive a real Tween, publish_value each tick, read the
+# fixture back, assert the shape matches the configured animation.
+add_executable(pulp-test-motion-animation-smoke test_motion_animation_smoke.cpp)
+target_link_libraries(pulp-test-motion-animation-smoke PRIVATE
+    pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-motion-animation-smoke)
+
 # Motion visual-analysis self-check — Phase 4 pipeline smoke.
 # Skips cleanly (exit 3) when Python deps are absent so CI without
 # numpy/Pillow/scikit-image doesn't false-fail.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1457,6 +1457,14 @@ add_executable(pulp-test-motion test_motion.cpp)
 target_link_libraries(pulp-test-motion PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-motion)
 
+# Motion inspector — Phase 1 Motion.* protocol-domain tests
+if(TARGET pulp::inspect)
+    add_executable(pulp-test-motion-inspector test_motion_inspector.cpp)
+    target_link_libraries(pulp-test-motion-inspector PRIVATE
+        pulp::view pulp::inspect Catch2::Catch2WithMain)
+    catch_discover_tests(pulp-test-motion-inspector)
+endif()
+
 # Widget animation behavior tests
 add_executable(pulp-test-widget-animation test_widget_animation.cpp)
 target_link_libraries(pulp-test-widget-animation PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1465,6 +1465,22 @@ if(TARGET pulp::inspect)
     catch_discover_tests(pulp-test-motion-inspector)
 endif()
 
+# Motion visual-analysis self-check — Phase 4 pipeline smoke.
+# Skips cleanly (exit 3) when Python deps are absent so CI without
+# numpy/Pillow/scikit-image doesn't false-fail.
+find_package(Python3 COMPONENTS Interpreter QUIET)
+if(Python3_Interpreter_FOUND)
+    add_test(
+        NAME pulp-motion-visual-self-check
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_SOURCE_DIR}/tools/motion/visual/test_self_check.py
+    )
+    set_tests_properties(pulp-motion-visual-self-check PROPERTIES
+        SKIP_RETURN_CODE 3
+        LABELS "motion;visual"
+    )
+endif()
+
 # Widget animation behavior tests
 add_executable(pulp-test-widget-animation test_widget_animation.cpp)
 target_link_libraries(pulp-test-widget-animation PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/test_motion.cpp
+++ b/test/test_motion.cpp
@@ -11,8 +11,13 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
 #include <memory>
+#include <sstream>
 #include <string>
+#include <unistd.h>
 #include <vector>
 
 using Catch::Approx;
@@ -660,6 +665,226 @@ TEST_CASE("publish_value respects epsilon threshold",
             e.kind == SampleEvent::Kind::Sample) ++change_events;
     }
     REQUIRE(change_events == 2);
+}
+
+// ── Fixture record / replay (Phase 5) ────────────────────────────────
+
+namespace {
+std::string tmp_fixture_path(const std::string& tag) {
+    std::ostringstream ss;
+    ss << "/tmp/pulp-motion-fixture-" << tag << "-"
+       << static_cast<long>(::getpid()) << "-"
+       << std::rand() << ".jsonl";
+    return ss.str();
+}
+}  // namespace
+
+TEST_CASE("Fixture round-trip: write events, load them back",
+          "[motion][fixture]") {
+    Fixture fx;
+    const auto path = tmp_fixture_path("roundtrip");
+    Coordinator::instance().add_sink(make_fixture_sink(path));
+    Coordinator::instance().set_firehose(true);
+
+    publish_value("Card", "opacity", 0.0);
+    publish_value("Card", "opacity", 0.5);
+    publish_value("Card", "opacity", 1.0);
+    publish_value("Card", "opacity", 1.0);  // → End
+
+    auto loaded = load_fixture(path);
+    REQUIRE(loaded.size() >= 4);
+
+    std::size_t baseline = 0, start = 0, sample = 0, end = 0;
+    for (const auto& e : loaded) {
+        if (e.kind == SampleEvent::Kind::Baseline) ++baseline;
+        if (e.kind == SampleEvent::Kind::Start)    ++start;
+        if (e.kind == SampleEvent::Kind::Sample)   ++sample;
+        if (e.kind == SampleEvent::Kind::End)      ++end;
+    }
+    REQUIRE(baseline == 1);
+    REQUIRE(start == 1);
+    REQUIRE(sample >= 1);
+    REQUIRE(end == 1);
+
+    std::remove(path.c_str());
+}
+
+TEST_CASE("Fixture replay re-emits events to a sink",
+          "[motion][fixture]") {
+    Fixture fx;
+    const auto path = tmp_fixture_path("replay");
+    Coordinator::instance().add_sink(make_fixture_sink(path));
+    Coordinator::instance().set_firehose(true);
+
+    publish_value("X", "y", 0.0);
+    publish_value("X", "y", 1.0);
+    publish_value("X", "y", 1.0);
+
+    std::vector<SampleEvent> replayed;
+    auto replay_count = replay_fixture(path, make_buffer_sink(&replayed));
+    REQUIRE(replay_count > 0);
+    REQUIRE(replayed.size() == static_cast<std::size_t>(replay_count));
+
+    bool has_baseline = false, has_end = false;
+    for (const auto& e : replayed) {
+        if (e.kind == SampleEvent::Kind::Baseline) has_baseline = true;
+        if (e.kind == SampleEvent::Kind::End) has_end = true;
+    }
+    REQUIRE(has_baseline);
+    REQUIRE(has_end);
+    std::remove(path.c_str());
+}
+
+TEST_CASE("Fixture load rejects unknown schema version",
+          "[motion][fixture]") {
+    const auto path = tmp_fixture_path("badschema");
+    {
+        std::ofstream f(path, std::ios::trunc);
+        f << "{\"motion_fixture_version\":999}\n";
+        f << "{\"kind\":\"baseline\",\"view\":\"V\",\"metric\":\"m\","
+             "\"t\":0,\"frame\":0,\"precision\":3,"
+             "\"components\":{\"value\":1.0},\"deltas\":{}}\n";
+    }
+    auto loaded = load_fixture(path);
+    REQUIRE(loaded.empty());
+    std::remove(path.c_str());
+}
+
+TEST_CASE("assert_matches: identical fixtures produce empty diff",
+          "[motion][fixture]") {
+    Fixture fx;
+    const auto path = tmp_fixture_path("match");
+    Coordinator::instance().add_sink(make_fixture_sink(path));
+    Coordinator::instance().set_firehose(true);
+    publish_value("V", "v", 0.0);
+    publish_value("V", "v", 1.0);
+    publish_value("V", "v", 1.0);
+    auto a = load_fixture(path);
+    auto b = load_fixture(path);
+    auto diff = assert_matches(a, b);
+    REQUIRE(diff.matches());
+    REQUIRE(diff.differences.empty());
+    std::remove(path.c_str());
+}
+
+TEST_CASE("assert_matches: component drift produces a diff item",
+          "[motion][fixture]") {
+    Fixture fx;
+    const auto path1 = tmp_fixture_path("driftA");
+    const auto path2 = tmp_fixture_path("driftB");
+    Coordinator::instance().add_sink(make_fixture_sink(path1));
+    Coordinator::instance().set_firehose(true);
+    publish_value("V", "v", 0.0);
+    publish_value("V", "v", 1.0);
+    publish_value("V", "v", 1.0);
+    auto golden = load_fixture(path1);
+
+    // Reset, then publish a similar series but with the second sample
+    // shifted by 0.5 (well above the default tolerance of 0.05).
+    Coordinator::instance().reset();
+    Coordinator::instance().bind(fx.clock);
+    Coordinator::instance().set_tracing_enabled(true);
+    Coordinator::instance().set_firehose(true);
+    Coordinator::instance().add_sink(make_fixture_sink(path2));
+    publish_value("V", "v", 0.0);
+    publish_value("V", "v", 0.5);    // drift
+    publish_value("V", "v", 0.5);
+    auto captured = load_fixture(path2);
+
+    auto diff = assert_matches(golden, captured);
+    REQUIRE_FALSE(diff.matches());
+    bool found_drift = false;
+    for (const auto& it : diff.differences) {
+        if (it.kind == "component-drift") found_drift = true;
+    }
+    REQUIRE(found_drift);
+
+    std::remove(path1.c_str());
+    std::remove(path2.c_str());
+}
+
+// ── Assertion helpers (Phase 5) ──────────────────────────────────────
+
+TEST_CASE("extract_scalar pulls only the named (view, metric, comp)",
+          "[motion][assert]") {
+    std::vector<SampleEvent> events;
+    auto mk = [&](const std::string& v, const std::string& m,
+                  double t, double val) {
+        SampleEvent e;
+        e.kind = SampleEvent::Kind::Sample;
+        e.view_name = v;
+        e.metric_name = m;
+        e.t_seconds = t;
+        e.components = { {"value", val} };
+        events.push_back(e);
+    };
+    mk("A", "x", 0.0, 1.0);
+    mk("B", "x", 0.1, 99.0);  // wrong view
+    mk("A", "y", 0.2, 88.0);  // wrong metric
+    mk("A", "x", 0.3, 2.0);
+
+    auto series = extract_scalar(events, "A", "x");
+    REQUIRE(series.size() == 2);
+    REQUIRE(series[0].value == Approx(1.0));
+    REQUIRE(series[1].value == Approx(2.0));
+}
+
+TEST_CASE("is_monotonic detects direction reversal",
+          "[motion][assert]") {
+    std::vector<ScalarSample> ascending = {
+        {0.0, 0.0}, {0.1, 0.5}, {0.2, 0.9}, {0.3, 1.0}
+    };
+    REQUIRE(is_monotonic(ascending));
+
+    std::vector<ScalarSample> reverses = {
+        {0.0, 0.0}, {0.1, 0.5}, {0.2, 0.7}, {0.3, 0.4}, {0.4, 1.0}
+    };
+    REQUIRE_FALSE(is_monotonic(reverses));
+
+    std::vector<ScalarSample> descending = {
+        {0.0, 1.0}, {0.1, 0.5}, {0.2, 0.0}
+    };
+    REQUIRE(is_monotonic(descending));
+}
+
+TEST_CASE("settling_time_seconds spans first to last change",
+          "[motion][assert]") {
+    std::vector<ScalarSample> s = {
+        {0.0, 0.0}, {0.1, 0.0}, {0.2, 0.5}, {0.4, 1.0}, {0.6, 1.0}, {0.8, 1.0}
+    };
+    REQUIRE(settling_time_seconds(s) == Approx(0.2));
+}
+
+TEST_CASE("start_delay_seconds = time from t0 to first change",
+          "[motion][assert]") {
+    std::vector<ScalarSample> s = {
+        {0.0, 0.0}, {0.1, 0.0}, {0.2, 0.0}, {0.3, 0.5}, {0.4, 1.0}
+    };
+    REQUIRE(start_delay_seconds(s) == Approx(0.3));
+}
+
+TEST_CASE("overshoot reports peak excursion beyond final value",
+          "[motion][assert]") {
+    std::vector<ScalarSample> s = {
+        {0.0, 0.0}, {0.1, 0.5}, {0.2, 1.0}, {0.3, 1.2}, {0.4, 1.05}, {0.5, 1.0}
+    };
+    REQUIRE(overshoot(s) == Approx(0.2));
+}
+
+TEST_CASE("frame_jitter_seconds is 0 for constant cadence",
+          "[motion][assert]") {
+    std::vector<ScalarSample> s = {
+        {0.0, 0.0}, {0.1, 0.5}, {0.2, 1.0}, {0.3, 1.5}, {0.4, 2.0}
+    };
+    REQUIRE(frame_jitter_seconds(s) == Approx(0.0).margin(1e-9));
+}
+
+TEST_CASE("final_value returns the last sample's value",
+          "[motion][assert]") {
+    std::vector<ScalarSample> s = {
+        {0.0, 0.0}, {0.1, 0.5}, {0.2, 0.95}
+    };
+    REQUIRE(final_value(s) == Approx(0.95));
 }
 
 TEST_CASE("Emitted event counter advances", "[motion]") {

--- a/test/test_motion.cpp
+++ b/test/test_motion.cpp
@@ -559,6 +559,109 @@ TEST_CASE("Presentation walker handles ScrollView ancestor offset",
     REQUIRE(find_component(comps, "minY") == Approx(50.f).margin(0.5));
 }
 
+// ── Publish channel (Phase 3) ────────────────────────────────────────
+
+TEST_CASE("publish_value is a no-op when firehose is off", "[motion][publish]") {
+    Fixture fx;
+    REQUIRE(Coordinator::instance().firehose() == false);
+    publish_value("Card", "opacity", 0.5);
+    publish_value("Card", "opacity", 0.6);
+    REQUIRE(fx.buffer.empty());
+}
+
+TEST_CASE("publish_value with firehose emits a full Baseline/Start/Sample/End burst",
+          "[motion][publish]") {
+    Fixture fx;
+    Coordinator::instance().set_firehose(true);
+
+    publish_value("Card", "opacity", 0.5);   // Baseline
+    publish_value("Card", "opacity", 0.6);   // Start + Sample
+    publish_value("Card", "opacity", 0.6);   // stable → End
+    publish_value("Card", "opacity", 0.6);   // still stable, no event
+
+    std::size_t baseline = 0, start = 0, sample = 0, end = 0;
+    for (const auto& e : fx.buffer) {
+        if (e.kind == SampleEvent::Kind::Baseline) ++baseline;
+        if (e.kind == SampleEvent::Kind::Start)    ++start;
+        if (e.kind == SampleEvent::Kind::Sample)   ++sample;
+        if (e.kind == SampleEvent::Kind::End)      ++end;
+    }
+    REQUIRE(baseline == 1);
+    REQUIRE(start == 1);
+    REQUIRE(sample == 1);
+    REQUIRE(end == 1);
+}
+
+TEST_CASE("publish_value End burst fires on first stable publish",
+          "[motion][publish]") {
+    Fixture fx;
+    Coordinator::instance().set_firehose(true);
+
+    publish_value("X", "y", 0.0);   // Baseline
+    publish_value("X", "y", 1.0);   // Start + Sample
+    publish_value("X", "y", 1.0);   // stable → End
+
+    std::size_t start = 0, end = 0;
+    for (const auto& e : fx.buffer) {
+        if (e.kind == SampleEvent::Kind::Start) ++start;
+        if (e.kind == SampleEvent::Kind::End)   ++end;
+    }
+    REQUIRE(start == 1);
+    REQUIRE(end == 1);
+}
+
+TEST_CASE("publish_components routes multiple keys independently",
+          "[motion][publish]") {
+    Fixture fx;
+    Coordinator::instance().set_firehose(true);
+
+    publish_components("Card", "frame", { {"x", 0.0}, {"y", 0.0} });
+    publish_components("Toast", "alpha", { {"value", 1.0} });
+    publish_components("Card", "frame", { {"x", 5.0}, {"y", 0.0} });
+
+    std::size_t card_evts = 0, toast_evts = 0;
+    for (const auto& e : fx.buffer) {
+        if (e.view_name == "Card")  ++card_evts;
+        if (e.view_name == "Toast") ++toast_evts;
+    }
+    REQUIRE(card_evts >= 3);  // Baseline + Start + Sample
+    REQUIRE(toast_evts == 1); // Baseline only
+}
+
+TEST_CASE("publish_value respects tracing_enabled gate",
+          "[motion][publish]") {
+    Fixture fx;
+    Coordinator::instance().set_firehose(true);
+    Coordinator::instance().set_tracing_enabled(false);
+    publish_value("Card", "opacity", 0.5);
+    REQUIRE(fx.buffer.empty());
+}
+
+TEST_CASE("publish_value respects epsilon threshold",
+          "[motion][publish]") {
+    Fixture fx;
+    Coordinator::instance().set_firehose(true);
+
+    publish_value("X", "y", 1.0, {3, /*epsilon=*/0.05});  // Baseline
+    publish_value("X", "y", 1.01);  // below epsilon → no Start/Sample
+    publish_value("X", "y", 1.02);  // still below
+
+    std::size_t change_events = 0;
+    for (const auto& e : fx.buffer) {
+        if (e.kind == SampleEvent::Kind::Start ||
+            e.kind == SampleEvent::Kind::Sample) ++change_events;
+    }
+    REQUIRE(change_events == 0);
+
+    publish_value("X", "y", 1.10);  // crosses epsilon → Start + Sample
+    change_events = 0;
+    for (const auto& e : fx.buffer) {
+        if (e.kind == SampleEvent::Kind::Start ||
+            e.kind == SampleEvent::Kind::Sample) ++change_events;
+    }
+    REQUIRE(change_events == 2);
+}
+
 TEST_CASE("Emitted event counter advances", "[motion]") {
     Fixture fx;
     double v = 0.0;

--- a/test/test_motion.cpp
+++ b/test/test_motion.cpp
@@ -5,6 +5,7 @@
 
 #include <pulp/view/motion.hpp>
 #include <pulp/view/frame_clock.hpp>
+#include <pulp/view/ui_components.hpp>
 #include <pulp/view/view.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -381,6 +382,182 @@ TEST_CASE("format_line Start/End markers include frame + time", "[motion]") {
 }
 
 // ── Emitted-event counter ────────────────────────────────────────────
+
+// ── Presentation geometry walker (Phase 2) ───────────────────────────
+
+namespace {
+double find_component(const std::vector<std::pair<std::string, double>>& comps,
+                      const std::string& name) {
+    for (const auto& [k, v] : comps) if (k == name) return v;
+    return 0.0;
+}
+}  // namespace
+
+TEST_CASE("Presentation: uniform scale expands AABB around transform origin",
+          "[motion][presentation]") {
+    Fixture fx;
+    View v;
+    v.set_bounds({ 100.f, 100.f, 100.f, 50.f });
+    v.set_transform_origin(0.5f, 0.5f);
+    v.set_scale(2.0f);
+
+    auto handle = Coordinator::instance().trace("V", { 60 })
+        .geometry("frame", v,
+                  { GeometryProperty::MinX, GeometryProperty::MinY,
+                    GeometryProperty::Width, GeometryProperty::Height },
+                  GeometrySpace::Window, GeometrySource::Presentation)
+        .attach();
+    fx.clock.tick(1.0f / 60.0f);
+    REQUIRE(fx.buffer.size() == 1);
+    const auto& comps = fx.buffer.front().components;
+    // Scale 2 around the center (150, 125) → AABB is twice as wide/tall,
+    // centered on the same point. So minX = 150 - 100 = 50, minY = 125 - 50 = 75.
+    REQUIRE(find_component(comps, "minX")   == Approx(50.f).margin(0.01));
+    REQUIRE(find_component(comps, "minY")   == Approx(75.f).margin(0.01));
+    REQUIRE(find_component(comps, "width")  == Approx(200.f).margin(0.01));
+    REQUIRE(find_component(comps, "height") == Approx(100.f).margin(0.01));
+}
+
+TEST_CASE("Layout source ignores paint-time scale", "[motion][presentation]") {
+    Fixture fx;
+    View v;
+    v.set_bounds({ 100.f, 100.f, 100.f, 50.f });
+    v.set_transform_origin(0.5f, 0.5f);
+    v.set_scale(2.0f);
+
+    auto handle = Coordinator::instance().trace("V", { 60 })
+        .geometry("frame", v,
+                  { GeometryProperty::MinX, GeometryProperty::MinY,
+                    GeometryProperty::Width, GeometryProperty::Height },
+                  GeometrySpace::Window, GeometrySource::Layout)
+        .attach();
+    fx.clock.tick(1.0f / 60.0f);
+    const auto& comps = fx.buffer.front().components;
+    REQUIRE(find_component(comps, "minX")   == Approx(100.f));
+    REQUIRE(find_component(comps, "minY")   == Approx(100.f));
+    REQUIRE(find_component(comps, "width")  == Approx(100.f));
+    REQUIRE(find_component(comps, "height") == Approx(50.f));
+}
+
+TEST_CASE("Presentation: translate shifts the AABB", "[motion][presentation]") {
+    Fixture fx;
+    View v;
+    v.set_bounds({ 50.f, 60.f, 100.f, 100.f });
+    v.set_translate(10.f, 20.f);
+
+    auto handle = Coordinator::instance().trace("V", { 60 })
+        .geometry("frame", v,
+                  { GeometryProperty::MinX, GeometryProperty::MinY,
+                    GeometryProperty::Width, GeometryProperty::Height },
+                  GeometrySpace::Window, GeometrySource::Presentation)
+        .attach();
+    fx.clock.tick(1.0f / 60.0f);
+    const auto& comps = fx.buffer.front().components;
+    REQUIRE(find_component(comps, "minX") == Approx(60.f).margin(0.01));
+    REQUIRE(find_component(comps, "minY") == Approx(80.f).margin(0.01));
+    REQUIRE(find_component(comps, "width")  == Approx(100.f));
+    REQUIRE(find_component(comps, "height") == Approx(100.f));
+}
+
+TEST_CASE("Presentation: 90deg rotation swaps width/height in AABB",
+          "[motion][presentation]") {
+    Fixture fx;
+    View v;
+    v.set_bounds({ 0.f, 0.f, 100.f, 50.f });
+    v.set_transform_origin(0.5f, 0.5f);
+    v.set_rotation(90.f);
+
+    auto handle = Coordinator::instance().trace("V", { 60 })
+        .geometry("frame", v,
+                  { GeometryProperty::Width, GeometryProperty::Height },
+                  GeometrySpace::Window, GeometrySource::Presentation)
+        .attach();
+    fx.clock.tick(1.0f / 60.0f);
+    const auto& comps = fx.buffer.front().components;
+    // Width and height swap (with a small float tolerance).
+    REQUIRE(find_component(comps, "width")  == Approx(50.f).margin(0.5));
+    REQUIRE(find_component(comps, "height") == Approx(100.f).margin(0.5));
+}
+
+TEST_CASE("Presentation: 2D affine matrix (translate) applies",
+          "[motion][presentation]") {
+    Fixture fx;
+    View v;
+    v.set_bounds({ 0.f, 0.f, 100.f, 100.f });
+    // Pure translate via 2D matrix: identity scale, e=10, f=20.
+    v.set_transform_matrix(1.f, 0.f, 0.f, 1.f, 10.f, 20.f);
+
+    auto handle = Coordinator::instance().trace("V", { 60 })
+        .geometry("frame", v,
+                  { GeometryProperty::MinX, GeometryProperty::MinY,
+                    GeometryProperty::Width, GeometryProperty::Height },
+                  GeometrySpace::Window, GeometrySource::Presentation)
+        .attach();
+    fx.clock.tick(1.0f / 60.0f);
+    const auto& comps = fx.buffer.front().components;
+    REQUIRE(find_component(comps, "minX") == Approx(10.f).margin(0.01));
+    REQUIRE(find_component(comps, "minY") == Approx(20.f).margin(0.01));
+    REQUIRE(find_component(comps, "width")  == Approx(100.f).margin(0.01));
+    REQUIRE(find_component(comps, "height") == Approx(100.f).margin(0.01));
+}
+
+TEST_CASE("Presentation: parent scale propagates to child position",
+          "[motion][presentation]") {
+    Fixture fx;
+    View parent;
+    parent.set_bounds({ 0.f, 0.f, 200.f, 200.f });
+    parent.set_transform_origin(0.0f, 0.0f);
+    parent.set_scale(2.0f);
+
+    auto child = std::make_unique<View>();
+    child->set_bounds({ 10.f, 20.f, 30.f, 40.f });
+    View* child_ptr = child.get();
+    parent.add_child(std::move(child));
+
+    auto handle = Coordinator::instance().trace("Child", { 60 })
+        .geometry("frame", *child_ptr,
+                  { GeometryProperty::MinX, GeometryProperty::MinY,
+                    GeometryProperty::Width, GeometryProperty::Height },
+                  GeometrySpace::Window, GeometrySource::Presentation)
+        .attach();
+    fx.clock.tick(1.0f / 60.0f);
+    const auto& comps = fx.buffer.front().components;
+    // Parent scaled 2x from (0,0): child (10,20) → (20,40), size 30x40 → 60x80.
+    REQUIRE(find_component(comps, "minX")   == Approx(20.f).margin(0.01));
+    REQUIRE(find_component(comps, "minY")   == Approx(40.f).margin(0.01));
+    REQUIRE(find_component(comps, "width")  == Approx(60.f).margin(0.01));
+    REQUIRE(find_component(comps, "height") == Approx(80.f).margin(0.01));
+}
+
+TEST_CASE("Presentation walker handles ScrollView ancestor offset",
+          "[motion][presentation]") {
+    Fixture fx;
+    pulp::view::ScrollView scroll;
+    scroll.set_bounds({ 10.f, 20.f, 200.f, 100.f });
+    scroll.set_content_size({ 0.f, 600.f });
+
+    auto item = std::make_unique<View>();
+    item->set_bounds({ 0.f, 50.f, 100.f, 24.f });
+    View* item_ptr = item.get();
+    scroll.add_child(std::move(item));
+
+    scroll.set_scroll(0.f, 20.f);
+    // set_scroll animates by default; force the smoothed value to settle.
+    scroll.advance_animations(10.0f);
+
+    auto handle = Coordinator::instance().trace("Item", { 60 })
+        .geometry("frame", *item_ptr,
+                  { GeometryProperty::MinX, GeometryProperty::MinY,
+                    GeometryProperty::Width, GeometryProperty::Height },
+                  GeometrySpace::Window, GeometrySource::Presentation)
+        .attach();
+    fx.clock.tick(1.0f / 60.0f);
+    const auto& comps = fx.buffer.front().components;
+    // ScrollView contributes translate(10, 20) - translate(0, 20) = (10, 0)
+    // before painting children. Item at (0, 50) → presentation (10, 50).
+    REQUIRE(find_component(comps, "minX") == Approx(10.f).margin(0.5));
+    REQUIRE(find_component(comps, "minY") == Approx(50.f).margin(0.5));
+}
 
 TEST_CASE("Emitted event counter advances", "[motion]") {
     Fixture fx;

--- a/test/test_motion.cpp
+++ b/test/test_motion.cpp
@@ -1,0 +1,393 @@
+/// @file test_motion.cpp
+/// Catch2 unit tests for pulp::view::motion (Phase 0: coordinator,
+/// FrameClock binding, emission semantics, accumulator-gated FPS,
+/// Start/Sample/End burst framing, deltas, sinks, geometry walker).
+
+#include <pulp/view/motion.hpp>
+#include <pulp/view/frame_clock.hpp>
+#include <pulp/view/view.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using Catch::Approx;
+using pulp::view::FrameClock;
+using pulp::view::Rect;
+using pulp::view::View;
+using namespace pulp::view::motion;
+
+namespace {
+
+/// RAII fixture: resets the singleton coordinator, enables tracing,
+/// binds a fresh FrameClock, and installs a buffer sink.
+class Fixture {
+public:
+    Fixture() {
+        Coordinator::instance().reset();
+        Coordinator::instance().bind(clock);
+        Coordinator::instance().set_tracing_enabled(true);
+        sink_id = Coordinator::instance().add_sink(make_buffer_sink(&buffer));
+    }
+    ~Fixture() { Coordinator::instance().reset(); }
+
+    FrameClock clock;
+    std::vector<SampleEvent> buffer;
+    int sink_id = 0;
+};
+
+std::size_t count_kind(const std::vector<SampleEvent>& b,
+                       SampleEvent::Kind k,
+                       const std::string& metric = {}) {
+    std::size_t n = 0;
+    for (const auto& e : b) {
+        if (e.kind == k && (metric.empty() || e.metric_name == metric)) ++n;
+    }
+    return n;
+}
+
+}  // namespace
+
+// ── Binding ──────────────────────────────────────────────────────────
+
+TEST_CASE("Coordinator binds and unbinds a FrameClock", "[motion]") {
+    Fixture fx;
+    REQUIRE(Coordinator::instance().is_bound());
+    Coordinator::instance().unbind();
+    REQUIRE_FALSE(Coordinator::instance().is_bound());
+}
+
+TEST_CASE("Coordinator off by default after reset", "[motion]") {
+    Coordinator::instance().reset();
+    REQUIRE_FALSE(Coordinator::instance().tracing_enabled());
+    REQUIRE_FALSE(Coordinator::instance().is_bound());
+    REQUIRE(Coordinator::instance().active_trace_count() == 0);
+}
+
+// ── Emission semantics ───────────────────────────────────────────────
+
+TEST_CASE("Baseline emitted on first sample", "[motion]") {
+    Fixture fx;
+    double v = 1.0;
+    auto handle = Coordinator::instance()
+        .trace("Test", { /*fps=*/60 })
+        .value("opacity", [&]{ return v; })
+        .attach();
+
+    fx.clock.tick(1.0f / 60.0f);
+    REQUIRE(count_kind(fx.buffer, SampleEvent::Kind::Baseline, "opacity") == 1);
+    REQUIRE(fx.buffer.front().components.size() == 1);
+    REQUIRE(fx.buffer.front().components.front().second == Approx(1.0));
+}
+
+TEST_CASE("No emission when value is stable", "[motion]") {
+    Fixture fx;
+    double v = 0.5;
+    auto handle = Coordinator::instance()
+        .trace("Test", { 60 })
+        .value("opacity", [&]{ return v; })
+        .attach();
+
+    fx.clock.tick(1.0f / 60.0f);  // baseline
+    const std::size_t after_baseline = fx.buffer.size();
+    for (int i = 0; i < 10; ++i) fx.clock.tick(1.0f / 60.0f);
+    REQUIRE(fx.buffer.size() == after_baseline);
+}
+
+TEST_CASE("Burst: Baseline -> Start -> Samples -> End with delta", "[motion]") {
+    Fixture fx;
+    double v = 0.0;
+    auto handle = Coordinator::instance()
+        .trace("Card", { 60 })
+        .value("opacity", [&]{ return v; })
+        .attach();
+
+    fx.clock.tick(1.0f / 60.0f);              // baseline (v=0)
+    v = 0.25; fx.clock.tick(1.0f / 60.0f);    // Start + Sample
+    v = 0.50; fx.clock.tick(1.0f / 60.0f);    // Sample
+    v = 0.75; fx.clock.tick(1.0f / 60.0f);    // Sample
+    fx.clock.tick(1.0f / 60.0f);              // End (stable)
+
+    REQUIRE(count_kind(fx.buffer, SampleEvent::Kind::Baseline) == 1);
+    REQUIRE(count_kind(fx.buffer, SampleEvent::Kind::Start) == 1);
+    REQUIRE(count_kind(fx.buffer, SampleEvent::Kind::Sample) == 3);
+    REQUIRE(count_kind(fx.buffer, SampleEvent::Kind::End) == 1);
+
+    const SampleEvent* end = nullptr;
+    for (const auto& e : fx.buffer) {
+        if (e.kind == SampleEvent::Kind::End) { end = &e; break; }
+    }
+    REQUIRE(end != nullptr);
+    REQUIRE(end->deltas.size() == 1);
+    REQUIRE(end->deltas.front().first == "value");
+    REQUIRE(end->deltas.front().second == Approx(0.75));
+}
+
+TEST_CASE("Epsilon threshold suppresses jitter", "[motion]") {
+    Fixture fx;
+    double v = 1.0;
+    auto handle = Coordinator::instance()
+        .trace("Test", { 60 })
+        .value("x", [&]{ return v; }, /*precision=*/3, /*epsilon=*/0.01)
+        .attach();
+
+    fx.clock.tick(1.0f / 60.0f);             // baseline
+    const std::size_t base = fx.buffer.size();
+    v = 1.005;
+    for (int i = 0; i < 5; ++i) fx.clock.tick(1.0f / 60.0f);
+    REQUIRE(fx.buffer.size() == base);       // below epsilon: silent
+    v = 1.05;
+    fx.clock.tick(1.0f / 60.0f);
+    REQUIRE(fx.buffer.size() > base);        // above epsilon: emits
+}
+
+TEST_CASE("Monotonic FrameClock timestamps stamped on events", "[motion]") {
+    Fixture fx;
+    double v = 0.0;
+    auto handle = Coordinator::instance()
+        .trace("Test", { 60 })
+        .value("x", [&]{ return v; })
+        .attach();
+
+    fx.clock.tick(1.0f / 60.0f);
+    v = 1.0;
+    fx.clock.tick(1.0f / 60.0f);
+    v = 2.0;
+    fx.clock.tick(1.0f / 60.0f);
+
+    REQUIRE(fx.buffer.size() >= 3);
+    double prev_t = -1.0;
+    std::uint64_t prev_f = 0;
+    for (const auto& e : fx.buffer) {
+        REQUIRE(e.t_seconds >= prev_t);
+        REQUIRE(e.frame >= prev_f);
+        prev_t = e.t_seconds;
+        prev_f = e.frame;
+    }
+}
+
+// ── FPS gating ───────────────────────────────────────────────────────
+
+TEST_CASE("FPS gating samples at requested rate via accumulator", "[motion]") {
+    Fixture fx;
+    double v = 0.0;
+    auto handle = Coordinator::instance()
+        .trace("Test", { /*fps=*/30 })
+        .value("v", [&]{ v += 1.0; return v; })  // changes every sample
+        .attach();
+
+    // 60 ticks at 60 fps = 1.0 s. Expect ~30 sample-ish events
+    // (Baseline + Samples), tolerating ±2 for FP drift.
+    for (int i = 0; i < 60; ++i) fx.clock.tick(1.0f / 60.0f);
+
+    const auto samples = count_kind(fx.buffer, SampleEvent::Kind::Sample)
+                       + count_kind(fx.buffer, SampleEvent::Kind::Baseline);
+    REQUIRE(samples >= 28);
+    REQUIRE(samples <= 32);
+}
+
+// ── Multi-component metrics ──────────────────────────────────────────
+
+TEST_CASE("multi() emits all components together", "[motion]") {
+    Fixture fx;
+    double x = 0.0, y = 0.0;
+    auto handle = Coordinator::instance()
+        .trace("Pointer", { 60 })
+        .multi("xy", {
+            {"x", [&]{ return x; }},
+            {"y", [&]{ return y; }},
+        })
+        .attach();
+
+    fx.clock.tick(1.0f / 60.0f);
+    REQUIRE(fx.buffer.size() == 1);
+    REQUIRE(fx.buffer.front().components.size() == 2);
+    // Components are emitted sorted by name.
+    REQUIRE(fx.buffer.front().components[0].first == "x");
+    REQUIRE(fx.buffer.front().components[1].first == "y");
+}
+
+// ── Multiple sinks / independent traces ──────────────────────────────
+
+TEST_CASE("Multiple traces are independent", "[motion]") {
+    Fixture fx;
+    double a = 0.0, b = 100.0;
+    auto h1 = Coordinator::instance().trace("A", { 60 })
+        .value("v", [&]{ return a; }).attach();
+    auto h2 = Coordinator::instance().trace("B", { 60 })
+        .value("v", [&]{ return b; }).attach();
+
+    fx.clock.tick(1.0f / 60.0f);                  // both emit baseline
+    a = 1.0;
+    fx.clock.tick(1.0f / 60.0f);                  // A: Start + Sample
+    fx.clock.tick(1.0f / 60.0f);                  // A: End
+
+    std::size_t a_baseline = 0, a_start = 0, a_end = 0;
+    std::size_t b_baseline = 0, b_start = 0, b_end = 0;
+    for (const auto& e : fx.buffer) {
+        if (e.view_name == "A") {
+            if (e.kind == SampleEvent::Kind::Baseline) ++a_baseline;
+            if (e.kind == SampleEvent::Kind::Start) ++a_start;
+            if (e.kind == SampleEvent::Kind::End) ++a_end;
+        } else if (e.view_name == "B") {
+            if (e.kind == SampleEvent::Kind::Baseline) ++b_baseline;
+            if (e.kind == SampleEvent::Kind::Start) ++b_start;
+            if (e.kind == SampleEvent::Kind::End) ++b_end;
+        }
+    }
+    REQUIRE(a_baseline == 1);
+    REQUIRE(a_start == 1);
+    REQUIRE(a_end == 1);
+    REQUIRE(b_baseline == 1);
+    REQUIRE(b_start == 0);
+    REQUIRE(b_end == 0);
+}
+
+// ── Trace lifetime / sink lifetime ───────────────────────────────────
+
+TEST_CASE("TraceHandle RAII detaches on destruction", "[motion]") {
+    Fixture fx;
+    {
+        auto handle = Coordinator::instance()
+            .trace("Ephemeral", { 60 })
+            .value("x", []{ return 0.0; })
+            .attach();
+        REQUIRE(Coordinator::instance().active_trace_count() == 1);
+    }
+    REQUIRE(Coordinator::instance().active_trace_count() == 0);
+}
+
+TEST_CASE("Sink can be removed mid-stream", "[motion]") {
+    Fixture fx;
+    double v = 0.0;
+    auto handle = Coordinator::instance().trace("X", { 60 })
+        .value("v", [&]{ return v; }).attach();
+
+    fx.clock.tick(1.0f / 60.0f);                  // baseline
+    Coordinator::instance().remove_sink(fx.sink_id);
+    const std::size_t base = fx.buffer.size();
+    for (int i = 0; i < 5; ++i) {
+        v += 1.0;
+        fx.clock.tick(1.0f / 60.0f);
+    }
+    REQUIRE(fx.buffer.size() == base);
+}
+
+TEST_CASE("Tracing disabled produces no events", "[motion]") {
+    Fixture fx;
+    Coordinator::instance().set_tracing_enabled(false);
+    double v = 0.0;
+    auto handle = Coordinator::instance().trace("X", { 60 })
+        .value("v", [&]{ return v; }).attach();
+    fx.clock.tick(1.0f / 60.0f);
+    REQUIRE(fx.buffer.empty());
+}
+
+// ── Geometry walker (Layout source) ──────────────────────────────────
+
+TEST_CASE("geometry() samples view bounds in window space", "[motion]") {
+    Fixture fx;
+    View parent;
+    parent.set_bounds({ 10.f, 20.f, 400.f, 300.f });
+    auto child_owner = std::make_unique<View>();
+    child_owner->set_bounds({ 5.f, 7.f, 100.f, 50.f });
+    View* child = child_owner.get();
+    parent.add_child(std::move(child_owner));
+
+    auto handle = Coordinator::instance().trace("Child", { 60 })
+        .geometry("frame", *child,
+                  { GeometryProperty::MinX, GeometryProperty::MinY,
+                    GeometryProperty::Width, GeometryProperty::Height },
+                  GeometrySpace::Window, GeometrySource::Layout)
+        .attach();
+
+    fx.clock.tick(1.0f / 60.0f);
+    REQUIRE(fx.buffer.size() == 1);
+    const auto& comps = fx.buffer.front().components;
+    REQUIRE(comps.size() == 4);
+    // Components are sorted alphabetically (height, minX, minY, width).
+    auto find = [&](const std::string& name) -> double {
+        for (const auto& [k, v] : comps) if (k == name) return v;
+        return 0.0;
+    };
+    REQUIRE(find("minX") == Approx(15.f));   // parent.x + child.x = 10 + 5
+    REQUIRE(find("minY") == Approx(27.f));   // parent.y + child.y = 20 + 7
+    REQUIRE(find("width") == Approx(100.f));
+    REQUIRE(find("height") == Approx(50.f));
+}
+
+TEST_CASE("geometry() ViewLocal returns local-origin frame", "[motion]") {
+    Fixture fx;
+    View v;
+    v.set_bounds({ 50.f, 60.f, 200.f, 100.f });
+    auto handle = Coordinator::instance().trace("V", { 60 })
+        .geometry("frame", v,
+                  { GeometryProperty::MinX, GeometryProperty::MinY,
+                    GeometryProperty::Width, GeometryProperty::Height },
+                  GeometrySpace::ViewLocal, GeometrySource::Layout)
+        .attach();
+
+    fx.clock.tick(1.0f / 60.0f);
+    REQUIRE(fx.buffer.size() == 1);
+    auto find = [&](const std::string& name) -> double {
+        for (const auto& [k, val] : fx.buffer.front().components)
+            if (k == name) return val;
+        return 0.0;
+    };
+    REQUIRE(find("minX") == Approx(0.f));
+    REQUIRE(find("minY") == Approx(0.f));
+    REQUIRE(find("width") == Approx(200.f));
+    REQUIRE(find("height") == Approx(100.f));
+}
+
+// ── Line formatting ──────────────────────────────────────────────────
+
+TEST_CASE("format_line produces canonical PulpMotion output", "[motion]") {
+    SampleEvent e;
+    e.kind = SampleEvent::Kind::Sample;
+    e.view_name = "Card";
+    e.metric_name = "frame";
+    e.precision = 2;
+    // Components must already be sorted (the coordinator does this).
+    e.components = {
+        {"height", 80.0}, {"minX", 12.0}, {"minY", 34.0}, {"width", 120.0},
+    };
+    const auto s = format_line(e);
+    REQUIRE(s == "[PulpMotion][Card][frame] height=80.00 minX=12.00 minY=34.00 width=120.00");
+}
+
+TEST_CASE("format_line Start/End markers include frame + time", "[motion]") {
+    SampleEvent start;
+    start.kind = SampleEvent::Kind::Start;
+    start.view_name = "X";
+    start.metric_name = "y";
+    start.frame = 42;
+    start.t_seconds = 1.5;
+    REQUIRE(format_line(start) == "[PulpMotion][X][y] -- Start frame=42 t=1.500000 --");
+
+    SampleEvent end;
+    end.kind = SampleEvent::Kind::End;
+    end.view_name = "X";
+    end.metric_name = "y";
+    end.frame = 50;
+    end.t_seconds = 2.0;
+    end.precision = 2;
+    end.deltas = { {"x", 10.0}, {"y", -5.0} };
+    REQUIRE(format_line(end) ==
+            "[PulpMotion][X][y] -- End frame=50 t=2.000000 -- xDelta=10.00 yDelta=-5.00");
+}
+
+// ── Emitted-event counter ────────────────────────────────────────────
+
+TEST_CASE("Emitted event counter advances", "[motion]") {
+    Fixture fx;
+    double v = 0.0;
+    auto handle = Coordinator::instance().trace("X", { 60 })
+        .value("v", [&]{ return v; }).attach();
+    REQUIRE(Coordinator::instance().emitted_event_count() == 0);
+    fx.clock.tick(1.0f / 60.0f);
+    REQUIRE(Coordinator::instance().emitted_event_count() >= 1);
+}

--- a/test/test_motion.cpp
+++ b/test/test_motion.cpp
@@ -15,6 +15,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <memory>
+#include <set>
 #include <sstream>
 #include <string>
 #include <unistd.h>
@@ -29,19 +30,30 @@ using namespace pulp::view::motion;
 namespace {
 
 /// RAII fixture: resets the singleton coordinator, enables tracing,
-/// binds a fresh FrameClock, and installs a buffer sink.
+/// binds a fresh FrameClock, and installs two sinks — one that
+/// excludes the Phase 7 one-shot `TraceStarted` events (the default
+/// `buffer`, preserving pre-Phase-7 test assertions), and one that
+/// keeps every event (`full_buffer`, for Phase 7 tests that need to
+/// see registration events).
 class Fixture {
 public:
     Fixture() {
         Coordinator::instance().reset();
         Coordinator::instance().bind(clock);
         Coordinator::instance().set_tracing_enabled(true);
-        sink_id = Coordinator::instance().add_sink(make_buffer_sink(&buffer));
+        sink_id = Coordinator::instance().add_sink(
+            [this](const SampleEvent& e) {
+                full_buffer.push_back(e);
+                if (e.kind != SampleEvent::Kind::TraceStarted) {
+                    buffer.push_back(e);
+                }
+            });
     }
     ~Fixture() { Coordinator::instance().reset(); }
 
     FrameClock clock;
-    std::vector<SampleEvent> buffer;
+    std::vector<SampleEvent> buffer;        ///< data events only
+    std::vector<SampleEvent> full_buffer;   ///< includes TraceStarted
     int sink_id = 0;
 };
 
@@ -51,6 +63,29 @@ std::size_t count_kind(const std::vector<SampleEvent>& b,
     std::size_t n = 0;
     for (const auto& e : b) {
         if (e.kind == k && (metric.empty() || e.metric_name == metric)) ++n;
+    }
+    return n;
+}
+
+/// Find the first event matching (kind, optional metric). Returns nullptr
+/// if no match.
+const SampleEvent* first_of(const std::vector<SampleEvent>& b,
+                            SampleEvent::Kind k,
+                            const std::string& metric = {}) {
+    for (const auto& e : b) {
+        if (e.kind == k && (metric.empty() || e.metric_name == metric))
+            return &e;
+    }
+    return nullptr;
+}
+
+/// Number of data + framing events excluding the one-shot TraceStarted
+/// emission (Phase 7). Pre-Phase-7 tests assumed buffer.size() never
+/// counted a registration event.
+std::size_t data_event_count(const std::vector<SampleEvent>& b) {
+    std::size_t n = 0;
+    for (const auto& e : b) {
+        if (e.kind != SampleEvent::Kind::TraceStarted) ++n;
     }
     return n;
 }
@@ -85,8 +120,10 @@ TEST_CASE("Baseline emitted on first sample", "[motion]") {
 
     fx.clock.tick(1.0f / 60.0f);
     REQUIRE(count_kind(fx.buffer, SampleEvent::Kind::Baseline, "opacity") == 1);
-    REQUIRE(fx.buffer.front().components.size() == 1);
-    REQUIRE(fx.buffer.front().components.front().second == Approx(1.0));
+    const auto* baseline = first_of(fx.buffer, SampleEvent::Kind::Baseline, "opacity");
+    REQUIRE(baseline != nullptr);
+    REQUIRE(baseline->components.size() == 1);
+    REQUIRE(baseline->components.front().second == Approx(1.0));
 }
 
 TEST_CASE("No emission when value is stable", "[motion]") {
@@ -372,7 +409,9 @@ TEST_CASE("format_line Start/End markers include frame + time", "[motion]") {
     start.metric_name = "y";
     start.frame = 42;
     start.t_seconds = 1.5;
-    REQUIRE(format_line(start) == "[PulpMotion][X][y] -- Start frame=42 t=1.500000 --");
+    start.burst_id = 3;
+    REQUIRE(format_line(start) ==
+            "[PulpMotion][X][y] -- Start burst=3 frame=42 t=1.500000 --");
 
     SampleEvent end;
     end.kind = SampleEvent::Kind::End;
@@ -381,9 +420,10 @@ TEST_CASE("format_line Start/End markers include frame + time", "[motion]") {
     end.frame = 50;
     end.t_seconds = 2.0;
     end.precision = 2;
+    end.burst_id = 3;
     end.deltas = { {"x", 10.0}, {"y", -5.0} };
     REQUIRE(format_line(end) ==
-            "[PulpMotion][X][y] -- End frame=50 t=2.000000 -- xDelta=10.00 yDelta=-5.00");
+            "[PulpMotion][X][y] -- End burst=3 frame=50 t=2.000000 -- xDelta=10.00 yDelta=-5.00");
 }
 
 // ── Emitted-event counter ────────────────────────────────────────────
@@ -885,6 +925,185 @@ TEST_CASE("final_value returns the last sample's value",
         {0.0, 0.0}, {0.1, 0.5}, {0.2, 0.95}
     };
     REQUIRE(final_value(s) == Approx(0.95));
+}
+
+// ── Phase 7: TraceStarted + stable IDs + Provenance ──────────────────
+
+TEST_CASE("TraceStarted emits exactly once with provenance",
+          "[motion][phase7]") {
+    Fixture fx;
+    Provenance prov;
+    prov.source_kind = "tween";
+    prov.source_id = "Card.opacity";
+    prov.source_file = "card.cpp";
+    prov.source_line = 412;
+
+    auto handle = Coordinator::instance().trace("Card", { 60 })
+        .with_provenance(prov)
+        .value("opacity", []{ return 0.0; })
+        .attach();
+
+    fx.clock.tick(1.0f / 60.0f);
+    fx.clock.tick(1.0f / 60.0f);
+    fx.clock.tick(1.0f / 60.0f);
+
+    // TraceStarted appears in full_buffer, not the filtered buffer.
+    std::size_t ts_count = 0;
+    const SampleEvent* ts_event = nullptr;
+    for (const auto& e : fx.full_buffer) {
+        if (e.kind == SampleEvent::Kind::TraceStarted) {
+            ++ts_count;
+            ts_event = &e;
+        }
+    }
+    REQUIRE(ts_count == 1);
+    REQUIRE(ts_event != nullptr);
+    REQUIRE(ts_event->provenance.source_kind == "tween");
+    REQUIRE(ts_event->provenance.source_id == "Card.opacity");
+    REQUIRE(ts_event->provenance.source_file == "card.cpp");
+    REQUIRE(ts_event->provenance.source_line == 412);
+    REQUIRE(ts_event->trace_id > 0);
+}
+
+TEST_CASE("Sample events carry stable trace_id/metric_id/burst_id",
+          "[motion][phase7]") {
+    Fixture fx;
+    double v = 0.0;
+    auto handle = Coordinator::instance().trace("V", { 60 })
+        .value("x", [&]{ return v; })
+        .attach();
+
+    fx.clock.tick(1.0f / 60.0f);        // baseline
+    v = 1.0;
+    fx.clock.tick(1.0f / 60.0f);        // burst 1 Start + Sample
+    fx.clock.tick(1.0f / 60.0f);        // burst 1 End
+    v = 2.0;
+    fx.clock.tick(1.0f / 60.0f);        // burst 2 Start + Sample
+    fx.clock.tick(1.0f / 60.0f);        // burst 2 End
+
+    int trace_id_seen = -1;
+    std::set<int> burst_ids_seen;
+    for (const auto& e : fx.buffer) {
+        if (e.kind == SampleEvent::Kind::Start) {
+            burst_ids_seen.insert(e.burst_id);
+        }
+        if (trace_id_seen < 0) trace_id_seen = e.trace_id;
+        REQUIRE(e.trace_id == trace_id_seen);
+        REQUIRE(e.metric_id == 0);
+    }
+    REQUIRE(burst_ids_seen.size() == 2);
+    REQUIRE(burst_ids_seen.count(1) == 1);
+    REQUIRE(burst_ids_seen.count(2) == 1);
+}
+
+TEST_CASE("Fixture round-trip preserves trace_id, metric_id, burst_id, and provenance",
+          "[motion][phase7][fixture]") {
+    Fixture fx;
+    const auto path = tmp_fixture_path("phase7");
+    Coordinator::instance().add_sink(make_fixture_sink(path));
+
+    Provenance prov;
+    prov.source_kind = "design-import";
+    prov.source_id = "figma:LevelMeter/Panel";
+
+    double v = 0.0;
+    auto handle = Coordinator::instance().trace("Panel", { 60 })
+        .with_provenance(prov)
+        .value("opacity", [&]{ return v; })
+        .attach();
+
+    fx.clock.tick(1.0f / 60.0f);   // TraceStarted + Baseline
+    v = 1.0;
+    fx.clock.tick(1.0f / 60.0f);   // Start + Sample
+    fx.clock.tick(1.0f / 60.0f);   // End
+
+    auto loaded = load_fixture(path);
+    REQUIRE_FALSE(loaded.empty());
+
+    // First event should be TraceStarted with provenance.
+    REQUIRE(loaded.front().kind == SampleEvent::Kind::TraceStarted);
+    REQUIRE(loaded.front().provenance.source_kind == "design-import");
+    REQUIRE(loaded.front().provenance.source_id == "figma:LevelMeter/Panel");
+
+    // IDs should be present on every event.
+    int trace_id = loaded.front().trace_id;
+    REQUIRE(trace_id > 0);
+    for (const auto& e : loaded) {
+        if (e.kind == SampleEvent::Kind::TraceStarted) continue;
+        REQUIRE(e.trace_id == trace_id);
+        REQUIRE(e.metric_id == 0);
+    }
+    std::remove(path.c_str());
+}
+
+TEST_CASE("load_fixture rejects v1 schema (only v2 accepted)",
+          "[motion][phase7][fixture]") {
+    const auto path = tmp_fixture_path("v1reject");
+    {
+        std::ofstream f(path, std::ios::trunc);
+        f << "{\"motion_fixture_version\":1}\n";
+        f << "{\"kind\":\"baseline\",\"view\":\"V\",\"metric\":\"m\","
+             "\"t\":0,\"frame\":0,\"precision\":3,"
+             "\"components\":{\"value\":1.0},\"deltas\":{}}\n";
+    }
+    auto loaded = load_fixture(path);
+    REQUIRE(loaded.empty());
+    std::remove(path.c_str());
+}
+
+TEST_CASE("assert_matches aligns events by stable IDs, not position",
+          "[motion][phase7][fixture]") {
+    // Two identical fixtures, but the second one has events shuffled
+    // (within burst order is preserved; across-burst order is not).
+    Fixture fx;
+    Provenance prov;
+    prov.source_kind = "test";
+    prov.source_id = "shuffle";
+
+    const auto path = tmp_fixture_path("shuffleA");
+    Coordinator::instance().add_sink(make_fixture_sink(path));
+
+    double v = 0.0;
+    auto h = Coordinator::instance().trace("V", { 60 })
+        .with_provenance(prov)
+        .value("x", [&]{ return v; })
+        .attach();
+
+    fx.clock.tick(1.0f / 60.0f);   // baseline
+    v = 1.0;
+    fx.clock.tick(1.0f / 60.0f);   // burst 1 Start+Sample
+    fx.clock.tick(1.0f / 60.0f);   // burst 1 End
+    v = 2.0;
+    fx.clock.tick(1.0f / 60.0f);   // burst 2 Start+Sample
+    fx.clock.tick(1.0f / 60.0f);   // burst 2 End
+
+    auto golden = load_fixture(path);
+    REQUIRE_FALSE(golden.empty());
+
+    // Build a shuffled "captured" — swap burst-1 and burst-2 events
+    // (the trace-started event stays at the front).
+    std::vector<SampleEvent> shuffled = golden;
+    // Keep TraceStarted + Baseline first, then put burst-2 events
+    // before burst-1 events. The grouped assertion should still match.
+    std::vector<SampleEvent> reorder;
+    for (const auto& e : shuffled) {
+        if (e.kind == SampleEvent::Kind::TraceStarted ||
+            e.kind == SampleEvent::Kind::Baseline) {
+            reorder.push_back(e);
+        }
+    }
+    for (const auto& e : shuffled) {
+        if (e.burst_id == 2) reorder.push_back(e);
+    }
+    for (const auto& e : shuffled) {
+        if (e.burst_id == 1) reorder.push_back(e);
+    }
+
+    FixtureMatchOptions opts;
+    opts.require_same_event_count = false;
+    auto diff = assert_matches(golden, reorder, opts);
+    REQUIRE(diff.matches());
+    std::remove(path.c_str());
 }
 
 TEST_CASE("Emitted event counter advances", "[motion]") {

--- a/test/test_motion.cpp
+++ b/test/test_motion.cpp
@@ -1106,6 +1106,49 @@ TEST_CASE("assert_matches aligns events by stable IDs, not position",
     std::remove(path.c_str());
 }
 
+// ── Codex P1: NaN/Inf round-trip through fixture ─────────────────────
+
+TEST_CASE("Fixture round-trips NaN and Inf component values",
+          "[motion][fixture][codex-p1]") {
+    Fixture fx;
+    const auto path = tmp_fixture_path("nonfinite");
+    Coordinator::instance().add_sink(make_fixture_sink(path));
+    Coordinator::instance().set_firehose(true);
+
+    publish_value("V", "v", 0.0);
+    publish_value("V", "v",
+                  std::numeric_limits<double>::quiet_NaN());  // burst Start
+    publish_value("V", "v",
+                  std::numeric_limits<double>::infinity());
+    publish_value("V", "v",
+                  -std::numeric_limits<double>::infinity());
+
+    auto loaded = load_fixture(path);
+    REQUIRE_FALSE(loaded.empty());
+
+    // Collect every "value" sample.
+    std::vector<double> values;
+    for (const auto& e : loaded) {
+        if (e.kind != SampleEvent::Kind::Baseline &&
+            e.kind != SampleEvent::Kind::Sample) continue;
+        for (const auto& [k, v] : e.components) {
+            if (k == "value") values.push_back(v);
+        }
+    }
+    REQUIRE(values.size() >= 4);
+
+    bool saw_nan = false, saw_pos_inf = false, saw_neg_inf = false;
+    for (double v : values) {
+        if (std::isnan(v)) saw_nan = true;
+        if (std::isinf(v) && v > 0) saw_pos_inf = true;
+        if (std::isinf(v) && v < 0) saw_neg_inf = true;
+    }
+    REQUIRE(saw_nan);
+    REQUIRE(saw_pos_inf);
+    REQUIRE(saw_neg_inf);
+    std::remove(path.c_str());
+}
+
 TEST_CASE("Emitted event counter advances", "[motion]") {
     Fixture fx;
     double v = 0.0;

--- a/test/test_motion.cpp
+++ b/test/test_motion.cpp
@@ -18,8 +18,15 @@
 #include <set>
 #include <sstream>
 #include <string>
-#include <unistd.h>
 #include <vector>
+
+#if defined(_WIN32)
+#include <process.h>
+#define pulp_test_getpid() static_cast<long>(::_getpid())
+#else
+#include <unistd.h>
+#define pulp_test_getpid() static_cast<long>(::getpid())
+#endif
 
 using Catch::Approx;
 using pulp::view::FrameClock;
@@ -711,9 +718,21 @@ TEST_CASE("publish_value respects epsilon threshold",
 
 namespace {
 std::string tmp_fixture_path(const std::string& tag) {
+    // Cross-platform temp dir: TMPDIR / TMP / TEMP, fallback to /tmp
+    // (POSIX) or current dir (Windows when none set).
+    const char* tmp = std::getenv("TMPDIR");
+    if (!tmp) tmp = std::getenv("TMP");
+    if (!tmp) tmp = std::getenv("TEMP");
+    if (!tmp) {
+#if defined(_WIN32)
+        tmp = ".";
+#else
+        tmp = "/tmp";
+#endif
+    }
     std::ostringstream ss;
-    ss << "/tmp/pulp-motion-fixture-" << tag << "-"
-       << static_cast<long>(::getpid()) << "-"
+    ss << tmp << "/pulp-motion-fixture-" << tag << "-"
+       << pulp_test_getpid() << "-"
        << std::rand() << ".jsonl";
     return ss.str();
 }

--- a/test/test_motion_animation_smoke.cpp
+++ b/test/test_motion_animation_smoke.cpp
@@ -1,0 +1,153 @@
+/// @file test_motion_animation_smoke.cpp
+/// End-to-end smoke that mirrors a real plugin scenario:
+///   1. Create a Tween from Pulp's animation.hpp.
+///   2. Bind the motion coordinator to a FrameClock.
+///   3. Install a fixture sink that writes JSONL to disk.
+///   4. Drive ticks at 60 FPS, advance the tween, publish the value.
+///   5. Load the fixture back from disk, extract the scalar series,
+///      run the assertion helpers, and verify the shape matches the
+///      configured animation.
+///
+/// This proves end-to-end that a plugin author can wire a real
+/// animation into the motion observability system without any
+/// hand-rolled instrumentation glue.
+
+#include <pulp/view/animation.hpp>
+#include <pulp/view/frame_clock.hpp>
+#include <pulp/view/motion.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+
+using Catch::Approx;
+using pulp::view::FrameClock;
+using pulp::view::Tween;
+namespace easing = pulp::view::easing;
+using namespace pulp::view::motion;
+
+namespace {
+
+std::string smoke_fixture_path() {
+    std::ostringstream ss;
+    ss << "/tmp/pulp-motion-anim-smoke-"
+       << static_cast<long>(::getpid()) << "-"
+       << std::rand() << ".jsonl";
+    return ss.str();
+}
+
+}  // namespace
+
+TEST_CASE("End-to-end: real Tween → publish_value → fixture → assertion helpers",
+          "[motion][smoke][animation]") {
+    Coordinator::instance().reset();
+
+    FrameClock clock;
+    Coordinator::instance().bind(clock);
+    Coordinator::instance().set_tracing_enabled(true);
+    Coordinator::instance().set_firehose(true);
+
+    const auto fixture_path = smoke_fixture_path();
+    Coordinator::instance().add_sink(make_fixture_sink(fixture_path));
+
+    // The "plugin animation": opacity tween from 0 → 1 over 500 ms
+    // with ease_out_cubic. Mirrors what a Knob hover-glow or a
+    // dropdown fade-in would look like inside an editor.
+    constexpr float duration_s = 0.5f;
+    Tween tween(/*from=*/0.0f, /*to=*/1.0f, duration_s,
+                easing::ease_out_cubic);
+
+    // Drive ticks at 60 FPS until the tween settles plus a few
+    // stable ticks so the burst End fires.
+    constexpr float fps = 60.0f;
+    constexpr float dt = 1.0f / fps;
+    constexpr int extra_settle_ticks = 5;
+    const int total_ticks =
+        static_cast<int>(std::ceil(duration_s * fps)) + extra_settle_ticks;
+
+    for (int i = 0; i < total_ticks; ++i) {
+        const float v = tween.advance(dt);
+        publish_value("Gain Knob", "opacity",
+                      static_cast<double>(v),
+                      /*opts=*/{ /*precision=*/3, /*epsilon=*/0.001 });
+        clock.tick(dt);
+    }
+
+    // Drop the fixture sink so the file closes cleanly before we read.
+    Coordinator::instance().reset();
+
+    // ── Read it back ──────────────────────────────────────────────
+    auto events = load_fixture(fixture_path);
+    REQUIRE_FALSE(events.empty());
+
+    // Extract the scalar series and run assertion helpers.
+    auto series = extract_scalar(events, "Gain Knob", "opacity", "value");
+    REQUIRE(series.size() >= 5);
+
+    // The tween is strictly monotonic (ease_out_cubic is monotonic).
+    REQUIRE(is_monotonic(series));
+
+    // Final value should land at the tween's target.
+    REQUIRE(final_value(series) == Approx(1.0).margin(0.001));
+
+    // Settling time should be close to the configured tween duration.
+    // Allow a tolerance because the first non-zero change happens on
+    // the first tick where the publish epsilon (0.001) is crossed —
+    // that's at t ≈ 1/60 ≈ 0.017 s into the animation, not t=0.
+    const double settling = settling_time_seconds(series);
+    REQUIRE(settling > duration_s * 0.7);
+    REQUIRE(settling < duration_s * 1.3);
+
+    // ease_out_cubic doesn't overshoot.
+    REQUIRE(overshoot(series) < 0.01);
+
+    // Frame jitter on a FrameClock driven at a constant dt should be 0.
+    REQUIRE(frame_jitter_seconds(series) == Approx(0.0).margin(1e-6));
+
+    // ── Burst framing checks ─────────────────────────────────────
+    std::size_t baseline = 0, start = 0, sample = 0, end = 0;
+    for (const auto& e : events) {
+        if (e.kind == SampleEvent::Kind::Baseline) ++baseline;
+        if (e.kind == SampleEvent::Kind::Start)    ++start;
+        if (e.kind == SampleEvent::Kind::Sample)   ++sample;
+        if (e.kind == SampleEvent::Kind::End)      ++end;
+    }
+    REQUIRE(baseline == 1);
+    REQUIRE(start == 1);
+    REQUIRE(sample >= 5);   // many intermediate samples
+    REQUIRE(end == 1);      // burst closed after tween settled
+
+    // ── Stable IDs survived the round trip ───────────────────────
+    for (const auto& e : events) {
+        // Publish channel uses trace_id = 0 (reserved) per Phase 7.
+        REQUIRE(e.trace_id == 0);
+        REQUIRE(e.metric_id == 0);
+        if (e.kind == SampleEvent::Kind::Start ||
+            e.kind == SampleEvent::Kind::Sample ||
+            e.kind == SampleEvent::Kind::End) {
+            REQUIRE(e.burst_id >= 1);
+        }
+    }
+
+    // Print a human-readable summary so the developer running this
+    // by hand can see the data flowed end to end.
+    std::cout << "\n[motion smoke] fixture: " << fixture_path << "\n"
+              << "[motion smoke] events=" << events.size()
+              << " baseline=" << baseline
+              << " start=" << start
+              << " sample=" << sample
+              << " end=" << end << "\n"
+              << "[motion smoke] settling_time=" << settling << "s"
+              << " final_value=" << final_value(series)
+              << " overshoot=" << overshoot(series)
+              << " jitter=" << frame_jitter_seconds(series) << "s"
+              << " monotonic=" << (is_monotonic(series) ? "yes" : "no") << "\n";
+
+    std::remove(fixture_path.c_str());
+}

--- a/test/test_motion_animation_smoke.cpp
+++ b/test/test_motion_animation_smoke.cpp
@@ -24,7 +24,14 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+
+#if defined(_WIN32)
+#include <process.h>
+#define pulp_smoke_getpid() static_cast<long>(::_getpid())
+#else
 #include <unistd.h>
+#define pulp_smoke_getpid() static_cast<long>(::getpid())
+#endif
 
 using Catch::Approx;
 using pulp::view::FrameClock;
@@ -35,9 +42,21 @@ using namespace pulp::view::motion;
 namespace {
 
 std::string smoke_fixture_path() {
+    // Cross-platform temp dir: TMPDIR / TMP / TEMP, fallback to /tmp
+    // (POSIX) or current dir (Windows when none set).
+    const char* tmp = std::getenv("TMPDIR");
+    if (!tmp) tmp = std::getenv("TMP");
+    if (!tmp) tmp = std::getenv("TEMP");
+    if (!tmp) {
+#if defined(_WIN32)
+        tmp = ".";
+#else
+        tmp = "/tmp";
+#endif
+    }
     std::ostringstream ss;
-    ss << "/tmp/pulp-motion-anim-smoke-"
-       << static_cast<long>(::getpid()) << "-"
+    ss << tmp << "/pulp-motion-anim-smoke-"
+       << pulp_smoke_getpid() << "-"
        << std::rand() << ".jsonl";
     return ss.str();
 }

--- a/test/test_motion_inspector.cpp
+++ b/test/test_motion_inspector.cpp
@@ -1,0 +1,259 @@
+/// @file test_motion_inspector.cpp
+/// Catch2 integration tests for the inspector-side Motion.* domain.
+/// Drives MotionInspector::handle() with synthesized requests against
+/// a real View tree + FrameClock and asserts request/response shapes,
+/// trace registration, and event broadcasting through a captured
+/// InspectorServer broadcast sink.
+
+#include <pulp/inspect/motion_inspector.hpp>
+#include <pulp/inspect/protocol.hpp>
+#include <pulp/inspect/inspector_server.hpp>
+#include <pulp/view/frame_clock.hpp>
+#include <pulp/view/motion.hpp>
+#include <pulp/view/view.hpp>
+
+#include <choc/text/choc_JSON.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+using Catch::Approx;
+using pulp::inspect::InspectorMessage;
+using pulp::inspect::InspectorServer;
+using pulp::inspect::MotionInspector;
+using pulp::inspect::make_request;
+using pulp::view::FrameClock;
+using pulp::view::Rect;
+using pulp::view::View;
+using pulp::view::motion::Coordinator;
+
+namespace {
+
+/// Test scaffold: real View tree (parent + named child), real
+/// FrameClock, a coordinator bound to it. The MotionInspector uses a
+/// caller-supplied capture hook in place of a real InspectorServer
+/// because TCP isn't allowed in unit tests.
+struct Scaffold {
+    Scaffold() {
+        Coordinator::instance().reset();
+        Coordinator::instance().bind(clock);
+
+        parent.set_bounds({ 10.f, 20.f, 400.f, 300.f });
+        auto child = std::make_unique<View>();
+        child->set_id("card");
+        child->set_bounds({ 5.f, 7.f, 100.f, 50.f });
+        child_ptr = child.get();
+        parent.add_child(std::move(child));
+
+        // Server isn't actually started — we capture via a coordinator
+        // sink that mimics what MotionInspector::broadcast_event sends.
+        // For the integration test we use a real MotionInspector with
+        // server = nullptr so no broadcast happens, and we observe
+        // raw SampleEvents via a buffer sink.
+        coord_sink_id = Coordinator::instance().add_sink(
+            [this](const pulp::view::motion::SampleEvent& e) {
+                std::lock_guard<std::mutex> lk(mtx);
+                events.push_back(e);
+            });
+    }
+
+    ~Scaffold() {
+        if (coord_sink_id) Coordinator::instance().remove_sink(coord_sink_id);
+        Coordinator::instance().reset();
+    }
+
+    FrameClock clock;
+    View parent;
+    View* child_ptr = nullptr;
+    int coord_sink_id = 0;
+    std::mutex mtx;
+    std::vector<pulp::view::motion::SampleEvent> events;
+};
+
+/// Parse a response body that should contain a JSON object.
+choc::value::Value parse_obj(const std::string& s) {
+    return choc::json::parse(s);
+}
+
+}  // namespace
+
+// ── Motion.startTrace basic happy path ────────────────────────────────
+
+TEST_CASE("Motion.startTrace registers a geometry trace by node id", "[motion-inspector]") {
+    Scaffold s;
+    MotionInspector mi(s.parent, /*server=*/nullptr);
+
+    const std::string params = R"({
+        "view_name": "CardTrace",
+        "fps": 60,
+        "metrics": [
+            {
+                "kind": "geometry",
+                "name": "frame",
+                "node_id": "card",
+                "properties": ["minX", "minY", "width", "height"],
+                "space": "window",
+                "source": "layout"
+            }
+        ]
+    })";
+
+    auto resp = mi.handle(make_request(7, "Motion.startTrace", params));
+    REQUIRE_FALSE(resp.is_error);
+    REQUIRE(resp.id == 7);
+    auto body = parse_obj(resp.params_json);
+    REQUIRE(body.hasObjectMember("trace_id"));
+    REQUIRE(body["trace_id"].getInt64() >= 1);
+    REQUIRE(mi.active_trace_count() == 1);
+    REQUIRE(Coordinator::instance().active_trace_count() == 1);
+    REQUIRE(Coordinator::instance().tracing_enabled());
+}
+
+// ── Tick produces motion events through the coordinator sink ──────────
+
+TEST_CASE("Ticking the clock samples the registered geometry trace", "[motion-inspector]") {
+    Scaffold s;
+    MotionInspector mi(s.parent, /*server=*/nullptr);
+
+    const std::string params = R"({
+        "view_name": "CardTrace",
+        "fps": 60,
+        "metrics": [
+            {
+                "kind": "geometry",
+                "name": "frame",
+                "node_id": "card",
+                "properties": ["minX", "minY", "width", "height"]
+            }
+        ]
+    })";
+    REQUIRE_FALSE(mi.handle(make_request(1, "Motion.startTrace", params)).is_error);
+
+    // Tick 1: baseline.
+    s.clock.tick(1.0f / 60.0f);
+    // Mutate the child's bounds, tick to produce Start + Sample.
+    s.child_ptr->set_bounds({ 5.f, 27.f, 100.f, 50.f });
+    s.clock.tick(1.0f / 60.0f);
+    // Stable: produces End on next tick.
+    s.clock.tick(1.0f / 60.0f);
+
+    std::size_t baseline_n = 0, start_n = 0, sample_n = 0, end_n = 0;
+    {
+        std::lock_guard<std::mutex> lk(s.mtx);
+        for (const auto& e : s.events) {
+            using K = pulp::view::motion::SampleEvent::Kind;
+            if (e.view_name != "CardTrace" || e.metric_name != "frame") continue;
+            if (e.kind == K::Baseline) ++baseline_n;
+            if (e.kind == K::Start)    ++start_n;
+            if (e.kind == K::Sample)   ++sample_n;
+            if (e.kind == K::End)      ++end_n;
+        }
+    }
+    REQUIRE(baseline_n == 1);
+    REQUIRE(start_n == 1);
+    REQUIRE(sample_n == 1);
+    REQUIRE(end_n == 1);
+}
+
+// ── Stop trace removes the registration ───────────────────────────────
+
+TEST_CASE("Motion.stopTrace removes the trace", "[motion-inspector]") {
+    Scaffold s;
+    MotionInspector mi(s.parent, /*server=*/nullptr);
+
+    const std::string params = R"({
+        "view_name": "X", "fps": 60,
+        "metrics": [{ "kind": "geometry", "name": "f", "node_id": "card" }]
+    })";
+    auto resp = mi.handle(make_request(1, "Motion.startTrace", params));
+    REQUIRE_FALSE(resp.is_error);
+    const auto trace_id = parse_obj(resp.params_json)["trace_id"].getInt64();
+    REQUIRE(mi.active_trace_count() == 1);
+
+    std::ostringstream stop_params;
+    stop_params << "{\"trace_id\":" << trace_id << "}";
+    auto stop_resp = mi.handle(make_request(2, "Motion.stopTrace", stop_params.str()));
+    REQUIRE_FALSE(stop_resp.is_error);
+    REQUIRE(parse_obj(stop_resp.params_json)["removed"].getBool() == true);
+    REQUIRE(mi.active_trace_count() == 0);
+    REQUIRE(Coordinator::instance().active_trace_count() == 0);
+}
+
+// ── Unknown node id is a clean error ──────────────────────────────────
+
+TEST_CASE("Motion.startTrace errors on unknown node id", "[motion-inspector]") {
+    Scaffold s;
+    MotionInspector mi(s.parent, /*server=*/nullptr);
+
+    const std::string params = R"({
+        "view_name": "X", "fps": 60,
+        "metrics": [{ "kind": "geometry", "name": "f", "node_id": "no-such" }]
+    })";
+    auto resp = mi.handle(make_request(99, "Motion.startTrace", params));
+    REQUIRE(resp.is_error);
+    REQUIRE(mi.active_trace_count() == 0);
+}
+
+// ── Missing metrics array is an error ─────────────────────────────────
+
+TEST_CASE("Motion.startTrace errors when metrics array missing", "[motion-inspector]") {
+    Scaffold s;
+    MotionInspector mi(s.parent, /*server=*/nullptr);
+    auto resp = mi.handle(make_request(1, "Motion.startTrace",
+                                       R"({"view_name":"X","fps":30})"));
+    REQUIRE(resp.is_error);
+}
+
+// ── Snapshot returns coordinator state ────────────────────────────────
+
+TEST_CASE("Motion.snapshot returns coordinator state", "[motion-inspector]") {
+    Scaffold s;
+    MotionInspector mi(s.parent, /*server=*/nullptr);
+
+    const std::string start_params = R"({
+        "view_name": "X", "fps": 60,
+        "metrics": [{ "kind": "geometry", "name": "f", "node_id": "card" }]
+    })";
+    REQUIRE_FALSE(mi.handle(make_request(1, "Motion.startTrace", start_params)).is_error);
+
+    auto snap = mi.handle(make_request(2, "Motion.snapshot"));
+    REQUIRE_FALSE(snap.is_error);
+    auto body = parse_obj(snap.params_json);
+    REQUIRE(body["tracing_enabled"].getBool() == true);
+    REQUIRE(body["active_traces"].getInt64() == 1);
+    REQUIRE(body["inspector_traces"].getInt64() == 1);
+}
+
+// ── List traces returns registered ids ────────────────────────────────
+
+TEST_CASE("Motion.listTraces returns active inspector trace ids", "[motion-inspector]") {
+    Scaffold s;
+    MotionInspector mi(s.parent, /*server=*/nullptr);
+
+    const std::string p = R"({
+        "view_name": "X", "fps": 60,
+        "metrics": [{ "kind": "geometry", "name": "f", "node_id": "card" }]
+    })";
+    REQUIRE_FALSE(mi.handle(make_request(1, "Motion.startTrace", p)).is_error);
+    REQUIRE_FALSE(mi.handle(make_request(2, "Motion.startTrace", p)).is_error);
+
+    auto resp = mi.handle(make_request(3, "Motion.listTraces"));
+    REQUIRE_FALSE(resp.is_error);
+    auto body = parse_obj(resp.params_json);
+    REQUIRE(body["trace_ids"].isArray());
+    REQUIRE(body["trace_ids"].size() == 2);
+}
+
+// ── Unknown method is a clean error ───────────────────────────────────
+
+TEST_CASE("Unknown Motion.* method returns an error", "[motion-inspector]") {
+    Scaffold s;
+    MotionInspector mi(s.parent, /*server=*/nullptr);
+    auto resp = mi.handle(make_request(1, "Motion.nope"));
+    REQUIRE(resp.is_error);
+}

--- a/test/test_pulp_mcp_launcher.sh
+++ b/test/test_pulp_mcp_launcher.sh
@@ -42,8 +42,13 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 case1="$TMPDIR_T/case1"
 stage_fake_repo "$case1"
 
+# Override HOME to a clean tmpdir so the launcher's
+# `${HOME}/.pulp/bin/pulp-mcp` probe doesn't accidentally find a real
+# installed binary on a dev machine that has run `install.sh`.
+# Scrubbing PATH alone isn't enough — HOME is searched independently.
 set +e
-output=$(PATH=/usr/bin:/bin "$case1/tools/mcp/pulp-mcp-launcher" 2>&1)
+output=$(HOME="$TMPDIR_T/case1-home" PATH=/usr/bin:/bin \
+    "$case1/tools/mcp/pulp-mcp-launcher" 2>&1)
 rc=$?
 set -e
 
@@ -73,7 +78,8 @@ STUB
 chmod +x "$case2/build/tools/mcp/pulp-mcp"
 
 set +e
-output=$(PATH=/usr/bin:/bin "$case2/tools/mcp/pulp-mcp-launcher" 2>&1)
+output=$(HOME="$TMPDIR_T/case2-home" PATH=/usr/bin:/bin \
+    "$case2/tools/mcp/pulp-mcp-launcher" 2>&1)
 rc=$?
 set -e
 
@@ -101,7 +107,8 @@ STUB
 chmod +x "$pathdir/pulp-mcp"
 
 set +e
-output=$(PATH="$pathdir:/usr/bin:/bin" "$case3/tools/mcp/pulp-mcp-launcher" 2>&1)
+output=$(HOME="$TMPDIR_T/case3-home" PATH="$pathdir:/usr/bin:/bin" \
+    "$case3/tools/mcp/pulp-mcp-launcher" 2>&1)
 rc=$?
 set -e
 
@@ -127,7 +134,8 @@ STUB
 chmod +x "$case4/build/tools/mcp/pulp-mcp"
 
 set +e
-output=$(PATH=/usr/bin:/bin "$case4/tools/mcp/pulp-mcp-launcher" --foo bar baz 2>&1)
+output=$(HOME="$TMPDIR_T/case4-home" PATH=/usr/bin:/bin \
+    "$case4/tools/mcp/pulp-mcp-launcher" --foo bar baz 2>&1)
 rc=$?
 set -e
 

--- a/tools/motion/visual/README.md
+++ b/tools/motion/visual/README.md
@@ -1,0 +1,69 @@
+# `tools/motion/visual/` — Pulp Motion visual-analysis pipeline
+
+Operates on a directory of sequential PNG frames (any source: host
+window capture, scripted `pulp-ui-preview` frame dumps, an external
+`ffmpeg` extraction) and produces a structured report:
+
+- `analysis.json` — machine-readable per-frame metrics
+- `summary.md` — agent-readable Markdown summary
+- `diff/*.png` — pairwise pixel-diff heatmaps
+- `keyframes.png` — keyframe sprite for the summary
+
+This is the pixel-truth fallback for animations whose values aren't
+observable via the runtime scalar trace (Phases 0–3) — typically
+transitions, GPU filters, mask compositing, anything that only shows
+up as pixels.
+
+## Install
+
+```bash
+pip install -r tools/motion/visual/requirements.txt
+```
+
+Dependencies are MIT / BSD / Apache 2.0 only.
+
+## Use
+
+```bash
+python3 -m tools.motion.visual.analyze_sequence \
+    --frames-dir ./captures/card-open/ \
+    --output     ./reports/card-open/
+```
+
+Useful flags:
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--pattern` | `frame_*.png` | Glob for frame filenames |
+| `--keyframes N` | `2` | Top-delta keyframes in addition to first/mid/last |
+| `--max-diff-frames N` | `8` | Cap on emitted diff PNGs; `0` = unlimited |
+
+## Self-check
+
+```bash
+python3 tools/motion/visual/test_self_check.py
+```
+
+Synthesizes a 6-frame sliding-rectangle sequence, runs the analyzer,
+asserts artifact presence and JSON shape. Exits with `3` if Python
+dependencies aren't installed (so CTest can skip cleanly).
+
+## Output schema
+
+`analysis.json` carries a `schema_version` field. Downstream consumers
+(the assertion CLI, agent skills) read this and refuse unknown
+versions. Bump the constant in `analyze_sequence.py` on breaking
+changes.
+
+## What it does NOT do
+
+- **Scripted capture** — driving `pulp-ui-preview` to dump a
+  deterministic frame sequence is a separate step. Today, capture is
+  whatever produces sequential PNGs in a directory (manual `screencapture`
+  loop, `ffmpeg`, or a future scripted mode).
+- **Optical flow** — pixel diff + SSIM are sufficient for the current
+  agent workflows; optical flow is a follow-up if SSIM ever proves
+  insufficient.
+- **Motion-trace correlation** — pairing scalar traces (Phase 0 sample
+  events) with visual frames lives in the assertion / record-replay
+  pipeline.

--- a/tools/motion/visual/__init__.py
+++ b/tools/motion/visual/__init__.py
@@ -1,0 +1,13 @@
+"""Pulp Motion visual-analysis pipeline.
+
+Operates on a directory of sequential PNG frames (any source: a host
+window-capture loop, scripted `ui-preview` frame dumps, an
+external `ffmpeg` extraction) and produces a structured report:
+
+  - `analysis.json`  — machine-readable per-frame metrics
+  - `summary.md`     — agent-readable Markdown summary
+  - `diff/*.png`     — pairwise pixel-diff heatmaps
+  - `keyframes.png`  — keyframe sprite for the summary
+
+See `analyze_sequence.py` for the entry point and CLI.
+"""

--- a/tools/motion/visual/analyze_sequence.py
+++ b/tools/motion/visual/analyze_sequence.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Pulp Motion visual-analysis pipeline.
+
+Given a directory of sequential PNG frames (`frame_0000.png`,
+`frame_0001.png`, …), compute per-frame metrics, select keyframes,
+generate pairwise pixel-diff heatmaps and a keyframe sprite, and write
+a structured JSON + Markdown report.
+
+Usage:
+    python3 -m tools.motion.visual.analyze_sequence \\
+        --frames-dir ./frames \\
+        --output     ./report
+
+CLI flags:
+    --frames-dir DIR    Directory of sequential PNG frames (required).
+    --output     DIR    Output directory for the report (required).
+    --pattern    GLOB   Frame filename glob (default `frame_*.png`).
+    --keyframes  N      Number of top-delta keyframes to include in the
+                        sprite, in addition to first/mid/last (default 2).
+    --max-diff-frames N Cap on how many pairwise diff PNGs to emit; the
+                        N pairs with the largest SSIM drop are kept
+                        (default 8). Use 0 for unlimited.
+
+Outputs (under --output):
+    analysis.json   metrics, keyframes, diff catalogue, version stamp
+    summary.md      agent-facing summary
+    diff/*.png      pairwise diff heatmaps
+    keyframes.png   horizontal sprite of selected keyframes
+
+Exit codes:
+    0  Analysis succeeded.
+    2  Frames directory missing / empty.
+    3  Dependency missing or load failed (numpy / Pillow /
+       scikit-image). Treats as ctest SKIP_RETURN_CODE.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+# Schema version for the on-disk report. Bump on breaking changes;
+# downstream tools (Phase 5 assertion CLI) read this and refuse
+# unknown versions.
+REPORT_SCHEMA_VERSION = 1
+
+
+# ── Dependency import (graceful skip) ────────────────────────────────
+
+def _try_import_deps() -> Optional[Tuple[object, object, object]]:
+    """Import numpy + PIL + scikit-image. Return None on failure so the
+    caller can exit 3 (ctest skip) rather than crash."""
+    try:
+        import numpy as np  # noqa: F401
+        from PIL import Image  # noqa: F401
+        from skimage.metrics import structural_similarity  # noqa: F401
+        return np, Image, structural_similarity
+    except Exception as e:
+        print(
+            f"pulp-motion-visual: missing dependency ({e}); "
+            "install with `pip install -r tools/motion/visual/requirements.txt`",
+            file=sys.stderr,
+        )
+        return None
+
+
+# ── Data classes ─────────────────────────────────────────────────────
+
+@dataclass
+class FrameInfo:
+    index: int
+    path: str
+    width: int
+    height: int
+    mean_brightness: float  # 0..1
+
+
+@dataclass
+class PairMetrics:
+    from_index: int
+    to_index: int
+    ssim: float            # 1.0 = identical, lower = more different
+    pixel_diff_mean: float # 0..1, mean abs diff
+    pixel_diff_max: float  # 0..1, max abs diff
+    diff_png_path: Optional[str] = None
+
+
+@dataclass
+class KeyframeInfo:
+    index: int
+    role: str   # "first" | "mid" | "last" | "top-delta"
+    path: str
+
+
+@dataclass
+class Report:
+    schema_version: int
+    frames: List[FrameInfo]
+    pairs: List[PairMetrics]
+    keyframes: List[KeyframeInfo]
+    sprite_path: Optional[str]
+    summary: dict
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+def list_frames(frames_dir: Path, pattern: str) -> List[Path]:
+    return sorted(frames_dir.glob(pattern))
+
+
+def load_frame_array(path: Path, np_mod, Image):
+    """Load a frame as an H×W×3 uint8 numpy array (RGB)."""
+    img = Image.open(str(path)).convert("RGB")
+    return np_mod.asarray(img), img.size
+
+
+def compute_pair_metrics(
+    from_arr, to_arr, np_mod, ssim_fn
+) -> Tuple[float, float, float, "np_mod.ndarray"]:
+    """Returns (ssim, mean_diff, max_diff, diff_uint8_h×w)."""
+    # Use luminance for SSIM (mirrors common motion-diff practice).
+    luma_from = from_arr @ np_mod.array([0.299, 0.587, 0.114], dtype=np_mod.float32)
+    luma_to   = to_arr   @ np_mod.array([0.299, 0.587, 0.114], dtype=np_mod.float32)
+    ssim = float(ssim_fn(luma_from, luma_to, data_range=255.0))
+    diff_abs = np_mod.abs(luma_from - luma_to)
+    mean_diff = float(diff_abs.mean()) / 255.0
+    max_diff = float(diff_abs.max()) / 255.0
+    diff_uint8 = np_mod.clip(diff_abs * 3.0, 0, 255).astype(np_mod.uint8)
+    return ssim, mean_diff, max_diff, diff_uint8
+
+
+def write_diff_heatmap(diff_uint8, dest_path: Path, np_mod, Image) -> None:
+    """Write a grayscale diff heatmap. Larger differences → brighter."""
+    img = Image.fromarray(diff_uint8, mode="L")
+    img.save(str(dest_path), format="PNG")
+
+
+def make_keyframe_sprite(
+    keyframe_paths: List[Path], dest_path: Path, Image
+) -> None:
+    """Compose a horizontal sprite of the selected keyframes."""
+    if not keyframe_paths:
+        return
+    imgs = [Image.open(str(p)).convert("RGB") for p in keyframe_paths]
+    w = max(im.size[0] for im in imgs)
+    h = max(im.size[1] for im in imgs)
+    n = len(imgs)
+    sprite = Image.new("RGB", (w * n, h), color=(0, 0, 0))
+    for i, im in enumerate(imgs):
+        sprite.paste(im, (i * w, 0))
+    sprite.save(str(dest_path), format="PNG")
+
+
+def select_keyframes(
+    frames: List[FrameInfo],
+    pairs: List[PairMetrics],
+    top_delta: int,
+) -> List[KeyframeInfo]:
+    """Pick first, mid, last, plus the `top_delta` highest-delta frames."""
+    if not frames:
+        return []
+    chosen: dict[int, str] = {}
+    chosen[frames[0].index] = "first"
+    chosen[frames[-1].index] = "last"
+    if len(frames) > 2:
+        chosen.setdefault(frames[len(frames) // 2].index, "mid")
+    # rank pairs by lowest SSIM (== largest change) and pick their `to` index.
+    by_change = sorted(pairs, key=lambda p: p.ssim)
+    for p in by_change[:top_delta]:
+        chosen.setdefault(p.to_index, "top-delta")
+    out: List[KeyframeInfo] = []
+    by_idx = {f.index: f for f in frames}
+    for idx in sorted(chosen.keys()):
+        f = by_idx[idx]
+        out.append(KeyframeInfo(index=idx, role=chosen[idx], path=f.path))
+    return out
+
+
+def write_summary_md(report: Report, output_dir: Path) -> None:
+    md = []
+    md.append("# Motion visual analysis\n")
+    md.append(f"- schema_version: {report.schema_version}")
+    md.append(f"- frames: {len(report.frames)}")
+    md.append(f"- pairs: {len(report.pairs)}")
+    md.append(f"- keyframes: {len(report.keyframes)}\n")
+
+    md.append("## Summary metrics\n")
+    s = report.summary
+    md.append(f"- mean SSIM (consecutive pairs): {s.get('mean_ssim', 0):.4f}")
+    md.append(f"- min SSIM (consecutive pairs):  {s.get('min_ssim', 0):.4f}")
+    md.append(f"- mean pixel diff: {s.get('mean_pixel_diff', 0):.4f}")
+    md.append(f"- max pixel diff: {s.get('max_pixel_diff', 0):.4f}\n")
+
+    md.append("## Keyframes\n")
+    for k in report.keyframes:
+        md.append(f"- `frame_{k.index:04d}` — {k.role}")
+    md.append("")
+
+    md.append("## Diff catalogue\n")
+    for p in report.pairs:
+        if p.diff_png_path:
+            md.append(
+                f"- pair `{p.from_index:04d}→{p.to_index:04d}`: "
+                f"ssim={p.ssim:.4f} mean_diff={p.pixel_diff_mean:.4f} "
+                f"max_diff={p.pixel_diff_max:.4f} ([diff]({p.diff_png_path}))"
+            )
+
+    (output_dir / "summary.md").write_text("\n".join(md) + "\n", encoding="utf-8")
+
+
+def write_json(report: Report, output_dir: Path) -> None:
+    payload = {
+        "schema_version": report.schema_version,
+        "frames": [asdict(f) for f in report.frames],
+        "pairs": [asdict(p) for p in report.pairs],
+        "keyframes": [asdict(k) for k in report.keyframes],
+        "sprite_path": report.sprite_path,
+        "summary": report.summary,
+    }
+    (output_dir / "analysis.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8"
+    )
+
+
+# ── Main analysis ────────────────────────────────────────────────────
+
+def analyze(
+    frames_dir: Path,
+    output_dir: Path,
+    pattern: str = "frame_*.png",
+    keyframes_top: int = 2,
+    max_diff_frames: int = 8,
+) -> int:
+    deps = _try_import_deps()
+    if deps is None:
+        return 3
+    np_mod, Image, ssim_fn = deps
+
+    frame_paths = list_frames(frames_dir, pattern)
+    if not frame_paths:
+        print(
+            f"pulp-motion-visual: no frames matched `{pattern}` in {frames_dir}",
+            file=sys.stderr,
+        )
+        return 2
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    diff_dir = output_dir / "diff"
+    diff_dir.mkdir(exist_ok=True)
+
+    # Load all frames + compute per-frame metrics.
+    arrays = []
+    frames: List[FrameInfo] = []
+    for i, path in enumerate(frame_paths):
+        arr, (w, h) = load_frame_array(path, np_mod, Image)
+        arrays.append(arr)
+        mean = float(arr.mean()) / 255.0
+        frames.append(FrameInfo(index=i, path=str(path),
+                                width=w, height=h, mean_brightness=mean))
+
+    # Compute pairwise metrics.
+    pairs: List[PairMetrics] = []
+    for i in range(len(arrays) - 1):
+        ssim, mean_diff, max_diff, diff_uint8 = compute_pair_metrics(
+            arrays[i].astype("float32"),
+            arrays[i + 1].astype("float32"),
+            np_mod,
+            ssim_fn,
+        )
+        pairs.append(PairMetrics(
+            from_index=i, to_index=i + 1,
+            ssim=ssim, pixel_diff_mean=mean_diff, pixel_diff_max=max_diff,
+        ))
+
+    # Emit diff PNGs for the top-N highest-change pairs (or all if 0).
+    if max_diff_frames <= 0:
+        diff_targets = pairs
+    else:
+        diff_targets = sorted(pairs, key=lambda p: p.ssim)[:max_diff_frames]
+    for p in diff_targets:
+        out_path = diff_dir / f"diff_{p.from_index:04d}_{p.to_index:04d}.png"
+        # Recompute the diff array (cheap; only for the chosen pairs).
+        _, _, _, diff_uint8 = compute_pair_metrics(
+            arrays[p.from_index].astype("float32"),
+            arrays[p.to_index].astype("float32"),
+            np_mod, ssim_fn,
+        )
+        write_diff_heatmap(diff_uint8, out_path, np_mod, Image)
+        p.diff_png_path = str(out_path.relative_to(output_dir))
+
+    # Select keyframes + emit sprite.
+    keyframes = select_keyframes(frames, pairs, top_delta=keyframes_top)
+    sprite_path: Optional[str] = None
+    if keyframes:
+        sprite_dest = output_dir / "keyframes.png"
+        make_keyframe_sprite([Path(k.path) for k in keyframes], sprite_dest, Image)
+        sprite_path = str(sprite_dest.relative_to(output_dir))
+
+    summary = {
+        "mean_ssim": (sum(p.ssim for p in pairs) / len(pairs)) if pairs else 1.0,
+        "min_ssim": min((p.ssim for p in pairs), default=1.0),
+        "mean_pixel_diff": (
+            sum(p.pixel_diff_mean for p in pairs) / len(pairs)
+        ) if pairs else 0.0,
+        "max_pixel_diff": max((p.pixel_diff_max for p in pairs), default=0.0),
+    }
+    report = Report(
+        schema_version=REPORT_SCHEMA_VERSION,
+        frames=frames, pairs=pairs, keyframes=keyframes,
+        sprite_path=sprite_path, summary=summary,
+    )
+    write_json(report, output_dir)
+    write_summary_md(report, output_dir)
+    return 0
+
+
+# ── CLI ──────────────────────────────────────────────────────────────
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="pulp-motion-visual",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--frames-dir", required=True, type=Path,
+                        help="Directory of sequential PNG frames")
+    parser.add_argument("--output", required=True, type=Path,
+                        help="Output directory for the report")
+    parser.add_argument("--pattern", default="frame_*.png",
+                        help="Frame filename glob (default `frame_*.png`)")
+    parser.add_argument("--keyframes", type=int, default=2, dest="keyframes_top",
+                        help="Top-delta keyframes in addition to first/mid/last")
+    parser.add_argument("--max-diff-frames", type=int, default=8,
+                        help="Cap on diff PNGs emitted; 0 = unlimited")
+    args = parser.parse_args(argv)
+    return analyze(
+        frames_dir=args.frames_dir,
+        output_dir=args.output,
+        pattern=args.pattern,
+        keyframes_top=args.keyframes_top,
+        max_diff_frames=args.max_diff_frames,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/motion/visual/requirements.txt
+++ b/tools/motion/visual/requirements.txt
@@ -1,0 +1,6 @@
+# Pulp Motion visual-analysis dependencies.
+# All MIT / BSD / Apache 2.0 — license-clean for the analysis lane.
+# Not redistributed in plugin/app artifacts.
+numpy>=1.24
+Pillow>=10.0
+scikit-image>=0.22

--- a/tools/motion/visual/test_self_check.py
+++ b/tools/motion/visual/test_self_check.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Self-check for `tools/motion/visual/analyze_sequence.py`.
+
+Synthesizes a small sequence of PNG frames in a temp dir, runs the
+analyzer end-to-end, and asserts the expected artifacts + JSON shape.
+Returns:
+    0  → analysis succeeded and artifacts are well-formed
+    3  → Python deps missing (numpy / Pillow / scikit-image) — ctest
+          SKIP_RETURN_CODE so CI without the deps installed skips
+          cleanly instead of failing
+    1  → unexpected failure
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR.parent.parent.parent) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR.parent.parent.parent))
+
+from tools.motion.visual import analyze_sequence  # noqa: E402
+
+
+def synthesize_frames(out_dir: Path, n_frames: int = 6) -> None:
+    """Render `n_frames` frames where a colored rectangle slides right
+    by 10 px per frame. Uses Pillow directly (already a required dep)."""
+    try:
+        from PIL import Image, ImageDraw
+    except Exception as e:
+        print(f"self-check: missing Pillow ({e})", file=sys.stderr)
+        sys.exit(3)
+    width, height = 120, 60
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(n_frames):
+        img = Image.new("RGB", (width, height), color=(20, 20, 30))
+        draw = ImageDraw.Draw(img)
+        x = i * 10
+        draw.rectangle([(x, 10), (x + 30, 50)], fill=(220, 80, 30))
+        img.save(out_dir / f"frame_{i:04d}.png")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        td_path = Path(td)
+        frames_dir = td_path / "frames"
+        synthesize_frames(frames_dir, n_frames=6)
+        output_dir = td_path / "report"
+
+        rc = analyze_sequence.analyze(
+            frames_dir=frames_dir,
+            output_dir=output_dir,
+            pattern="frame_*.png",
+            keyframes_top=2,
+            max_diff_frames=4,
+        )
+        if rc == 3:
+            return 3
+        if rc != 0:
+            print(f"self-check: analyzer returned {rc}", file=sys.stderr)
+            return 1
+
+        # ── Assert artifacts exist ─────────────────────────────────
+        json_path = output_dir / "analysis.json"
+        md_path = output_dir / "summary.md"
+        sprite_path = output_dir / "keyframes.png"
+        diff_dir = output_dir / "diff"
+        for required in (json_path, md_path, sprite_path, diff_dir):
+            if not required.exists():
+                print(f"self-check: missing artifact {required}", file=sys.stderr)
+                return 1
+
+        # ── Assert JSON shape ──────────────────────────────────────
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+        if data["schema_version"] != analyze_sequence.REPORT_SCHEMA_VERSION:
+            print("self-check: schema version mismatch", file=sys.stderr)
+            return 1
+        if len(data["frames"]) != 6:
+            print(f"self-check: expected 6 frames, got {len(data['frames'])}",
+                  file=sys.stderr)
+            return 1
+        if len(data["pairs"]) != 5:
+            print(f"self-check: expected 5 pairs, got {len(data['pairs'])}",
+                  file=sys.stderr)
+            return 1
+        if "mean_ssim" not in data["summary"]:
+            print("self-check: missing summary.mean_ssim", file=sys.stderr)
+            return 1
+
+        # The synthetic frames have constant motion (rectangle shift),
+        # so SSIM should be < 1.0 and pixel diff > 0 on every pair.
+        for p in data["pairs"]:
+            if p["ssim"] >= 1.0:
+                print(f"self-check: pair {p} ssim should be < 1.0", file=sys.stderr)
+                return 1
+            if p["pixel_diff_mean"] <= 0.0:
+                print(f"self-check: pair {p} mean diff should be > 0",
+                      file=sys.stderr)
+                return 1
+
+        # Keyframes must include first + last at minimum.
+        roles = {k["role"] for k in data["keyframes"]}
+        if "first" not in roles or "last" not in roles:
+            print(f"self-check: keyframes missing first/last (got {roles})",
+                  file=sys.stderr)
+            return 1
+
+        # At least one diff PNG should have been emitted (we capped at 4
+        # and there are 5 pairs).
+        diff_pngs = list(diff_dir.glob("diff_*.png"))
+        if not diff_pngs:
+            print("self-check: no diff PNGs emitted", file=sys.stderr)
+            return 1
+
+        print(f"self-check OK ({len(data['frames'])} frames, "
+              f"{len(data['pairs'])} pairs, "
+              f"{len(data['keyframes'])} keyframes, "
+              f"{len(diff_pngs)} diff PNGs)")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -159,6 +159,15 @@
         "examples/jsfx-*/**"
       ]
     },
+    "motion": {
+      "paths": [
+        "core/view/include/pulp/view/motion.hpp",
+        "core/view/src/motion.cpp",
+        "inspect/include/pulp/inspect/motion_inspector.hpp",
+        "inspect/src/motion_inspector.cpp",
+        "tools/motion/**"
+      ]
+    },
     "mpe": {
       "paths": [
         "core/midi/include/**/*mpe*",


### PR DESCRIPTION
End-to-end agent-first motion observability for Pulp views and animations. Off by default in production; activate per-trace at runtime. 10 commits in this PR (Phases 0-7 + plugin smoke + Codex review fixes + version bump).

## What ships

- `pulp::view::motion::Coordinator` — process-wide singleton bound to a `FrameClock` (one tick subscription, per-trace accumulators).
- `TraceBuilder` DSL — `value(...).multi(...).geometry(...).with_provenance(...).attach()` returns an RAII `TraceHandle`.
- **Phase 2 presentation walker** — `paint_all()`-order 2D-affine composition (transform-origin pivot + translate / rotate / scale + full affine + ScrollView scroll-offset quirk recognition). `Layout` vs `Presentation` source selectable per metric.
- **Phase 3 publish channel** — `publish_value(view, metric, v)` / `publish_components(...)` lets animation primitives emit samples without taking a sampler subscription. Firehose mode (`Coordinator::set_firehose(true)`) fans publishes to all sinks.
- **Phase 5 record/replay/assert** — `make_fixture_sink(path)` writes a versioned JSONL fixture. `load_fixture` / `replay_fixture` read it back. `assert_matches(golden, captured)` returns a structured diff aligned by stable identifiers.
- **Phase 7 stable IDs + Provenance** — every `SampleEvent` carries `trace_id`, `metric_id`, `burst_id`; new `TraceStarted` event carries a `Provenance` envelope (`source_kind`, `source_id`, `source_file`, `source_line`).
- **Assertion helpers** — `is_monotonic`, `settling_time_seconds`, `start_delay_seconds`, `overshoot`, `frame_jitter_seconds`, `final_value` kept deliberately separate so failures stay diagnostic.
- **`Motion.*` inspector domain** — `Motion.startTrace` / `Motion.stopTrace` / `Motion.snapshot` / `Motion.listTraces` requests + `Motion.start` / `Motion.sample` / `Motion.end` events. Wired into `examples/ui-preview` behind `PULP_MOTION_SERVER=1` / `PULP_MOTION_LOG=1` / `PULP_MOTION_FIREHOSE=1` env knobs.
- **Python visual-analysis pipeline** at `tools/motion/visual/analyze_sequence.py` — SSIM, pixel diff, keyframe selection, sprite, JSON+Markdown report (schema v1). CTest entry skips gracefully when numpy/Pillow/scikit-image are missing.
- **User guide** at `docs/guides/motion-observability.md` + single `motion` agent skill at `.agents/skills/motion/`. Modules.yaml, docs-index.yaml, skill_path_map.json all updated.

## Test coverage

- `pulp-test-motion` — 49 cases / 169 assertions (coordinator, walker, publish, fixture record/replay/assert, assertion helpers, NaN/Inf round-trip).
- `pulp-test-motion-inspector` — 8 cases / 32 assertions (Motion.* protocol).
- `pulp-test-motion-animation-smoke` — end-to-end: real `Tween` → `publish_value` → fixture → load → assertion helpers. 98 assertions.
- `pulp-motion-visual-self-check` — Python pipeline self-check (synthesizes frames, runs analyzer, asserts artifact shape). Skips when deps absent.
- Sibling tests (`pulp-test-animation`, `pulp-test-frame-clock`, `pulp-test-widget-animation`, `pulp-test-view`) unaffected.

## Compatibility

- Off by default. When `Coordinator::tracing_enabled()` is false (default), the `FrameClock` callback is a single branch and returns immediately — zero overhead in shipping builds.
- Headers auto-installed via the existing `core/view/include/pulp/` install rule — downstream plugins linking `pulp::view` see `pulp/view/motion.hpp` with no extra config.
- Existing plugin builds verified: `pulp-test-host` (1268 assertions), `pulp-test-clap-entry`, `PulpGain` standalone launch all clean with the motion-linked view library.

## Phase 7+ follow-up

The next PR will bundle Phase 8 (reduced-motion `MotionPolicy` + `MotionPreferences`), Phase 9 (provenance adapters across `Tween` / CSS / `AnimatorSet` / rAF / design-import), Phase 10 (input + motion recording with `View::simulate_*` replay), motion cost attribution, and timeline scrubber. All five share the Phase 7 fixture schema as their common artifact contract — see [planning/2026-05-16-pulp-motion-phase7-plus.md](https://github.com/danielraffel/pulp-planning).