### PR TITLE
chore(ci): route recovery canary through pool label

### DIFF
--- a/.github/workflows/shipyard-recovery-worker-canary.yml
+++ b/.github/workflows/shipyard-recovery-worker-canary.yml
@@ -35,7 +35,7 @@ jobs:
       - macOS
       - ARM64
       - pulp-build-vm
-      - shipyard-recovery-canary-m5-20260814
+      - shipyard-recovery-pool
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/scripts/test_shipyard_recovery_worker_canary_workflow.py
+++ b/tools/scripts/test_shipyard_recovery_worker_canary_workflow.py
@@ -28,7 +28,7 @@ class RecoveryWorkerCanaryWorkflowTests(unittest.TestCase):
         self.assertIn("inputs.expected_head", group)
         self.assertEqual(self.doc["concurrency"]["cancel-in-progress"], "false")
 
-    def test_unique_m5_disposable_label_is_not_a_generic_fleet_selector(self) -> None:
+    def test_canary_uses_the_dedicated_recovery_pool(self) -> None:
         labels = self.doc["jobs"]["m5-disposable-proof"]["runs-on"]
         self.assertEqual(
             labels,
@@ -37,7 +37,7 @@ class RecoveryWorkerCanaryWorkflowTests(unittest.TestCase):
                 "macOS",
                 "ARM64",
                 "pulp-build-vm",
-                "shipyard-recovery-canary-m5-20260814",
+                "shipyard-recovery-pool",
             ],
         )
 


### PR DESCRIPTION
The recovery canary workflow was pinned to the retired static runner label `shipyard-recovery-canary-m5-20260814`, leaving the job permanently queued with no runner. Route it through the existing `shipyard-recovery-pool` label instead, preserving ephemeral runner selection and fail-closed semantics.

Evidence: run 32428996839 / job 96616672164 queued with no runner under the old label, then cancelled.
Validation: decisions contract OK; workflow label assertion; pre-push 29 tests clean.

<!-- whence {"labels": ["1·codex", "2·m5", "5·unresolved"], "prov": {"agent": "codex", "tab": "", "workstream": "", "launcher": "unresolved", "route": "unresolved", "router": "", "origin_state": "unnamed", "goals": ""}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m5` |
| **Launcher** | `unresolved` |
| **Route** | `unresolved` |
| **Origin state** | `unnamed` |
| **Directory** | `~/Code/pulp` |
| **Session** | `01a01d46-3a4a-7d80-801c-1b3cb8268ccd` |

**Resume**
```
codex resume 01a01d46-3a4a-7d80-801c-1b3cb8268ccd
```

<sub>stamped 2026-08-20 23:41 UTC</sub>
<!-- /whence -->