### PR TITLE
chore: bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.433.0",
+      "version": "0.433.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.433.0"
+  "version": "0.433.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.433.0",
+  "version": "0.433.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/docs/status/pulp-tooling-disposition.json
+++ b/docs/status/pulp-tooling-disposition.json
@@ -4494,7 +4494,7 @@
       {
         "name": "claude-marketplace:pulp",
         "disposition": "pulp-owned",
-        "version": "0.433.0",
+        "version": "0.433.1",
         "source": "./",
         "min_cli_version": "0.31.0",
         "registration_keys": [
@@ -4509,13 +4509,13 @@
           "version"
         ],
         "catalog_name": "pulp",
-        "catalog_version": "0.433.0",
+        "catalog_version": "0.433.1",
         "catalog_metadata_version": "1.0.0"
       },
       {
         "name": "claude-plugin:pulp",
         "disposition": "pulp-owned",
-        "version": "0.433.0",
+        "version": "0.433.1",
         "commands": "./.claude/commands",
         "skills": "./.agents/skills",
         "registration_keys": [


### PR DESCRIPTION
chore: bump versions

Assigned from Version-Bump intent on e99e4abdd7b3..b7a4c47ee1d3.
plugin 0.433.0->0.433.1 (patch)

Version-Bump-Applied: b7a4c47ee1d38d579b8b32f23b53590c4d5e108d

<!-- whence {"labels": ["1·codex", "2·m3", "3·pre-colo", "4·DSP", "5·unresolved"], "prov": {"agent": "codex", "tab": "DSP", "workstream": "", "launcher": "unresolved", "route": "unresolved", "router": "", "origin_state": "known", "goals": ""}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m3` |
| **Workspace** | `pre-colo` |
| **Tab** | DSP |
| **Launcher** | `unresolved` |
| **Route** | `unresolved` |
| **Origin state** | `known` |
| **Directory** | `/Volumes/Workshop/Code/pulp` |
| **Session** | `01a01d48-922d-7a92-8e49-40876ef346f6` |

**Resume**
```
codex resume 01a01d48-922d-7a92-8e49-40876ef346f6
```
**Jump to this tab**
```
cmux surface focus 2C4C668A-B447-4BB9-8CF0-C7149FACA5A5
```
**Relaunch (any agent)**
```
cmux surface resume get --surface 2C4C668A-B447-4BB9-8CF0-C7149FACA5A5
```

<sub>stamped 2026-08-20 13:18 UTC</sub>
<!-- /whence -->